### PR TITLE
DF-212 Removed 9.5 reference from v13 guides

### DIFF
--- a/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
@@ -30,7 +30,7 @@ These features are explained in detail in the following sections.
     psycopg2 copy_from
     ```
 
--   Use of a version 13, 12, 11, 10, 9.6, or 9.5 EDB\*Loader client is not supported for Advanced Server with version 9.2 or earlier.
+-   Use of a version 13, 12, 11, 10, or 9.6 EDB\*Loader client is not supported for Advanced Server with version 9.2 or earlier.
 
 <div id="data_loading_methods" class="registered_link"></div>
 

--- a/product_docs/docs/epas/13/epas_guide/03_database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/01_top_performance_related_parameters/05_checkpoint_segments.mdx
+++ b/product_docs/docs/epas/13/epas_guide/03_database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/01_top_performance_related_parameters/05_checkpoint_segments.mdx
@@ -4,4 +4,4 @@ title: "checkpoint_segments"
 
 <div id="checkpoint_segments" class="registered_link"></div>
 
-Now deprecated; this parameter is not supported by server versions 9.5 or later.
+Now deprecated; this parameter is not supported by Advanced Server. 

--- a/product_docs/docs/epas/13/epas_upgrade_guide/04_upgrading_an_installation_with_pg_upgrade/01_performing_an_upgrade/index.mdx
+++ b/product_docs/docs/epas/13/epas_upgrade_guide/04_upgrading_an_installation_with_pg_upgrade/01_performing_an_upgrade/index.mdx
@@ -18,7 +18,7 @@ After extracting the metadata from the old cluster, `pg_upgrade` performs the bo
 
 `pg_upgrade` runs the `pg_dumpall` script against the new cluster to create (empty) database objects of the same shape and type as those found in the old cluster. Then, `pg_upgrade` links or copies each table and index from the old cluster to the new cluster.
 
-If you are upgrading from a version of Advanced Server prior to 9.5 to Advanced Server 13 and have installed the `edb_dblink_oci` or `edb_dblink_libpq` extension, you must drop the extension before performing an upgrade. To drop the extension, connect to the server with the psql or PEM client, and invoke the commands:
+If you are upgrading to Advanced Server 13 and have installed the `edb_dblink_oci` or `edb_dblink_libpq` extension, you must drop the extension before performing an upgrade. To drop the extension, connect to the server with the psql or PEM client, and invoke the commands:
 
 ```text
 DROP EXTENSION edb_dblink_oci;

--- a/product_docs/docs/epas/13/epas_upgrade_guide/04_upgrading_an_installation_with_pg_upgrade/03_upgrading_to_advanced_server.mdx
+++ b/product_docs/docs/epas/13/epas_upgrade_guide/04_upgrading_an_installation_with_pg_upgrade/03_upgrading_to_advanced_server.mdx
@@ -22,7 +22,7 @@ The easiest way to empty the target database is to drop the database and then cr
 
 On Windows, navigate through the `Control Panel` to the `Services` manager; highlight each service in the `Services` list, and select `Stop`.
 
