### PR TITLE
Fix for pagePath missing without JS on

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -220,10 +220,14 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       fileUrlSegment,
     )}`;
 
+    const path = isLatest
+      ? replacePathVersion(doc.fields.path)
+      : doc.fields.path;
     actions.createPage({
-      path: isLatest ? replacePathVersion(doc.fields.path) : doc.fields.path,
+      path: path,
       component: require.resolve('./src/templates/doc.js'),
       context: {
+        pagePath: path,
         navLinks: navLinks,
         versions: versionIndex[doc.fields.product],
         nodePath: doc.fields.path,
@@ -259,6 +263,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       path: doc.fields.path,
       component: require.resolve('./src/templates/learn-doc.js'),
       context: {
+        pagePage: doc.fields.path,
         navLinks: navLinks,
         githubFileLink: githubFileLink,
         githubEditLink: githubEditLink,
@@ -273,11 +278,13 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         );
       }
 
+      const path = `${doc.fields.path}/${katacodaPage.scenario}`;
       actions.createPage({
-        path: `${doc.fields.path}/${katacodaPage.scenario}`,
+        path: path,
         component: require.resolve('./src/templates/katacoda-page.js'),
         context: {
           ...katacodaPage,
+          pagePath: path,
           learn: {
             title: doc.frontmatter.title,
             description: doc.frontmatter.description,
@@ -307,6 +314,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       path: doc.fields.path,
       component: require.resolve('./src/templates/gh-doc.js'),
       context: {
+        pagePath: doc.fields.path,
         navLinks: navLinks,
         githubFileLink: showGithubLink ? githubFileLink : null,
         githubFileHistoryLink: showGithubLink ? githubFileHistoryLink : null,

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -182,11 +182,12 @@ const FeedbackDropdown = ({ githubIssuesLink }) => (
   </DropdownButton>
 );
 
-const DocTemplate = ({ data, pageContext, path: pagePath }) => {
+const DocTemplate = ({ data, pageContext }) => {
   const { fields, frontmatter, body, tableOfContents } = data.mdx;
   const { path, mtime } = fields;
   const depth = path.split('/').length;
   const {
+    pagePath,
     navLinks,
     versions,
     githubFileLink,

--- a/src/templates/gh-doc.js
+++ b/src/templates/gh-doc.js
@@ -38,9 +38,14 @@ const ContentRow = ({ children }) => (
   </div>
 );
 
-const GhDocTemplate = ({ data, pageContext, path: pagePath }) => {
+const GhDocTemplate = ({ data, pageContext }) => {
   const { mdx } = data;
-  const { navLinks, githubFileLink, githubFileHistoryLink } = pageContext;
+  const {
+    pagePath,
+    navLinks,
+    githubFileLink,
+    githubFileHistoryLink,
+  } = pageContext;
   const pageMeta = {
     title: mdx.frontmatter.title,
     description: mdx.frontmatter.description,

--- a/src/templates/katacoda-page.js
+++ b/src/templates/katacoda-page.js
@@ -2,7 +2,9 @@ import React from 'react';
 import { Container } from 'react-bootstrap';
 import { BackButton, KatacodaPageEmbed, Layout, Logo } from '../components';
 
-const KatacodaPageTemplate = ({ pageContext, path }) => {
+const KatacodaPageTemplate = ({ pageContext }) => {
+  const path = pageContext.pagePath;
+
   const pageMeta = {
     title: `${pageContext.learn.title} - Tutorial`,
     description: pageContext.learn.description,

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -73,10 +73,11 @@ const Tiles = ({ mdx, navLinks }) => {
   return null;
 };
 
-const LearnDocTemplate = ({ data, pageContext, path: pagePath }) => {
+const LearnDocTemplate = ({ data, pageContext }) => {
   const { mdx } = data;
   const { mtime } = mdx.fields;
   const {
+    pagePath,
     navLinks,
     githubFileLink,
     githubEditLink,
@@ -85,7 +86,7 @@ const LearnDocTemplate = ({ data, pageContext, path: pagePath }) => {
   const pageMeta = {
     title: mdx.frontmatter.title,
     description: mdx.frontmatter.description,
-    path: mdx.fields.path,
+    path: pagePath,
   };
 
   const showToc = !!mdx.tableOfContents.items;


### PR DESCRIPTION
Use pagePath in context instead of path, which gatsby rehydrates client side. This solution works with js disabled