### PR TITLE
Manually fix multiline notes that were lost

### DIFF
--- a/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
@@ -1231,9 +1231,9 @@ The restrictions on the target table of a direct path load are the following:
 !!! Note
     Currently, a direct path load in EDB\*Loader is more restrictive than in Oracle SQL\*Loader. The preceding restrictions do not apply to Oracle SQL\*Loader in most cases. The following restrictions apply to a control file used in a direct path load:
 
--   Multiple table loads are not supported. That is, only one `INTO TABLE` clause may be specified in the control file.
--   SQL expressions may not be used in the data field definitions of the `INTO TABLE` clause.
--   The `FREEZE` option is not supported for direct path loading.
+    -   Multiple table loads are not supported. That is, only one `INTO TABLE` clause may be specified in the control file.
+    -   SQL expressions may not be used in the data field definitions of the `INTO TABLE` clause.
+    -   The `FREEZE` option is not supported for direct path loading.
 
 To run a direct path load, add the `DIRECT=TRUE` option as shown by the following example:
 

--- a/product_docs/docs/epas/13/epas_compat_tools_guide/03_edb_wrap.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/03_edb_wrap.mdx
@@ -207,8 +207,8 @@ Be aware that audit logs produced by the Postgres server will show wrapped progr
 !!! Note
     At this time, the bodies of the objects created by the following statements will not be stored in obfuscated form:
 
-```text
-CREATE [OR REPLACE] TYPE type_name AS OBJECT
-CREATE [OR REPLACE] TYPE type_name UNDER type_name
-CREATE [OR REPLACE] TYPE BODY type_name
-```
+     ```text
+     CREATE [OR REPLACE] TYPE type_name AS OBJECT
+     CREATE [OR REPLACE] TYPE type_name UNDER type_name
+     CREATE [OR REPLACE] TYPE BODY type_name
+     ```

--- a/product_docs/docs/jdbc_connector/42.2.12.3/09_security_and_encryption/01_using_ssl/01_configuring_the_server.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.12.3/09_security_and_encryption/01_using_ssl/01_configuring_the_server.mdx
@@ -11,11 +11,11 @@ For information about configuring PostgreSQL or Advanced Server for SSL, refer t
 !!! Note
     Before you access your SSL enabled server from Java, ensure that you can log in to your server via `edb-psql`. The sample output should look similar to the one shown below if you have established a SSL connection:
 
-```text
-$ ./bin/edb-psql -U enterprisedb -d edb
-psql.bin (12.0.1)
-SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
-Type "help" for help.
+    ```text
+    $ ./bin/edb-psql -U enterprisedb -d edb
+    psql.bin (12.0.1)
+    SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
+    Type "help" for help.
 
-edb=#
-```
+    edb=#
+    ```

--- a/product_docs/docs/pem/8.0/pem_upgrade/01_upgrading_pem_installation/04_upgrading_pem_installation_linux_graphical.mdx
+++ b/product_docs/docs/pem/8.0/pem_upgrade/01_upgrading_pem_installation/04_upgrading_pem_installation_linux_graphical.mdx
@@ -56,10 +56,10 @@ The default installation location for the PEM Agent when installed by the graphi
     !!! Note
         You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
 
-    If you are a Red Hat Network user,
+        If you are a Red Hat Network user,
 
-    -   You must also enable the `rhel-<x>-server-optional-rpms` repository to use EPEL packages, where *x* specifies the version of RHEL on the host. You can make the repository accessible by enabling the `RHEL optional subchannel` for `RHN-Classic`. If you have a certificate-based subscription, then you must also enable `rhel-<x>-server-eus-optional-rpms` repository to use EPEL packages or please see the `Red Hat Subscription Management Guide` for the required repository.
-    -   You must also enable the `rhel-<x>-server-extras-rpms` repository, where `x` specifies the version of the RHEL on the host.
+        -   You must also enable the `rhel-<x>-server-optional-rpms` repository to use EPEL packages, where *x* specifies the version of RHEL on the host. You can make the repository accessible by enabling the `RHEL optional subchannel` for `RHN-Classic`. If you have a certificate-based subscription, then you must also enable `rhel-<x>-server-eus-optional-rpms` repository to use EPEL packages or please see the `Red Hat Subscription Management Guide` for the required repository.
+        -   You must also enable the `rhel-<x>-server-extras-rpms` repository, where `x` specifies the version of the RHEL on the host.
 
 
 3.  Install and configure the `edb.repo` file:


### PR DESCRIPTION
Some of these were manually converted in ways that lost the encapsulation, making them kinda incongruous