### PR TITLE
Card deck enhancements: Frontmatter-configurable rendering, sort order

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -83,6 +83,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             iconName
             originalFilePath
             productStub
+            indexMode
             katacodaPages {
               scenario
               account
@@ -390,6 +391,13 @@ exports.createSchemaCustomization = ({ actions }) => {
 
     type Frontmatter {
       originalFilePath: String
+      indexMode: TileModes
+    }
+
+    enum TileModes {
+      none
+      simple
+      full
     }
   `;
   createTypes(typeDefs);

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -83,7 +83,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             iconName
             originalFilePath
             productStub
-            indexMode
+            indexCards
             katacodaPages {
               scenario
               account
@@ -100,6 +100,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           fields {
             docType
             path
+            depth
             product
             version
             topic
@@ -391,7 +392,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
     type Frontmatter {
       originalFilePath: String
-      indexMode: TileModes
+      indexCards: TileModes
     }
 
     enum TileModes {

--- a/src/components/card-decks.js
+++ b/src/components/card-decks.js
@@ -11,8 +11,9 @@ const FullCard = ({ card }) => {
       <Link to={card.fields.path}>
         <Icon
           iconName={iconName}
-          className={`${iconName === iconNames.DOTTED_BOX &&
-            'opacity-1'} mt-3 ml-3`}
+          className={`${
+            iconName === iconNames.DOTTED_BOX && 'opacity-1'
+          } mt-3 ml-3`}
           width="100"
           height="100"
         />
@@ -26,7 +27,7 @@ const FullCard = ({ card }) => {
 
         <p className="card-text">{card.frontmatter.description}</p>
 
-        {card.children.map(child => (
+        {card.children.map((child) => (
           <Link
             key={child.fields.path}
             to={child.fields.path}
@@ -54,12 +55,16 @@ const SimpleCard = ({ card }) => (
   </div>
 );
 
-const CardDecks = ({ cards, colSize = 4, cardType = 'simple' }) => {
+const CardDecks = ({ cards, cardType = 'simple' }) => {
   return (
     <div className="card-deck row no-gutters">
-      {cards.map(card => {
+      {cards.map((card) => {
         return (
-          <Col key={card.fields.path} md={colSize} className="d-flex">
+          <Col
+            key={card.fields.path}
+            md={cardType === 'full' ? 6 : 4}
+            className="d-flex"
+          >
             {cardType === 'full' ? (
               <FullCard card={card} />
             ) : (


### PR DESCRIPTION
There are two rendering modes for the "card deck" index generated for pages in the advo section: simple and full, with the latter being used ONLY when exactly 4 directories deep. Three if you count not rendering one at all if less than 4 levels deep in the directory hierarchy. This is... A pain to remember. 

Also, the card decks ignore the sort order used in the sidebar.

Both of these keep tripping me up, so this PR attempts to fix them both.

1. Add an optional `indexMode` key to frontmatter, with 3 possible values: "none", "simple", "full". If omitted, current "guess based on depth" behavior remains; if specified, then:

	- none == no card deck
	- simple == card deck without icons or children
	- full == card deck with icons and children (if any)

2. Sort the things!

Combined, these provide a lot more control over and utility for index appearance.

![before](https://user-images.githubusercontent.com/63653723/107994382-c0304380-6f99-11eb-8468-26e238781c57.png)

![after](https://user-images.githubusercontent.com/63653723/107994417-cde5c900-6f99-11eb-87d0-5f0132c189ff.png)

