### PR TITLE
Docs for using VSCode's remote containers plugin to run this repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,21 +4,27 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # To fully customize the contents of this image, use the following Dockerfile instead:
-# https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/javascript-node-14/.devcontainer/Dockerfile
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-14
+# https://github.com/microsoft/vscode-dev-containers/blob/master/containers/python-3/.devcontainer/Dockerfile
 
-# ** [Optional] Uncomment this section to install additional packages. **
-#
-# ENV DEBIAN_FRONTEND=noninteractive
-# RUN apt-get update \
-#    && apt-get -y install --no-install-recommends <your-package-list-here> \
-#    #
-#    # Clean up
-#    && apt-get autoremove -y \
-#    && apt-get clean -y \
-#    && rm -rf /var/lib/apt/lists/*
-# ENV DEBIAN_FRONTEND=dialog
+# [Choice] Python version: 3, 3.8, 3.7, 3.6
+ARG VARIANT=3
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
-RUN npm i -g gatsby-cli 
-RUN npm i -g yarn
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# latest gatsby, yarn
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh \
+    && npm install -g gatsby-cli \
+    && npm install -g yarn" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
-// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/javascript-node-14
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json 
 {
-	"name": "Node.js 14",
+	"name": "EDB Docs w/ Python 3 and Node.js 14",
 	"dockerFile": "Dockerfile",
 
 	// Set *default* container specific settings.json values on container create.
@@ -22,12 +21,9 @@
 	"appPort": [8000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install",
+	"postCreateCommand": "yarn install && git submodule update --init",
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "node"
 }
-
-
-
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ This repo contains the Gatsby application that powers EDB's documentation websit
 1. Clone the repo!
 2. (MacOS) Install the [homebrew package manager](https://brew.sh/), if it's not already installed.
 3. Install Node.js. We're currently using Node.js version 12. To install this version, first install `nvm` (Node Version Manager). This can be done with (MacOS) `brew install nvm`, followed by `nvm install`. Optionally, you can skip installing `nvm` and install Node.js 12 directly if you prefer.
-4. Install yarn and gatsby with `npm i -g gatsby-cli` and `npm i -g yarn`
-5. Install all required packages with `yarn`
-6. Pull the shared icon files down with `git submodule update --init`
-7. Run the site locally with `yarn develop`. The site should now be running at `http://localhost:8000/`!
+4. Install Python 3.6 or higher (this is not needed for the core system, but is required by several source scripts)
+5. Install yarn and gatsby with `npm i -g gatsby-cli` and `npm i -g yarn`
+6. Install all required packages with `yarn`
+7. Pull the shared icon files down with `git submodule update --init`
+8. Select sources with `yarn config-sources` (see section below for details)
+9. Pull sources with `yarn pull-sources` (see section below for details)
+10. Run the site locally with `yarn develop`. The site should now be running at `http://localhost:8000/`!
+
+## Running without a local installation
+
+If you wish to work with Docs without installing the prerequesites locally, you can do so from within a Docker container using VSCode. See: [Working on Docs in a Docker container using VSCode](README_DOCKER_VSCODE.md)
 
 ## Sources
 - Advocacy (`/advocacy_docs`, always loaded)

--- a/README_DOCKER_VSCODE.md
+++ b/README_DOCKER_VSCODE.md
@@ -1,6 +1,6 @@
 # Working on Docs in a Docker container using VSCode
 
-If you cannot or do not wish to install the prerequestite versions of Python, Node, Yarn, Gatsby, etc. on your local machine, *and* you're fond of using VSCode, then you can skip past the first seven steps under the "installation" section in the [README](README.md) and work with Docs entirely from within a Docker container managed by VSCode.
+If you cannot or do not wish to install the prerequisite versions of Python, Node, Yarn, Gatsby, etc. on your local machine, *and* you're fond of using VSCode, then you can skip past the first seven steps under the "installation" section in the [README](README.md) and work with Docs entirely from within a Docker container managed by VSCode.
 
 ## Prerequesites
 

--- a/README_DOCKER_VSCODE.md
+++ b/README_DOCKER_VSCODE.md
@@ -1,0 +1,22 @@
+# Working on Docs in a Docker container using VSCode
+
+If you cannot or do not wish to install the prerequestite versions of Python, Node, Yarn, Gatsby, etc. on your local machine, *and* you're fond of using VSCode, then you can skip past the first seven steps under the "installation" section in the [README](README.md) and work with Docs entirely from within a Docker container managed by VSCode.
+
+## Prerequesites
+
+1. [Docker](https://docs.docker.com/get-docker/) (for MacOS or Windows, that'll be Docker Desktop)
+2. [Visual Studio Code](https://code.visualstudio.com/docs/setup/setup-overview)
+3. The [Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) for VSCode
+
+## Installation
+
+1. In VSCode, from the command pallet select the `Remote-Containers: Clone Repository in Container Volume...` command
+2. Paste in the URL of this repository, or a GitHub branch URL, or a GitHub PR URL 
+3. Choose "isolated volume" (in most cases this will be what you want) 
+4. Wait for VSCode to build the container, then open a terminal
+8. Select sources with `yarn config-sources` (see [README](README.md) for details)
+9. Pull sources with `yarn pull-sources` (see [README](README.md) for details)
+10. Run the site locally with `yarn develop`. VSCode will remap port 8000 used within the container to a free port on your machine, which you can view from the Remote Explorer panel in the left sidebar - or ctrl+click the URL that Gatsby prints in the terminal to open directly.
+
+You can create as many distinct containers and volumes as you wish, which can be handy for comparing PRs side-by-side without disturbing your primary work. To browse them (or clean them up) open the "Remote Explorer" tool in VSCode.
+


### PR DESCRIPTION
Along with some overdue updates to the dockerfile, and some other notes on prerequesites in the README. 

Could use a sanity-check on this - I've been using VSCode + containers pretty much exclusively for months, so good to know if these instructions make sense.