### PR TITLE
Remove code conversion artifacts

### DIFF
--- a/product_docs/docs/epas/10/03_epas_compat_reference/002_the_sql_language.mdx
+++ b/product_docs/docs/epas/10/03_epas_compat_reference/002_the_sql_language.mdx
@@ -91,7 +91,7 @@ These are some examples of valid numeric constants:
 
 42
 3.5
-4.
+4\.
 .001
 5e2
 1.925e-3

--- a/product_docs/docs/epas/11/05_epas_compat_bip_guide/03_built-in_packages/18_dbms_utility.mdx
+++ b/product_docs/docs/epas/11/05_epas_compat_bip_guide/03_built-in_packages/18_dbms_utility.mdx
@@ -478,7 +478,7 @@ DECLARE
     CURSOR emp_cur IS SELECT ename FROM emp;
 BEGIN
     FOR r_emp IN emp_cur LOOP
-        r_hash(r_emp.ename.. code-block:: text) :=
+        r_hash(r_emp.ename) :=
             DBMS_UTILITY.GET_HASH_VALUE(r_emp.ename,100,1024);
     END LOOP;
     FOR r_emp IN emp_cur LOOP
@@ -489,7 +489,7 @@ END;
 
 SMITH      377
 ALLEN      740
-WARD       718.. code-block:: text
+WARD       718
 JONES      131
 MARTIN     176
 BLAKE      568

--- a/product_docs/docs/epas/12/06_epas_compat_bip_guide/03_built-in_packages/18_dbms_utility.mdx
+++ b/product_docs/docs/epas/12/06_epas_compat_bip_guide/03_built-in_packages/18_dbms_utility.mdx
@@ -485,7 +485,7 @@ DECLARE
     CURSOR emp_cur IS SELECT ename FROM emp;
 BEGIN
     FOR r_emp IN emp_cur LOOP
-        r_hash(r_emp.ename.. code-block:: text) :=
+        r_hash(r_emp.ename) :=
             DBMS_UTILITY.GET_HASH_VALUE(r_emp.ename,100,1024);
     END LOOP;
     FOR r_emp IN emp_cur LOOP
@@ -496,7 +496,7 @@ END;
 
 SMITH      377
 ALLEN      740
-WARD       718.. code-block:: text
+WARD       718
 JONES      131
 MARTIN     176
 BLAKE      568

--- a/product_docs/docs/epas/13/epas_compat_bip_guide/03_built-in_packages/05_dbms_job/07_submit.mdx
+++ b/product_docs/docs/epas/13/epas_compat_bip_guide/03_built-in_packages/05_dbms_job/07_submit.mdx
@@ -33,7 +33,6 @@ SUBMIT(<job> OUT BINARY_INTEGER, <what> VARCHAR2
 
  **Note**: The `no_parse` option is not supported in this implementation of `SUBMIT()`. It is included for compatibility only.
 
-
 **Examples**
 
 The following example creates a job using stored procedure, `job_proc`. The job will execute immediately and run once a day thereafter as set by the `interval` parameter, `SYSDATE + 1`.

--- a/product_docs/docs/epas/13/epas_compat_bip_guide/03_built-in_packages/18_dbms_utility.mdx
+++ b/product_docs/docs/epas/13/epas_compat_bip_guide/03_built-in_packages/18_dbms_utility.mdx
@@ -483,7 +483,7 @@ DECLARE
     CURSOR emp_cur IS SELECT ename FROM emp;
 BEGIN
     FOR r_emp IN emp_cur LOOP
-        r_hash(r_emp.ename.. code-block:: text) :=
+        r_hash(r_emp.ename) :=
             DBMS_UTILITY.GET_HASH_VALUE(r_emp.ename,100,1024);
     END LOOP;
     FOR r_emp IN emp_cur LOOP
@@ -494,7 +494,7 @@ END;
 
 SMITH      377
 ALLEN      740
-WARD       718.. code-block:: text
+WARD       718
 JONES      131
 MARTIN     176
 BLAKE      568

--- a/product_docs/docs/epas/13/epas_compat_reference/02_the_sql_language/03_functions_and_operators/02_comparison_operators.mdx
+++ b/product_docs/docs/epas/13/epas_compat_reference/02_the_sql_language/03_functions_and_operators/02_comparison_operators.mdx
@@ -39,7 +39,7 @@ There is no difference between the two respective forms apart from the CPU cycle
 To check whether a value is or is not null, use the constructs
 
  `expression IS NULL`
- 
+
  `expression IS NOT NULL`
 
 Do not write `expression = NULL` because `NULL` is not "equal to" `NULL`. (The null value represents an unknown value, and it is not known whether two unknown values are equal.) This behavior conforms to the SQL standard.

--- a/product_docs/docs/epas/13/epas_compat_reference/02_the_sql_language/03_functions_and_operators/03_mathematical_functions_and_operators.mdx
+++ b/product_docs/docs/epas/13/epas_compat_reference/02_the_sql_language/03_functions_and_operators/03_mathematical_functions_and_operators.mdx
@@ -8,13 +8,13 @@ Mathematical operators are provided for many Advanced Server types. For types wi
 
 The following table shows the available mathematical operators:
 
-| Operator | Description                        | Example  | Result |
-| -------- | ---------------------------------- | -------- | ------ |
-| `+`      | Addition                           | `2 + 3`  | `5`    |
-| `-`      | Subtraction                        | `2 – 3`  | `-1`   |
-| `*`      | Multiplication                     | `2 * 3`  | `6`    |
-| `/`      | Division (See the following note)  | `4 / 2`  | `2`    |
-| `**`     | Exponentiation Operator            | `2 ** 3` | `8`    |
+| Operator | Description                       | Example  | Result |
+| -------- | --------------------------------- | -------- | ------ |
+| `+`      | Addition                          | `2 + 3`  | `5`    |
+| `-`      | Subtraction                       | `2 – 3`  | `-1`   |
+| `*`      | Multiplication                    | `2 * 3`  | `6`    |
+| `/`      | Division (See the following note) | `4 / 2`  | `2`    |
+| `**`     | Exponentiation Operator           | `2 ** 3` | `8`    |
 
 **Note**: If the `db_dialect` configuration parameter in the `postgresql.conf` file is set to `redwood`, then division of a pair of `INTEGER` data types does not result in a truncated value. Any fractional result is retained as shown by the following example:
 

--- a/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/index.mdx
@@ -8,6 +8,6 @@ SPL is a block-structured language. The first section that can appear in a block
 
 <div class="toctree" maxdepth="3">
 
-declaring_a_variable using_%\_type_in_variable_declarations using_%\_row_type_in_record_declarations user_defined_record_types_and_record_variables
+declaring_a_variable using\_%\_type_in_variable_declarations using\_%\_row_type_in_record_declarations user_defined_record_types_and_record_variables
 
 </div>

--- a/product_docs/docs/epas/13/epas_compat_spl/08_static_cursors/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/08_static_cursors/index.mdx
@@ -10,6 +10,6 @@ Cursors are most often used in the context of a `FOR` or `WHILE` loop. A conditi
 
 <div class="toctree" maxdepth="3">
 
-declaring_a_cursor opening_a_cursor fetching_rows_from_a_cursor closing_a_cursor using_%\_rowtype_with_cursors cursor_attributes cursor_for_loop parameterized_cursors
+declaring_a_cursor opening_a_cursor fetching_rows_from_a_cursor closing_a_cursor using\_%\_rowtype_with_cursors cursor_attributes cursor_for_loop parameterized_cursors
 
 </div>

--- a/product_docs/docs/jdbc_connector/42.2.12.1/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.12.1/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
@@ -204,7 +204,121 @@ String commandText = "{call deptSelect(?,?,?)}";
 CallableStatement stmt = con.prepareCall(commandText);
 ```
 
-The `setObject()` method binds a value to an `IN or`IN OUT`placeholder. When calling`setObject()`you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setObject(1, new Integer(c.readLine("Dept No :")));  The JDBC type of each`OUT`parameter must be registered before the`CallableStatement`object can be executed. Registering the JDBC type is done with the`registerOutParameter()`method.  .. code-block:: text    stmt.registerOutParameter(2, Types.VARCHAR);   stmt.registerOutParameter(3, Types.VARCHAR);  After executing the statement, the`CallableStatement’s`getter method retrieves the`OUT`parameter values: to retrieve a`VARCHAR`value, use the`getString()`getter method.  .. code-block:: text    stmt.execute();   System.out.println("Dept Name: " + stmt.getString(2));   System.out.println("Location : " + stmt.getString(3));  In the current example`GetDeptInfo()`registers two`OUT`parameters and (after executing the stored procedure) retrieves the values returned in the`OUT`parameters. Since both`OUT`parameters are defined as`VARCHAR`values,`GetDeptInfo()`uses the`getString()`method to retrieve the`OUT`parameters.  .. raw:: latex      \newpage  Executing Stored Procedures with IN OUT parameters --------------------------------------------------  .. index:: executing stored procedures with in out parameters  The code in the next example creates and invokes a stored procedure named`empQuery`defined with one`IN`parameter (`p_deptno`), two`IN OUT`parameters (`p_empno`and`p_ename`) and three`OUT`parameters (`p_job`,`p_hiredate`and`p_sal`).`empQuery`then returns information about the employee in the two IN`OUT`parameters and three`OUT`parameters.  Listing 1.10-a creates a stored procedure named`empQuery`:  .. code-block:: text    CREATE OR REPLACE PROCEDURE empQuery   (       p_deptno        IN     NUMBER,       p_empno         IN OUT NUMBER,       p_ename         IN OUT VARCHAR2,       p_job           OUT    VARCHAR2,       p_hiredate      OUT    DATE,       p_sal           OUT    NUMBER   )   IS   BEGIN     SELECT empno, ename, job, hiredate, sal       INTO p_empno, p_ename, p_job, p_hiredate, p_sal       FROM emp       WHERE deptno = p_deptno         AND (empno = p_empno         OR ename = UPPER(p_ename));   END;  Listing 1.10-b demonstrates invoking the`empQuery`procedure, providing values for the`IN`parameters, and handling the`OUT`and`IN OUT`parameters:  .. code-block:: text    public void CallSample4(Connection con)   {     try     {       Console c = System.console();       String commandText = "{call empQuery(?,?,?,?,?,?)}";       CallableStatement stmt = con.prepareCall(commandText);       stmt.setInt(1, new Integer(c.readLine("Department No:")));       stmt.setInt(2, new Integer(c.readLine("Employee No:")));       stmt.setString(3, new String(c.readLine("Employee Name:")));       stmt.registerOutParameter(2, Types.INTEGER);       stmt.registerOutParameter(3, Types.VARCHAR);       stmt.registerOutParameter(4, Types.VARCHAR);       stmt.registerOutParameter(5, Types.TIMESTAMP);       stmt.registerOutParameter(6, Types.NUMERIC);       stmt.execute();       System.out.println("Employee No: " + stmt.getInt(2));       System.out.println("Employee Name: " + stmt.getString(3));       System.out.println("Job : " + stmt.getString(4));       System.out.println("Hiredate : " + stmt.getTimestamp(5));       System.out.println("Salary : " + stmt.getBigDecimal(6));     }     catch(Exception err)     {       System.out.println("An error has occurred.");       System.out.println("See full details below.");       err.printStackTrace();     }   }  Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:  .. code-block:: text    String commandText = "{call empQuery(?,?,?,?,?,?)}";   CallableStatement stmt = con.prepareCall(commandText);  The`setInt()`method is a type-specific`setter`method that binds an`Integer`value to an`IN`or`IN OUT`placeholder. The call to`setInt()`specifies a parameter number and provides a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setInt(1, new Integer(c.readLine("Department No:")));   stmt.setInt(2, new Integer(c.readLine("Employee No:")));  The`setString()`method binds a`String`value to an`IN`or`IN OUT`placeholder:  .. code-block:: text    stmt.setString(3, new String(c.readLine("Employee Name:")));  Before executing the`CallableStatement`, you must register the JDBC type of each`OUT`parameter by calling the`registerOutParameter()`method.  .. code-block:: text    stmt.registerOutParameter(2, Types.INTEGER);   stmt.registerOutParameter(3, Types.VARCHAR);   stmt.registerOutParameter(4, Types.VARCHAR);   stmt.registerOutParameter(5, Types.TIMESTAMP);   stmt.registerOutParameter(6, Types.NUMERIC);  Remember, before calling a procedure with an`IN`parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an`OUT`parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an`IN OUT\`\` parameter, you must perform all three actions:
+The `setObject()` method binds a value to an `IN` or `IN OUT` placeholder. When calling `setObject()` you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:     
+
+```java
+stmt.setObject(1, new Integer(c.readLine("Dept No :")));  
+```
+
+The JDBC type of each `OUT` parameter must be registered before the `CallableStatement` object can be executed. Registering the JDBC type is done with the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.VARCHAR);
+stmt.registerOutParameter(3, Types.VARCHAR);
+```
+
+After executing the statement, the `CallableStatement’s`getter method retrieves the `OUT` parameter values: to retrieve a `VARCHAR` value, use the `getString()` getter method.      
+
+```java
+stmt.execute();   
+System.out.println("Dept Name: " + stmt.getString(2));   
+System.out.println("Location : " + stmt.getString(3));  
+```
+
+In the current example `GetDeptInfo()` registers two `OUT` parameters and (after executing the stored procedure) retrieves the values returned in the `OUT` parameters. Since both `OUT` parameters are defined as `VARCHAR` values, `GetDeptInfo()` uses the `getString()` method to retrieve the `OUT` parameters.  
+
+## Executing Stored Procedures with IN OUT parameters
+
+The code in the next example creates and invokes a stored procedure named `empQuery` defined with one `IN` parameter (`p_deptno`), two`IN OUT`parameters (`p_empno` and `p_ename`) and three `OUT` parameters (`p_job`,`p_hiredate` and `p_sal`). `empQuery` then returns information about the employee in the two `IN OUT` parameters and three `OUT` parameters.  
+
+Listing 1.10-a creates a stored procedure named `empQuery` :
+
+```sql
+CREATE OR REPLACE PROCEDURE empQuery
+(
+    p_deptno        IN     NUMBER,
+    p_empno         IN OUT NUMBER,
+    p_ename         IN OUT VARCHAR2,
+    p_job           OUT    VARCHAR2,
+    p_hiredate      OUT    DATE,
+    p_sal           OUT    NUMBER
+)
+IS
+BEGIN
+  SELECT empno, ename, job, hiredate, sal
+    INTO p_empno, p_ename, p_job, p_hiredate, p_sal
+    FROM emp
+    WHERE deptno = p_deptno
+      AND (empno = p_empno
+      OR ename = UPPER(p_ename));
+END;
+```
+
+Listing 1.10-b demonstrates invoking the `empQuery` procedure, providing values for the `IN` parameters, and handling the `OUT` and`IN OUT`parameters:
+
+```java
+public void CallSample4(Connection con)
+{
+  try
+  {
+    Console c = System.console();
+    String commandText = "{call empQuery(?,?,?,?,?,?)}";
+    CallableStatement stmt = con.prepareCall(commandText);
+    stmt.setInt(1, new Integer(c.readLine("Department No:")));
+    stmt.setInt(2, new Integer(c.readLine("Employee No:")));
+    stmt.setString(3, new String(c.readLine("Employee Name:")));
+    stmt.registerOutParameter(2, Types.INTEGER);
+    stmt.registerOutParameter(3, Types.VARCHAR);
+    stmt.registerOutParameter(4, Types.VARCHAR);
+    stmt.registerOutParameter(5, Types.TIMESTAMP);
+    stmt.registerOutParameter(6, Types.NUMERIC);
+    stmt.execute();
+    System.out.println("Employee No: " + stmt.getInt(2));
+    System.out.println("Employee Name: " + stmt.getString(3));
+    System.out.println("Job : " + stmt.getString(4));
+    System.out.println("Hiredate : " + stmt.getTimestamp(5));
+    System.out.println("Salary : " + stmt.getBigDecimal(6));
+  }
+  catch(Exception err)
+  {
+    System.out.println("An error has occurred.");
+    System.out.println("See full details below.");
+    err.printStackTrace();
+  }
+}
+```
+
+Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:
+
+```java
+String commandText = "{call empQuery(?,?,?,?,?,?)}";   
+CallableStatement stmt = con.prepareCall(commandText);  
+```
+
+The `setInt()` method is a type-specific `setter` method that binds an `Integer` value to an `IN` or `IN OUT` placeholder. The call to `setInt()` specifies a parameter number and provides a value to substitute in place of that placeholder:
+
+```java
+stmt.setInt(1, new Integer(c.readLine("Department No:")));   
+stmt.setInt(2, new Integer(c.readLine("Employee No:")));  
+```
+
+The `setString()` method binds a `String` value to an `IN` or `IN OUT` placeholder:      
+
+```java
+stmt.setString(3, new String(c.readLine("Employee Name:")));  
+```
+
+Before executing the `CallableStatement` , you must register the JDBC type of each `OUT` parameter by calling the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.INTEGER);
+stmt.registerOutParameter(3, Types.VARCHAR);
+stmt.registerOutParameter(4, Types.VARCHAR);
+stmt.registerOutParameter(5, Types.TIMESTAMP);
+stmt.registerOutParameter(6, Types.NUMERIC);
+```
+
+Remember, before calling a procedure with an `IN` parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an `OUT` parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an `IN OUT` parameter, you must perform all three actions:
 
 -   Assign a value to the parameter.
 -   Register the type of the parameter.

--- a/product_docs/docs/jdbc_connector/42.2.12.1/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.12.1/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
@@ -18,10 +18,6 @@ To declare a weakly-typed `REF_CURSOR`:
 
 ```
 name SYS_REFCURSOR;
-
-.. raw:: latex
-
-  \newpage
 ```
 
 ## Using a REF CURSOR to retrieve a ResultSet

--- a/product_docs/docs/jdbc_connector/42.2.12.3/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.12.3/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
@@ -30,7 +30,7 @@ Each question mark serves as a placeholder for a parameter. The stored procedure
 
 Listing 1.7-a shows a stored procedure that increases the salary of each employee by `10%`. `increaseSalary` expects no arguments from the caller and does not return any information:
 
-```text
+```sql
 CREATE OR REPLACE PROCEDURE increaseSalary
 IS
   BEGIN
@@ -40,7 +40,7 @@ IS
 
 Listing 1.7-b demonstrates how to invoke the `increaseSalary` procedure:
 
-```text
+```java
 public void SimpleCallSample(Connection con)
 {
   try
@@ -60,13 +60,13 @@ public void SimpleCallSample(Connection con)
 
 To invoke a stored procedure from a Java application, use a `CallableStatement` object. The `CallableStatement` class is derived from the `Statement` class and, like the `Statement` class, you obtain a `CallableStatement` object by asking a `Connection` object to create one for you. To create a `CallableStatement` from a `Connection`, use the `prepareCall()` method:
 
-```text
+```java
 CallableStatement stmt = con.prepareCall("{call increaseSalary()}");
 ```
 
 As the name implies, the `prepareCall()` method prepares the statement, but does not execute it. As you will see in the next example, an application typically binds parameter values between the call to `prepareCall()` and the call to `execute()`. To invoke the stored procedure on the server, call the `execute()` method.
 
-```text
+```java
 stmt.execute();
 ```
 
@@ -80,7 +80,7 @@ The code in the next example first creates and then invokes a stored procedure n
 
 Listing 1.8-a creates the stored procedure in the Advanced Server database:
 
-```text
+```sql
 CREATE OR REPLACE PROCEDURE empInsert(
     pEname  IN VARCHAR,
     pJob    IN VARCHAR,
@@ -104,7 +104,7 @@ END;
 
 Listing 1.8-b demonstrates how to invoke the stored procedure from Java:
 
-```text
+```java
 public void CallExample2(Connection con)
 {
   try
@@ -131,14 +131,14 @@ public void CallExample2(Connection con)
 
 Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:
 
-```text
+```java
 String commandText = "{call EMP_INSERT(?,?,?,?,?,?)}";
 CallableStatement stmt = con.prepareCall(commandText);
 ```
 
 The `setObject()` method binds a value to an `IN` or `IN` `OUT` placeholder. Each call to `setObject()` specifies a parameter number and a value to bind to that parameter:
 
-```text
+```java
 stmt.setObject(1, new String(c.readLine("Employee Name :")));
 stmt.setObject(2, new String(c.readLine("Job :")));
 stmt.setObject(3, new Float(c.readLine("Salary :")));
@@ -153,7 +153,7 @@ After supplying a value for each placeholder, this method executes the statement
 
 The next example creates and invokes an SPL stored procedure called `deptSelect`. This procedure requires one `IN` parameter (department number) and returns two `OUT` parameters (the department name and location) corresponding to the department number. The code in Listing 1.9-a creates the `deptSelect` procedure:
 
