### PR TITLE
Change VersionDropdown to use Link instead of bootstrap Dropdown.Item

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -29,7 +29,7 @@ const isAbsoluteOrProtocolRelativeUrl = (url) => {
 };
 
 const hasNonMarkdownExtension = (url) => {
-  return url.match(/\.\w+$/) && !url.match(/\.mdx?$/);
+  return url.match(/\.[a-zA-Z]+$/) && !url.match(/\.mdx?$/);
 };
 
 const rewriteUrl = (url, pageUrl, pageIsIndex, pathPrefix) => {

--- a/src/components/version-dropdown.js
+++ b/src/components/version-dropdown.js
@@ -1,10 +1,18 @@
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
-import usePathPrefix from '../hooks/use-path-prefix';
+import { Link } from './';
+
+const DropdownItem = ({ to, active, children }) => (
+  <Link
+    to={to}
+    className={`dropdown-item ${active && 'active font-weight-bold'}`}
+  >
+    {children}
+  </Link>
+);
 
 const VersionDropdown = ({ versionArray, path }) => {
   const activeVersion = path.split('/')[2];
-  const pathPrefix = usePathPrefix();
 
   return (
     <Dropdown>
@@ -16,15 +24,14 @@ const VersionDropdown = ({ versionArray, path }) => {
       </Dropdown.Toggle>
 
       <Dropdown.Menu className="version-dropdown">
-        {versionArray.map(version => (
-          <Dropdown.Item
-            href={pathPrefix + version.url}
+        {versionArray.map((version) => (
+          <DropdownItem
+            to={version.url}
             key={version.url}
             active={activeVersion === version.version}
-            className={activeVersion === version.version && 'font-weight-bold'}
           >
             Version {version.version}
-          </Dropdown.Item>
+          </DropdownItem>
         ))}
       </Dropdown.Menu>
     </Dropdown>


### PR DESCRIPTION
Fixes https://github.com/EnterpriseDB/docs/issues/940

Also fixes a bug where paths ending in a version number with a decimal (`/epas/9.6` for example) would be built as `a` instead of `Link`, because `.6` would be detected as a file extension