### PR TITLE
<Link> improvements

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -31,11 +31,7 @@ const rewriteUrl = (url, pageUrl, pageIsIndex) => {
   // URL here, but it doesn't matter
   const base = new URL(pageUrl, 'loc:/');
   const result = new URL(url, base);
-  // if does not end with extension, end with a slash
-  // if (!result.pathname.match(/\/$|\.\w+$/)) {
-  //   console.log(result);
-  //   result.pathname += '/';
-  // }
+
   return forceTrailingSlash(result.href.replace(/^loc:/, ''));
 };
 

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -11,6 +11,10 @@ const forceTrailingSlash = url => {
   return url.replace(/\/?(\?|#|$)/, '/$1');
 };
 
+const isAbsoluteOrProtocolRelativeUrl = url => {
+  return isAbsoluteUrl(url) || url.trim().startsWith('//');
+};
+
 const rewriteUrl = (url, pageUrl, pageIsIndex) => {
   if (!pageUrl) return forceTrailingSlash(url);
 
@@ -28,12 +32,15 @@ const rewriteUrl = (url, pageUrl, pageIsIndex) => {
   const base = new URL(pageUrl, 'loc:/');
   const result = new URL(url, base);
   // if does not end with extension, end with a slash
-  if (!result.pathname.match(/\/$|\.\w+$/)) result.pathname += '/';
-  return result.href.replace(/^loc:/, '');
+  // if (!result.pathname.match(/\/$|\.\w+$/)) {
+  //   console.log(result);
+  //   result.pathname += '/';
+  // }
+  return forceTrailingSlash(result.href.replace(/^loc:/, ''));
 };
 
 const Link = ({ to, pageUrl, pageIsIndex, ...rest }) => {
-  if (isAbsoluteUrl(to)) {
+  if (isAbsoluteOrProtocolRelativeUrl(to)) {
     return (
       <a href={to} {...rest}>
         {rest.children}


### PR DESCRIPTION
- make protocol relative urls use `<a>` tags
- force trailing backslash outside of `URL` to avoid browser specific issues