### PR TITLE
PDF Action Update - pull before commiting

### DIFF
--- a/.github/workflows/update-pdfs-on-develop.yml
+++ b/.github/workflows/update-pdfs-on-develop.yml
@@ -36,6 +36,7 @@ jobs:
       run: npm run build-all-pdfs
 
     - run: git status
+    - run: git pull
     - name: Commit pdfs to develop
       run: |
         git config user.name josh-heyer


### PR DESCRIPTION
Right now if someone pushes a commit to develop while the pdf update action is running, it won't be able to commit the new pdfs. This should 🤞 fix that!