### PR TITLE
Custom components for use in writing advocacy content

### DIFF
--- a/advocacy_docs/getting-started/connecting_to_postgres/python/02_django.mdx
+++ b/advocacy_docs/getting-started/connecting_to_postgres/python/02_django.mdx
@@ -12,6 +12,10 @@ tags:
 ---
 import Katacoda from '../../../../src/advocacy_components/katacoda';
 
+<Attention>
+    Don't forget to [install psycopg2](/getting-started/connecting_to_postgres/python) before trying to connect!
+</Attention>
+
 Django allows persisting and querying data models via [a rich set of options to map classes to database tables](https://docs.djangoproject.com/en/3.0/topics/db/). The connection to PostgreSQL is configured via the "default" key in the `DATABASES` dictionary in Django settings (usually configured by editing a project's `settings.py`):
 
 ```python
@@ -29,7 +33,7 @@ DATABASES = {
 (Don't forget to [install psycopg2](/getting-started/connecting_to_postgres/python) before trying to connect!)
 
 If you prefer to use a connection URL, you may use [the dj-database-url library](https://pypi.org/project/dj-database-url/) to translate this into Django's dictionary format. Django also allows [multiple database connections](https://docs.djangoproject.com/en/3.0/topics/db/multi-db/) to be configured.
-      
+
 Refer to [the Django documentation](https://docs.djangoproject.com/en/3.0/topics/db/) for more options.
 
 ## Interactive tutorial
@@ -42,14 +46,14 @@ You have data that you need to display on the web. A PostgreSQL database is avai
 ### What you'll do in this tutorial
 
 1. Install Django and psycopg2
-2. Create a new Django app and connect it to PostgreSQL 
+2. Create a new Django app and connect it to PostgreSQL
 3. Create data models and run a migration to set up the PostgreSQL tables
 4. Create views, set up URL routing
 5. Run the app!
 
 ### What's already done
 
-- A development environment with Python installed is ready 
+- A development environment with Python installed is ready
 - A fresh PostgreSQL database named "demo" has been created, and is accessible via port 5432
 
 <Katacoda account="shog9" scenario="django2" hideintro="true" clickToShowText='Start tutorial'/>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -5,8 +5,10 @@ import TextBalancer from '../components/text-balancer';
 import { MDXProvider } from '@mdx-js/react';
 import Icon from '../components/icon/';
 import Katacoda from '../advocacy_components/katacoda';
+import Alert from 'react-bootstrap/Alert';
 
 import '../styles/index.scss';
+
 
 const Layout = ({ children, pageMeta, background = 'light' }) => {
   const { baseUrl, imageUrl, title, description } = useSiteMetadata();
@@ -49,6 +51,9 @@ const Layout = ({ children, pageMeta, background = 'light' }) => {
           img: props => <img {...props} className='mw-100' />, // eslint-disable-line jsx-a11y/alt-text
           Icon,
           Katacoda,
+          Attention: props => (
+            <Alert variant="warning" {...props}/>
+          ),
         }}
       >
         {children}


### PR DESCRIPTION
`<Attention>Message [link text](/link/location)</Attention>`

I'm trying to make a reusable component that allows authors to draw attention to some useful contextual information at the top of an article.

Using `MDXProvider`, I'm able to create my custom tag, however markdown links are not being rendered. I would like for authors to specify URL links in standard markdown so they don't need to learn multiple linking conventions.

I've explored remark plugins, but I think they're beyond my skill level.
