### PR TITLE
Fix capitalisation of "Barman"

### DIFF
--- a/scripts/source/source_barman.py
+++ b/scripts/source/source_barman.py
@@ -36,7 +36,7 @@ def process_md(file_path):
 
 def create_index():
     with open('external_sources/barman/doc/manual/barman/index.mdx', 'w') as index_file:
-        index_file.write("---\ntitle: 'BaRMan Manual'\n---\n\nAutomatically generated index file")
+        index_file.write("---\ntitle: 'Barman Manual'\n---\n\nAutomatically generated index file")
 
 def source_barman():
     print('Pulling barman...')


### PR DESCRIPTION
The Barman docs use "Barman" consistently. I think there might be some remnant uses of "BaRMan" in external webpages, but we shouldn't propagate it.