-```text
+```sql
 CREATE OR REPLACE PROCEDURE deptSelect
 (
   p_deptno IN  INTEGER,
@@ -173,7 +173,7 @@ END;
 
 Listing 1.9-b shows the Java code required to invoke the `deptSelect` stored procedure:
 
-```text
+```java
 public void GetDeptInfo(Connection con)
 {
   try
@@ -199,12 +199,126 @@ public void GetDeptInfo(Connection con)
 
 Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:
 
-```text
+```java
 String commandText = "{call deptSelect(?,?,?)}";
 CallableStatement stmt = con.prepareCall(commandText);
 ```
 
-The `setObject()` method binds a value to an `IN or`IN OUT`placeholder. When calling`setObject()`you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setObject(1, new Integer(c.readLine("Dept No :")));  The JDBC type of each`OUT`parameter must be registered before the`CallableStatement`object can be executed. Registering the JDBC type is done with the`registerOutParameter()`method.  .. code-block:: text    stmt.registerOutParameter(2, Types.VARCHAR);   stmt.registerOutParameter(3, Types.VARCHAR);  After executing the statement, the`CallableStatement’s`getter method retrieves the`OUT`parameter values: to retrieve a`VARCHAR`value, use the`getString()`getter method.  .. code-block:: text    stmt.execute();   System.out.println("Dept Name: " + stmt.getString(2));   System.out.println("Location : " + stmt.getString(3));  In the current example`GetDeptInfo()`registers two`OUT`parameters and (after executing the stored procedure) retrieves the values returned in the`OUT`parameters. Since both`OUT`parameters are defined as`VARCHAR`values,`GetDeptInfo()`uses the`getString()`method to retrieve the`OUT`parameters.  .. raw:: latex      \newpage  Executing Stored Procedures with IN OUT parameters --------------------------------------------------  .. index:: executing stored procedures with in out parameters  The code in the next example creates and invokes a stored procedure named`empQuery`defined with one`IN`parameter (`p_deptno`), two`IN OUT`parameters (`p_empno`and`p_ename`) and three`OUT`parameters (`p_job`,`p_hiredate`and`p_sal`).`empQuery`then returns information about the employee in the two IN`OUT`parameters and three`OUT`parameters.  Listing 1.10-a creates a stored procedure named`empQuery`:  .. code-block:: text    CREATE OR REPLACE PROCEDURE empQuery   (       p_deptno        IN     NUMBER,       p_empno         IN OUT NUMBER,       p_ename         IN OUT VARCHAR2,       p_job           OUT    VARCHAR2,       p_hiredate      OUT    DATE,       p_sal           OUT    NUMBER   )   IS   BEGIN     SELECT empno, ename, job, hiredate, sal       INTO p_empno, p_ename, p_job, p_hiredate, p_sal       FROM emp       WHERE deptno = p_deptno         AND (empno = p_empno         OR ename = UPPER(p_ename));   END;  Listing 1.10-b demonstrates invoking the`empQuery`procedure, providing values for the`IN`parameters, and handling the`OUT`and`IN OUT`parameters:  .. code-block:: text    public void CallSample4(Connection con)   {     try     {       Console c = System.console();       String commandText = "{call empQuery(?,?,?,?,?,?)}";       CallableStatement stmt = con.prepareCall(commandText);       stmt.setInt(1, new Integer(c.readLine("Department No:")));       stmt.setInt(2, new Integer(c.readLine("Employee No:")));       stmt.setString(3, new String(c.readLine("Employee Name:")));       stmt.registerOutParameter(2, Types.INTEGER);       stmt.registerOutParameter(3, Types.VARCHAR);       stmt.registerOutParameter(4, Types.VARCHAR);       stmt.registerOutParameter(5, Types.TIMESTAMP);       stmt.registerOutParameter(6, Types.NUMERIC);       stmt.execute();       System.out.println("Employee No: " + stmt.getInt(2));       System.out.println("Employee Name: " + stmt.getString(3));       System.out.println("Job : " + stmt.getString(4));       System.out.println("Hiredate : " + stmt.getTimestamp(5));       System.out.println("Salary : " + stmt.getBigDecimal(6));     }     catch(Exception err)     {       System.out.println("An error has occurred.");       System.out.println("See full details below.");       err.printStackTrace();     }   }  Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:  .. code-block:: text    String commandText = "{call empQuery(?,?,?,?,?,?)}";   CallableStatement stmt = con.prepareCall(commandText);  The`setInt()`method is a type-specific`setter`method that binds an`Integer`value to an`IN`or`IN OUT`placeholder. The call to`setInt()`specifies a parameter number and provides a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setInt(1, new Integer(c.readLine("Department No:")));   stmt.setInt(2, new Integer(c.readLine("Employee No:")));  The`setString()`method binds a`String`value to an`IN`or`IN OUT`placeholder:  .. code-block:: text    stmt.setString(3, new String(c.readLine("Employee Name:")));  Before executing the`CallableStatement`, you must register the JDBC type of each`OUT`parameter by calling the`registerOutParameter()`method.  .. code-block:: text    stmt.registerOutParameter(2, Types.INTEGER);   stmt.registerOutParameter(3, Types.VARCHAR);   stmt.registerOutParameter(4, Types.VARCHAR);   stmt.registerOutParameter(5, Types.TIMESTAMP);   stmt.registerOutParameter(6, Types.NUMERIC);  Remember, before calling a procedure with an`IN`parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an`OUT`parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an`IN OUT\`\` parameter, you must perform all three actions:
+The `setObject()` method binds a value to an `IN` or `IN OUT` placeholder. When calling `setObject()` you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:     
+
+```java
+stmt.setObject(1, new Integer(c.readLine("Dept No :")));  
+```
+
+The JDBC type of each `OUT` parameter must be registered before the `CallableStatement` object can be executed. Registering the JDBC type is done with the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.VARCHAR);
+stmt.registerOutParameter(3, Types.VARCHAR);
+```
+
+After executing the statement, the `CallableStatement’s`getter method retrieves the `OUT` parameter values: to retrieve a `VARCHAR` value, use the `getString()` getter method.      
+
+```java
+stmt.execute();   
+System.out.println("Dept Name: " + stmt.getString(2));   
+System.out.println("Location : " + stmt.getString(3));  
+```
+
+In the current example `GetDeptInfo()` registers two `OUT` parameters and (after executing the stored procedure) retrieves the values returned in the `OUT` parameters. Since both `OUT` parameters are defined as `VARCHAR` values, `GetDeptInfo()` uses the `getString()` method to retrieve the `OUT` parameters.  
+
+## Executing Stored Procedures with IN OUT parameters
+
+The code in the next example creates and invokes a stored procedure named `empQuery` defined with one `IN` parameter (`p_deptno`), two`IN OUT`parameters (`p_empno` and `p_ename`) and three `OUT` parameters (`p_job`,`p_hiredate` and `p_sal`). `empQuery` then returns information about the employee in the two `IN OUT` parameters and three `OUT` parameters.  
+
+Listing 1.10-a creates a stored procedure named `empQuery` :
+
+```sql
+CREATE OR REPLACE PROCEDURE empQuery
+(
+    p_deptno        IN     NUMBER,
+    p_empno         IN OUT NUMBER,
+    p_ename         IN OUT VARCHAR2,
+    p_job           OUT    VARCHAR2,
+    p_hiredate      OUT    DATE,
+    p_sal           OUT    NUMBER
+)
+IS
+BEGIN
+  SELECT empno, ename, job, hiredate, sal
+    INTO p_empno, p_ename, p_job, p_hiredate, p_sal
+    FROM emp
+    WHERE deptno = p_deptno
+      AND (empno = p_empno
+      OR ename = UPPER(p_ename));
+END;
+```
+
+Listing 1.10-b demonstrates invoking the `empQuery` procedure, providing values for the `IN` parameters, and handling the `OUT` and`IN OUT`parameters:
+
+```java
+public void CallSample4(Connection con)
+{
+  try
+  {
+    Console c = System.console();
+    String commandText = "{call empQuery(?,?,?,?,?,?)}";
+    CallableStatement stmt = con.prepareCall(commandText);
+    stmt.setInt(1, new Integer(c.readLine("Department No:")));
+    stmt.setInt(2, new Integer(c.readLine("Employee No:")));
+    stmt.setString(3, new String(c.readLine("Employee Name:")));
+    stmt.registerOutParameter(2, Types.INTEGER);
+    stmt.registerOutParameter(3, Types.VARCHAR);
+    stmt.registerOutParameter(4, Types.VARCHAR);
+    stmt.registerOutParameter(5, Types.TIMESTAMP);
+    stmt.registerOutParameter(6, Types.NUMERIC);
+    stmt.execute();
+    System.out.println("Employee No: " + stmt.getInt(2));
+    System.out.println("Employee Name: " + stmt.getString(3));
+    System.out.println("Job : " + stmt.getString(4));
+    System.out.println("Hiredate : " + stmt.getTimestamp(5));
+    System.out.println("Salary : " + stmt.getBigDecimal(6));
+  }
+  catch(Exception err)
+  {
+    System.out.println("An error has occurred.");
+    System.out.println("See full details below.");
+    err.printStackTrace();
+  }
+}
+```
+
+Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:
+
+```java
+String commandText = "{call empQuery(?,?,?,?,?,?)}";   
+CallableStatement stmt = con.prepareCall(commandText);  
+```
+
+The `setInt()` method is a type-specific `setter` method that binds an `Integer` value to an `IN` or `IN OUT` placeholder. The call to `setInt()` specifies a parameter number and provides a value to substitute in place of that placeholder:
+
+```java
+stmt.setInt(1, new Integer(c.readLine("Department No:")));   
+stmt.setInt(2, new Integer(c.readLine("Employee No:")));  
+```
+
+The `setString()` method binds a `String` value to an `IN` or `IN OUT` placeholder:      
+
+```java
+stmt.setString(3, new String(c.readLine("Employee Name:")));  
+```
+
+Before executing the `CallableStatement` , you must register the JDBC type of each `OUT` parameter by calling the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.INTEGER);
+stmt.registerOutParameter(3, Types.VARCHAR);
+stmt.registerOutParameter(4, Types.VARCHAR);
+stmt.registerOutParameter(5, Types.TIMESTAMP);
+stmt.registerOutParameter(6, Types.NUMERIC);
+```
+
+Remember, before calling a procedure with an `IN` parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an `OUT` parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an `IN OUT` parameter, you must perform all three actions:
 
 -   Assign a value to the parameter.
 -   Register the type of the parameter.

--- a/product_docs/docs/jdbc_connector/42.2.12.3/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.12.3/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
@@ -18,10 +18,6 @@ To declare a weakly-typed `REF_CURSOR`:
 
 ```Text
 name SYS_REFCURSOR;
-
-.. raw:: latex
-
-  \newpage
 ```
 
 ## Using a REF CURSOR to retrieve a ResultSet

--- a/product_docs/docs/jdbc_connector/42.2.8.1/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.8.1/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
@@ -216,7 +216,121 @@ String commandText = "{call deptSelect(?,?,?)}";
 CallableStatement stmt = con.prepareCall(commandText);
 ```
 
-The `setObject()` method binds a value to an `IN or`IN OUT`placeholder. When calling`setObject()`you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setObject(1, new Integer(c.readLine("Dept No :")));  The JDBC type of each`OUT`parameter must be registered before the`CallableStatement`object can be executed. Registering the JDBC type is done with the`registerOutParameter()`method.  .. code-block:: text    stmt.registerOutParameter(2, Types.VARCHAR);   stmt.registerOutParameter(3, Types.VARCHAR);  After executing the statement, the`CallableStatement’s`getter method retrieves the`OUT`parameter values: to retrieve a`VARCHAR`value, use the`getString()`getter method.  .. code-block:: text    stmt.execute();   System.out.println("Dept Name: " + stmt.getString(2));   System.out.println("Location : " + stmt.getString(3));  In the current example`GetDeptInfo()`registers two`OUT`parameters and (after executing the stored procedure) retrieves the values returned in the`OUT`parameters. Since both`OUT`parameters are defined as`VARCHAR`values,`GetDeptInfo()`uses the`getString()`method to retrieve the`OUT`parameters.  .. raw:: latex      \newpage  Executing Stored Procedures with IN OUT parameters --------------------------------------------------  .. index:: executing stored procedures with in out parameters  The code in the next example creates and invokes a stored procedure named`empQuery`defined with one`IN`parameter (`p_deptno`), two`IN OUT`parameters (`p_empno`and`p_ename`) and three`OUT`parameters (`p_job`,`p_hiredate`and`p_sal`).`empQuery`then returns information about the employee in the two IN`OUT`parameters and three`OUT`parameters.  Listing 1.10-a creates a stored procedure named`empQuery`:  Listing 1.10-a  .. code-block:: SQL    CREATE OR REPLACE PROCEDURE empQuery   (       p_deptno        IN     NUMBER,       p_empno         IN OUT NUMBER,       p_ename         IN OUT VARCHAR2,       p_job           OUT    VARCHAR2,       p_hiredate      OUT    DATE,       p_sal           OUT    NUMBER   )   IS   BEGIN     SELECT empno, ename, job, hiredate, sal       INTO p_empno, p_ename, p_job, p_hiredate, p_sal       FROM emp       WHERE deptno = p_deptno         AND (empno = p_empno         OR ename = UPPER(p_ename));   END;  Listing 1.10-b demonstrates invoking the`empQuery`procedure, providing values for the`IN`parameters, and handling the`OUT`and`IN OUT`parameters:  Listing 1.10-b  .. code-block:: text    public void CallSample4(Connection con)   {     try     {       Console c = System.console();       String commandText = "{call emp_query(?,?,?,?,?,?)}";       CallableStatement stmt = con.prepareCall(commandText);       stmt.setInt(1, new Integer(c.readLine("Department No:")));       stmt.setInt(2, new Integer(c.readLine("Employee No:")));       stmt.setString(3, new String(c.readLine("Employee Name:")));       stmt.registerOutParameter(2, Types.INTEGER);       stmt.registerOutParameter(3, Types.VARCHAR);       stmt.registerOutParameter(4, Types.VARCHAR);       stmt.registerOutParameter(5, Types.TIMESTAMP);       stmt.registerOutParameter(6, Types.NUMERIC);       stmt.execute();       System.out.println("Employee No: " + stmt.getInt(2));       System.out.println("Employee Name: " + stmt.getString(3));       System.out.println("Job : " + stmt.getString(4));       System.out.println("Hiredate : " + stmt.getTimestamp(5));       System.out.println("Salary : " + stmt.getBigDecimal(6));     }     catch(Exception err)     {       System.out.println("An error has occurred.");       System.out.println("See full details below.");       err.printStackTrace();     }   }  Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:  .. code-block:: text    String commandText = "{call emp_query(?,?,?,?,?,?)}";   CallableStatement stmt = con.prepareCall(commandText);  The`setInt()`method is a type-specific`setter`method that binds an`Integer`value to an`IN`or`IN OUT`placeholder. The call to`setInt()`specifies a parameter number and provides a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setInt(1, new Integer(c.readLine("Department No:")));   stmt.setInt(2, new Integer(c.readLine("Employee No:")));  The`setString()`method binds a`String`value to an`IN`or`IN OUT`placeholder:  .. code-block:: text    stmt.setString(3, new String(c.readLine("Employee Name:")));  Before executing the`CallableStatement`, you must register the JDBC type of each`OUT`parameter by calling the`registerOutParameter()`method.  .. code-block:: text     stmt.registerOutParameter(2, Types.INTEGER);   stmt.registerOutParameter(3, Types.VARCHAR);   stmt.registerOutParameter(4, Types.VARCHAR);   stmt.registerOutParameter(5, Types.TIMESTAMP);   stmt.registerOutParameter(6, Types.NUMERIC);  Remember, before calling a procedure with an`IN`parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an`OUT`parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an`IN OUT\`\` parameter, you must perform all three actions:
+The `setObject()` method binds a value to an `IN` or `IN OUT` placeholder. When calling `setObject()` you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:     
+
+```java
+stmt.setObject(1, new Integer(c.readLine("Dept No :")));  
+```
+
+The JDBC type of each `OUT` parameter must be registered before the `CallableStatement` object can be executed. Registering the JDBC type is done with the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.VARCHAR);
+stmt.registerOutParameter(3, Types.VARCHAR);
+```
+
+After executing the statement, the `CallableStatement’s`getter method retrieves the `OUT` parameter values: to retrieve a `VARCHAR` value, use the `getString()` getter method.      
+
+```java
+stmt.execute();   
+System.out.println("Dept Name: " + stmt.getString(2));   
+System.out.println("Location : " + stmt.getString(3));  
+```
+
+In the current example `GetDeptInfo()` registers two `OUT` parameters and (after executing the stored procedure) retrieves the values returned in the `OUT` parameters. Since both `OUT` parameters are defined as `VARCHAR` values, `GetDeptInfo()` uses the `getString()` method to retrieve the `OUT` parameters.  
+
+## Executing Stored Procedures with IN OUT parameters
+
+The code in the next example creates and invokes a stored procedure named `empQuery` defined with one `IN` parameter (`p_deptno`), two`IN OUT`parameters (`p_empno` and `p_ename`) and three `OUT` parameters (`p_job`,`p_hiredate` and `p_sal`). `empQuery` then returns information about the employee in the two `IN OUT` parameters and three `OUT` parameters.  
+
+Listing 1.10-a creates a stored procedure named `empQuery` :
+
+```sql
+CREATE OR REPLACE PROCEDURE empQuery
+(
+    p_deptno        IN     NUMBER,
+    p_empno         IN OUT NUMBER,
+    p_ename         IN OUT VARCHAR2,
+    p_job           OUT    VARCHAR2,
+    p_hiredate      OUT    DATE,
+    p_sal           OUT    NUMBER
+)
+IS
+BEGIN
+  SELECT empno, ename, job, hiredate, sal
+    INTO p_empno, p_ename, p_job, p_hiredate, p_sal
+    FROM emp
+    WHERE deptno = p_deptno
+      AND (empno = p_empno
+      OR ename = UPPER(p_ename));
+END;
+```
+
+Listing 1.10-b demonstrates invoking the `empQuery` procedure, providing values for the `IN` parameters, and handling the `OUT` and`IN OUT`parameters:
+
+```java
+public void CallSample4(Connection con)
+{
+  try
+  {
+    Console c = System.console();
+    String commandText = "{call empQuery(?,?,?,?,?,?)}";
+    CallableStatement stmt = con.prepareCall(commandText);
+    stmt.setInt(1, new Integer(c.readLine("Department No:")));
+    stmt.setInt(2, new Integer(c.readLine("Employee No:")));
+    stmt.setString(3, new String(c.readLine("Employee Name:")));
+    stmt.registerOutParameter(2, Types.INTEGER);
+    stmt.registerOutParameter(3, Types.VARCHAR);
+    stmt.registerOutParameter(4, Types.VARCHAR);
+    stmt.registerOutParameter(5, Types.TIMESTAMP);
+    stmt.registerOutParameter(6, Types.NUMERIC);
+    stmt.execute();
+    System.out.println("Employee No: " + stmt.getInt(2));
+    System.out.println("Employee Name: " + stmt.getString(3));
+    System.out.println("Job : " + stmt.getString(4));
+    System.out.println("Hiredate : " + stmt.getTimestamp(5));
+    System.out.println("Salary : " + stmt.getBigDecimal(6));
+  }
+  catch(Exception err)
+  {
+    System.out.println("An error has occurred.");
+    System.out.println("See full details below.");
+    err.printStackTrace();
+  }
+}
+```
+
+Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:
+
+```java
+String commandText = "{call empQuery(?,?,?,?,?,?)}";   
+CallableStatement stmt = con.prepareCall(commandText);  
+```
+
+The `setInt()` method is a type-specific `setter` method that binds an `Integer` value to an `IN` or `IN OUT` placeholder. The call to `setInt()` specifies a parameter number and provides a value to substitute in place of that placeholder:
+
+```java
+stmt.setInt(1, new Integer(c.readLine("Department No:")));   
+stmt.setInt(2, new Integer(c.readLine("Employee No:")));  
+```
+
+The `setString()` method binds a `String` value to an `IN` or `IN OUT` placeholder:      
+
+```java
+stmt.setString(3, new String(c.readLine("Employee Name:")));  
+```
+
+Before executing the `CallableStatement` , you must register the JDBC type of each `OUT` parameter by calling the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.INTEGER);
+stmt.registerOutParameter(3, Types.VARCHAR);
+stmt.registerOutParameter(4, Types.VARCHAR);
+stmt.registerOutParameter(5, Types.TIMESTAMP);
+stmt.registerOutParameter(6, Types.NUMERIC);
+```
+
+Remember, before calling a procedure with an `IN` parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an `OUT` parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an `IN OUT` parameter, you must perform all three actions:
 
 -   Assign a value to the parameter.
 -   Register the type of the parameter.

--- a/product_docs/docs/jdbc_connector/42.2.8.1/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.8.1/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
@@ -18,10 +18,6 @@ To declare a weakly-typed `REF_CURSOR`:
 
 ```
 name SYS_REFCURSOR;
-
-.. raw:: latex
-
-  \newpage
 ```
 
 ## Using a REF CURSOR to retrieve a ResultSet

--- a/product_docs/docs/jdbc_connector/42.2.9.1/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.9.1/08_advanced_jdbc_connector_functionality/03_executing_stored_procedures.mdx
@@ -40,7 +40,7 @@ IS
 
 Listing 1.7-b demonstrates how to invoke the `increaseSalary` procedure:
 
-```text
+```java
 public void SimpleCallSample(Connection con)
 {
   try
@@ -60,13 +60,13 @@ public void SimpleCallSample(Connection con)
 
 To invoke a stored procedure from a Java application, use a `CallableStatement` object. The `CallableStatement` class is derived from the `Statement` class and, like the `Statement` class, you obtain a `CallableStatement` object by asking a `Connection` object to create one for you. To create a `CallableStatement` from a `Connection`, use the `prepareCall()` method:
 
-```text
+```java
 CallableStatement stmt = con.prepareCall("{call increaseSalary()}");
 ```
 
 As the name implies, the `prepareCall()` method prepares the statement, but does not execute it. As you will see in the next example, an application typically binds parameter values between the call to `prepareCall()` and the call to `execute()`. To invoke the stored procedure on the server, call the `execute()` method.
 
-```text
+```java
 stmt.execute();
 ```
 
@@ -104,7 +104,7 @@ END;
 
 Listing 1.8-b demonstrates how to invoke the stored procedure from Java:
 
-```text
+```java
 public void CallExample2(Connection con)
 {
   try
@@ -131,14 +131,14 @@ public void CallExample2(Connection con)
 
 Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:
 
-```text
+```java
 String commandText = "{call EMP_INSERT(?,?,?,?,?,?)}";
 CallableStatement stmt = con.prepareCall(commandText);
 ```
 
 The `setObject()` method binds a value to an `IN` or `IN` `OUT` placeholder. Each call to `setObject()` specifies a parameter number and a value to bind to that parameter:
 
-```text
+```java
 stmt.setObject(1, new String(c.readLine("Employee Name :")));
 stmt.setObject(2, new String(c.readLine("Job :")));
 stmt.setObject(3, new Float(c.readLine("Salary :")));
@@ -173,7 +173,7 @@ END;
 
 Listing 1.9-b shows the Java code required to invoke the `deptSelect` stored procedure:
 
