### PR TITLE
aim for saner breaks on card decks

### DIFF
--- a/src/components/card-decks.js
+++ b/src/components/card-decks.js
@@ -62,7 +62,9 @@ const CardDecks = ({ cards, cardType = 'simple' }) => {
         return (
           <Col
             key={card.fields.path}
-            md={cardType === 'full' ? 6 : 4}
+            md={12}
+            lg={6}
+            xl={cardType === 'simple' && 4}
             className="d-flex"
           >
             {cardType === 'full' ? (


### PR DESCRIPTION
Eh, @cero-miedo mind weighing in on this? I'd just copied the existing breaks in #935 but... Didn't bother to check if they made sense. When I did, I noticed stuff like this:

![3 unreadable columns](https://user-images.githubusercontent.com/63653723/108135836-0d81e300-7076-11eb-9eb4-a0a040bbb84a.png)

That's at a 1024px window size (Chrome, Windows 10) - kiiinda sketchy. Even at 1278 (half my larger screen) 3 columns is pushing it for longer words like "Recommended", but at least most of the text is readable. 

This PR specifies a couple of breaks for both simple and full cards to try & keep 'em readable as long as possible.

![card-breaks](https://user-images.githubusercontent.com/63653723/108136131-a6b0f980-7076-11eb-950a-979956e7b605.gif)