-On Linux, open a terminal window, assume superuser privileges, and manually stop each service; for example, if you are on Linux 6.x, invoke the following command to stop the pgAgent service:
+On Linux, open a terminal window, assume superuser privileges, and manually stop each service; for example, invoke the following command to stop the pgAgent service:
 
 ```text
 service edb-pgagent-13 stop
@@ -50,7 +50,7 @@ You must allow trust authentication for the previous Advanced Server installatio
 
 ![Configuring Advanced Server to use trust authentication.](../images/configuring_advanced_server_to_use_trust_authentication.png)
 
-Fig. 1: *Configuring Advanced Server to use trust authentication.*
+Fig. 1: *Configuring Advanced Server to use trust authentication*
 
 After editing each file, save the file and exit the editor.
 
@@ -66,46 +66,20 @@ The services that are most likely to be running in your installation are:
 
 | **Service:**                                   | **On Linux:**                          | **On Windows:**                                            |
 | ---------------------------------------------- | -------------------------------------- | ---------------------------------------------------------- |
-| Postgres Plus Advanced Server 9.0              | ppas-9.0                               | ppas-9.0                                                   |
-| Postgres Plus Advanced Server 9.1              | ppas-9.1                               | ppas-9.1                                                   |
-| Postgres Plus Advanced Server 9.2              | ppas-9.2                               | ppas-9.2                                                   |
-| Postgres Plus Advanced Server 9.3              | ppas-9.3                               | ppas-9.3                                                   |
-| Postgres Plus Advanced Server 9.4              | ppas-9.4                               | ppas-9.4                                                   |
-| Postgres Plus Advanced Server 9.5              | ppas-9.5                               | ppas-9.5                                                   |
 | EnterpriseDB Postgres Advanced Server 9.6      | edb-as-9.6                             | edb-as-9.6                                                 |
 | EnterpriseDB Postgres Advanced Server 10       | edb-as-10                              | edb-as-10                                                  |
 | EnterpriseDB Postgres Advanced Server 11       | edb-as-11                              | edb-as-11                                                  |
 | EnterpriseDB Postgres Advanced Server 12       | edb-as-12                              | edb-as-12                                                  |
 | EnterpriseDB Postgres Advanced Server 13       | edb-as-13                              | edb-as-13                                                  |
-| Advanced Server 9.0 Scheduling Agent           | ppasAgent-90                           | Postgres Plus Advanced Server 90 Scheduling Agent          |
-| Advanced Server 9.1 Scheduling Agent           | ppasAgent-91                           | Postgres Plus Advanced Server 91 Scheduling Agent          |
-| Advanced Server 9.2 Scheduling Agent           | ppas-agent-9.2                         | Postgres Plus Advanced Server 9.2 Scheduling Agent         |
-| Advanced Server 9.3 Scheduling Agent           | ppas-agent-9.3                         | Postgres Plus Advanced Server 9.3 Scheduling Agent         |
-| Advanced Server 9.4 Scheduling Agent           | ppas-agent-9.4                         | Postgres Plus Advanced Server 9.4 Scheduling Agent         |
-| Advanced Server 9.5 Scheduling Agent           | ppas-agent-9.5                         | Postgres Plus Advanced Server 9.5 Scheduling Agent         |
 | Advanced Server 9.6 Scheduling Agent (pgAgent) | edb-pgagent-9.6                        | EnterpriseDB Postgres Advanced Server 9.6 Scheduling Agent |
-| Infinite Cache 9.2                             | ppas-infinitecache-9.2                 | N/A                                                        |
-| Infinite Cache 9.3                             | ppas-infinitecache-9.3                 | N/A                                                        |
-| Infinite Cache 9.4                             | ppas-infinitecache                     | N/A                                                        |
-| Infinite Cache 9.5                             | ppas-infinitecache                     | N/A                                                        |
 | Infinite Cache 9.6                             | edb-icache                             | N/A                                                        |
 | Infinite Cache 10                              | edb-icache                             | N/A                                                        |
-| PgBouncer 9.0                                  | pgbouncer-90                           | pgbouncer-90                                               |
-| PgBouncer 9.1                                  | pgbouncer-91                           | pgbouncer-91                                               |
-| PgBouncer 9.2                                  | pgbouncer-9.2                          | pgbouncer-9.2                                              |
-| PgBouncer 9.3                                  | pgbouncer-9.3                          | pgbouncer-9.3                                              |
 | PgBouncer                                      | Pgbouncer                              | Pgbouncer                                                  |
 | PgBouncer 1.6                                  | ppas-pgbouncer-1.6 or ppas-pgbouncer16 | ppas-pgbouncer-1.6                                         |
 | PgBouncer 1.7                                  | edb-pgbouncer-1.7                      | edb-pgbouncer-1.7                                          |
-| PgPool 9.2                                     | ppas-pgpool-9.2                        | N/A                                                        |
-| PgPool 9.3                                     | ppas-pgpool-9.3                        | N/A                                                        |
 | PgPool                                         | ppas-pgpool                            | N/A                                                        |
 | PgPool 3.4                                     | ppas-pgpool-3.4 or ppas-pgpool34       | N/A                                                        |
 | pgPool-II                                      | edb-pgpool-3.5                         | N/A                                                        |
-| Slony 9.2                                      | ppas-replication-9.2                   | ppas-replication-9.2                                       |
-| Slony 9.3                                      | ppas-replication-9.3                   | ppas-replication-9.3                                       |
-| Slony 9.4                                      | ppas-replication-9.4                   | ppas-replication-9.4                                       |
-| Slony 9.5                                      | ppas-replication-9.5                   | ppas-replication-9.5                                       |
 | Slony 9.6                                      | edb-slony-replication-9.6              | edb-slony-replication-9.6                                  |
 | xDB Publication Server 9.0                     | edb-xdbpubserver-90                    | Publication Service 90                                     |
 | xDB Publication Server 9.1                     | edb-xdbpubserver-91                    | Publication Service 91                                     |

--- a/product_docs/docs/epas/13/epas_upgrade_guide/07_migration.mdx
+++ b/product_docs/docs/epas/13/epas_upgrade_guide/07_migration.mdx
@@ -57,8 +57,8 @@ Version 13 contains a number of changes that may affect compatibility with previ
 
 -   The `SELECT DISTINCT...ORDER BY` clause of the `SELECT DISTINCT` query behavior differs after upgrade.
 
-    If `SELECT DISTINCT` is specified or if a `SELECT` statement includes the `SELECT DISTINCT …ORDER BY` clause then all the expressions in `ORDER BY` must be present in the select list of the `SELECT DISTINCT` query (applicable when upgrading from version 9.5 or 9.6 to any higher version of Advanced Server).
+    If `SELECT DISTINCT` is specified or if a `SELECT` statement includes the `SELECT DISTINCT …ORDER BY` clause then all the expressions in `ORDER BY` must be present in the select list of the `SELECT DISTINCT` query (applicable when upgrading from version 9.6 to any higher version of Advanced Server).
 
--   All objects depending on collation must be rebuilt using `pg_upgrade` to migrate from earlier versions (12, 11, 10, 9.6, 9.5) using ICU to the latest Advanced Server version.
+-   All objects depending on collation must be rebuilt using `pg_upgrade` to migrate from earlier versions (12, 11, 10, 9.6) using ICU to the latest Advanced Server version.
 
     A change in collation definitions can lead to corrupt indexes and other problems because the database system relies on stored objects having a certain sort order. Generally, this should be avoided, but it can happen in legitimate circumstances, such as when using `pg_upgrade` to upgrade to server binaries linked with a newer version of ICU. When this happens, all objects depending on the collation should be rebuilt, for example, using `REINDEX`. When that is done, the collation version can be refreshed using the command `ALTER COLLATION ... REFRESH VERSION`. This will update the system catalog to record the current collator version and will make the warning go away. Note that this does not actually check whether all affected objects have been rebuilt correctly.


### PR DESCRIPTION
DF-212: Removed the 9.5 reference from v13 guides as 9.5 support ended in Jan 2021. Pls merge these changes, will verify it on staging