### PR TITLE
slight copy adjustments on the index

### DIFF
--- a/advocacy_docs/supported-open-source/pgbackrest/index.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'pgBackRest Guide'
+title: 'pgBackRest'
 description: 'Introduction to pgBackRest, a reliable PostgreSQL backup & restore tool'
 product: 'pgBackRest'
 tags:
@@ -10,14 +10,12 @@ tags:
 indexCards: simple
 ---
 
-## Introduction
+pgBackRest is an easy-to-use backup and restore tool that aims to enable your organization to implement disaster recovery solutions for PostgreSQL databases. 
 
-_pgBackRest_ is an easy-to-use backup and restore tool that aims to enable your organization to implement disaster recovery solutions for _Postgres_ databases. Taking an online hot backup of _Postgres_ and restoring it is now as easy as it could be!
+!!! Note
+    Looking for pgBackRest documentation? Head over to [http://www.pgbackrest.org](http://www.pgbackrest.org)
 
-_pgBackRest_ [v2.32](https://github.com/pgbackrest/pgbackrest/releases/tag/release/2.32) is the current stable release. Release notes are on the [Releases](http://www.pgbackrest.org/release.html) page.
+pgBackRest [v2.32](https://github.com/pgbackrest/pgbackrest/releases/tag/release/2.32) is the current stable release. Release notes are on the [Releases](http://www.pgbackrest.org/release.html) page.
 
 EDB collaborates with the community on this open-source software. The packages provided in EDB repositories are technically equivalent to the packages provided by the **PostgreSQL** community. All of the use cases shown in this document are fully tested and supported by **EDB Postgres Advanced Server**.
 
-For more information about _pgBackRest_, including reference and usage information, please visit the [project site](http://www.pgbackrest.org).
-
-## In this guide


### PR DESCRIPTION
- Removed italics around mentions of pgBackRest (we don't italicize product names anywhere else)
- switched from "Postgres" to "PostgreSQL"
- put the link to the .org in a Markdown admonition (!!! Note...), per the new standard
- removed language in the intro about pgBackRest being "as easy as could be" as this is for users and not marketing per se