-```text
+```java
 public void GetDeptInfo(Connection con)
 {
   try
@@ -204,7 +204,121 @@ String commandText = "{call deptSelect(?,?,?)}";
 CallableStatement stmt = con.prepareCall(commandText);
 ```
 
-The `setObject()` method binds a value to an `IN or`IN OUT`placeholder. When calling`setObject()`you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setObject(1, new Integer(c.readLine("Dept No :")));  The JDBC type of each`OUT`parameter must be registered before the`CallableStatement`object can be executed. Registering the JDBC type is done with the`registerOutParameter()`method.  .. code-block:: text    stmt.registerOutParameter(2, Types.VARCHAR);   stmt.registerOutParameter(3, Types.VARCHAR);  After executing the statement, the`CallableStatement’s`getter method retrieves the`OUT`parameter values: to retrieve a`VARCHAR`value, use the`getString()`getter method.  .. code-block:: text    stmt.execute();   System.out.println("Dept Name: " + stmt.getString(2));   System.out.println("Location : " + stmt.getString(3));  In the current example`GetDeptInfo()`registers two`OUT`parameters and (after executing the stored procedure) retrieves the values returned in the`OUT`parameters. Since both`OUT`parameters are defined as`VARCHAR`values,`GetDeptInfo()`uses the`getString()`method to retrieve the`OUT`parameters.  .. raw:: latex      \newpage  Executing Stored Procedures with IN OUT parameters --------------------------------------------------  .. index:: executing stored procedures with in out parameters  The code in the next example creates and invokes a stored procedure named`empQuery`defined with one`IN`parameter (`p_deptno`), two`IN OUT`parameters (`p_empno`and`p_ename`) and three`OUT`parameters (`p_job`,`p_hiredate`and`p_sal`).`empQuery`then returns information about the employee in the two IN`OUT`parameters and three`OUT`parameters.  Listing 1.10-a creates a stored procedure named`empQuery`:  .. code-block:: SQL    CREATE OR REPLACE PROCEDURE empQuery   (       p_deptno        IN     NUMBER,       p_empno         IN OUT NUMBER,       p_ename         IN OUT VARCHAR2,       p_job           OUT    VARCHAR2,       p_hiredate      OUT    DATE,       p_sal           OUT    NUMBER   )   IS   BEGIN     SELECT empno, ename, job, hiredate, sal       INTO p_empno, p_ename, p_job, p_hiredate, p_sal       FROM emp       WHERE deptno = p_deptno         AND (empno = p_empno         OR ename = UPPER(p_ename));   END;  Listing 1.10-b demonstrates invoking the`empQuery`procedure, providing values for the`IN`parameters, and handling the`OUT`and`IN OUT`parameters:  .. code-block:: text    public void CallSample4(Connection con)   {     try     {       Console c = System.console();       String commandText = "{call emp_query(?,?,?,?,?,?)}";       CallableStatement stmt = con.prepareCall(commandText);       stmt.setInt(1, new Integer(c.readLine("Department No:")));       stmt.setInt(2, new Integer(c.readLine("Employee No:")));       stmt.setString(3, new String(c.readLine("Employee Name:")));       stmt.registerOutParameter(2, Types.INTEGER);       stmt.registerOutParameter(3, Types.VARCHAR);       stmt.registerOutParameter(4, Types.VARCHAR);       stmt.registerOutParameter(5, Types.TIMESTAMP);       stmt.registerOutParameter(6, Types.NUMERIC);       stmt.execute();       System.out.println("Employee No: " + stmt.getInt(2));       System.out.println("Employee Name: " + stmt.getString(3));       System.out.println("Job : " + stmt.getString(4));       System.out.println("Hiredate : " + stmt.getTimestamp(5));       System.out.println("Salary : " + stmt.getBigDecimal(6));     }     catch(Exception err)     {       System.out.println("An error has occurred.");       System.out.println("See full details below.");       err.printStackTrace();     }   }  Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:  .. code-block:: text    String commandText = "{call emp_query(?,?,?,?,?,?)}";   CallableStatement stmt = con.prepareCall(commandText);  The`setInt()`method is a type-specific`setter`method that binds an`Integer`value to an`IN`or`IN OUT`placeholder. The call to`setInt()`specifies a parameter number and provides a value to substitute in place of that placeholder:  .. code-block:: text    stmt.setInt(1, new Integer(c.readLine("Department No:")));   stmt.setInt(2, new Integer(c.readLine("Employee No:")));  The`setString()`method binds a`String`value to an`IN`or`IN OUT`placeholder:  .. code-block:: text    stmt.setString(3, new String(c.readLine("Employee Name:")));  Before executing the`CallableStatement`, you must register the JDBC type of each`OUT`parameter by calling the`registerOutParameter()`method.  .. code-block:: text     stmt.registerOutParameter(2, Types.INTEGER);   stmt.registerOutParameter(3, Types.VARCHAR);   stmt.registerOutParameter(4, Types.VARCHAR);   stmt.registerOutParameter(5, Types.TIMESTAMP);   stmt.registerOutParameter(6, Types.NUMERIC);  Remember, before calling a procedure with an`IN`parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an`OUT`parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an`IN OUT\`\` parameter, you must perform all three actions:
+The `setObject()` method binds a value to an `IN` or `IN OUT` placeholder. When calling `setObject()` you must identify a placeholder (by its ordinal number) and provide a value to substitute in place of that placeholder:     
+
+```java
+stmt.setObject(1, new Integer(c.readLine("Dept No :")));  
+```
+
+The JDBC type of each `OUT` parameter must be registered before the `CallableStatement` object can be executed. Registering the JDBC type is done with the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.VARCHAR);
+stmt.registerOutParameter(3, Types.VARCHAR);
+```
+
+After executing the statement, the `CallableStatement’s`getter method retrieves the `OUT` parameter values: to retrieve a `VARCHAR` value, use the `getString()` getter method.      
+
+```java
+stmt.execute();   
+System.out.println("Dept Name: " + stmt.getString(2));   
+System.out.println("Location : " + stmt.getString(3));  
+```
+
+In the current example `GetDeptInfo()` registers two `OUT` parameters and (after executing the stored procedure) retrieves the values returned in the `OUT` parameters. Since both `OUT` parameters are defined as `VARCHAR` values, `GetDeptInfo()` uses the `getString()` method to retrieve the `OUT` parameters.  
+
+## Executing Stored Procedures with IN OUT parameters
+
+The code in the next example creates and invokes a stored procedure named `empQuery` defined with one `IN` parameter (`p_deptno`), two`IN OUT`parameters (`p_empno` and `p_ename`) and three `OUT` parameters (`p_job`,`p_hiredate` and `p_sal`). `empQuery` then returns information about the employee in the two `IN OUT` parameters and three `OUT` parameters.  
+
+Listing 1.10-a creates a stored procedure named `empQuery` :
+
+```sql
+CREATE OR REPLACE PROCEDURE empQuery
+(
+    p_deptno        IN     NUMBER,
+    p_empno         IN OUT NUMBER,
+    p_ename         IN OUT VARCHAR2,
+    p_job           OUT    VARCHAR2,
+    p_hiredate      OUT    DATE,
+    p_sal           OUT    NUMBER
+)
+IS
+BEGIN
+  SELECT empno, ename, job, hiredate, sal
+    INTO p_empno, p_ename, p_job, p_hiredate, p_sal
+    FROM emp
+    WHERE deptno = p_deptno
+      AND (empno = p_empno
+      OR ename = UPPER(p_ename));
+END;
+```
+
+Listing 1.10-b demonstrates invoking the `empQuery` procedure, providing values for the `IN` parameters, and handling the `OUT` and`IN OUT`parameters:
+
+```java
+public void CallSample4(Connection con)
+{
+  try
+  {
+    Console c = System.console();
+    String commandText = "{call empQuery(?,?,?,?,?,?)}";
+    CallableStatement stmt = con.prepareCall(commandText);
+    stmt.setInt(1, new Integer(c.readLine("Department No:")));
+    stmt.setInt(2, new Integer(c.readLine("Employee No:")));
+    stmt.setString(3, new String(c.readLine("Employee Name:")));
+    stmt.registerOutParameter(2, Types.INTEGER);
+    stmt.registerOutParameter(3, Types.VARCHAR);
+    stmt.registerOutParameter(4, Types.VARCHAR);
+    stmt.registerOutParameter(5, Types.TIMESTAMP);
+    stmt.registerOutParameter(6, Types.NUMERIC);
+    stmt.execute();
+    System.out.println("Employee No: " + stmt.getInt(2));
+    System.out.println("Employee Name: " + stmt.getString(3));
+    System.out.println("Job : " + stmt.getString(4));
+    System.out.println("Hiredate : " + stmt.getTimestamp(5));
+    System.out.println("Salary : " + stmt.getBigDecimal(6));
+  }
+  catch(Exception err)
+  {
+    System.out.println("An error has occurred.");
+    System.out.println("See full details below.");
+    err.printStackTrace();
+  }
+}
+```
+
+Each placeholder (?) in the command (`commandText`) represents a point in the command that is later replaced with data:
+
+```java
+String commandText = "{call empQuery(?,?,?,?,?,?)}";   
+CallableStatement stmt = con.prepareCall(commandText);  
+```
+
+The `setInt()` method is a type-specific `setter` method that binds an `Integer` value to an `IN` or `IN OUT` placeholder. The call to `setInt()` specifies a parameter number and provides a value to substitute in place of that placeholder:
+
+```java
+stmt.setInt(1, new Integer(c.readLine("Department No:")));   
+stmt.setInt(2, new Integer(c.readLine("Employee No:")));  
+```
+
+The `setString()` method binds a `String` value to an `IN` or `IN OUT` placeholder:      
+
+```java
+stmt.setString(3, new String(c.readLine("Employee Name:")));  
+```
+
+Before executing the `CallableStatement` , you must register the JDBC type of each `OUT` parameter by calling the `registerOutParameter()` method.      
+
+```java
+stmt.registerOutParameter(2, Types.INTEGER);
+stmt.registerOutParameter(3, Types.VARCHAR);
+stmt.registerOutParameter(4, Types.VARCHAR);
+stmt.registerOutParameter(5, Types.TIMESTAMP);
+stmt.registerOutParameter(6, Types.NUMERIC);
+```
+
+Remember, before calling a procedure with an `IN` parameter, you must assign a value to that parameter with a setter method. Before calling a procedure with an `OUT` parameter, you register the type of that parameter; then you can retrieve the value returned by calling a getter method. When calling a procedure that defines an `IN OUT` parameter, you must perform all three actions:
 
 -   Assign a value to the parameter.
 -   Register the type of the parameter.

--- a/product_docs/docs/jdbc_connector/42.2.9.1/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.9.1/08_advanced_jdbc_connector_functionality/04_using_ref_cursors_with_java.mdx
@@ -18,10 +18,6 @@ To declare a weakly-typed `REF_CURSOR`:
 
 ```Text
 name SYS_REFCURSOR;
-
-.. raw:: latex
-
-  \newpage
 ```
 
 ## Using a REF CURSOR to retrieve a ResultSet

--- a/product_docs/docs/mongo_data_adapter/5.2.8/04_installing_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/04_installing_the_mongo_data_adapter.mdx
@@ -27,13 +27,13 @@ Install the `epel-release` package:
 
 ```text
  yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
- ```
+```
 
 Enable the optional, extras, and HA repositories:
 
 ```text
  subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"  --enable "rhel-ha-for-rhel-*-server-rpms"
- ```
+```
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
@@ -49,9 +49,9 @@ After receiving your repository credentials:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
- ```text
- yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
- ```
+```text
+yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
+```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
@@ -59,22 +59,22 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
- ```text
- [edb]
- name=EnterpriseDB RPMs $releasever - $basearch
- baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
- enabled=1
- gpgcheck=1
- gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
- ```
+```text
+[edb]
+name=EnterpriseDB RPMs $releasever - $basearch
+baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
+```
 
 **Installing the MongoDB Foreign Data Wrapper**
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
- ```
- yum install edb-as<xx>-mongo_fdw
- ```
+```
+yum install edb-as<xx>-mongo_fdw
+```
 
 where `xx` is the server version number.
 
@@ -90,16 +90,16 @@ Before installing the MongoDB Foreign Data Wrapper, you must install the followi
 
 Install the `epel-release` package:
 
- ```text
- dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
- ```
+```text
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
 
 Enable the `codeready-builder-for-rhel-8-\*-rpms` repository:
 
- ```text
- ARCH=$( /bin/arch )
- subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
- ```
+```text
+ARCH=$( /bin/arch )
+subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
+```
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
@@ -115,9 +115,9 @@ After receiving your repository credentials:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
- ```text
- dnf -y https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
- ```
+```text
+dnf -y https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
+```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
@@ -125,22 +125,22 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
- ```text
- [edb]
- name=EnterpriseDB RPMs $releasever - $basearch
- baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
- enabled=1
- gpgcheck=1
- gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
- ```
+```text
+[edb]
+name=EnterpriseDB RPMs $releasever - $basearch
+baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
+```
 
 **Installing the MongoDB Foreign Data Wrapper**
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
- ```text
- dnf install edb-as<xx>-mongo_fdw
- ```
+```text
+dnf install edb-as<xx>-mongo_fdw
+```
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
 
@@ -154,9 +154,9 @@ Before installing the MongoDB Foreign Data Wrapper, you must install the followi
 
 Install the `epel-release` package:
 
- ```text
- yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
- ```
+```text
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+```
 
 <div class="note">
 
@@ -184,8 +184,8 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
- ```text
- yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm> ```
+````text
+yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm> ```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
@@ -193,22 +193,22 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
- ```text
- [edb]
- name=EnterpriseDB RPMs $releasever - $basearch
- baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
- enabled=1
- gpgcheck=1
- gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
- ```
+```text
+[edb]
+name=EnterpriseDB RPMs $releasever - $basearch
+baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
+````
 
 **Installing the MongoDB Foreign Data Wrapper**
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
- ```text
- yum install edb-as<xx>-mongo_fdw
- ```
+```text
+yum install edb-as<xx>-mongo_fdw
+```
 
 where `xx` is the server version number.
 
@@ -224,15 +224,15 @@ Before installing the MongoDB Foreign Data Wrapper, you must install the followi
 
 Install the `epel-release` package:
 
- ```text
- dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
- ```
+```text
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
 
 Enable the `PowerTools` repository:
 
- ```text
- dnf config-manager --set-enabled PowerTools
- ```
+```text
+dnf config-manager --set-enabled PowerTools
+```
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
@@ -248,9 +248,9 @@ After receiving your repository credentials:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
- ```text
- dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
- ```
+```text
+dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
+```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
@@ -258,22 +258,22 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
- ```text
- [edb]
- name=EnterpriseDB RPMs $releasever - $basearch
- baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
- enabled=1
- gpgcheck=1
- gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
- ```
+```text
+[edb]
+name=EnterpriseDB RPMs $releasever - $basearch
+baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
+```
 
 **Installing the MongoDB Foreign Data Wrapper**
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
- ```text
- dnf install edb-as<xx>-mongo_fdw
- ```
+```text
+dnf install edb-as<xx>-mongo_fdw
+```
 
 where `xx` is the server version number.
 
@@ -289,54 +289,54 @@ The following steps will walk you through using the EDB apt repository to instal
 
 1.  Assume superuser privileges:
 
-     ```text
-     sudo su –
-     ```
+    ```text
+    sudo su –
+    ```
 
 2.  Configure the EDB repository:
 
     On Debian 9 and Ubuntu:
 
-     ```text
-     sh -c 'echo "deb https://username:password@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
-     ```
+    ```text
+    sh -c 'echo "deb https://username:password@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
+    ```
 
     On Debian 10:
 
     1.  Set up the EDB repository:
 
-     ```text
-     sh -c 'echo "deb [arch=amd64] https://apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
-     ```
+        ```text
+        sh -c 'echo "deb [arch=amd64] https://apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
+        ```
 
     2.  Substitute your EDB credentials for the `username` and `password` in the following command:
 
-     ```text
-     sh -c 'echo "machine apt.enterprisedb.com login <username> password <password>" > /etc/apt/auth.conf.d/edb.conf'
-     ```
+        ```text
+        sh -c 'echo "machine apt.enterprisedb.com login <username> password <password>" > /etc/apt/auth.conf.d/edb.conf'
+        ```
 
 3.  Add support to your system for secure APT repositories:
 
-     ```text
-     apt-get install apt-transport-https
-     ```
+    ```text
+    apt-get install apt-transport-https
+    ```
 
 4.  Add the EDB signing key:
 
-     ```text
-     wget -q -O - https://<username>:<password>@apt.enterprisedb.com/edb-deb.gpg.key | apt-key add -
-     ```
+    ```text
+    wget -q -O - https://<username>:<password>@apt.enterprisedb.com/edb-deb.gpg.key | apt-key add -
+    ```
 
 5.  Update the repository metadata:
 
-     ```text
-     apt-get update
-     ```
+    ```text
+    apt-get update
+    ```
 
 6.  Install the Debian package:
 
-     ```text
-     apt-get install edb-as<xx>-mongo-fdw
-     ```
+    ```text
+    apt-get install edb-as<xx>-mongo-fdw
+    ```
 
 where `xx` is the server version number.

--- a/product_docs/docs/mongo_data_adapter/5.2.8/06_configuring_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/06_configuring_the_mongo_data_adapter.mdx
@@ -6,10 +6,10 @@ title: "Configuring the MongoDB Foreign Data Wrapper"
 
 Before using the MongoDB Foreign Data Wrapper, you must:
 
- 1.  Use the [CREATE EXTENSION](#create-extension) command to create the MongoDB Foreign Data Wrapper extension on the Postgres host.
- 2.  Use the [CREATE SERVER](#create-server) command to define a connection to the MongoDB server.
- 3.  Use the [CREATE USER MAPPING](#create-user-mapping) command to define a mapping that associates a Postgres role with the server.
- 4.  Use the [CREATE FOREIGN TABLE](#create-foreign-table) command to define a table in the Postgres database that corresponds to a database that resides on the MongoDB cluster.
+1.  Use the [CREATE EXTENSION](#create-extension) command to create the MongoDB Foreign Data Wrapper extension on the Postgres host.
+2.  Use the [CREATE SERVER](#create-server) command to define a connection to the MongoDB server.
+3.  Use the [CREATE USER MAPPING](#create-user-mapping) command to define a mapping that associates a Postgres role with the server.
+4.  Use the [CREATE FOREIGN TABLE](#create-foreign-table) command to define a table in the Postgres database that corresponds to a database that resides on the MongoDB cluster.
 
 <div id="create_extension" class="registered_link"></div>
 
@@ -295,15 +295,15 @@ MongoDB foreign data wrapper supports the write capability feature.
 
 When using the foreign data wrapper, you must create a table on the Postgres server that mirrors the table that resides on the MongoDB server. The MongoDB data wrapper will automatically convert the following MongoDB data types to the target Postgres type:
 
-| **MongoDB (BSON Type)**      | **Postgres**                             |
-| ---------------------------- | ---------------------------------------- |
-| ARRAY                        | JSON                                     |
-| BOOL                         | BOOL                                     |
-| BINARY                       | BYTEA                                    |
-| DATE_TIME                    | DATE/TIMESTAMP/TIMESTAMPTZ               |
-| DOCUMENT                     | JSON                                     |
-| DOUBLE                       | FLOAT/FLOAT4/FLOAT8/DOUBLE PRECISION/NUMERIC |
-| INT32                        | SMALLINT/INT2/INT/INTEGER/INT4           |
-| INT64                        | BIGINT/INT8                              |
-| OID                          | NAME                                     |
-| UTF8                         | BPCHAR/VARCHAR/CHARCTER VARYING/TEXT     |
+| **MongoDB (BSON Type)** | **Postgres**                                 |
+| ----------------------- | -------------------------------------------- |
+| ARRAY                   | JSON                                         |
+| BOOL                    | BOOL                                         |
+| BINARY                  | BYTEA                                        |
+| DATE_TIME               | DATE/TIMESTAMP/TIMESTAMPTZ                   |
+| DOCUMENT                | JSON                                         |
+| DOUBLE                  | FLOAT/FLOAT4/FLOAT8/DOUBLE PRECISION/NUMERIC |
+| INT32                   | SMALLINT/INT2/INT/INTEGER/INT4               |
+| INT64                   | BIGINT/INT8                                  |
+| OID                     | NAME                                         |
+| UTF8                    | BPCHAR/VARCHAR/CHARCTER VARYING/TEXT         |

--- a/product_docs/docs/odbc_connector/12.0.0.1/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.0.0.1/06_edb-odbc_driver_functionality.mdx
@@ -583,13 +583,14 @@ SQLRETURN SQLSetStmtAttr
 
 -   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
       If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
-    | Value Type             | Meaning                                       |
-    | ---------------------- | --------------------------------------------- |
-    |                        |                                               |
-    | Character string       | The length of the character string or SQL_NTS |
-    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
-    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
-    | Any other type         | SQL_IS_POINTER                                |
+
+| Value Type             | Meaning                                       |
+| ---------------------- | --------------------------------------------- |
+|                        |                                               |
+| Character string       | The length of the character string or SQL_NTS |
+| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+| Any other type         | SQL_IS_POINTER                                |
 
 ## Error Handling
 

--- a/product_docs/docs/odbc_connector/12.0.0.1/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.0.0.1/06_edb-odbc_driver_functionality.mdx
@@ -19,38 +19,28 @@ You can also use ODBC functions to set various attributes of the objects that yo
 
 The ODBC `SQLGetInfo()` function returns information about the EDB-ODBC driver and Advanced Server. You must have an open connection to call `SQLGetInfo()`, unless you specify `SQL_ODBC_VER` as the `info_type`. The signature for `SQLGetInfo()` is:
 
-```text
+```c++
 SQLRETURN SQLGetInfo
 (
-SQLHDBC *conn_handle*, // Input
-SQLUSMALLINT *info_type*, // Input
-SQLPOINTER *info_pointer*, // Output
-SQLSMALLINT *buffer_len*, // Input
-SQLSMALLINT *\ *string_length_pointer* // Output
+    SQLHDBC  conn_handle , // Input
+    SQLUSMALLINT  info_type , // Input
+    SQLPOINTER  info_pointer , // Output
+    SQLSMALLINT  buffer_len , // Input
+    SQLSMALLINT *  string_length_pointer  // Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `info_type` The type of information SQLGetInfo() is retrieving.
 
-`info_type`
+-   `info_pointer` A pointer to a memory buffer that will hold the retrieved value.
 
-The type of information SQLGetInfo() is retrieving.
+      If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
 
-`info_pointer`
+-   `buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
 
-A pointer to a memory buffer that will hold the retrieved value.
-
-If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
-
-`buffer_len`
-
-`buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
-
-`string_length_pointer`
-
-`string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
+-   `string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
 
 A typical usage is to call `SQLGetInfo()` with a `NULL info_pointer` to obtain the length of the requested value, allocate the required number of bytes, and then call `SQLGetInfo()` again (providing the address of the newly allocated buffer) to obtain the actual value. The first call retrieves the number of bytes required to hold the value; the second call retrieves the value.
 
@@ -236,7 +226,7 @@ The following table lists the information returned by EDB-ODBC about the Advance
 | SQL_SCHEMA_USAGE: Indicates the SQL statements that may refer to schemas.                                                                                                                                                                                                 | Returns: SQL_OU_DML_STATEMENTS, SQL_OU_TABLE_DEFINITION, SQL_OU_INDEX_DEFINITION, SQL_OU_PRIVILEGE_DEFINITION.                                                                                                                                                                                              |
 | SQL_SCROLL_CONCURRENCY: Indicates the cursor concurrency control options supported by the server.                                                                                                                                                                         | Returns: SQL_SCCO_READ_ONLY, SQL_SCCO_OPT_ROWVER.                                                                                                                                                                                                                                                           |
 | SQL_SCROLL_OPTIONS: Indicates the cursor scroll options supported by the server.                                                                                                                                                                                          | Returns: SQL_SO_FORWARD_ONLY, SQL_SO_KEYSET_DRIVEN, SQL_SO_STATIC.                                                                                                                                                                                                                                          |
-| SQL*SEARCH_PATTERN_ESCAPE: The escape character that allows use of the wildcard characters % and * in search patterns.                                                                                                                                                    | Returns . The '' character is used as an escape character for the '%' and '\_' characters in search patterns.                                                                                                                                                                                               |
+| SQL_SEARCH_PATTERN_ESCAPE: The escape character that allows use of the wildcard characters % and \_ in search patterns.                                                                                                                                                   | Returns . The '' character is used as an escape character for the '%' and '\_' characters in search patterns.                                                                                                                                                                                               |
 | SQL_SERVER_NAME: Indicates the name of the host.                                                                                                                                                                                                                          | The returned value is determined by connection properties.                                                                                                                                                                                                                                                  |
 | SQL_SPECIAL_CHARACTERS: Indicates any special characters allowed in identifier names.                                                                                                                                                                                     | Returns \_. The underscore character is allowed in identifier names.                                                                                                                                                                                                                                        |
 | SQL_SQL_CONFORMANCE: Indicates the level of SQL-92 compliance.                                                                                                                                                                                                            | Returns SQL_SC_SQL92_ENTRY. The driver is SQL92 Entry level compliant.                                                                                                                                                                                                                                      |
@@ -278,102 +268,72 @@ You can use the ODBC `SQLGetConnectAttr()` and `SQLSetConnectAttr()` functions t
 
 The `SQLGetConnectAttr()` function returns the current value of a connection attribute. The signature is:
 
-```text
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *conn_handle,* //Input
-SQLINTEGER *attribute,* //Input
-SQLPOINTER *value_pointer,* //Output
-SQLINTEGER *buffer_length,* //Input
-SQLINTEGER *\ *string_length_pointer* //Output
+    SQLHDBC  conn_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_pointer,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `attribute` identifies the attribute whose value you wish to retrieve.
 
-`attribute`
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
 
-`attribute` identifies the attribute whose value you wish to retrieve.
+-   `buffer_length` If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
 
-`value_pointer`
+      If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
 
-A pointer to the location in memory that will receive the `attribute` value.
+    | Value type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
 
-`buffer_length`
-
-If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
-
-If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
-
-| Value type             | Meaning                                   |
-| ---------------------- | ----------------------------------------- |
-| Character string       | The length of the character string        |
-| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
-| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
-| Any other type         | SQL_IS_POINTER                            |
-
-`string_length_pointer`
-
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
+-   `string_length_pointer` A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
 
 This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
 
 The following table lists the connection attributes supported by EDB-ODBC.
 
-<div class="table-with-scroll">
-<table class="table">
-<thead>
-<tr class="header">
-<th>Attribute</th>
-<th>Supported?</th>
-<th>Notes</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>SQL_ATTR_ACCESS_MODE</td>
-<td>NO</td>
-<td>SQL_MODE_READ_WRITE</td>
-</tr>
-<tr class="even">
-<td><p>SQL_ATTR_ASYNC_ENABLE SQL_ATTR_AUTO_IPD SQL_ATTR_AUTOCOMMIT SQL_ATTR_CONNECTION_TIMEOUT SQL_ATTR_CURRENT_CATALOG SQL_ATTR_DISCONNECT_BEHAVIOR</p></td>
-<td><p>NO NO</p>
-<p>NO NO NO</p></td>
-<td><p>SQL_ASYNC_ENABLE_OFF</p>
-<p>SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF</p></td>
-</tr>
-<tr class="odd">
-<td><p>SQL_ATTR_ENLIST_IN_DTC SQL_ATTR_ENLIST_IN_XA</p></td>
-<td><p>YES NO</p></td>
-<td><p>For win32 and with conditional compilation</p></td>
-</tr>
-<tr class="even">
-<td><p>SQL_ATTR_LOGIN_TIMEOUT SQL_ATTR_ODBC_CURSORS SQL_ATTR_PACKET_SIZE SQL_ATTR_QUIET_MODE SQL_ATTR_TRACE SQL_ATTR_TRACEFILE SQL_ATTR_TRANSLATE_LIB SQL_ATTR_TRANSLATE_OPTION</p></td>
-<td><p>NO NO NO NO NO NO NO NO</p></td>
-<td><p>SQL_LOGIN_TIMEOUT</p></td>
-</tr>
-<tr class="odd">
-<td>SQL_ATTR_TXN_ISOLATION</td>
-<td>YES</td>
-<td>SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION</td>
-</tr>
-</tbody>
-</table>
-</div>
+| Attribute                    | Supported? | Notes                                                 |
+| ---------------------------- | ---------- | ----------------------------------------------------- |
+| SQL_ATTR_ACCESS_MODE         | NO         | SQL_MODE_READ_WRITE                                   |
+| SQL_ATTR_ASYNC_ENABLE        | NO         | SQL_ASYNC_ENABLE_OFF                                  |
+| SQL_ATTR_AUTO_IPD            | NO         |                                                       |
+| SQL_ATTR_AUTOCOMMIT          | YES        | SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF |
+| SQL_ATTR_CONNECTION_TIMEOUT  | NO         |                                                       |
+| SQL_ATTR_CURRENT_CATALOG     | NO         |                                                       |
+| SQL_ATTR_DISCONNECT_BEHAVIOR | NO         |                                                       |
+| SQL_ATTR_ENLIST_IN_DTC       | YES        | For win32 and with conditional compilation            |
+| SQL_ATTR_ENLIST_IN_XA        | NO         |                                                       |
+| SQL_ATTR_LOGIN_TIMEOUT       | NO         | SQL_LOGIN_TIMEOUT                                     |
+| SQL_ATTR_ODBC_CURSORS        | NO         |                                                       |
+| SQL_ATTR_PACKET_SIZE         | NO         |                                                       |
+| SQL_ATTR_QUIET_MODE          | NO         |                                                       |
+| SQL_ATTR_TRACE               | NO         |                                                       |
+| SQL_ATTR_TRACEFILE           | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_LIB       | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_OPTION    | NO         |                                                       |
+| SQL_ATTR_TXN_ISOLATION       | YES        | SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION          |
 
 ### SQLSetConnectAttr()
 
 You can use the ODBC `SQLSetConnectAttr()` function to set the values of connection attributes. The signature of the function is:
 
-```text
+```c++
 SQLRETURN SQLSetConnectAttr
 (
-SQLHDBC *conn_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_pointer*, // Input
-SQLINTEGER *string_length*, // Input
+    SQLHDBC  conn_handle , // Input
+    SQLINTEGER  attribute , // Input
+    SQLPOINTER  value_pointer , // Input
+    SQLINTEGER  string_length , // Input
 );
 ```
 
@@ -438,14 +398,14 @@ You can use the ODBC `SQLGetEnvAttr()` and `SQLSetEnvAttr()` functions to retrie
 
 Use the `SQLGetEnvAttr()` function to find the current value of environment attributes on your system. The signature of the function is:
 
-```text
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *env_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_ptr*, // Output
-SQLINTEGER *buffer_length*, // Input
-SQLINTEGER *\ *string_length_pointer* // Output
+    SQLHDBC env_handle, // Input
+    SQLINTEGER attribute, // Input
+    SQLPOINTER value_ptr, // Output
+    SQLINTEGER buffer_length, // Input
+    SQLINTEGER * string_length_pointer // Output
 );
 ```
 
@@ -467,7 +427,218 @@ If the attribute is a character string, `buffer_length` is the length of `value_
 
 `string_length_pointer`
 
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer* is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_NO_DATA`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the environment attributes supported by EDB-ODBC.   =========================== =================================== =================================== Attribute                   Supported?                          Restrictions? =========================== =================================== =================================== SQL_ATTR_CONNECTION_POOLING SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF Determined by connection properties SQL_ATTR_ODBC_VERSION       (SQL_OV_ODBC3)                      NONE                              (SQL_OV_ODBC2) SQL_ATTR_OUTPUT_NTS         SQL_SUCCESS                         NONE =========================== =================================== ===================================  .. raw:: latex      \newpage  SQLSetEnvAttr() ---------------  You can use the`SQLSetEnvAttr()`function to set the values of environment attributes. The signature of the function is:  .. code-block:: text     SQLRETURN SQLSetEnvAttr    (    SQLHENV *env_handle*, //Input    SQLINTEGER *attribute*, //Input    SQLPOINTER *value_pointer*, //Input    SQLINTEGER *string_length* //Input    );`env_handle`The environment handle.`attribute`  `attribute`identifies the attribute whose value you wish to set.`value_pointer`A pointer to the value assigned to the`attribute`. The value will be a`NULL`terminated character string or a 32 bit integer value depending on the specified`attribute`.`string_length`If`value_pointer`is a pointer to a binary buffer or character string,`string_length`is the length of`value_pointer`. If the value being assigned to the attribute is a character,`string_length`is the length of that character string. If`value_pointer`is NULL,`string_length`is not returned. If value_pointer is an integer,`string_length`is ignored.`SQLSetEnvAttr()`returns`SQL_SUCCESS`,`SQL_INVALID_HANDLE`,`SQL_ERROR`or`SQL_SUCCESS_WITH_INFO`.  The application must call`SQLSetEnvAttr()`before allocating a connection handle; all values applied to environment attributes will persist until`SQLFreeHandle()`is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously.  The following table lists the environment attributes you can set with`SQLSetAttr()`.   ===================== ================== ========================================================================================================================== Attribute             Value_pointer type Restrictions? ===================== ================== ========================================================================================================================== SQL_ATTR_ODBC_VERSION 32 bit Integer     Set this attribute before the application calls any function that includes an SQLHENV argument. SQL_ATTR_OUTPUT_NTS   32-bit Integer     Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). ===================== ================== ==========================================================================================================================  .. raw:: latex      \newpage  Statement Attributes ====================  .. index:: ODBC statement attributes  You can use the ODBC`SQLGetStmtAttr()`and`SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  SQLGetStmtAttr() ----------------  The`SQLGetStmtAttr()`function returns the current value of statement attribute. The signature is:  .. code-block:: text     SQLRETURN SQLGetConnectAttr    (    SQLHDBC *stmt_handle,* //Input    SQLINTEGER *attribute,* //Input    SQLPOINTER *value_ptr,* //Output    SQLINTEGER *buffer_length,* //Input    SQLINTEGER *\ *string_length_pointer* //Output    );`stmt_handle`The statement handle`attribute`  `attribute`is the attribute value`value_pointer`A pointer to the location in memory that will receive the`attribute`value.`buffer_length`If the attribute is defined by ODBC,`buffer_length`is the length of`value_pointer`(if`value_pointer`points to a character string or binary buffer). If`value_pointer`points to an integer,`buffer_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`buffer_length`parameter.`buffer_length`can be:  ====================== ========================================= Value Type             Meaning ====================== ========================================= Character string       The length of the character string Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =========================================`string_length_pointer`A pointer to an`SQLINTEGER`that receives the number of bytes required to hold the requested value. If`value_pointer`is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the statement attributes supported by EDB-ODBC:  ============================== ========== ======================= Attribute                      Supported? Restrictions? ============================== ========== ======================= SQL_ATTR_APP_PARAM_DESC        YES SQL_ATTR_APP_ROW_DESC          YES SQL_ATTR_ASYNC_ENABLE          NO SQL_ATTR_CONCURRENCY           YES        SQL_CONCUR_READ_ONLY SQL_ATTR_CURSOR_SCROLLABLE     YES SQL_ATTR_CURSOR_TYPE           YES        SQL_CURSOR_FORWARD_ONLY SQL_ATTR_CURSOR_SENSITIVITY    YES        SQL_INSENSITIVE SQL_ATTR_ENABLE_AUTO_IPD       NO SQL_ATTR_FETCH_BOOKMARK_PTR    YES SQL_ATTR_IMP_PARAM_DESC        YES SQL_ATTR_IMP_ROW_DESC          YES SQL_ATTR_KEYSET_SIZE           NO SQL_ATTR_MAX_LENGTH            NO SQL_ATTR_MAX_ROWS              NO SQL_ATTR_METADATA_ID           YES SQL_ATTR_NOSCAN                NO SQL_ATTR_PARAM_BIND_OFFSET_PTR YES        ODBC V2.0 SQL_ATTR_PARAM_BIND_TYPE       YES SQL_ATTR_PARAM_OPERATION_PTR   YES SQL_ATTR_PARAM_STATUS_PTR      YES SQL_ATTR_PARAMS_PROCESSED_PTR  YES SQL_ATTR_PARAMSET_SIZE         YES SQL_ATTR_QUERY_TIMEOUT         NO SQL_ATTR_RETRIEVE_DATA         NO SQL_ATTR_ROW_BIND_OFFSET_PTR   YES SQL_ATTR_ROW_BIND_TYPE         NO SQL_ATTR_ROW_NUMBER            YES SQL_ATTR_ROW_OPERATION_PTR     YES SQL_ATTR_ROW_STATUS_PTR        YES SQL_ATTR_ROWS_FETCHED_PTR      YES SQL_ATTR_ROW_ARRAY_SIZE        YES SQL_ATTR_SIMULATE_CURSOR       NO SQL_ATTR_USE_BOOKMARKS         YES SQL_ROWSET_SIZE                YES ============================== ========== =======================  . raw:: latex      \newpage  SQLSetStmtAttr() ----------------  You can use the`SQLSetStmtAttr()`function to set the values of environment attributes. The signature is:  .. code-block:: text     SQLRETURN SQLSetStmtAttr     (     SQLHENV *stmt_handle*, //Input     SQLINTEGER *attribute*, //Input     SQLPOINTER *value_pointer*, //Input     SQLINTEGER *string_length* //Input     );  *stmt_handle*  *stmt_handle* is the environment handle.`attribute`  `attribute`identifies the statement attribute whose value you wish to set.`value_pointer`  `value_pointer`is a pointer to the location in memory that holds the value that will be assigned to the attribute.`value_pointer`can be a pointer to:  -  A null-terminated character string  -  A binary buffer  -  A value defined by the driver  -  A value of the type`SQLLEN`,`SQLULEN`or`SQLUSMALLINT`Value-pointer can also optionally hold one of the following values:  -  An ODBC descriptor handle  -  A`SQLUINTEGER`value  -  A`SQLULEN`value  -  A signed INTEGER (if attribute is a driver-specific value)`string_length`If`attribute`is defined by ODBC and`value_pointer`points to a binary buffer or character string,`string_length`is the length of`value_pointer`. If`value_pointer`points to an integer,`string_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`string_length`parameter. Possible`string_length`values are:  ====================== ============================================= Value Type             Meaning ====================== ============================================= Character string       The length of the character string or SQL_NTS Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =============================================  .. raw:: latex      \newpage  Error Handling ==============  .. index:: Status and error data  Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC`SQLGetDiagRec()`function.  SQLGetDiagRec() ---------------  The`SQLGetDiagRec()`function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:  . code-block:: text     SQLRETURN SQLGetDiagRec(     SQLSMALLINT *handle_type*, // Input     SQLHANDLE *handle*, // Input     SQLSMALLINT *record_number*, // Input     SQLCHAR *\ *SQLState_pointer*, // Output     SQLINTEGER *\ *native_error_pointer*, // Output     SQLCHAR *\ *error_text_pointer*, // Output     SQLSMALLINT *buffer_length*, // Input     SQLSMALLINT *text_length_pointer // Output     );`handle_type`The handle type of the`handle`argument.`handle_type`must be one of the following:  -`SQL_HANDLE_ENV`specifies an environment handle.  -`SQL_HANDLE_STMT`specifies a statement handle.  -`SQL_HANDLE_DBC`specifies a connection handle.  -`SQL_HANDLE_DESC`specifies a descriptor handle.`handle`The handle associated with the attribute error message.`record_number`The status record that the application is seeking information from (must be greater than or equal to 1).`SQLState_pointer`Pointer to a memory buffer that receives the`SQLState`error code from the record.`native_error_pointer`Pointer to a buffer that receives the native error message for the data source (contained in the`SQL_DIAG_NATIVE`field).`error_text_pointer`Pointer to a memory buffer that receives the error text (contained in the`SQL_DIAG_MESSAGE_TEXT`field)`buffer_length`The length of the`error_text`buffer.`text_length_pointer`Pointer to the buffer that receives the size (in characters) of the`error_text_pointer`field. If the number of characters in the`error_text_pointer`parameter exceeds the number available (in`buffer_length`),`error_text_pointer`will be truncated.`SQLGetDiagRec()`returns`SQL_SUCCESS`,`SQL_ERROR`,`SQL_INVALID_HANDLE`,`SQL_SUCCESS_WITH_DATA`or`SQL_NO_DATA`.  .. raw:: latex      \newpage  Supported ODBC API Functions ============================  .. index:: ODBC API functions  The following table lists the ODBC API functions; the right column specifies`Yes`if the API is supported by the EDB-ODBC driver. Use the ODBC`SQLGetFunctions()`function (specifying a function ID of`SQL_API_ODBC3_ALL_FUNCTIONS\`\`) to return a current version of this list.
+A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is NULL, `string_length_pointer` is not returned.
+
+This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO` , `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+The following table lists the environment attributes supported by EDB-ODBC. 
+
+| Attribute                   | Supported?                          | Restrictions?                       |
+| --------------------------- | ----------------------------------- | ----------------------------------- |
+|                             |                                     |                                     |
+| SQL_ATTR_CONNECTION_POOLING | SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF | Determined by connection properties |
+| SQL_ATTR_ODBC_VERSION       | (SQL_OV_ODBC3)                      |                                     |
+
+(SQL_OV_ODBC2)        | NONE                                |
+| SQL_ATTR_OUTPUT_NTS         | SQL_SUCCESS                              | NONE                                |
+
+## SQLSetEnvAttr()
+
+You can use the `SQLSetEnvAttr()` function to set the values of environment attributes. The signature of the function is:
+
+```c++
+SQLRETURN SQLSetEnvAttr
+(
+    SQLHENV  env_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `env_handle` The environment handle.
+-   `attribute` identifies the attribute whose value you wish to set.
+-   `value_pointer` A pointer to the value assigned to the `attribute`. 
+-   The value will be a `NULL` terminated character string or a 32 bit integer value depending on the specified `attribute`.
+-   `string_length` If `value_pointer` is a pointer to a binary buffer or character string,`string\_length` is the length of `value_pointer`. If the value being assigned to the attribute is a character, `string_length` is the length of that character string. If `value_pointer` is NULL, `string_length` is not returned. If value_pointer is an integer,`string_length`is ignored. 
+
+`SQLSetEnvAttr()` returns `SQL_SUCCESS`, `SQL_INVALID_HANDLE`, `SQL_ERROR` or `SQL_SUCCESS_WITH_INFO`.  The application must call `SQLSetEnvAttr()` before allocating a connection handle; all values applied to environment attributes will persist until `SQLFreeHandle()` is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously. 
+
+The following table lists the environment attributes you can set with `SQLSetAttr()`.   
+
+| Attribute             | Value_pointer type | Restrictions?                                                                                                              |
+| --------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| SQL_ATTR_ODBC_VERSION | 32 bit Integer     | Set this attribute before the application calls any function that includes an SQLHENV argument.                            |
+| SQL_ATTR_OUTPUT_NTS   | 32-bit Integer     | Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). |
+
+## Statement Attributes
+
+You can use the ODBC `SQLGetStmtAttr()` and `SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  
+
+### SQLGetStmtAttr()
+
+The `SQLGetStmtAttr()` function returns the current value of statement attribute. The signature is:
+
+```c++
+SQLRETURN SQLGetConnectAttr
+(
+    SQLHDBC  stmt_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_ptr,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
+);
+```
+
+-   `stmt_handle` The statement handle 
+
+-   `attribute` is the attribute value
+
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
+
+-   `buffer_length` If the attribute is defined by ODBC, `buffer_length` is the length of `value_pointer` (if `value_pointer` points to a character string or binary buffer).  If `value_pointer` points to an integer, `buffer_length` is ignored. 
+
+      If EDB-ODBC defines the attribute, the application sets the `buffer_length` parameter. `buffer_length`can be:
+
+    | Value Type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    |                        |                                           |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
+
+-   `string_length_pointer` A pointer to an `SQLINTEGER` that receives the number of bytes required to hold the requested value. If `value_pointer` is NULL, `string_length_pointer` is not returned.  
+
+      This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+    | Attribute                      | Supported? | Restrictions?           |
+    | ------------------------------ | ---------- | ----------------------- |
+    |                                |            |                         |
+    | SQL_ATTR_APP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_APP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_ASYNC_ENABLE          | NO         |                         |
+    | SQL_ATTR_CONCURRENCY           | YES        | SQL_CONCUR_READ_ONLY    |
+    | SQL_ATTR_CURSOR_SCROLLABLE     | YES        |                         |
+    | SQL_ATTR_CURSOR_TYPE           | YES        | SQL_CURSOR_FORWARD_ONLY |
+    | SQL_ATTR_CURSOR_SENSITIVITY    | YES        | SQL_INSENSITIVE         |
+    | SQL_ATTR_ENABLE_AUTO_IPD       | NO         |                         |
+    | SQL_ATTR_FETCH_BOOKMARK_PTR    | YES        |                         |
+    | SQL_ATTR_IMP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_IMP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_KEYSET_SIZE           | NO         |                         |
+    | SQL_ATTR_MAX_LENGTH            | NO         |                         |
+    | SQL_ATTR_MAX_ROWS              | NO         |                         |
+    | SQL_ATTR_METADATA_ID           | YES        |                         |
+    | SQL_ATTR_NOSCAN                | NO         |                         |
+    | SQL_ATTR_PARAM_BIND_OFFSET_PTR | YES        | ODBC V2.0               |
+    | SQL_ATTR_PARAM_BIND_TYPE       | YES        |                         |
+    | SQL_ATTR_PARAM_OPERATION_PTR   | YES        |                         |
+    | SQL_ATTR_PARAM_STATUS_PTR      | YES        |                         |
+    | SQL_ATTR_PARAMS_PROCESSED_PTR  | YES        |                         |
+    | SQL_ATTR_PARAMSET_SIZE         | YES        |                         |
+    | SQL_ATTR_QUERY_TIMEOUT         | NO         |                         |
+    | SQL_ATTR_RETRIEVE_DATA         | NO         |                         |
+    | SQL_ATTR_ROW_BIND_OFFSET_PTR   | YES        |                         |
+    | SQL_ATTR_ROW_BIND_TYPE         | NO         |                         |
+    | SQL_ATTR_ROW_NUMBER            | YES        |                         |
+    | SQL_ATTR_ROW_OPERATION_PTR     | YES        |                         |
+    | SQL_ATTR_ROW_STATUS_PTR        | YES        |                         |
+    | SQL_ATTR_ROWS_FETCHED_PTR      | YES        |                         |
+    | SQL_ATTR_ROW_ARRAY_SIZE        | YES        |                         |
+    | SQL_ATTR_SIMULATE_CURSOR       | NO         |                         |
+    | SQL_ATTR_USE_BOOKMARKS         | YES        |                         |
+    | SQL_ROWSET_SIZE                | YES        |                         |
+
+### SQLSetStmtAttr()
+
+You can use the `SQLSetStmtAttr()` function to set the values of environment attributes. The signature is:
+
+```c++
+SQLRETURN SQLSetStmtAttr
+(
+    SQLHENV  stmt_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `stmt_handle` is the environment handle.
+
+-   `attribute` identifies the statement attribute whose value you wish to set.
+
+-   `value_pointer` is a pointer to the location in memory that holds the value that will be assigned to the attribute. `value_pointer`can be a pointer to:
+
+    -   A null-terminated character string  
+    -   A binary buffer  
+    -   A value defined by the driver  
+    -   A value of the type `SQLLEN`, `SQLULEN` or `SQLUSMALLINT` 
+
+        Value-pointer can also optionally hold one of the following values:  
+    -   An ODBC descriptor handle  
+    -   A `SQLUINTEGER` value  
+    -   A `SQLULEN` value  
+    -   A signed INTEGER (if attribute is a driver-specific value)
+
+-   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
+      If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
+    | Value Type             | Meaning                                       |
+    | ---------------------- | --------------------------------------------- |
+    |                        |                                               |
+    | Character string       | The length of the character string or SQL_NTS |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+    | Any other type         | SQL_IS_POINTER                                |
+
+## Error Handling
+
+Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC `SQLGetDiagRec()` function.  
+
+### SQLGetDiagRec()
+
+ The `SQLGetDiagRec()` function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:
+
+```c++
+SQLRETURN SQLGetDiagRec
+(
+    SQLSMALLINT handle_type, // Input
+    SQLHANDLE handle, // Input
+    SQLSMALLINT record_number, // Input
+    SQLCHAR *SQLState_pointer, // Output
+    SQLINTEGER *native_error_pointer, // Output
+    SQLCHAR *error_text_pointer, // Output
+    SQLSMALLINT buffer_length, // Input
+    SQLSMALLINT *text_length_pointer // Output
+);
+```
+
+-   `handle_type` The handle type of the `handle` argument. `handle_type`must be one of the following:  
+
+    -   `SQL_HANDLE_ENV` specifies an environment handle. 
+    -   `SQL_HANDLE_STMT` specifies a statement handle.  
+    -   `SQL_HANDLE_DBC` specifies a connection handle.
+    -   `SQL_HANDLE_DESC` specifies a descriptor handle.
+
+-   `handle` The handle associated with the attribute error message.
+
+-   `record_number` The status record that the application is seeking information from (must be greater than or equal to 1).
+
+-   `SQLState_pointer` Pointer to a memory buffer that receives the `SQLState` error code from the record. 
+
+-   `native_error_pointer` Pointer to a buffer that receives the native error message for the data source (contained in the `SQL_DIAG_NATIVE` field).
+
+-   `error_text_pointer` Pointer to a memory buffer that receives the error text (contained in the `SQL_DIAG_MESSAGE_TEXT` field) 
+
+-   `buffer_length` The length of the `error_text` buffer.
+
+-   `text_length_pointer` Pointer to the buffer that receives the size (in characters) of the `error_text_pointer` field. If the number of characters in the `error_text_pointer` parameter exceeds the number available (in `buffer_length`), `error_text_pointer` will be truncated.
+
+`SQLGetDiagRec()` returns `SQL_SUCCESS`, `SQL_ERROR`, `SQL_INVALID_HANDLE`, `SQL_SUCCESS_WITH_DATA` or `SQL_NO_DATA`.
+
+## Supported ODBC API Functions
+
+The following table lists the ODBC API functions; the right column specifies `Yes` if the API is supported by the EDB-ODBC driver. Use the ODBC `SQLGetFunctions()` function (specifying a function ID of `SQL_API_ODBC3_ALL_FUNCTIONS`) to return a current version of this list.
 
 | ODBC API Function Name | Supported by EDB-ODBC? |
 | ---------------------- | ---------------------- |

--- a/product_docs/docs/odbc_connector/12.0.0.2/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.0.0.2/06_edb-odbc_driver_functionality.mdx
@@ -583,13 +583,14 @@ SQLRETURN SQLSetStmtAttr
 
 -   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
       If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
-    | Value Type             | Meaning                                       |
-    | ---------------------- | --------------------------------------------- |
-    |                        |                                               |
-    | Character string       | The length of the character string or SQL_NTS |
-    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
-    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
-    | Any other type         | SQL_IS_POINTER                                |
+
+| Value Type             | Meaning                                       |
+| ---------------------- | --------------------------------------------- |
+|                        |                                               |
+| Character string       | The length of the character string or SQL_NTS |
+| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+| Any other type         | SQL_IS_POINTER                                |
 
 ## Error Handling
 

--- a/product_docs/docs/odbc_connector/12.0.0.2/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.0.0.2/06_edb-odbc_driver_functionality.mdx
@@ -19,38 +19,28 @@ You can also use ODBC functions to set various attributes of the objects that yo
 
 The ODBC `SQLGetInfo()` function returns information about the EDB-ODBC driver and Advanced Server. You must have an open connection to call `SQLGetInfo()`, unless you specify `SQL_ODBC_VER` as the `info_type`. The signature for `SQLGetInfo()` is:
 
-```
+```c++
 SQLRETURN SQLGetInfo
 (
-SQLHDBC *conn_handle*, // Input
-SQLUSMALLINT *info_type*, // Input
-SQLPOINTER *info_pointer*, // Output
-SQLSMALLINT *buffer_len*, // Input
-SQLSMALLINT \*\ *string_length_pointer* // Output
+    SQLHDBC  conn_handle , // Input
+    SQLUSMALLINT  info_type , // Input
+    SQLPOINTER  info_pointer , // Output
+    SQLSMALLINT  buffer_len , // Input
+    SQLSMALLINT *  string_length_pointer  // Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `info_type` The type of information SQLGetInfo() is retrieving.
 
-`info_type`
+-   `info_pointer` A pointer to a memory buffer that will hold the retrieved value.
 
-The type of information SQLGetInfo() is retrieving.
+      If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
 
-`info_pointer`
+-   `buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
 
-A pointer to a memory buffer that will hold the retrieved value.
-
-If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
-
-`buffer_len`
-
-`buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
-
-`string_length_pointer`
-
-`string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
+-   `string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
 
 A typical usage is to call `SQLGetInfo()` with a `NULL info_pointer` to obtain the length of the requested value, allocate the required number of bytes, and then call `SQLGetInfo()` again (providing the address of the newly allocated buffer) to obtain the actual value. The first call retrieves the number of bytes required to hold the value; the second call retrieves the value.
 
@@ -278,63 +268,72 @@ You can use the ODBC `SQLGetConnectAttr()` and `SQLSetConnectAttr()` functions t
 
 The `SQLGetConnectAttr()` function returns the current value of a connection attribute. The signature is:
 
-```
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *conn_handle,* //Input
-SQLINTEGER *attribute,* //Input
-SQLPOINTER *value_pointer,* //Output
-SQLINTEGER *buffer_length,* //Input
-SQLINTEGER \*\ *string_length_pointer* //Output
+    SQLHDBC  conn_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_pointer,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `attribute` identifies the attribute whose value you wish to retrieve.
 
-`attribute`
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
 
-`attribute` identifies the attribute whose value you wish to retrieve.
+-   `buffer_length` If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
 
-`value_pointer`
+      If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
 
-A pointer to the location in memory that will receive the `attribute` value.
+    | Value type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
 
-`buffer_length`
-
-If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
-
-If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
-
-| Value type             | Meaning                                   |
-| ---------------------- | ----------------------------------------- |
-| Character string       | The length of the character string        |
-| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
-| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
-| Any other type         | SQL_IS_POINTER                            |
-
-`string_length_pointer`
-
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
+-   `string_length_pointer` A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
 
 This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
 
 The following table lists the connection attributes supported by EDB-ODBC.
 
-<table><thead><tr class="header"><th>Attribute</th><th>Supported?</th><th>Notes</th></tr></thead><tbody><tr class="odd"><td>SQL_ATTR_ACCESS_MODE</td><td>NO</td><td>SQL_MODE_READ_WRITE</td></tr><tr class="even"><td><p>SQL_ATTR_ASYNC_ENABLE SQL_ATTR_AUTO_IPD SQL_ATTR_AUTOCOMMIT SQL_ATTR_CONNECTION_TIMEOUT SQL_ATTR_CURRENT_CATALOG SQL_ATTR_DISCONNECT_BEHAVIOR</p></td><td><p>NO NO</p><p>NO NO NO</p></td><td><p>SQL_ASYNC_ENABLE_OFF</p><p>SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF</p></td></tr><tr class="odd"><td><p>SQL_ATTR_ENLIST_IN_DTC SQL_ATTR_ENLIST_IN_XA</p></td><td><p>YES NO</p></td><td><p>For win32 and with conditional compilation</p></td></tr><tr class="even"><td><p>SQL_ATTR_LOGIN_TIMEOUT SQL_ATTR_ODBC_CURSORS SQL_ATTR_PACKET_SIZE SQL_ATTR_QUIET_MODE SQL_ATTR_TRACE SQL_ATTR_TRACEFILE SQL_ATTR_TRANSLATE_LIB SQL_ATTR_TRANSLATE_OPTION</p></td><td><p>NO NO NO NO NO NO NO NO</p></td><td><p>SQL_LOGIN_TIMEOUT</p></td></tr><tr class="odd"><td>SQL_ATTR_TXN_ISOLATION</td><td>YES</td><td>SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION</td></tr></tbody></table>
+| Attribute                    | Supported? | Notes                                                 |
+| ---------------------------- | ---------- | ----------------------------------------------------- |
+| SQL_ATTR_ACCESS_MODE         | NO         | SQL_MODE_READ_WRITE                                   |
+| SQL_ATTR_ASYNC_ENABLE        | NO         | SQL_ASYNC_ENABLE_OFF                                  |
+| SQL_ATTR_AUTO_IPD            | NO         |                                                       |
+| SQL_ATTR_AUTOCOMMIT          | YES        | SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF |
+| SQL_ATTR_CONNECTION_TIMEOUT  | NO         |                                                       |
+| SQL_ATTR_CURRENT_CATALOG     | NO         |                                                       |
+| SQL_ATTR_DISCONNECT_BEHAVIOR | NO         |                                                       |
+| SQL_ATTR_ENLIST_IN_DTC       | YES        | For win32 and with conditional compilation            |
+| SQL_ATTR_ENLIST_IN_XA        | NO         |                                                       |
+| SQL_ATTR_LOGIN_TIMEOUT       | NO         | SQL_LOGIN_TIMEOUT                                     |
+| SQL_ATTR_ODBC_CURSORS        | NO         |                                                       |
+| SQL_ATTR_PACKET_SIZE         | NO         |                                                       |
+| SQL_ATTR_QUIET_MODE          | NO         |                                                       |
+| SQL_ATTR_TRACE               | NO         |                                                       |
+| SQL_ATTR_TRACEFILE           | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_LIB       | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_OPTION    | NO         |                                                       |
+| SQL_ATTR_TXN_ISOLATION       | YES        | SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION          |
 
 ### SQLSetConnectAttr()
 
 You can use the ODBC `SQLSetConnectAttr()` function to set the values of connection attributes. The signature of the function is:
 
-```
+```c++
 SQLRETURN SQLSetConnectAttr
 (
-SQLHDBC *conn_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_pointer*, // Input
-SQLINTEGER *string_length*, // Input
+    SQLHDBC  conn_handle , // Input
+    SQLINTEGER  attribute , // Input
+    SQLPOINTER  value_pointer , // Input
+    SQLINTEGER  string_length , // Input
 );
 ```
 
@@ -399,14 +398,14 @@ You can use the ODBC `SQLGetEnvAttr()` and `SQLSetEnvAttr()` functions to retrie
 
 Use the `SQLGetEnvAttr()` function to find the current value of environment attributes on your system. The signature of the function is:
 
-```
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *env_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_ptr*, // Output
-SQLINTEGER *buffer_length*, // Input
-SQLINTEGER \*\ *string_length_pointer* // Output
+    SQLHDBC env_handle, // Input
+    SQLINTEGER attribute, // Input
+    SQLPOINTER value_ptr, // Output
+    SQLINTEGER buffer_length, // Input
+    SQLINTEGER * string_length_pointer // Output
 );
 ```
 
@@ -428,7 +427,218 @@ If the attribute is a character string, `buffer_length` is the length of `value_
 
 `string_length_pointer`
 
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer* is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_NO_DATA`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the environment attributes supported by EDB-ODBC.   =========================== =================================== =================================== Attribute                   Supported?                          Restrictions? =========================== =================================== =================================== SQL_ATTR_CONNECTION_POOLING SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF Determined by connection properties SQL_ATTR_ODBC_VERSION       (SQL_OV_ODBC3)                      NONE                              (SQL_OV_ODBC2) SQL_ATTR_OUTPUT_NTS         SQL_SUCCESS                         NONE =========================== =================================== ===================================  .. raw:: latex      \newpage  SQLSetEnvAttr() ---------------  You can use the`SQLSetEnvAttr()`function to set the values of environment attributes. The signature of the function is:  .. code-block:: text     SQLRETURN SQLSetEnvAttr    (    SQLHENV *env_handle*, //Input    SQLINTEGER *attribute*, //Input    SQLPOINTER *value_pointer*, //Input    SQLINTEGER *string_length* //Input    );`env_handle`The environment handle.`attribute``attribute`identifies the attribute whose value you wish to set.`value\_pointer`A pointer to the value assigned to the`attribute`. The value will be a`NULL`terminated character string or a 32 bit integer value depending on the specified`attribute`.`string\_length`If`value\_pointer`is a pointer to a binary buffer or character string,`string\_length`is the length of`value\_pointer`. If the value being assigned to the attribute is a character,`string\_length`is the length of that character string. If`value\_pointer`is NULL,`string\_length`is not returned. If value_pointer is an integer,`string\_length`is ignored.`SQLSetEnvAttr()`returns`SQL\_SUCCESS`,`SQL\_INVALID\_HANDLE`,`SQL\_ERROR`or`SQL\_SUCCESS\_WITH\_INFO`.  The application must call`SQLSetEnvAttr()`before allocating a connection handle; all values applied to environment attributes will persist until`SQLFreeHandle()`is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously.  The following table lists the environment attributes you can set with`SQLSetAttr()`.   ===================== ================== ========================================================================================================================== Attribute             Value_pointer type Restrictions? ===================== ================== ========================================================================================================================== SQL_ATTR_ODBC_VERSION 32 bit Integer     Set this attribute before the application calls any function that includes an SQLHENV argument. SQL_ATTR_OUTPUT_NTS   32-bit Integer     Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). ===================== ================== ==========================================================================================================================  .. raw:: latex      \newpage  Statement Attributes ====================  .. index:: ODBC statement attributes  You can use the ODBC`SQLGetStmtAttr()`and`SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  SQLGetStmtAttr() ----------------  The`SQLGetStmtAttr()`function returns the current value of statement attribute. The signature is:  .. code-block:: text     SQLRETURN SQLGetConnectAttr    (    SQLHDBC *stmt_handle,* //Input    SQLINTEGER *attribute,* //Input    SQLPOINTER *value_ptr,* //Output    SQLINTEGER *buffer_length,* //Input    SQLINTEGER \*\ *string_length_pointer* //Output    );`stmt\_handle`The statement handle`attribute``attribute`is the attribute value`value_pointer`A pointer to the location in memory that will receive the`attribute`value.`buffer_length`If the attribute is defined by ODBC,`buffer_length`is the length of`value_pointer`(if`value_pointer`points to a character string or binary buffer). If`value_pointer`points to an integer,`buffer_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`buffer_length`parameter.`buffer_length`can be:  ====================== ========================================= Value Type             Meaning ====================== ========================================= Character string       The length of the character string Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =========================================`string_length_pointer`A pointer to an`SQLINTEGER`that receives the number of bytes required to hold the requested value. If`value_pointer`is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the statement attributes supported by EDB-ODBC:  ============================== ========== ======================= Attribute                      Supported? Restrictions? ============================== ========== ======================= SQL_ATTR_APP_PARAM_DESC        YES SQL_ATTR_APP_ROW_DESC          YES SQL_ATTR_ASYNC_ENABLE          NO SQL_ATTR_CONCURRENCY           YES        SQL_CONCUR_READ_ONLY SQL_ATTR_CURSOR_SCROLLABLE     YES SQL_ATTR_CURSOR_TYPE           YES        SQL_CURSOR_FORWARD_ONLY SQL_ATTR_CURSOR_SENSITIVITY    YES        SQL_INSENSITIVE SQL_ATTR_ENABLE_AUTO_IPD       NO SQL_ATTR_FETCH_BOOKMARK_PTR    YES SQL_ATTR_IMP_PARAM_DESC        YES SQL_ATTR_IMP_ROW_DESC          YES SQL_ATTR_KEYSET_SIZE           NO SQL_ATTR_MAX_LENGTH            NO SQL_ATTR_MAX_ROWS              NO SQL_ATTR_METADATA_ID           YES SQL_ATTR_NOSCAN                NO SQL_ATTR_PARAM_BIND_OFFSET_PTR YES        ODBC V2.0 SQL_ATTR_PARAM_BIND_TYPE       YES SQL_ATTR_PARAM_OPERATION_PTR   YES SQL_ATTR_PARAM_STATUS_PTR      YES SQL_ATTR_PARAMS_PROCESSED_PTR  YES SQL_ATTR_PARAMSET_SIZE         YES SQL_ATTR_QUERY_TIMEOUT         NO SQL_ATTR_RETRIEVE_DATA         NO SQL_ATTR_ROW_BIND_OFFSET_PTR   YES SQL_ATTR_ROW_BIND_TYPE         NO SQL_ATTR_ROW_NUMBER            YES SQL_ATTR_ROW_OPERATION_PTR     YES SQL_ATTR_ROW_STATUS_PTR        YES SQL_ATTR_ROWS_FETCHED_PTR      YES SQL_ATTR_ROW_ARRAY_SIZE        YES SQL_ATTR_SIMULATE_CURSOR       NO SQL_ATTR_USE_BOOKMARKS         YES SQL_ROWSET_SIZE                YES ============================== ========== =======================  . raw:: latex      \newpage  SQLSetStmtAttr() ----------------  You can use the`SQLSetStmtAttr()`function to set the values of environment attributes. The signature is:  .. code-block:: text     SQLRETURN SQLSetStmtAttr     (     SQLHENV *stmt_handle*, //Input     SQLINTEGER *attribute*, //Input     SQLPOINTER *value_pointer*, //Input     SQLINTEGER *string_length* //Input     );  *stmt_handle*  *stmt_handle* is the environment handle.`attribute``attribute`identifies the statement attribute whose value you wish to set.`value\_pointer``value_pointer`is a pointer to the location in memory that holds the value that will be assigned to the attribute.`value_pointer`can be a pointer to:  -  A null-terminated character string  -  A binary buffer  -  A value defined by the driver  -  A value of the type`SQLLEN`,`SQLULEN`or`SQLUSMALLINT`Value-pointer can also optionally hold one of the following values:  -  An ODBC descriptor handle  -  A`SQLUINTEGER`value  -  A`SQLULEN`value  -  A signed INTEGER (if attribute is a driver-specific value)`string_length`If`attribute`is defined by ODBC and`value_pointer`points to a binary buffer or character string,`string_length`is the length of`value_pointer`. If`value_pointer`points to an integer,`string_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`string_length`parameter. Possible`string_length`values are:  ====================== ============================================= Value Type             Meaning ====================== ============================================= Character string       The length of the character string or SQL_NTS Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =============================================  .. raw:: latex      \newpage  Error Handling ==============  .. index:: Status and error data  Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC`SQLGetDiagRec()`function.  SQLGetDiagRec() ---------------  The`SQLGetDiagRec()`function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:  . code-block:: text     SQLRETURN SQLGetDiagRec(     SQLSMALLINT *handle_type*, // Input     SQLHANDLE *handle*, // Input     SQLSMALLINT *record_number*, // Input     SQLCHAR \*\ *SQLState_pointer*, // Output     SQLINTEGER \*\ *native_error_pointer*, // Output     SQLCHAR \*\ *error_text_pointer*, // Output     SQLSMALLINT *buffer_length*, // Input     SQLSMALLINT \*text_length_pointer // Output     );`handle_type`The handle type of the`handle`argument.`handle_type`must be one of the following:  -`SQL_HANDLE_ENV`specifies an environment handle.  -`SQL_HANDLE_STMT`specifies a statement handle.  -`SQL_HANDLE_DBC`specifies a connection handle.  -`SQL_HANDLE_DESC`specifies a descriptor handle.`handle`The handle associated with the attribute error message.`record_number`The status record that the application is seeking information from (must be greater than or equal to 1).`SQLState_pointer`Pointer to a memory buffer that receives the`SQLState`error code from the record.`native_error_pointer`Pointer to a buffer that receives the native error message for the data source (contained in the`SQL_DIAG_NATIVE`field).`error_text_pointer`Pointer to a memory buffer that receives the error text (contained in the`SQL_DIAG_MESSAGE_TEXT`field)`buffer_length`The length of the`error_text`buffer.`text_length_pointer`Pointer to the buffer that receives the size (in characters) of the`error_text_pointer`field. If the number of characters in the`error_text_pointer`parameter exceeds the number available (in`buffer_length`),`error_text_pointer`will be truncated.`SQLGetDiagRec()`returns`SQL_SUCCESS`,`SQL_ERROR`,`SQL_INVALID_HANDLE`,`SQL_SUCCESS_WITH_DATA`or`SQL_NO_DATA`.  .. raw:: latex      \newpage  Supported ODBC API Functions ============================  .. index:: ODBC API functions  The following table lists the ODBC API functions; the right column specifies`Yes`if the API is supported by the EDB-ODBC driver. Use the ODBC`SQLGetFunctions()`function (specifying a function ID of`SQL_API_ODBC3_ALL_FUNCTIONS\`\`) to return a current version of this list.
+A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is NULL, `string_length_pointer` is not returned.
+
+This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO` , `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+The following table lists the environment attributes supported by EDB-ODBC. 
+
+| Attribute                   | Supported?                          | Restrictions?                       |
+| --------------------------- | ----------------------------------- | ----------------------------------- |
+|                             |                                     |                                     |
+| SQL_ATTR_CONNECTION_POOLING | SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF | Determined by connection properties |
+| SQL_ATTR_ODBC_VERSION       | (SQL_OV_ODBC3)                      |                                     |
+
+(SQL_OV_ODBC2)        | NONE                                |
+| SQL_ATTR_OUTPUT_NTS         | SQL_SUCCESS                              | NONE                                |
+
+## SQLSetEnvAttr()
+
+You can use the `SQLSetEnvAttr()` function to set the values of environment attributes. The signature of the function is:
+
+```c++
+SQLRETURN SQLSetEnvAttr
+(
+    SQLHENV  env_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `env_handle` The environment handle.
+-   `attribute` identifies the attribute whose value you wish to set.
+-   `value_pointer` A pointer to the value assigned to the `attribute`. 
+-   The value will be a `NULL` terminated character string or a 32 bit integer value depending on the specified `attribute`.
+-   `string_length` If `value_pointer` is a pointer to a binary buffer or character string,`string\_length` is the length of `value_pointer`. If the value being assigned to the attribute is a character, `string_length` is the length of that character string. If `value_pointer` is NULL, `string_length` is not returned. If value_pointer is an integer,`string_length`is ignored. 
+
+`SQLSetEnvAttr()` returns `SQL_SUCCESS`, `SQL_INVALID_HANDLE`, `SQL_ERROR` or `SQL_SUCCESS_WITH_INFO`.  The application must call `SQLSetEnvAttr()` before allocating a connection handle; all values applied to environment attributes will persist until `SQLFreeHandle()` is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously. 
+
+The following table lists the environment attributes you can set with `SQLSetAttr()`.   
+
+| Attribute             | Value_pointer type | Restrictions?                                                                                                              |
+| --------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| SQL_ATTR_ODBC_VERSION | 32 bit Integer     | Set this attribute before the application calls any function that includes an SQLHENV argument.                            |
+| SQL_ATTR_OUTPUT_NTS   | 32-bit Integer     | Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). |
+
+## Statement Attributes
+
+You can use the ODBC `SQLGetStmtAttr()` and `SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  
+
+### SQLGetStmtAttr()
+
+The `SQLGetStmtAttr()` function returns the current value of statement attribute. The signature is:
+
+```c++
+SQLRETURN SQLGetConnectAttr
+(
+    SQLHDBC  stmt_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_ptr,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
+);
+```
+
+-   `stmt_handle` The statement handle 
+
+-   `attribute` is the attribute value
+
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
+
+-   `buffer_length` If the attribute is defined by ODBC, `buffer_length` is the length of `value_pointer` (if `value_pointer` points to a character string or binary buffer).  If `value_pointer` points to an integer, `buffer_length` is ignored. 
+
+      If EDB-ODBC defines the attribute, the application sets the `buffer_length` parameter. `buffer_length`can be:
+
+    | Value Type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    |                        |                                           |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
+
+-   `string_length_pointer` A pointer to an `SQLINTEGER` that receives the number of bytes required to hold the requested value. If `value_pointer` is NULL, `string_length_pointer` is not returned.  
+
+      This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+    | Attribute                      | Supported? | Restrictions?           |
+    | ------------------------------ | ---------- | ----------------------- |
+    |                                |            |                         |
+    | SQL_ATTR_APP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_APP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_ASYNC_ENABLE          | NO         |                         |
+    | SQL_ATTR_CONCURRENCY           | YES        | SQL_CONCUR_READ_ONLY    |
+    | SQL_ATTR_CURSOR_SCROLLABLE     | YES        |                         |
+    | SQL_ATTR_CURSOR_TYPE           | YES        | SQL_CURSOR_FORWARD_ONLY |
+    | SQL_ATTR_CURSOR_SENSITIVITY    | YES        | SQL_INSENSITIVE         |
+    | SQL_ATTR_ENABLE_AUTO_IPD       | NO         |                         |
+    | SQL_ATTR_FETCH_BOOKMARK_PTR    | YES        |                         |
+    | SQL_ATTR_IMP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_IMP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_KEYSET_SIZE           | NO         |                         |
+    | SQL_ATTR_MAX_LENGTH            | NO         |                         |
+    | SQL_ATTR_MAX_ROWS              | NO         |                         |
+    | SQL_ATTR_METADATA_ID           | YES        |                         |
+    | SQL_ATTR_NOSCAN                | NO         |                         |
+    | SQL_ATTR_PARAM_BIND_OFFSET_PTR | YES        | ODBC V2.0               |
+    | SQL_ATTR_PARAM_BIND_TYPE       | YES        |                         |
+    | SQL_ATTR_PARAM_OPERATION_PTR   | YES        |                         |
+    | SQL_ATTR_PARAM_STATUS_PTR      | YES        |                         |
+    | SQL_ATTR_PARAMS_PROCESSED_PTR  | YES        |                         |
+    | SQL_ATTR_PARAMSET_SIZE         | YES        |                         |
+    | SQL_ATTR_QUERY_TIMEOUT         | NO         |                         |
+    | SQL_ATTR_RETRIEVE_DATA         | NO         |                         |
+    | SQL_ATTR_ROW_BIND_OFFSET_PTR   | YES        |                         |
+    | SQL_ATTR_ROW_BIND_TYPE         | NO         |                         |
+    | SQL_ATTR_ROW_NUMBER            | YES        |                         |
+    | SQL_ATTR_ROW_OPERATION_PTR     | YES        |                         |
+    | SQL_ATTR_ROW_STATUS_PTR        | YES        |                         |
+    | SQL_ATTR_ROWS_FETCHED_PTR      | YES        |                         |
+    | SQL_ATTR_ROW_ARRAY_SIZE        | YES        |                         |
+    | SQL_ATTR_SIMULATE_CURSOR       | NO         |                         |
+    | SQL_ATTR_USE_BOOKMARKS         | YES        |                         |
+    | SQL_ROWSET_SIZE                | YES        |                         |
+
+### SQLSetStmtAttr()
+
+You can use the `SQLSetStmtAttr()` function to set the values of environment attributes. The signature is:
+
+```c++
+SQLRETURN SQLSetStmtAttr
+(
+    SQLHENV  stmt_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `stmt_handle` is the environment handle.
+
+-   `attribute` identifies the statement attribute whose value you wish to set.
+
+-   `value_pointer` is a pointer to the location in memory that holds the value that will be assigned to the attribute. `value_pointer`can be a pointer to:
+
+    -   A null-terminated character string  
+    -   A binary buffer  
+    -   A value defined by the driver  
+    -   A value of the type `SQLLEN`, `SQLULEN` or `SQLUSMALLINT` 
+
+        Value-pointer can also optionally hold one of the following values:  
+    -   An ODBC descriptor handle  
+    -   A `SQLUINTEGER` value  
+    -   A `SQLULEN` value  
+    -   A signed INTEGER (if attribute is a driver-specific value)
+
+-   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
+      If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
+    | Value Type             | Meaning                                       |
+    | ---------------------- | --------------------------------------------- |
+    |                        |                                               |
+    | Character string       | The length of the character string or SQL_NTS |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+    | Any other type         | SQL_IS_POINTER                                |
+
+## Error Handling
+
+Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC `SQLGetDiagRec()` function.  
+
+### SQLGetDiagRec()
+
+ The `SQLGetDiagRec()` function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:
+
+```c++
+SQLRETURN SQLGetDiagRec
+(
+    SQLSMALLINT handle_type, // Input
+    SQLHANDLE handle, // Input
+    SQLSMALLINT record_number, // Input
+    SQLCHAR *SQLState_pointer, // Output
+    SQLINTEGER *native_error_pointer, // Output
+    SQLCHAR *error_text_pointer, // Output
+    SQLSMALLINT buffer_length, // Input
+    SQLSMALLINT *text_length_pointer // Output
+);
+```
+
+-   `handle_type` The handle type of the `handle` argument. `handle_type`must be one of the following:  
+
+    -   `SQL_HANDLE_ENV` specifies an environment handle. 
+    -   `SQL_HANDLE_STMT` specifies a statement handle.  
+    -   `SQL_HANDLE_DBC` specifies a connection handle.
+    -   `SQL_HANDLE_DESC` specifies a descriptor handle.
+
+-   `handle` The handle associated with the attribute error message.
+
+-   `record_number` The status record that the application is seeking information from (must be greater than or equal to 1).
+
+-   `SQLState_pointer` Pointer to a memory buffer that receives the `SQLState` error code from the record. 
+
+-   `native_error_pointer` Pointer to a buffer that receives the native error message for the data source (contained in the `SQL_DIAG_NATIVE` field).
+
+-   `error_text_pointer` Pointer to a memory buffer that receives the error text (contained in the `SQL_DIAG_MESSAGE_TEXT` field) 
+
+-   `buffer_length` The length of the `error_text` buffer.
+
+-   `text_length_pointer` Pointer to the buffer that receives the size (in characters) of the `error_text_pointer` field. If the number of characters in the `error_text_pointer` parameter exceeds the number available (in `buffer_length`), `error_text_pointer` will be truncated.
+
+`SQLGetDiagRec()` returns `SQL_SUCCESS`, `SQL_ERROR`, `SQL_INVALID_HANDLE`, `SQL_SUCCESS_WITH_DATA` or `SQL_NO_DATA`.
+
+## Supported ODBC API Functions
+
+The following table lists the ODBC API functions; the right column specifies `Yes` if the API is supported by the EDB-ODBC driver. Use the ODBC `SQLGetFunctions()` function (specifying a function ID of `SQL_API_ODBC3_ALL_FUNCTIONS`) to return a current version of this list.
 
 | ODBC API Function Name | Supported by EDB-ODBC? |
 | ---------------------- | ---------------------- |

--- a/product_docs/docs/odbc_connector/12.2.0.1/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.2.0.1/06_edb-odbc_driver_functionality.mdx
@@ -583,13 +583,14 @@ SQLRETURN SQLSetStmtAttr
 
 -   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
       If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
-    | Value Type             | Meaning                                       |
-    | ---------------------- | --------------------------------------------- |
-    |                        |                                               |
-    | Character string       | The length of the character string or SQL_NTS |
-    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
-    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
-    | Any other type         | SQL_IS_POINTER                                |
+
+| Value Type             | Meaning                                       |
+| ---------------------- | --------------------------------------------- |
+|                        |                                               |
+| Character string       | The length of the character string or SQL_NTS |
+| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+| Any other type         | SQL_IS_POINTER                                |
 
 ## Error Handling
 

--- a/product_docs/docs/odbc_connector/12.2.0.1/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.2.0.1/06_edb-odbc_driver_functionality.mdx
@@ -19,38 +19,28 @@ You can also use ODBC functions to set various attributes of the objects that yo
 
 The ODBC `SQLGetInfo()` function returns information about the EDB-ODBC driver and Advanced Server. You must have an open connection to call `SQLGetInfo()`, unless you specify `SQL_ODBC_VER` as the `info_type`. The signature for `SQLGetInfo()` is:
 
-```
+```c++
 SQLRETURN SQLGetInfo
 (
-SQLHDBC *conn_handle*, // Input
-SQLUSMALLINT *info_type*, // Input
-SQLPOINTER *info_pointer*, // Output
-SQLSMALLINT *buffer_len*, // Input
-SQLSMALLINT \*\ *string_length_pointer* // Output
+    SQLHDBC  conn_handle , // Input
+    SQLUSMALLINT  info_type , // Input
+    SQLPOINTER  info_pointer , // Output
+    SQLSMALLINT  buffer_len , // Input
+    SQLSMALLINT *  string_length_pointer  // Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `info_type` The type of information SQLGetInfo() is retrieving.
 
-`info_type`
+-   `info_pointer` A pointer to a memory buffer that will hold the retrieved value.
 
-The type of information SQLGetInfo() is retrieving.
+      If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
 
-`info_pointer`
+-   `buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
 
-A pointer to a memory buffer that will hold the retrieved value.
-
-If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
-
-`buffer_len`
-
-`buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
-
-`string_length_pointer`
-
-`string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
+-   `string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
 
 A typical usage is to call `SQLGetInfo()` with a `NULL info_pointer` to obtain the length of the requested value, allocate the required number of bytes, and then call `SQLGetInfo()` again (providing the address of the newly allocated buffer) to obtain the actual value. The first call retrieves the number of bytes required to hold the value; the second call retrieves the value.
 
@@ -278,63 +268,72 @@ You can use the ODBC `SQLGetConnectAttr()` and `SQLSetConnectAttr()` functions t
 
 The `SQLGetConnectAttr()` function returns the current value of a connection attribute. The signature is:
 
-```
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *conn_handle,* //Input
-SQLINTEGER *attribute,* //Input
-SQLPOINTER *value_pointer,* //Output
-SQLINTEGER *buffer_length,* //Input
-SQLINTEGER \*\ *string_length_pointer* //Output
+    SQLHDBC  conn_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_pointer,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `attribute` identifies the attribute whose value you wish to retrieve.
 
-`attribute`
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
 
-`attribute` identifies the attribute whose value you wish to retrieve.
+-   `buffer_length` If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
 
-`value_pointer`
+      If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
 
-A pointer to the location in memory that will receive the `attribute` value.
+    | Value type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
 
-`buffer_length`
-
-If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
-
-If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
-
-| Value type             | Meaning                                   |
-| ---------------------- | ----------------------------------------- |
-| Character string       | The length of the character string        |
-| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
-| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
-| Any other type         | SQL_IS_POINTER                            |
-
-`string_length_pointer`
-
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
+-   `string_length_pointer` A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
 
 This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
 
 The following table lists the connection attributes supported by EDB-ODBC.
 
-<table><thead><tr class="header"><th>Attribute</th><th>Supported?</th><th>Notes</th></tr></thead><tbody><tr class="odd"><td>SQL_ATTR_ACCESS_MODE</td><td>NO</td><td>SQL_MODE_READ_WRITE</td></tr><tr class="even"><td><p>SQL_ATTR_ASYNC_ENABLE SQL_ATTR_AUTO_IPD SQL_ATTR_AUTOCOMMIT SQL_ATTR_CONNECTION_TIMEOUT SQL_ATTR_CURRENT_CATALOG SQL_ATTR_DISCONNECT_BEHAVIOR</p></td><td><p>NO NO</p><p>NO NO NO</p></td><td><p>SQL_ASYNC_ENABLE_OFF</p><p>SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF</p></td></tr><tr class="odd"><td><p>SQL_ATTR_ENLIST_IN_DTC SQL_ATTR_ENLIST_IN_XA</p></td><td><p>YES NO</p></td><td><p>For win32 and with conditional compilation</p></td></tr><tr class="even"><td><p>SQL_ATTR_LOGIN_TIMEOUT SQL_ATTR_ODBC_CURSORS SQL_ATTR_PACKET_SIZE SQL_ATTR_QUIET_MODE SQL_ATTR_TRACE SQL_ATTR_TRACEFILE SQL_ATTR_TRANSLATE_LIB SQL_ATTR_TRANSLATE_OPTION</p></td><td><p>NO NO NO NO NO NO NO NO</p></td><td><p>SQL_LOGIN_TIMEOUT</p></td></tr><tr class="odd"><td>SQL_ATTR_TXN_ISOLATION</td><td>YES</td><td>SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION</td></tr></tbody></table>
+| Attribute                    | Supported? | Notes                                                 |
+| ---------------------------- | ---------- | ----------------------------------------------------- |
+| SQL_ATTR_ACCESS_MODE         | NO         | SQL_MODE_READ_WRITE                                   |
+| SQL_ATTR_ASYNC_ENABLE        | NO         | SQL_ASYNC_ENABLE_OFF                                  |
+| SQL_ATTR_AUTO_IPD            | NO         |                                                       |
+| SQL_ATTR_AUTOCOMMIT          | YES        | SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF |
+| SQL_ATTR_CONNECTION_TIMEOUT  | NO         |                                                       |
+| SQL_ATTR_CURRENT_CATALOG     | NO         |                                                       |
+| SQL_ATTR_DISCONNECT_BEHAVIOR | NO         |                                                       |
+| SQL_ATTR_ENLIST_IN_DTC       | YES        | For win32 and with conditional compilation            |
+| SQL_ATTR_ENLIST_IN_XA        | NO         |                                                       |
+| SQL_ATTR_LOGIN_TIMEOUT       | NO         | SQL_LOGIN_TIMEOUT                                     |
+| SQL_ATTR_ODBC_CURSORS        | NO         |                                                       |
+| SQL_ATTR_PACKET_SIZE         | NO         |                                                       |
+| SQL_ATTR_QUIET_MODE          | NO         |                                                       |
+| SQL_ATTR_TRACE               | NO         |                                                       |
+| SQL_ATTR_TRACEFILE           | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_LIB       | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_OPTION    | NO         |                                                       |
+| SQL_ATTR_TXN_ISOLATION       | YES        | SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION          |
 
 ### SQLSetConnectAttr()
 
 You can use the ODBC `SQLSetConnectAttr()` function to set the values of connection attributes. The signature of the function is:
 
-```
+```c++
 SQLRETURN SQLSetConnectAttr
 (
-SQLHDBC *conn_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_pointer*, // Input
-SQLINTEGER *string_length*, // Input
+    SQLHDBC  conn_handle , // Input
+    SQLINTEGER  attribute , // Input
+    SQLPOINTER  value_pointer , // Input
+    SQLINTEGER  string_length , // Input
 );
 ```
 
@@ -399,14 +398,14 @@ You can use the ODBC `SQLGetEnvAttr()` and `SQLSetEnvAttr()` functions to retrie
 
 Use the `SQLGetEnvAttr()` function to find the current value of environment attributes on your system. The signature of the function is:
 
-```
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *env_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_ptr*, // Output
-SQLINTEGER *buffer_length*, // Input
-SQLINTEGER \*\ *string_length_pointer* // Output
+    SQLHDBC env_handle, // Input
+    SQLINTEGER attribute, // Input
+    SQLPOINTER value_ptr, // Output
+    SQLINTEGER buffer_length, // Input
+    SQLINTEGER * string_length_pointer // Output
 );
 ```
 
@@ -428,7 +427,218 @@ If the attribute is a character string, `buffer_length` is the length of `value_
 
 `string_length_pointer`
 
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer* is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_NO_DATA`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the environment attributes supported by EDB-ODBC.   =========================== =================================== =================================== Attribute                   Supported?                          Restrictions? =========================== =================================== =================================== SQL_ATTR_CONNECTION_POOLING SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF Determined by connection properties SQL_ATTR_ODBC_VERSION       (SQL_OV_ODBC3)                      NONE                              (SQL_OV_ODBC2) SQL_ATTR_OUTPUT_NTS         SQL_SUCCESS                         NONE =========================== =================================== ===================================  .. raw:: latex      \newpage  SQLSetEnvAttr() ---------------  You can use the`SQLSetEnvAttr()`function to set the values of environment attributes. The signature of the function is:  .. code-block:: text     SQLRETURN SQLSetEnvAttr    (    SQLHENV *env_handle*, //Input    SQLINTEGER *attribute*, //Input    SQLPOINTER *value_pointer*, //Input    SQLINTEGER *string_length* //Input    );`env_handle`The environment handle.`attribute``attribute`identifies the attribute whose value you wish to set.`value\_pointer`A pointer to the value assigned to the`attribute`. The value will be a`NULL`terminated character string or a 32 bit integer value depending on the specified`attribute`.`string\_length`If`value\_pointer`is a pointer to a binary buffer or character string,`string\_length`is the length of`value\_pointer`. If the value being assigned to the attribute is a character,`string\_length`is the length of that character string. If`value\_pointer`is NULL,`string\_length`is not returned. If value_pointer is an integer,`string\_length`is ignored.`SQLSetEnvAttr()`returns`SQL\_SUCCESS`,`SQL\_INVALID\_HANDLE`,`SQL\_ERROR`or`SQL\_SUCCESS\_WITH\_INFO`.  The application must call`SQLSetEnvAttr()`before allocating a connection handle; all values applied to environment attributes will persist until`SQLFreeHandle()`is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously.  The following table lists the environment attributes you can set with`SQLSetAttr()`.   ===================== ================== ========================================================================================================================== Attribute             Value_pointer type Restrictions? ===================== ================== ========================================================================================================================== SQL_ATTR_ODBC_VERSION 32 bit Integer     Set this attribute before the application calls any function that includes an SQLHENV argument. SQL_ATTR_OUTPUT_NTS   32-bit Integer     Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). ===================== ================== ==========================================================================================================================  .. raw:: latex      \newpage  Statement Attributes ====================  .. index:: ODBC statement attributes  You can use the ODBC`SQLGetStmtAttr()`and`SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  SQLGetStmtAttr() ----------------  The`SQLGetStmtAttr()`function returns the current value of statement attribute. The signature is:  .. code-block:: text     SQLRETURN SQLGetConnectAttr    (    SQLHDBC *stmt_handle,* //Input    SQLINTEGER *attribute,* //Input    SQLPOINTER *value_ptr,* //Output    SQLINTEGER *buffer_length,* //Input    SQLINTEGER \*\ *string_length_pointer* //Output    );`stmt\_handle`The statement handle`attribute``attribute`is the attribute value`value_pointer`A pointer to the location in memory that will receive the`attribute`value.`buffer_length`If the attribute is defined by ODBC,`buffer_length`is the length of`value_pointer`(if`value_pointer`points to a character string or binary buffer). If`value_pointer`points to an integer,`buffer_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`buffer_length`parameter.`buffer_length`can be:  ====================== ========================================= Value Type             Meaning ====================== ========================================= Character string       The length of the character string Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =========================================`string_length_pointer`A pointer to an`SQLINTEGER`that receives the number of bytes required to hold the requested value. If`value_pointer`is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the statement attributes supported by EDB-ODBC:  ============================== ========== ======================= Attribute                      Supported? Restrictions? ============================== ========== ======================= SQL_ATTR_APP_PARAM_DESC        YES SQL_ATTR_APP_ROW_DESC          YES SQL_ATTR_ASYNC_ENABLE          NO SQL_ATTR_CONCURRENCY           YES        SQL_CONCUR_READ_ONLY SQL_ATTR_CURSOR_SCROLLABLE     YES SQL_ATTR_CURSOR_TYPE           YES        SQL_CURSOR_FORWARD_ONLY SQL_ATTR_CURSOR_SENSITIVITY    YES        SQL_INSENSITIVE SQL_ATTR_ENABLE_AUTO_IPD       NO SQL_ATTR_FETCH_BOOKMARK_PTR    YES SQL_ATTR_IMP_PARAM_DESC        YES SQL_ATTR_IMP_ROW_DESC          YES SQL_ATTR_KEYSET_SIZE           NO SQL_ATTR_MAX_LENGTH            NO SQL_ATTR_MAX_ROWS              NO SQL_ATTR_METADATA_ID           YES SQL_ATTR_NOSCAN                NO SQL_ATTR_PARAM_BIND_OFFSET_PTR YES        ODBC V2.0 SQL_ATTR_PARAM_BIND_TYPE       YES SQL_ATTR_PARAM_OPERATION_PTR   YES SQL_ATTR_PARAM_STATUS_PTR      YES SQL_ATTR_PARAMS_PROCESSED_PTR  YES SQL_ATTR_PARAMSET_SIZE         YES SQL_ATTR_QUERY_TIMEOUT         NO SQL_ATTR_RETRIEVE_DATA         NO SQL_ATTR_ROW_BIND_OFFSET_PTR   YES SQL_ATTR_ROW_BIND_TYPE         NO SQL_ATTR_ROW_NUMBER            YES SQL_ATTR_ROW_OPERATION_PTR     YES SQL_ATTR_ROW_STATUS_PTR        YES SQL_ATTR_ROWS_FETCHED_PTR      YES SQL_ATTR_ROW_ARRAY_SIZE        YES SQL_ATTR_SIMULATE_CURSOR       NO SQL_ATTR_USE_BOOKMARKS         YES SQL_ROWSET_SIZE                YES ============================== ========== =======================  . raw:: latex      \newpage  SQLSetStmtAttr() ----------------  You can use the`SQLSetStmtAttr()`function to set the values of environment attributes. The signature is:  .. code-block:: text     SQLRETURN SQLSetStmtAttr     (     SQLHENV *stmt_handle*, //Input     SQLINTEGER *attribute*, //Input     SQLPOINTER *value_pointer*, //Input     SQLINTEGER *string_length* //Input     );  *stmt_handle*  *stmt_handle* is the environment handle.`attribute``attribute`identifies the statement attribute whose value you wish to set.`value\_pointer``value_pointer`is a pointer to the location in memory that holds the value that will be assigned to the attribute.`value_pointer`can be a pointer to:  -  A null-terminated character string  -  A binary buffer  -  A value defined by the driver  -  A value of the type`SQLLEN`,`SQLULEN`or`SQLUSMALLINT`Value-pointer can also optionally hold one of the following values:  -  An ODBC descriptor handle  -  A`SQLUINTEGER`value  -  A`SQLULEN`value  -  A signed INTEGER (if attribute is a driver-specific value)`string_length`If`attribute`is defined by ODBC and`value_pointer`points to a binary buffer or character string,`string_length`is the length of`value_pointer`. If`value_pointer`points to an integer,`string_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`string_length`parameter. Possible`string_length`values are:  ====================== ============================================= Value Type             Meaning ====================== ============================================= Character string       The length of the character string or SQL_NTS Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =============================================  .. raw:: latex      \newpage  Error Handling ==============  .. index:: Status and error data  Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC`SQLGetDiagRec()`function.  SQLGetDiagRec() ---------------  The`SQLGetDiagRec()`function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:  . code-block:: text     SQLRETURN SQLGetDiagRec(     SQLSMALLINT *handle_type*, // Input     SQLHANDLE *handle*, // Input     SQLSMALLINT *record_number*, // Input     SQLCHAR \*\ *SQLState_pointer*, // Output     SQLINTEGER \*\ *native_error_pointer*, // Output     SQLCHAR \*\ *error_text_pointer*, // Output     SQLSMALLINT *buffer_length*, // Input     SQLSMALLINT \*text_length_pointer // Output     );`handle_type`The handle type of the`handle`argument.`handle_type`must be one of the following:  -`SQL_HANDLE_ENV`specifies an environment handle.  -`SQL_HANDLE_STMT`specifies a statement handle.  -`SQL_HANDLE_DBC`specifies a connection handle.  -`SQL_HANDLE_DESC`specifies a descriptor handle.`handle`The handle associated with the attribute error message.`record_number`The status record that the application is seeking information from (must be greater than or equal to 1).`SQLState_pointer`Pointer to a memory buffer that receives the`SQLState`error code from the record.`native_error_pointer`Pointer to a buffer that receives the native error message for the data source (contained in the`SQL_DIAG_NATIVE`field).`error_text_pointer`Pointer to a memory buffer that receives the error text (contained in the`SQL_DIAG_MESSAGE_TEXT`field)`buffer_length`The length of the`error_text`buffer.`text_length_pointer`Pointer to the buffer that receives the size (in characters) of the`error_text_pointer`field. If the number of characters in the`error_text_pointer`parameter exceeds the number available (in`buffer_length`),`error_text_pointer`will be truncated.`SQLGetDiagRec()`returns`SQL_SUCCESS`,`SQL_ERROR`,`SQL_INVALID_HANDLE`,`SQL_SUCCESS_WITH_DATA`or`SQL_NO_DATA`.  .. raw:: latex      \newpage  Supported ODBC API Functions ============================  .. index:: ODBC API functions  The following table lists the ODBC API functions; the right column specifies`Yes`if the API is supported by the EDB-ODBC driver. Use the ODBC`SQLGetFunctions()`function (specifying a function ID of`SQL_API_ODBC3_ALL_FUNCTIONS\`\`) to return a current version of this list.
+A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is NULL, `string_length_pointer` is not returned.
+
+This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO` , `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+The following table lists the environment attributes supported by EDB-ODBC. 
+
+| Attribute                   | Supported?                          | Restrictions?                       |
+| --------------------------- | ----------------------------------- | ----------------------------------- |
+|                             |                                     |                                     |
+| SQL_ATTR_CONNECTION_POOLING | SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF | Determined by connection properties |
+| SQL_ATTR_ODBC_VERSION       | (SQL_OV_ODBC3)                      |                                     |
+
+(SQL_OV_ODBC2)        | NONE                                |
+| SQL_ATTR_OUTPUT_NTS         | SQL_SUCCESS                              | NONE                                |
+
+## SQLSetEnvAttr()
+
+You can use the `SQLSetEnvAttr()` function to set the values of environment attributes. The signature of the function is:
+
+```c++
+SQLRETURN SQLSetEnvAttr
+(
+    SQLHENV  env_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `env_handle` The environment handle.
+-   `attribute` identifies the attribute whose value you wish to set.
+-   `value_pointer` A pointer to the value assigned to the `attribute`. 
+-   The value will be a `NULL` terminated character string or a 32 bit integer value depending on the specified `attribute`.
+-   `string_length` If `value_pointer` is a pointer to a binary buffer or character string,`string\_length` is the length of `value_pointer`. If the value being assigned to the attribute is a character, `string_length` is the length of that character string. If `value_pointer` is NULL, `string_length` is not returned. If value_pointer is an integer,`string_length`is ignored. 
+
+`SQLSetEnvAttr()` returns `SQL_SUCCESS`, `SQL_INVALID_HANDLE`, `SQL_ERROR` or `SQL_SUCCESS_WITH_INFO`.  The application must call `SQLSetEnvAttr()` before allocating a connection handle; all values applied to environment attributes will persist until `SQLFreeHandle()` is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously. 
+
+The following table lists the environment attributes you can set with `SQLSetAttr()`.   
+
+| Attribute             | Value_pointer type | Restrictions?                                                                                                              |
+| --------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| SQL_ATTR_ODBC_VERSION | 32 bit Integer     | Set this attribute before the application calls any function that includes an SQLHENV argument.                            |
+| SQL_ATTR_OUTPUT_NTS   | 32-bit Integer     | Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). |
+
+## Statement Attributes
+
+You can use the ODBC `SQLGetStmtAttr()` and `SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  
+
+### SQLGetStmtAttr()
+
+The `SQLGetStmtAttr()` function returns the current value of statement attribute. The signature is:
+
+```c++
+SQLRETURN SQLGetConnectAttr
+(
+    SQLHDBC  stmt_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_ptr,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
+);
+```
+
+-   `stmt_handle` The statement handle 
+
+-   `attribute` is the attribute value
+
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
+
+-   `buffer_length` If the attribute is defined by ODBC, `buffer_length` is the length of `value_pointer` (if `value_pointer` points to a character string or binary buffer).  If `value_pointer` points to an integer, `buffer_length` is ignored. 
+
+      If EDB-ODBC defines the attribute, the application sets the `buffer_length` parameter. `buffer_length`can be:
+
+    | Value Type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    |                        |                                           |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
+
+-   `string_length_pointer` A pointer to an `SQLINTEGER` that receives the number of bytes required to hold the requested value. If `value_pointer` is NULL, `string_length_pointer` is not returned.  
+
+      This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+    | Attribute                      | Supported? | Restrictions?           |
+    | ------------------------------ | ---------- | ----------------------- |
+    |                                |            |                         |
+    | SQL_ATTR_APP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_APP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_ASYNC_ENABLE          | NO         |                         |
+    | SQL_ATTR_CONCURRENCY           | YES        | SQL_CONCUR_READ_ONLY    |
+    | SQL_ATTR_CURSOR_SCROLLABLE     | YES        |                         |
+    | SQL_ATTR_CURSOR_TYPE           | YES        | SQL_CURSOR_FORWARD_ONLY |
+    | SQL_ATTR_CURSOR_SENSITIVITY    | YES        | SQL_INSENSITIVE         |
+    | SQL_ATTR_ENABLE_AUTO_IPD       | NO         |                         |
+    | SQL_ATTR_FETCH_BOOKMARK_PTR    | YES        |                         |
+    | SQL_ATTR_IMP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_IMP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_KEYSET_SIZE           | NO         |                         |
+    | SQL_ATTR_MAX_LENGTH            | NO         |                         |
+    | SQL_ATTR_MAX_ROWS              | NO         |                         |
+    | SQL_ATTR_METADATA_ID           | YES        |                         |
+    | SQL_ATTR_NOSCAN                | NO         |                         |
+    | SQL_ATTR_PARAM_BIND_OFFSET_PTR | YES        | ODBC V2.0               |
+    | SQL_ATTR_PARAM_BIND_TYPE       | YES        |                         |
+    | SQL_ATTR_PARAM_OPERATION_PTR   | YES        |                         |
+    | SQL_ATTR_PARAM_STATUS_PTR      | YES        |                         |
+    | SQL_ATTR_PARAMS_PROCESSED_PTR  | YES        |                         |
+    | SQL_ATTR_PARAMSET_SIZE         | YES        |                         |
+    | SQL_ATTR_QUERY_TIMEOUT         | NO         |                         |
+    | SQL_ATTR_RETRIEVE_DATA         | NO         |                         |
+    | SQL_ATTR_ROW_BIND_OFFSET_PTR   | YES        |                         |
+    | SQL_ATTR_ROW_BIND_TYPE         | NO         |                         |
+    | SQL_ATTR_ROW_NUMBER            | YES        |                         |
+    | SQL_ATTR_ROW_OPERATION_PTR     | YES        |                         |
+    | SQL_ATTR_ROW_STATUS_PTR        | YES        |                         |
+    | SQL_ATTR_ROWS_FETCHED_PTR      | YES        |                         |
+    | SQL_ATTR_ROW_ARRAY_SIZE        | YES        |                         |
+    | SQL_ATTR_SIMULATE_CURSOR       | NO         |                         |
+    | SQL_ATTR_USE_BOOKMARKS         | YES        |                         |
+    | SQL_ROWSET_SIZE                | YES        |                         |
+
+### SQLSetStmtAttr()
+
+You can use the `SQLSetStmtAttr()` function to set the values of environment attributes. The signature is:
+
+```c++
+SQLRETURN SQLSetStmtAttr
+(
+    SQLHENV  stmt_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `stmt_handle` is the environment handle.
+
+-   `attribute` identifies the statement attribute whose value you wish to set.
+
+-   `value_pointer` is a pointer to the location in memory that holds the value that will be assigned to the attribute. `value_pointer`can be a pointer to:
+
+    -   A null-terminated character string  
+    -   A binary buffer  
+    -   A value defined by the driver  
+    -   A value of the type `SQLLEN`, `SQLULEN` or `SQLUSMALLINT` 
+
+        Value-pointer can also optionally hold one of the following values:  
+    -   An ODBC descriptor handle  
+    -   A `SQLUINTEGER` value  
+    -   A `SQLULEN` value  
+    -   A signed INTEGER (if attribute is a driver-specific value)
+
+-   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
+      If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
+    | Value Type             | Meaning                                       |
+    | ---------------------- | --------------------------------------------- |
+    |                        |                                               |
+    | Character string       | The length of the character string or SQL_NTS |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+    | Any other type         | SQL_IS_POINTER                                |
+
+## Error Handling
+
+Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC `SQLGetDiagRec()` function.  
+
+### SQLGetDiagRec()
+
+ The `SQLGetDiagRec()` function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:
+
+```c++
+SQLRETURN SQLGetDiagRec
+(
+    SQLSMALLINT handle_type, // Input
+    SQLHANDLE handle, // Input
+    SQLSMALLINT record_number, // Input
+    SQLCHAR *SQLState_pointer, // Output
+    SQLINTEGER *native_error_pointer, // Output
+    SQLCHAR *error_text_pointer, // Output
+    SQLSMALLINT buffer_length, // Input
+    SQLSMALLINT *text_length_pointer // Output
+);
+```
+
+-   `handle_type` The handle type of the `handle` argument. `handle_type`must be one of the following:  
+
+    -   `SQL_HANDLE_ENV` specifies an environment handle. 
+    -   `SQL_HANDLE_STMT` specifies a statement handle.  
+    -   `SQL_HANDLE_DBC` specifies a connection handle.
+    -   `SQL_HANDLE_DESC` specifies a descriptor handle.
+
+-   `handle` The handle associated with the attribute error message.
+
+-   `record_number` The status record that the application is seeking information from (must be greater than or equal to 1).
+
+-   `SQLState_pointer` Pointer to a memory buffer that receives the `SQLState` error code from the record. 
+
+-   `native_error_pointer` Pointer to a buffer that receives the native error message for the data source (contained in the `SQL_DIAG_NATIVE` field).
+
+-   `error_text_pointer` Pointer to a memory buffer that receives the error text (contained in the `SQL_DIAG_MESSAGE_TEXT` field) 
+
+-   `buffer_length` The length of the `error_text` buffer.
+
+-   `text_length_pointer` Pointer to the buffer that receives the size (in characters) of the `error_text_pointer` field. If the number of characters in the `error_text_pointer` parameter exceeds the number available (in `buffer_length`), `error_text_pointer` will be truncated.
+
+`SQLGetDiagRec()` returns `SQL_SUCCESS`, `SQL_ERROR`, `SQL_INVALID_HANDLE`, `SQL_SUCCESS_WITH_DATA` or `SQL_NO_DATA`.
+
+## Supported ODBC API Functions
+
+The following table lists the ODBC API functions; the right column specifies `Yes` if the API is supported by the EDB-ODBC driver. Use the ODBC `SQLGetFunctions()` function (specifying a function ID of `SQL_API_ODBC3_ALL_FUNCTIONS`) to return a current version of this list.
 
 | ODBC API Function Name | Supported by EDB-ODBC? |
 | ---------------------- | ---------------------- |

--- a/product_docs/docs/odbc_connector/12.2.0.2/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.2.0.2/06_edb-odbc_driver_functionality.mdx
@@ -19,38 +19,28 @@ You can also use ODBC functions to set various attributes of the objects that yo
 
 The ODBC `SQLGetInfo()` function returns information about the EDB-ODBC driver and Advanced Server. You must have an open connection to call `SQLGetInfo()`, unless you specify `SQL_ODBC_VER` as the `info_type`. The signature for `SQLGetInfo()` is:
 
-```text
+```c++
 SQLRETURN SQLGetInfo
 (
-SQLHDBC *conn_handle*, // Input
-SQLUSMALLINT *info_type*, // Input
-SQLPOINTER *info_pointer*, // Output
-SQLSMALLINT *buffer_len*, // Input
-SQLSMALLINT \*\ *string_length_pointer* // Output
+    SQLHDBC  conn_handle , // Input
+    SQLUSMALLINT  info_type , // Input
+    SQLPOINTER  info_pointer , // Output
+    SQLSMALLINT  buffer_len , // Input
+    SQLSMALLINT *  string_length_pointer  // Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `info_type` The type of information SQLGetInfo() is retrieving.
 
-`info_type`
+-   `info_pointer` A pointer to a memory buffer that will hold the retrieved value.
 
-The type of information SQLGetInfo() is retrieving.
+      If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
 
-`info_pointer`
+-   `buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
 
-A pointer to a memory buffer that will hold the retrieved value.
-
-If the `info_type` argument is `SQL_DRIVER_HDESC` or `SQL_DRIVER_HSTMT`, the `info_pointer` argument is both `Input` and `Output`.
-
-`buffer_len`
-
-`buffer_len` is the length of the allocated memory buffer pointed to by `info_pointer`. If `info_pointer` is `NULL`, `buffer_len` is ignored. If the returned value is a fixed size, `buffer_len` is ignored. `buffer_len` is only used if the requested value is returned in the form of a character string.
-
-`string_length_pointer`
-
-`string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
+-   `string_length_pointer` is a pointer to an `SQLSMALLINT` value. `SQLGetInfo()` writes the size of the requested value in this integer.
 
 A typical usage is to call `SQLGetInfo()` with a `NULL info_pointer` to obtain the length of the requested value, allocate the required number of bytes, and then call `SQLGetInfo()` again (providing the address of the newly allocated buffer) to obtain the actual value. The first call retrieves the number of bytes required to hold the value; the second call retrieves the value.
 
@@ -278,70 +268,72 @@ You can use the ODBC `SQLGetConnectAttr()` and `SQLSetConnectAttr()` functions t
 
 The `SQLGetConnectAttr()` function returns the current value of a connection attribute. The signature is:
 
-```text
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *conn_handle,* //Input
-SQLINTEGER *attribute,* //Input
-SQLPOINTER *value_pointer,* //Output
-SQLINTEGER *buffer_length,* //Input
-SQLINTEGER \*\ *string_length_pointer* //Output
+    SQLHDBC  conn_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_pointer,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
 );
 ```
 
-`conn_handle`
+-   `conn_handle` The connection handle.
 
-The connection handle.
+-   `attribute` identifies the attribute whose value you wish to retrieve.
 
-`attribute`
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
 
-`attribute` identifies the attribute whose value you wish to retrieve.
+-   `buffer_length` If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
 
-`value_pointer`
+      If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
 
-A pointer to the location in memory that will receive the `attribute` value.
+    | Value type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
 
-`buffer_length`
-
-If `attribute` is defined by ODBC and `value_pointer` points to a character string or binary buffer, `buffer_length` is the length of `value_pointer`. If `value_pointer` points to a fixed-size value (such as an integer), `buffer_length` is ignored.
-
-If EDB-ODBC defines the attribute, `SQLGetConnectAttr()` sets the `buffer_length` parameter. `buffer_length` can be:
-
-| Value type             | Meaning                                   |
-| ---------------------- | ----------------------------------------- |
-| Character string       | The length of the character string        |
-| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
-| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
-| Any other type         | SQL_IS_POINTER                            |
-
-`string_length_pointer`
-
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
+-   `string_length_pointer` A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is `NULL`, `string_length_pointer` is not returned.
 
 This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
 
 The following table lists the connection attributes supported by EDB-ODBC.
 
-| Attribute                                                                                                                                                                | Supported?              | Notes                                                 |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ----------------------------------------------------- |
-| SQL_ATTR_ACCESS_MODE                                                                                                                                                     | NO                      | SQL_MODE_READ_WRITE                                   |
-| SQL_ATTR_ASYNC_ENABLE SQL_ATTR_AUTO_IPD                                                                                                                                  | NO NO                   | SQL_ASYNC_ENABLE_OFF                                  |
-| SQL_ATTR_AUTOCOMMIT SQL_ATTR_CONNECTION_TIMEOUT SQL_ATTR_CURRENT_CATALOG SQL_ATTR_DISCONNECT_BEHAVIOR                                                                    | YES NO NO NO            | SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF |
-| SQL_ATTR_ENLIST_IN_DTC SQL_ATTR_ENLIST_IN_XA                                                                                                                             | YES NO                  | For win32 and with conditional compilation            |
-| SQL_ATTR_LOGIN_TIMEOUT SQL_ATTR_ODBC_CURSORS SQL_ATTR_PACKET_SIZE SQL_ATTR_QUIET_MODE SQL_ATTR_TRACE SQL_ATTR_TRACEFILE SQL_ATTR_TRANSLATE_LIB SQL_ATTR_TRANSLATE_OPTION | NO NO NO NO NO NO NO NO | SQL_LOGIN_TIMEOUT                                     |
-| SQL_ATTR_TXN_ISOLATION                                                                                                                                                   | YES                     | SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION          |
+| Attribute                    | Supported? | Notes                                                 |
+| ---------------------------- | ---------- | ----------------------------------------------------- |
+| SQL_ATTR_ACCESS_MODE         | NO         | SQL_MODE_READ_WRITE                                   |
+| SQL_ATTR_ASYNC_ENABLE        | NO         | SQL_ASYNC_ENABLE_OFF                                  |
+| SQL_ATTR_AUTO_IPD            | NO         |                                                       |
+| SQL_ATTR_AUTOCOMMIT          | YES        | SQL_AUTOCOMMIT, SQL_AUTOCOMMIT_ON, SQL_AUTOCOMMIT_OFF |
+| SQL_ATTR_CONNECTION_TIMEOUT  | NO         |                                                       |
+| SQL_ATTR_CURRENT_CATALOG     | NO         |                                                       |
+| SQL_ATTR_DISCONNECT_BEHAVIOR | NO         |                                                       |
+| SQL_ATTR_ENLIST_IN_DTC       | YES        | For win32 and with conditional compilation            |
+| SQL_ATTR_ENLIST_IN_XA        | NO         |                                                       |
+| SQL_ATTR_LOGIN_TIMEOUT       | NO         | SQL_LOGIN_TIMEOUT                                     |
+| SQL_ATTR_ODBC_CURSORS        | NO         |                                                       |
+| SQL_ATTR_PACKET_SIZE         | NO         |                                                       |
+| SQL_ATTR_QUIET_MODE          | NO         |                                                       |
+| SQL_ATTR_TRACE               | NO         |                                                       |
+| SQL_ATTR_TRACEFILE           | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_LIB       | NO         |                                                       |
+| SQL_ATTR_TRANSLATE_OPTION    | NO         |                                                       |
+| SQL_ATTR_TXN_ISOLATION       | YES        | SQL_TXN_ISOLATION, SQL_DEFAULT_TXN_ISOLATION          |
 
 ### SQLSetConnectAttr()
 
 You can use the ODBC `SQLSetConnectAttr()` function to set the values of connection attributes. The signature of the function is:
 
-```text
+```c++
 SQLRETURN SQLSetConnectAttr
 (
-SQLHDBC *conn_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_pointer*, // Input
-SQLINTEGER *string_length*, // Input
+    SQLHDBC  conn_handle , // Input
+    SQLINTEGER  attribute , // Input
+    SQLPOINTER  value_pointer , // Input
+    SQLINTEGER  string_length , // Input
 );
 ```
 
@@ -406,14 +398,14 @@ You can use the ODBC `SQLGetEnvAttr()` and `SQLSetEnvAttr()` functions to retrie
 
 Use the `SQLGetEnvAttr()` function to find the current value of environment attributes on your system. The signature of the function is:
 
-```text
+```c++
 SQLRETURN SQLGetConnectAttr
 (
-SQLHDBC *env_handle*, // Input
-SQLINTEGER *attribute*, // Input
-SQLPOINTER *value_ptr*, // Output
-SQLINTEGER *buffer_length*, // Input
-SQLINTEGER \*\ *string_length_pointer* // Output
+    SQLHDBC env_handle, // Input
+    SQLINTEGER attribute, // Input
+    SQLPOINTER value_ptr, // Output
+    SQLINTEGER buffer_length, // Input
+    SQLINTEGER * string_length_pointer // Output
 );
 ```
 
@@ -435,7 +427,218 @@ If the attribute is a character string, `buffer_length` is the length of `value_
 
 `string_length_pointer`
 
-A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer* is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_NO_DATA`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the environment attributes supported by EDB-ODBC.   =========================== =================================== =================================== Attribute                   Supported?                          Restrictions? =========================== =================================== =================================== SQL_ATTR_CONNECTION_POOLING SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF Determined by connection properties SQL_ATTR_ODBC_VERSION       (SQL_OV_ODBC3)                      NONE                              (SQL_OV_ODBC2) SQL_ATTR_OUTPUT_NTS         SQL_SUCCESS                         NONE =========================== =================================== ===================================  .. raw:: latex      \newpage  SQLSetEnvAttr() ---------------  You can use the`SQLSetEnvAttr()`function to set the values of environment attributes. The signature of the function is:  .. code-block:: text     SQLRETURN SQLSetEnvAttr    (    SQLHENV *env_handle*, //Input    SQLINTEGER *attribute*, //Input    SQLPOINTER *value_pointer*, //Input    SQLINTEGER *string_length* //Input    );`env_handle`The environment handle.`attribute``attribute`identifies the attribute whose value you wish to set.`value\_pointer`A pointer to the value assigned to the`attribute`. The value will be a`NULL`terminated character string or a 32 bit integer value depending on the specified`attribute`.`string\_length`If`value\_pointer`is a pointer to a binary buffer or character string,`string\_length`is the length of`value\_pointer`. If the value being assigned to the attribute is a character,`string\_length`is the length of that character string. If`value\_pointer`is NULL,`string\_length`is not returned. If value_pointer is an integer,`string\_length`is ignored.`SQLSetEnvAttr()`returns`SQL\_SUCCESS`,`SQL\_INVALID\_HANDLE`,`SQL\_ERROR`or`SQL\_SUCCESS\_WITH\_INFO`.  The application must call`SQLSetEnvAttr()`before allocating a connection handle; all values applied to environment attributes will persist until`SQLFreeHandle()`is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously.  The following table lists the environment attributes you can set with`SQLSetAttr()`.   ===================== ================== ========================================================================================================================== Attribute             Value_pointer type Restrictions? ===================== ================== ========================================================================================================================== SQL_ATTR_ODBC_VERSION 32 bit Integer     Set this attribute before the application calls any function that includes an SQLHENV argument. SQL_ATTR_OUTPUT_NTS   32-bit Integer     Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). ===================== ================== ==========================================================================================================================  .. raw:: latex      \newpage  Statement Attributes ====================  .. index:: ODBC statement attributes  You can use the ODBC`SQLGetStmtAttr()`and`SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  SQLGetStmtAttr() ----------------  The`SQLGetStmtAttr()`function returns the current value of statement attribute. The signature is:  .. code-block:: text     SQLRETURN SQLGetConnectAttr    (    SQLHDBC *stmt_handle,* //Input    SQLINTEGER *attribute,* //Input    SQLPOINTER *value_ptr,* //Output    SQLINTEGER *buffer_length,* //Input    SQLINTEGER \*\ *string_length_pointer* //Output    );`stmt\_handle`The statement handle`attribute``attribute`is the attribute value`value_pointer`A pointer to the location in memory that will receive the`attribute`value.`buffer_length`If the attribute is defined by ODBC,`buffer_length`is the length of`value_pointer`(if`value_pointer`points to a character string or binary buffer). If`value_pointer`points to an integer,`buffer_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`buffer_length`parameter.`buffer_length`can be:  ====================== ========================================= Value Type             Meaning ====================== ========================================= Character string       The length of the character string Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =========================================`string_length_pointer`A pointer to an`SQLINTEGER`that receives the number of bytes required to hold the requested value. If`value_pointer`is NULL,`string_length_pointer`is not returned.  This function returns`SQL_SUCCESS`,`SQL_SUCCESS_WITH_INFO`,`SQL_ERROR`or`SQL_INVALID_HANDLE`.  The following table lists the statement attributes supported by EDB-ODBC:  ============================== ========== ======================= Attribute                      Supported? Restrictions? ============================== ========== ======================= SQL_ATTR_APP_PARAM_DESC        YES SQL_ATTR_APP_ROW_DESC          YES SQL_ATTR_ASYNC_ENABLE          NO SQL_ATTR_CONCURRENCY           YES        SQL_CONCUR_READ_ONLY SQL_ATTR_CURSOR_SCROLLABLE     YES SQL_ATTR_CURSOR_TYPE           YES        SQL_CURSOR_FORWARD_ONLY SQL_ATTR_CURSOR_SENSITIVITY    YES        SQL_INSENSITIVE SQL_ATTR_ENABLE_AUTO_IPD       NO SQL_ATTR_FETCH_BOOKMARK_PTR    YES SQL_ATTR_IMP_PARAM_DESC        YES SQL_ATTR_IMP_ROW_DESC          YES SQL_ATTR_KEYSET_SIZE           NO SQL_ATTR_MAX_LENGTH            NO SQL_ATTR_MAX_ROWS              NO SQL_ATTR_METADATA_ID           YES SQL_ATTR_NOSCAN                NO SQL_ATTR_PARAM_BIND_OFFSET_PTR YES        ODBC V2.0 SQL_ATTR_PARAM_BIND_TYPE       YES SQL_ATTR_PARAM_OPERATION_PTR   YES SQL_ATTR_PARAM_STATUS_PTR      YES SQL_ATTR_PARAMS_PROCESSED_PTR  YES SQL_ATTR_PARAMSET_SIZE         YES SQL_ATTR_QUERY_TIMEOUT         NO SQL_ATTR_RETRIEVE_DATA         NO SQL_ATTR_ROW_BIND_OFFSET_PTR   YES SQL_ATTR_ROW_BIND_TYPE         NO SQL_ATTR_ROW_NUMBER            YES SQL_ATTR_ROW_OPERATION_PTR     YES SQL_ATTR_ROW_STATUS_PTR        YES SQL_ATTR_ROWS_FETCHED_PTR      YES SQL_ATTR_ROW_ARRAY_SIZE        YES SQL_ATTR_SIMULATE_CURSOR       NO SQL_ATTR_USE_BOOKMARKS         YES SQL_ROWSET_SIZE                YES ============================== ========== =======================  .. raw:: latex      \newpage  SQLSetStmtAttr() ----------------  You can use the`SQLSetStmtAttr()`function to set the values of environment attributes. The signature is:  .. code-block:: text     SQLRETURN SQLSetStmtAttr     (     SQLHENV *stmt_handle*, //Input     SQLINTEGER *attribute*, //Input     SQLPOINTER *value_pointer*, //Input     SQLINTEGER *string_length* //Input     );  *stmt_handle*  *stmt_handle* is the environment handle.`attribute``attribute`identifies the statement attribute whose value you wish to set.`value\_pointer``value_pointer`is a pointer to the location in memory that holds the value that will be assigned to the attribute.`value_pointer`can be a pointer to:  -  A null-terminated character string  -  A binary buffer  -  A value defined by the driver  -  A value of the type`SQLLEN`,`SQLULEN`or`SQLUSMALLINT`Value-pointer can also optionally hold one of the following values:  -  An ODBC descriptor handle  -  A`SQLUINTEGER`value  -  A`SQLULEN`value  -  A signed INTEGER (if attribute is a driver-specific value)`string_length`If`attribute`is defined by ODBC and`value_pointer`points to a binary buffer or character string,`string_length`is the length of`value_pointer`. If`value_pointer`points to an integer,`string_length`is ignored.  If EDB-ODBC defines the attribute, the application sets the`string_length`parameter. Possible`string_length`values are:  ====================== ============================================= Value Type             Meaning ====================== ============================================= Character string       The length of the character string or SQL_NTS Binary buffer          The result of SQL_LEN_BINARY_ATTR(length) Fixed length data type SQL_IS_INTEGER or SQL_IS_UINTEGER Any other type         SQL_IS_POINTER ====================== =============================================  .. raw:: latex      \newpage  Error Handling ==============  .. index:: Status and error data  Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC`SQLGetDiagRec()`function.  SQLGetDiagRec() ---------------  The`SQLGetDiagRec()`function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:  . code-block:: text     SQLRETURN SQLGetDiagRec(     SQLSMALLINT *handle_type*, // Input     SQLHANDLE *handle*, // Input     SQLSMALLINT *record_number*, // Input     SQLCHAR \*\ *SQLState_pointer*, // Output     SQLINTEGER \*\ *native_error_pointer*, // Output     SQLCHAR \*\ *error_text_pointer*, // Output     SQLSMALLINT *buffer_length*, // Input     SQLSMALLINT \*text_length_pointer // Output     );`handle_type`The handle type of the`handle`argument.`handle_type`must be one of the following:  -`SQL_HANDLE_ENV`specifies an environment handle.  -`SQL_HANDLE_STMT`specifies a statement handle.  -`SQL_HANDLE_DBC`specifies a connection handle.  -`SQL_HANDLE_DESC`specifies a descriptor handle.`handle`The handle associated with the attribute error message.`record_number`The status record that the application is seeking information from (must be greater than or equal to 1).`SQLState_pointer`Pointer to a memory buffer that receives the`SQLState`error code from the record.`native_error_pointer`Pointer to a buffer that receives the native error message for the data source (contained in the`SQL_DIAG_NATIVE`field).`error_text_pointer`Pointer to a memory buffer that receives the error text (contained in the`SQL_DIAG_MESSAGE_TEXT`field)`buffer_length`The length of the`error_text`buffer.`text_length_pointer`Pointer to the buffer that receives the size (in characters) of the`error_text_pointer`field. If the number of characters in the`error_text_pointer`parameter exceeds the number available (in`buffer_length`),`error_text_pointer`will be truncated.`SQLGetDiagRec()`returns`SQL_SUCCESS`,`SQL_ERROR`,`SQL_INVALID_HANDLE`,`SQL_SUCCESS_WITH_DATA`or`SQL_NO_DATA`.  .. raw:: latex      \newpage  Supported ODBC API Functions ============================  .. index:: ODBC API functions  The following table lists the ODBC API functions; the right column specifies`Yes`if the API is supported by the EDB-ODBC driver. Use the ODBC`SQLGetFunctions()`function (specifying a function ID of`SQL_API_ODBC3_ALL_FUNCTIONS\`\`) to return a current version of this list.
+A pointer to a `SQLINTEGER` that receives the number of bytes available to return in `value_pointer`. If `value_pointer` is NULL, `string_length_pointer` is not returned.
+
+This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO` , `SQL_NO_DATA`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+The following table lists the environment attributes supported by EDB-ODBC. 
+
+| Attribute                   | Supported?                          | Restrictions?                       |
+| --------------------------- | ----------------------------------- | ----------------------------------- |
+|                             |                                     |                                     |
+| SQL_ATTR_CONNECTION_POOLING | SQL_CP_ONE_PER_DRIVER or SQL_CP_OFF | Determined by connection properties |
+| SQL_ATTR_ODBC_VERSION       | (SQL_OV_ODBC3)                      |                                     |
+
+(SQL_OV_ODBC2)        | NONE                                |
+| SQL_ATTR_OUTPUT_NTS         | SQL_SUCCESS                              | NONE                                |
+
+## SQLSetEnvAttr()
+
+You can use the `SQLSetEnvAttr()` function to set the values of environment attributes. The signature of the function is:
+
+```c++
+SQLRETURN SQLSetEnvAttr
+(
+    SQLHENV  env_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `env_handle` The environment handle.
+-   `attribute` identifies the attribute whose value you wish to set.
+-   `value_pointer` A pointer to the value assigned to the `attribute`. 
+-   The value will be a `NULL` terminated character string or a 32 bit integer value depending on the specified `attribute`.
+-   `string_length` If `value_pointer` is a pointer to a binary buffer or character string,`string\_length` is the length of `value_pointer`. If the value being assigned to the attribute is a character, `string_length` is the length of that character string. If `value_pointer` is NULL, `string_length` is not returned. If value_pointer is an integer,`string_length`is ignored. 
+
+`SQLSetEnvAttr()` returns `SQL_SUCCESS`, `SQL_INVALID_HANDLE`, `SQL_ERROR` or `SQL_SUCCESS_WITH_INFO`.  The application must call `SQLSetEnvAttr()` before allocating a connection handle; all values applied to environment attributes will persist until `SQLFreeHandle()` is called for the connection. ODBC version 3.x allows you to allocate multiple environment handles simultaneously. 
+
+The following table lists the environment attributes you can set with `SQLSetAttr()`.   
+
+| Attribute             | Value_pointer type | Restrictions?                                                                                                              |
+| --------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| SQL_ATTR_ODBC_VERSION | 32 bit Integer     | Set this attribute before the application calls any function that includes an SQLHENV argument.                            |
+| SQL_ATTR_OUTPUT_NTS   | 32-bit Integer     | Defaults to SQL_TRUE. Calls that set this attribute to SQL_FALSE return SQL_ERROR/SQLSTATEHYC00 (feature not implemented). |
+
+## Statement Attributes
+
+You can use the ODBC `SQLGetStmtAttr()` and `SQLSetStmtAttr()`functions to retrieve and set the value of a statement attribute.  
+
+### SQLGetStmtAttr()
+
+The `SQLGetStmtAttr()` function returns the current value of statement attribute. The signature is:
+
+```c++
+SQLRETURN SQLGetConnectAttr
+(
+    SQLHDBC  stmt_handle,  //Input
+    SQLINTEGER  attribute,  //Input
+    SQLPOINTER  value_ptr,  //Output
+    SQLINTEGER  buffer_length,  //Input
+    SQLINTEGER *  string_length_pointer  //Output
+);
+```
+
+-   `stmt_handle` The statement handle 
+
+-   `attribute` is the attribute value
+
+-   `value_pointer` A pointer to the location in memory that will receive the `attribute` value.
+
+-   `buffer_length` If the attribute is defined by ODBC, `buffer_length` is the length of `value_pointer` (if `value_pointer` points to a character string or binary buffer).  If `value_pointer` points to an integer, `buffer_length` is ignored. 
+
+      If EDB-ODBC defines the attribute, the application sets the `buffer_length` parameter. `buffer_length`can be:
+
+    | Value Type             | Meaning                                   |
+    | ---------------------- | ----------------------------------------- |
+    |                        |                                           |
+    | Character string       | The length of the character string        |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length) |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER         |
+    | Any other type         | SQL_IS_POINTER                            |
+
+-   `string_length_pointer` A pointer to an `SQLINTEGER` that receives the number of bytes required to hold the requested value. If `value_pointer` is NULL, `string_length_pointer` is not returned.  
+
+      This function returns `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_ERROR` or `SQL_INVALID_HANDLE`.
+
+    | Attribute                      | Supported? | Restrictions?           |
+    | ------------------------------ | ---------- | ----------------------- |
+    |                                |            |                         |
+    | SQL_ATTR_APP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_APP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_ASYNC_ENABLE          | NO         |                         |
+    | SQL_ATTR_CONCURRENCY           | YES        | SQL_CONCUR_READ_ONLY    |
+    | SQL_ATTR_CURSOR_SCROLLABLE     | YES        |                         |
+    | SQL_ATTR_CURSOR_TYPE           | YES        | SQL_CURSOR_FORWARD_ONLY |
+    | SQL_ATTR_CURSOR_SENSITIVITY    | YES        | SQL_INSENSITIVE         |
+    | SQL_ATTR_ENABLE_AUTO_IPD       | NO         |                         |
+    | SQL_ATTR_FETCH_BOOKMARK_PTR    | YES        |                         |
+    | SQL_ATTR_IMP_PARAM_DESC        | YES        |                         |
+    | SQL_ATTR_IMP_ROW_DESC          | YES        |                         |
+    | SQL_ATTR_KEYSET_SIZE           | NO         |                         |
+    | SQL_ATTR_MAX_LENGTH            | NO         |                         |
+    | SQL_ATTR_MAX_ROWS              | NO         |                         |
+    | SQL_ATTR_METADATA_ID           | YES        |                         |
+    | SQL_ATTR_NOSCAN                | NO         |                         |
+    | SQL_ATTR_PARAM_BIND_OFFSET_PTR | YES        | ODBC V2.0               |
+    | SQL_ATTR_PARAM_BIND_TYPE       | YES        |                         |
+    | SQL_ATTR_PARAM_OPERATION_PTR   | YES        |                         |
+    | SQL_ATTR_PARAM_STATUS_PTR      | YES        |                         |
+    | SQL_ATTR_PARAMS_PROCESSED_PTR  | YES        |                         |
+    | SQL_ATTR_PARAMSET_SIZE         | YES        |                         |
+    | SQL_ATTR_QUERY_TIMEOUT         | NO         |                         |
+    | SQL_ATTR_RETRIEVE_DATA         | NO         |                         |
+    | SQL_ATTR_ROW_BIND_OFFSET_PTR   | YES        |                         |
+    | SQL_ATTR_ROW_BIND_TYPE         | NO         |                         |
+    | SQL_ATTR_ROW_NUMBER            | YES        |                         |
+    | SQL_ATTR_ROW_OPERATION_PTR     | YES        |                         |
+    | SQL_ATTR_ROW_STATUS_PTR        | YES        |                         |
+    | SQL_ATTR_ROWS_FETCHED_PTR      | YES        |                         |
+    | SQL_ATTR_ROW_ARRAY_SIZE        | YES        |                         |
+    | SQL_ATTR_SIMULATE_CURSOR       | NO         |                         |
+    | SQL_ATTR_USE_BOOKMARKS         | YES        |                         |
+    | SQL_ROWSET_SIZE                | YES        |                         |
+
+### SQLSetStmtAttr()
+
+You can use the `SQLSetStmtAttr()` function to set the values of environment attributes. The signature is:
+
+```c++
+SQLRETURN SQLSetStmtAttr
+(
+    SQLHENV  stmt_handle , //Input
+    SQLINTEGER  attribute , //Input
+    SQLPOINTER  value_pointer , //Input
+    SQLINTEGER  string_length  //Input
+);
+```
+
+-   `stmt_handle` is the environment handle.
+
+-   `attribute` identifies the statement attribute whose value you wish to set.
+
+-   `value_pointer` is a pointer to the location in memory that holds the value that will be assigned to the attribute. `value_pointer`can be a pointer to:
+
+    -   A null-terminated character string  
+    -   A binary buffer  
+    -   A value defined by the driver  
+    -   A value of the type `SQLLEN`, `SQLULEN` or `SQLUSMALLINT` 
+
+        Value-pointer can also optionally hold one of the following values:  
+    -   An ODBC descriptor handle  
+    -   A `SQLUINTEGER` value  
+    -   A `SQLULEN` value  
+    -   A signed INTEGER (if attribute is a driver-specific value)
+
+-   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
+      If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
+    | Value Type             | Meaning                                       |
+    | ---------------------- | --------------------------------------------- |
+    |                        |                                               |
+    | Character string       | The length of the character string or SQL_NTS |
+    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+    | Any other type         | SQL_IS_POINTER                                |
+
+## Error Handling
+
+Diagnostic information for the ODBC functions mentioned in this guide can be retrieved via the ODBC `SQLGetDiagRec()` function.  
+
+### SQLGetDiagRec()
+
+ The `SQLGetDiagRec()` function returns status and error information from a diagnostic record written by the ODBC functions that retrieve or set attribute values. The signature is:
+
+```c++
+SQLRETURN SQLGetDiagRec
+(
+    SQLSMALLINT handle_type, // Input
+    SQLHANDLE handle, // Input
+    SQLSMALLINT record_number, // Input
+    SQLCHAR *SQLState_pointer, // Output
+    SQLINTEGER *native_error_pointer, // Output
+    SQLCHAR *error_text_pointer, // Output
+    SQLSMALLINT buffer_length, // Input
+    SQLSMALLINT *text_length_pointer // Output
+);
+```
+
+-   `handle_type` The handle type of the `handle` argument. `handle_type`must be one of the following:  
+
+    -   `SQL_HANDLE_ENV` specifies an environment handle. 
+    -   `SQL_HANDLE_STMT` specifies a statement handle.  
+    -   `SQL_HANDLE_DBC` specifies a connection handle.
+    -   `SQL_HANDLE_DESC` specifies a descriptor handle.
+
+-   `handle` The handle associated with the attribute error message.
+
+-   `record_number` The status record that the application is seeking information from (must be greater than or equal to 1).
+
+-   `SQLState_pointer` Pointer to a memory buffer that receives the `SQLState` error code from the record. 
+
+-   `native_error_pointer` Pointer to a buffer that receives the native error message for the data source (contained in the `SQL_DIAG_NATIVE` field).
+
+-   `error_text_pointer` Pointer to a memory buffer that receives the error text (contained in the `SQL_DIAG_MESSAGE_TEXT` field) 
+
+-   `buffer_length` The length of the `error_text` buffer.
+
+-   `text_length_pointer` Pointer to the buffer that receives the size (in characters) of the `error_text_pointer` field. If the number of characters in the `error_text_pointer` parameter exceeds the number available (in `buffer_length`), `error_text_pointer` will be truncated.
+
+`SQLGetDiagRec()` returns `SQL_SUCCESS`, `SQL_ERROR`, `SQL_INVALID_HANDLE`, `SQL_SUCCESS_WITH_DATA` or `SQL_NO_DATA`.
+
+## Supported ODBC API Functions
+
+The following table lists the ODBC API functions; the right column specifies `Yes` if the API is supported by the EDB-ODBC driver. Use the ODBC `SQLGetFunctions()` function (specifying a function ID of `SQL_API_ODBC3_ALL_FUNCTIONS`) to return a current version of this list.
 
 | ODBC API Function Name | Supported by EDB-ODBC? |
 | ---------------------- | ---------------------- |

--- a/product_docs/docs/odbc_connector/12.2.0.2/06_edb-odbc_driver_functionality.mdx
+++ b/product_docs/docs/odbc_connector/12.2.0.2/06_edb-odbc_driver_functionality.mdx
@@ -583,13 +583,14 @@ SQLRETURN SQLSetStmtAttr
 
 -   `string_length` If `attribute` is defined by ODBC and `value_pointer` points to a binary buffer or character string, `string_length` is the length of `value_pointer`. If `value_pointer` points to an integer, `string_length` is ignored. 
       If EDB-ODBC defines the attribute, the application sets the `string_length` parameter. Possible `string_length` values are:
-    | Value Type             | Meaning                                       |
-    | ---------------------- | --------------------------------------------- |
-    |                        |                                               |
-    | Character string       | The length of the character string or SQL_NTS |
-    | Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
-    | Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
-    | Any other type         | SQL_IS_POINTER                                |
+
+| Value Type             | Meaning                                       |
+| ---------------------- | --------------------------------------------- |
+|                        |                                               |
+| Character string       | The length of the character string or SQL_NTS |
+| Binary buffer          | The result of SQL_LEN_BINARY_ATTR(length)     |
+| Fixed length data type | SQL_IS_INTEGER or SQL_IS_UINTEGER             |
+| Any other type         | SQL_IS_POINTER                                |
 
 ## Error Handling
 

--- a/product_docs/docs/pem/7.10/pem_ent_feat/04_performance_monitoring_and_management.mdx
+++ b/product_docs/docs/pem/7.10/pem_ent_feat/04_performance_monitoring_and_management.mdx
@@ -621,7 +621,7 @@ Use the fields on the `Probe Dependency` tab to specify the names of probes refe
 
 ![*The SQL tab of the Alert Templates dialog*](images/alert_template_sql.png)
 
-Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
+Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param\_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
 
 The query can also include the following pre-defined variables:
 

--- a/product_docs/docs/pem/7.11/pem_ent_feat/04_performance_monitoring_and_management.mdx
+++ b/product_docs/docs/pem/7.11/pem_ent_feat/04_performance_monitoring_and_management.mdx
@@ -621,7 +621,7 @@ Use the fields on the `Probe Dependency` tab to specify the names of probes refe
 
 ![*The SQL tab of the Alert Templates dialog*](images/alert_template_sql.png)
 
-Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
+Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param\_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
 
 The query can also include the following pre-defined variables:
 

--- a/product_docs/docs/pem/7.12/pem_ent_feat/04_performance_monitoring_and_management.mdx
+++ b/product_docs/docs/pem/7.12/pem_ent_feat/04_performance_monitoring_and_management.mdx
@@ -628,7 +628,7 @@ Use the fields on the `Probe Dependency` tab to specify the names of probes refe
 
 ![*The SQL tab of the Alert Templates dialog*](images/alert_template_sql.png)
 
-Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
+Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param\_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
 
 The query can also include the following pre-defined variables:
 

--- a/product_docs/docs/pem/7.13/pem_ent_feat/05_performance_monitoring_and_management.mdx
+++ b/product_docs/docs/pem/7.13/pem_ent_feat/05_performance_monitoring_and_management.mdx
@@ -626,7 +626,7 @@ Use the fields on the `Probe Dependency` tab to specify the names of probes refe
 
 ![*The SQL tab of the Alert Templates dialog*](images/alert_template_sql.png)
 
-Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
+Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param\_*x*, where *x* indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
 
 The query can also include the following pre-defined variables:
 

--- a/product_docs/docs/pem/7.15/pem_ent_feat/04_performance_monitoring_and_management.mdx
+++ b/product_docs/docs/pem/7.15/pem_ent_feat/04_performance_monitoring_and_management.mdx
@@ -1159,7 +1159,7 @@ Use the fields on the `Probe Dependency` tab to specify the names of probes refe
 
 > ![*The SQL tab of the Alert Templates dialog*](images/pem_alert_templates_sqltab.png)
 >
-> Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param_`x`, where `x` indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
+> Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param\_`x`, where `x` indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
 >
 > The query can also include the following pre-defined variables:
 >

--- a/product_docs/docs/pem/7.16/pem_ent_feat/04_performance_monitoring_and_management.mdx
+++ b/product_docs/docs/pem/7.16/pem_ent_feat/04_performance_monitoring_and_management.mdx
@@ -633,7 +633,7 @@ Use the fields on the `Probe Dependency` tab to specify the names of probes refe
 
 > ![The SQL tab of the Alert Templates dialog](../images/pem_alert_templates_sqltab.png)
 >
-> Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param_`x`, where `x` indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
+> Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param\_`x`, where `x` indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
 >
 > The query can also include the following pre-defined variables:
 >

--- a/product_docs/docs/pem/8.0/pem_ent_feat/04_performance_monitoring_and_management.mdx
+++ b/product_docs/docs/pem/8.0/pem_ent_feat/04_performance_monitoring_and_management.mdx
@@ -634,7 +634,7 @@ Use the fields on the `Probe Dependency` tab to specify the names of probes refe
 
 > ![The SQL tab of the Alert Templates dialog](../images/pem_alert_templates_sqltab.png)
 >
-> Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param_`x`, where `x` indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
+> Within the query, parameters defined on the `Parameters` tab should be referenced sequentially by the variable param\_`x`, where `x` indicates the position of the parameter definition within the parameter list. For example, param_1 refers to the first parameter in the parameter list, param_2 refers to the second parameter in the parameter list, and so on.
 >
 > The query can also include the following pre-defined variables:
 >

--- a/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/07_pem_postgres_expert/03_pe_configuration_expert_recommendations.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/07_pem_postgres_expert/03_pe_configuration_expert_recommendations.mdx
@@ -153,7 +153,7 @@ default_statistics_target indicates the level of detail that should be used in g
 | -------------- | -------------------------------- |
 | Rule           | Check planner methods is enabled |
 | Recommendation | Avoid disabling planner methods. |
-| Trigger        | any `enable_*` GUC is off    |
+| Trigger        | any `enable_*` GUC is off        |
 | Severity       | High                             |
 
 **Description:** The enable_bitmapscan, enable_hashagg, enable_hashjoin, enable_indexscan, enable_material, enable_mergejoin, enable_nestloop, enable_seqscan, enable_sort, and enable_tidscan parameters are intended primarily for debugging and should not be turned off. It can sometimes be helpful to disable one or more of these parameters for a particular query, when there is no other way to obtain the desired plan. However, none of these parameters should ever be turned off on a system-wide basis.

--- a/product_docs/docs/pem/8.0/pem_online_help/12_release_notes/04_pem_release_notes_7_14.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/12_release_notes/04_pem_release_notes_7_14.mdx
@@ -104,6 +104,6 @@ PEM-3323 - Fixed an issue where user was not able to change the email group from
 [Issue #5400](https://redmine.postgresql.org/issues/5400) - Fixed internal server error when the database server is logged in with non-super user.  
 [Issue #5401](https://redmine.postgresql.org/issues/5401) - Fixed search object issue when the object name contains special characters.  
 [Issue #5410](https://redmine.postgresql.org/issues/5410) - Fixed an issue while removing the package body showing wrong modified SQL.  
-[Issue #5441](https://redmine.postgresql.org/issues/5441) - Fixed an issue where the search object not able to locate pg\_toast_\* tables in the pg_toast schema.  
+[Issue #5441](https://redmine.postgresql.org/issues/5441) - Fixed an issue where the search object not able to locate pg_toast\_\* tables in the pg_toast schema.  
 [Issue #5415](https://redmine.postgresql.org/issues/5415) - Ensure that the query tool context menu should work on the collection nodes.  
 [Issue #5447](https://redmine.postgresql.org/issues/5447) - Fixed failed to fetch utility error when click on refresh(any option) materialized view.


### PR DESCRIPTION
This started as a search and replace for `.. code-block:: text` in response to @sheet20 's notes in #496 ... and then I realized that these old formatting codes were, in some cases at least, appearing because the formatting around them was trashed. The connectors pages in particular were... In rough shape. Even in the old docs system there were cases of [code stripped of whitespace and littered with extraneous characters](https://www.enterprisedb.com/edb-docs/d/edb-postgres-odbc-connector/user-guides/odbc-guide/12.2.0.2/edb-odbc_driver_functionality.html#sqlgetstmtattr), [unformatted](https://www.enterprisedb.com/edb-docs/d/edb-postgres-odbc-connector/user-guides/odbc-guide/12.2.0.2/edb-odbc_driver_functionality.html#sqlgetdiagrec) or [cluttered with misplaced formatting options](https://www.enterprisedb.com/edb-docs/d/jdbc-connector/user-guides/jdbc-guide/42.2.12.3/using_ref_cursors_with_java.html#using-a-ref-cursor-to-retrieve-a-resultset) - but these small errors multiplied during the import, making the result nearly unreadable.

I've gone through these and reformatted them significantly, comparing against the old system along the way to ensure that I was at least keeping the spirit of what was intended alive, even if I had to introduce significant changes in order to do so.

Fixes #496 
