### PR TITLE
Smarter titles

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -22,10 +22,12 @@ const Layout = ({
   katacodaPanelData,
   background = 'light',
 }) => {
-  const { baseUrl, imageUrl, title } = useSiteMetadata();
+  const { baseUrl, imageUrl, title: siteTitle } = useSiteMetadata();
   const meta = pageMeta || {};
   const url = meta.path ? baseUrl + meta.path : baseUrl;
   // console.log(url);
+
+  const title = meta.title ? `EDB Docs - ${meta.title}` : siteTitle;
 
   const [dark, setDark] = useState(false);
 
@@ -53,7 +55,7 @@ const Layout = ({
     >
       <Helmet>
         <html lang="en" className={`${dark && 'dark'}`} />
-        <title>{meta.title || title}</title>
+        <title>{title}</title>
         {meta.description && (
           <meta name="description" content={meta.description} />
         )}

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -201,7 +201,7 @@ const DocTemplate = ({ data, pageContext }) => {
   const sections =
     navOrder && depth === 4 ? convertOrderToObjects(navOrder, navLinks) : null;
   const pageMeta = {
-    title: frontmatter.title,
+    title: `${frontmatter.title} v${version}`,
     description: frontmatter.description,
     path: pagePath,
     isIndexPage: isIndexPage,


### PR DESCRIPTION
Addresses #777 

- Add 'EDB Docs - ' prefix to titles using Layout
- add version to end of doc.js titles

Every page should have `EDB Docs - ` prefixes in front of the title, except for the index page. Versioned product docs will add the version at the end

*pgBackrest stub page*
![Screen Shot 2021-01-28 at 4 01 22 PM](https://user-images.githubusercontent.com/2780987/106198862-94802180-6182-11eb-89a6-1c3e6887db19.png)

*Epas 13*
![Screen Shot 2021-01-28 at 3 59 13 PM](https://user-images.githubusercontent.com/2780987/106198873-9649e500-6182-11eb-8a3c-5c846ed1d7e7.png)
