### PR TITLE
fix things that weren't really RST links

### DIFF
--- a/product_docs/docs/efm/4.1/efm_pgpool_ha_guide/03_components_ha_pgpool.mdx
+++ b/product_docs/docs/efm/4.1/efm_pgpool_ha_guide/03_components_ha_pgpool.mdx
@@ -26,7 +26,7 @@ The section lists the configuration of some important parameters in the `pgpool.
 
 **Backend node setting**
 
-There are three PostgreSQL backend nodes, one Primary and two Standby nodes. Configure using [backend](<>)\* configuration parameters in pgpool.conf, and use the equal backend weights for all nodes. This will make the read queries to be distributed equally among all nodes.
+There are three PostgreSQL backend nodes, one Primary and two Standby nodes. Configure using `backend_*` configuration parameters in `pgpool.conf`, and use the equal backend weights for all nodes. This will make the read queries to be distributed equally among all nodes.
 
 ```text
 backend_hostname0 = ‘server1_IP'

--- a/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/index.mdx
@@ -8,6 +8,6 @@ SPL is a block-structured language. The first section that can appear in a block
 
 <div class="toctree" maxdepth="3">
 
-declaring_a_variable [using](<>)%\_type_in_variable_declarations [using](<>)%\_row_type_in_record_declarations user_defined_record_types_and_record_variables
+declaring_a_variable using_%\_type_in_variable_declarations using_%\_row_type_in_record_declarations user_defined_record_types_and_record_variables
 
 </div>

--- a/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/07_pem_postgres_expert/03_pe_configuration_expert_recommendations.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/07_pem_postgres_expert/03_pe_configuration_expert_recommendations.mdx
@@ -153,7 +153,7 @@ default_statistics_target indicates the level of detail that should be used in g
 | -------------- | -------------------------------- |
 | Rule           | Check planner methods is enabled |
 | Recommendation | Avoid disabling planner methods. |
-| Trigger        | any [enable](<>)\* GUC is off    |
+| Trigger        | any `enable_*` GUC is off    |
 | Severity       | High                             |
 
 **Description:** The enable_bitmapscan, enable_hashagg, enable_hashjoin, enable_indexscan, enable_material, enable_mergejoin, enable_nestloop, enable_seqscan, enable_sort, and enable_tidscan parameters are intended primarily for debugging and should not be turned off. It can sometimes be helpful to disable one or more of these parameters for a particular query, when there is no other way to obtain the desired plan. However, none of these parameters should ever be turned off on a system-wide basis.

--- a/product_docs/docs/pem/8.0/pem_online_help/12_release_notes/04_pem_release_notes_7_14.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/12_release_notes/04_pem_release_notes_7_14.mdx
@@ -104,6 +104,6 @@ PEM-3323 - Fixed an issue where user was not able to change the email group from
 [Issue #5400](https://redmine.postgresql.org/issues/5400) - Fixed internal server error when the database server is logged in with non-super user.  
 [Issue #5401](https://redmine.postgresql.org/issues/5401) - Fixed search object issue when the object name contains special characters.  
 [Issue #5410](https://redmine.postgresql.org/issues/5410) - Fixed an issue while removing the package body showing wrong modified SQL.  
-[Issue #5441](https://redmine.postgresql.org/issues/5441) - Fixed an issue where the search object not able to locate pg\_[toast](<>)\* tables in the pg_toast schema.  
+[Issue #5441](https://redmine.postgresql.org/issues/5441) - Fixed an issue where the search object not able to locate pg\_toast_\* tables in the pg_toast schema.  
 [Issue #5415](https://redmine.postgresql.org/issues/5415) - Ensure that the query tool context menu should work on the collection nodes.  
 [Issue #5447](https://redmine.postgresql.org/issues/5447) - Fixed failed to fetch utility error when click on refresh(any option) materialized view.


### PR DESCRIPTION
@epbarger  noticed this; appears to be an artifact of how RSTs were converted - the syntax `word_` can indicate a link in RST, if there is an associated `_word` target for the link. Pandoc appears to have just... Converted them to links with no target.