### PR TITLE
Multi-page Barman tutorial (Single server, streaming)

### DIFF
--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Backup and Recovery: Single-Server Streaming"
+title: "Backup and Recovery: Single-Server Streaming with Barman"
 description: "A quick walk-through of Barman installation, configuration, and basic backup and restore operations"
-navTitle: "Tutorial: Single-Server Streaming"
+navTitle: "Demo: Single-Server Streaming"
 product: barman
 platform: ubuntu
 tags:

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
@@ -10,7 +10,7 @@ tags:
     - postgresql
     - streaming-replication
     - live-demo
-iconName: tutorial
+iconName: coffee
 directoryDefaults:
   prevNext: true
 ---

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
@@ -15,12 +15,11 @@ directoryDefaults:
   prevNext: true
 ---
 
-This tutorial provides a quick walk-through of setting up a backup and recovery scenario using a Barman server and a PostgreSQL server. It covers:
+This section demonstrates setting up a backup and recovery scenario using a Barman server and a PostgreSQL server. It covers:
 
 1. Configuring the database server to allow Barman to collect data via streaming replication
-2. Installing Barman on an Ubuntu system
-3. Configuring Barman for streaming replication
-4. Validating a Barman configuration
-5. Running a full backup
-6. Restoring a full backup
+2. Installing and configuring Barman for streaming replication and testing that configuration
+3. Running a full backup
+4. Restoring a full backup
 
+Each of these steps is interactive, with the prerequisites and results of the previous step captured in a Docker image. You can work through the entire scenario in order, or skip to the step that interests you.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Backup and Recovery: Single-Server Streaming with Barman"
-description: "A quick walk-through of Barman installation, configuration, and basic backup and restore operations"
+description: "A quick demonstration of Barman installation, configuration, and basic backup and restore operations"
 navTitle: "Demo: Single-Server Streaming"
 product: barman
 platform: ubuntu

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
@@ -1,0 +1,26 @@
+---
+title: "Backup and Recovery: Single-Server Streaming"
+description: "A quick walk-through of Barman installation, configuration, and basic backup and restore operations"
+navTitle: "Tutorial: Single-Server Streaming"
+product: barman
+platform: ubuntu
+tags:
+    - ubuntu
+    - barman
+    - postgresql
+    - streaming-replication
+    - live-demo
+iconName: tutorial
+directoryDefaults:
+  prevNext: true
+---
+
+This tutorial provides a quick walk-through of setting up a backup and recovery scenario using a Barman server and a PostgreSQL server. It covers:
+
+1. Configuring the database server to allow Barman to collect data via streaming replication
+2. Installing Barman on an Ubuntu system
+3. Configuring Barman for streaming replication
+4. Validating a Barman configuration
+5. Running a full backup
+6. Restoring a full backup
+

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -22,11 +22,11 @@ This is an interactive demonstration. You can follow along right in your browser
 <KatacodaPanel />
 
 !!! Note
-    The button above will load a Docker Compose application with two container images representing a 
-    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
-    and a backup server running Ubuntu.
-
-    You will see a `postgres@pg` prompt once the application has loaded; then you can follow the steps below.
+    The interactive demo loads a Docker Compose application with two container images representing a
+    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server for Barman.    
+    
+    Once you see a `postgres@pg` prompt, you can follow the steps below.
 
 We'll start by configuring the database itself to allow streaming replication. For this, we need two things:
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -1,0 +1,121 @@
+---
+title: "Backup and Recovery: Single-Server Streaming - Configuring PostgreSQL"
+description: "Configuring a PostgreSQL server for Barman streaming replication"
+navTitle: "Database Server Configuration"
+product: barman
+platform: ubuntu
+tags:
+    - ubuntu
+    - barman
+    - postgresql
+    - streaming-replication
+    - live-demo
+katacodaPanel:
+    scenario: ubuntu:2004
+    initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step01-db-setup/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it -u postgres pg /bin/bash
+    codelanguages: shell, sql, ini
+iconName: tutorial
+---
+
+This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+
+<KatacodaPanel />
+
+This example is based on a PostgreSQL 12 server running on Ubuntu with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded. 
+
+We'll start by configuring the database itself to allow streaming replication. For this, we need two things:
+
+1. A dedicated superuser for Barman to connect as
+2. A dedicated streaming user with the replication attribute and remote login permissions
+3. Free replication slots
+
+### User provisioning
+
+Let's call our dedicated backup user, "barman". We'll create it interactively via the [`createuser`](https://www.postgresql.org/docs/current/app-createuser.html) utility:
+
+```shell
+createuser --superuser --replication -P barman
+__OUTPUT__
+Enter password for new role: 
+Enter it again: 
+```
+
+Enter `example-password` when prompted (twice).
+
+!!! Note Make note of that password
+    We'll need to add it to the ~/.pgpass file on the backup server later!
+
+We're making this a superuser account, which will allow it full control of all databases on this server. **Be very careful** with superuser credentials! Anyone who can connect as a superuser account owns your data.
+
+Now we will create the streaming replication user, "streaming_barman". This doesn't need to be a superuser, but it does need the replication attribute:
+
+```shell
+createuser --replication -P streaming_barman
+__OUTPUT__
+Enter password for new role: 
+Enter it again: 
+```
+
+Enter `example-password` when prompted (twice).
+
+We'll also need to edit `pg_hba.conf` to allow the streaming user to connect from the backup server, by [explicitly allowing it to connect in replication mode](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html):
+
+```shell
+sed -i '$ a host   replication    streaming_barman   all md5' /var/lib/postgresql/data/pg_hba.conf
+cat /var/lib/postgresql/data/pg_hba.conf
+__OUTPUT__
+...
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+
+host all all all md5
+host   replication    streaming_barman   all md5
+```
+
+### Database settings for streaming
+
+We'll also need to make sure there are replication slots available, and that PostgreSQL will allow another sender to connect. We'll use psql to check the current settings:
+
+```shell
+psql -d pagila
+```
+
+```sql
+Show max_wal_senders;
+Show max_replication_slots;
+__OUTPUT__
+ max_wal_senders 
+-----------------
+ 10
+(1 row)
+
+ max_replication_slots 
+-----------------------
+ 10
+(1 row)
+```
+
+The default for both of these (for PostgreSQL 10 and above) is 10, so we're fine - but if we needed more (or if they'd been previously set to 0, thus [disabling replication](https://www.postgresql.org/docs/current/runtime-config-replication.html)) then we'd need to increase them.
+
+
+### Gazing fondly at data
+
+Before we end, let's query some data - this is what we're going to back up! 
+
+```sql
+select * from actor where last_name='KILMER';
+__OUTPUT__
+ actor_id | first_name | last_name |      last_update       
+----------+------------+-----------+------------------------
+       23 | SANDRA     | KILMER    | 2020-02-15 09:34:33+00
+       45 | REESE      | KILMER    | 2020-02-15 09:34:33+00
+       55 | FAY        | KILMER    | 2020-02-15 09:34:33+00
+      153 | MINNIE     | KILMER    | 2020-02-15 09:34:33+00
+      162 | OPRAH      | KILMER    | 2020-02-15 09:34:33+00
+(5 rows)
+```
+
+We'll verify later on that this can be restored reliably.
+
+Continue on with [Step #2: Backup Server Configuration](step02-backup-setup).

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -14,7 +14,7 @@ katacodaPanel:
     scenario: ubuntu:2004
     initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step01-db-setup/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it -u postgres pg /bin/bash
     codelanguages: shell, sql, ini
-iconName: tutorial
+iconName: coffee
 ---
 
 This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -21,7 +21,7 @@ This demo is interactive. You can follow along right in your browser, using Kata
 
 !!! Note
     When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
-    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `postgres@pg` prompt, you can follow the steps below.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -17,11 +17,16 @@ katacodaPanel:
 iconName: tutorial
 ---
 
-This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
 
 <KatacodaPanel />
 
-This example is based on a PostgreSQL 12 server running on Ubuntu with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded. 
+!!! Note
+    The button above will load a Docker Compose application with two container images representing a 
+    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server running Ubuntu.
+
+    You will see a `postgres@pg` prompt once the application has loaded; then you can follow the steps below.
 
 We'll start by configuring the database itself to allow streaming replication. For this, we need two things:
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -17,16 +17,16 @@ katacodaPanel:
 iconName: tutorial
 ---
 
-This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
-
-<KatacodaPanel />
+This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    The interactive demo loads a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
     PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `postgres@pg` prompt, you can follow the steps below.
+
+<KatacodaPanel />
 
 We'll start by configuring the database itself to allow streaming replication. For this, we need two things:
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -20,7 +20,7 @@ iconName: tutorial
 This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose environment with two container images representing a
     PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -14,7 +14,7 @@ katacodaPanel:
     scenario: ubuntu:2004
     initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step02-backup-setup/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it backup /bin/bash
     codelanguages: shell, sql, ini
-iconName: tutorial
+iconName: coffee
 ---
 
 In [the previous step](step01-db-setup), we configured the PostgreSQL server, creating users for Barman to connect and manage backups. In this step, we'll install and configure Barman on the backup server.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -30,13 +30,6 @@ This is an interactive demonstration. You can follow along right in your browser
     
     Once you see a `root@backup` prompt, you can follow the steps below.
 
-!!! Note
-    The button above will load a Docker Compose application with two container images representing a 
-    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
-    and a backup server running Ubuntu on which we'll install and run Barman.
-
-    You will see a `root@backup` prompt once the application has loaded; then you can follow the steps below.
-
 This walk-through uses an Ubuntu environment, so the first step is to configure the PostgreSQL repository ([details are on the PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt))
 
 1. Install prerequesite software

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -23,7 +23,7 @@ This demo is interactive. You can follow along right in your browser, using Kata
 
 !!! Note
     When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
-    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `root@backup` prompt, you can follow the steps below.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -19,9 +19,16 @@ iconName: tutorial
 
 In [the previous step](step01-db-setup), we configured the PostgreSQL server, creating users for Barman to connect and manage backups. In this step, we'll install and configure Barman on the backup server.
 
-This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
 
 <KatacodaPanel />
+
+!!! Note
+    The button above will load a Docker Compose application with two container images representing a 
+    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server running Ubuntu on which we'll install and run Barman.
+
+    You will see a `root@backup` prompt once the application has loaded; then you can follow the steps below.
 
 This walk-through uses an Ubuntu environment, so the first step is to configure the PostgreSQL repository ([details are on the PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt))
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -22,7 +22,7 @@ In [the previous step](step01-db-setup), we configured the PostgreSQL server, cr
 This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose environment with two container images representing a
     PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
@@ -30,7 +30,7 @@ This demo is interactive. You can follow along right in your browser, using Kata
 
 <KatacodaPanel />
 
-This walk-through uses an Ubuntu environment, so the first step is to configure the PostgreSQL repository ([details are on the PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt))
+This demonstration uses an Ubuntu environment, so the first step is to configure the PostgreSQL repository ([details are on the PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt))
 
 1. Install prerequesite software
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -19,16 +19,16 @@ iconName: tutorial
 
 In [the previous step](step01-db-setup), we configured the PostgreSQL server, creating users for Barman to connect and manage backups. In this step, we'll install and configure Barman on the backup server.
 
-This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
-
-<KatacodaPanel />
+This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    The interactive demo loads a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
     PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `root@backup` prompt, you can follow the steps below.
+
+<KatacodaPanel />
 
 This walk-through uses an Ubuntu environment, so the first step is to configure the PostgreSQL repository ([details are on the PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt))
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -1,0 +1,183 @@
+---
+title: "Backup and Recovery: Single-Server Streaming - Installing and Configuring Barman"
+description: "Installing Barman on an Ubuntu-based backup server, creating a configuration file and testing the connection"
+navTitle: "Barman Installation & Configuration"
+product: barman
+platform: ubuntu
+tags:
+    - ubuntu
+    - barman
+    - postgresql
+    - streaming-replication
+    - live-demo
+katacodaPanel:
+    scenario: ubuntu:2004
+    initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step02-backup-setup/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it backup /bin/bash
+    codelanguages: shell, sql, ini
+iconName: tutorial
+---
+
+In [the previous step](step01-db-setup), we configured the PostgreSQL server, creating users for Barman to connect and manage backups. In this step, we'll install and configure Barman on the backup server.
+
+This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+
+<KatacodaPanel />
+
+This walk-through uses an Ubuntu environment, so the first step is to configure the PostgreSQL repository ([details are on the PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt))
+
+1. Install prerequesite software
+
+    ```shell
+    apt-get update
+    apt-get install -y curl ca-certificates gnupg 
+    __OUTPUT__
+    ...
+    done
+    ```
+2. Add PostgreSQL's authentication key
+
+    ```shell
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    __OUTPUT__
+    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                    Dload  Upload   Total   Spent    Left  Speed
+    100  4812  100  4812    0     0  24426      0 --:--:-- --:--:-- --:--:-- 24426
+    OK    
+    ```
+
+3. Add the PostgreSQL repository to the list of sources, and update available packages
+
+    ```shell
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+    apt-get update
+    __OUTPUT__
+    ...
+    Reading package lists... Done
+    ```
+
+With the repository configured, we can use apt to install the PostgreSQL client software and Barman:
+
+```shell
+apt-get -y install barman
+__OUTPUT__
+...
+Processing triggers for systemd (245.4-4ubuntu3.4) ...
+Processing triggers for libc-bin (2.31-0ubuntu9.1) ...
+```
+
+For more details on installation (including instructions for other supported operating systems), see [the Installation section in the Barman guide](http://docs.pgbarman.org/release/2.12/#installation).
+
+## Configuration
+
+All the important details for a Barman server go into a server configuration file, by default located in `/etc/barman.d`. These are in the classic INI format, with relevant settings in a section named after the server we're going to back up. We'll also use that name for the configuration file itself. Since the server we intend to back up is named "pg", we'll use that:
+
+```ini
+cat <<'EOF' >> /etc/barman.d/pg.conf
+[pg]
+description =  "Example of PostgreSQL Database (Streaming-Only)"
+conninfo = host=pg user=barman dbname=pagila
+streaming_conninfo = host=pg user=streaming_barman dbname=pagila
+backup_method = postgres
+streaming_archiver = on
+slot_name = barman
+create_slot = auto
+EOF
+```
+
+Note that this references the users (`barman` and `streaming_barman`) that we created [in step #1 - Database Server Configuration](../step01-db-setup/). Also of interest is the value for `slot_name` - this is a replication slot that will also have to be created on the server - but we can instruct Barman to do that for us by setting `create_slot` to `auto`.
+
+The installation process created a brand-new barman user on the backup server, so let's switch to that for the rest of this:
+
+```shell
+su - barman
+```
+
+### PostgreSQL Connection Password File
+
+In order for Barman to connect via the user specified, we'll need to add the password we specified in the previous step to Barman's [.pgpass file](https://www.postgresql.org/docs/current/libpq-pgpass.html):
+
+```shell
+cat <<'EOF' >>~/.pgpass
+pg:*:*:barman:example-password
+pg:*:*:streaming_barman:example-password
+EOF
+chmod 0600 ~/.pgpass
+```
+
+Note the change in permissions - this is necessary to protect the visibility of the file, and PostgreSQL will not use it unless permissions are restricted.
+
+For more details on configuration files, see: [Configuration](http://docs.pgbarman.org/release/2.12/#configuration) in the pgBarman guide.
+
+### Verifying the configuration
+
+Now that the configuration is done, we can use Barman's check command to verify that it works:
+
+```shell
+barman check pg
+__OUTPUT__
+Server pg:
+        WAL archive: FAILED (please make sure WAL shipping is setup)
+        PostgreSQL: OK
+        superuser or standard user with backup privileges: OK
+        PostgreSQL streaming: OK
+        wal_level: OK
+        replication slot: OK
+        directories: OK
+        retention policy settings: OK
+        backup maximum age: OK (no last_backup_maximum_age provided)
+        compression settings: OK
+        failed backups: OK (there are 0 failed backups)
+        minimum redundancy requirements: OK (have 0 backups, expected at least 0)
+        pg_basebackup: OK
+        pg_basebackup compatible: OK
+        pg_basebackup supports tablespaces mapping: OK
+        systemid coherence: OK (no system Id stored on disk)
+        pg_receivexlog: OK
+        pg_receivexlog compatible: OK
+        receive-wal running: OK
+        archiver errors: OK
+```
+
+Uh-oh! WAL archive failed? Not a problem - that just means Barman hasn't seen any new WAL archives come in yet, which isn't surprising given this is an example 
+database with no writes happening! We can trigger an archive manually and verify that this works:
+
+```shell
+barman switch-wal --archive --archive-timeout 60 pg
+__OUTPUT__
+The WAL file 000000010000000000000002 has been closed on server 'pg'
+Waiting for the WAL file 000000010000000000000002 from server 'pg' (max: 60 seconds)
+Processing xlog segments from streaming for pg
+        000000010000000000000002
+```
+This forces WAL rotation and (with the `--archive` option) waits for the WAL to arrive. We'll give it 60 seconds (with the `--archive-timeout` option) to complete; 
+if it doesn't complete within that amount of time, try again. For more detail on these commands and their options, refer to [the Barman man page](https://docs.pgbarman.org/release/2.12/barman.1.html#commands).
+
+Once switch-wal has completed successfully, run the check again and you should see all checks passing:
+
+```shell
+barman check pg
+__OUTPUT__
+Server pg:
+        PostgreSQL: OK
+        superuser or standard user with backup privileges: OK
+        PostgreSQL streaming: OK
+        wal_level: OK
+        replication slot: OK
+        directories: OK
+        retention policy settings: OK
+        backup maximum age: OK (no last_backup_maximum_age provided)
+        compression settings: OK
+        failed backups: OK (there are 0 failed backups)
+        minimum redundancy requirements: OK (have 0 backups, expected at least 0)
+        pg_basebackup: OK
+        pg_basebackup compatible: OK
+        pg_basebackup supports tablespaces mapping: OK
+        systemid coherence: OK (no system Id stored on disk)
+        pg_receivexlog: OK
+        pg_receivexlog compatible: OK
+        receive-wal running: OK
+        archiver errors: OK
+```
+
+
+Continue on with [Step #3: Running Backups](step03-backup).

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -24,6 +24,13 @@ This is an interactive demonstration. You can follow along right in your browser
 <KatacodaPanel />
 
 !!! Note
+    The interactive demo loads a Docker Compose application with two container images representing a
+    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server for Barman.    
+    
+    Once you see a `root@backup` prompt, you can follow the steps below.
+
+!!! Note
     The button above will load a Docker Compose application with two container images representing a 
     PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server running Ubuntu on which we'll install and run Barman.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -22,7 +22,7 @@ With [the Barman server configured in our last step](step02-backup-setup), we ca
 This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose environment with two container images representing a
     PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -23,7 +23,7 @@ This demo is interactive. You can follow along right in your browser, using Kata
 
 !!! Note
     When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
-    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `barman@backup` prompt, you can follow the steps below.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -19,9 +19,17 @@ iconName: tutorial
 
 With [the Barman server configured in our last step](step02-backup-setup), we can run a full backup (or "base backup").
 
-This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
 
 <KatacodaPanel />
+
+!!! Note
+    The button above will load a Docker Compose application with two container images representing a 
+    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server running Ubuntu on which we'll run and store the backup.
+
+    You will see a `barman@backup` prompt once the application has loaded; then you can follow the steps below.
+
 
 To run a full backup, we use [Barman's `backup` command](http://docs.pgbarman.org/release/2.12/#backup):
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -14,7 +14,7 @@ katacodaPanel:
     scenario: ubuntu:2004
     initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step03-backup/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it -u barman backup /bin/bash
     codelanguages: shell, sql, ini
-iconName: tutorial
+iconName: coffee
 ---
 
 With [the Barman server configured in our last step](step02-backup-setup), we can run a full backup (or "base backup").

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -24,12 +24,11 @@ This is an interactive demonstration. You can follow along right in your browser
 <KatacodaPanel />
 
 !!! Note
-    The button above will load a Docker Compose application with two container images representing a 
-    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
-    and a backup server running Ubuntu on which we'll run and store the backup.
-
-    You will see a `barman@backup` prompt once the application has loaded; then you can follow the steps below.
-
+    The interactive demo loads a Docker Compose application with two container images representing a
+    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server for Barman.    
+    
+    Once you see a `barman@backup` prompt, you can follow the steps below.
 
 To run a full backup, we use [Barman's `backup` command](http://docs.pgbarman.org/release/2.12/#backup):
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -19,16 +19,16 @@ iconName: tutorial
 
 With [the Barman server configured in our last step](step02-backup-setup), we can run a full backup (or "base backup").
 
-This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
-
-<KatacodaPanel />
+This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    The interactive demo loads a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
     PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `barman@backup` prompt, you can follow the steps below.
+
+<KatacodaPanel />
 
 To run a full backup, we use [Barman's `backup` command](http://docs.pgbarman.org/release/2.12/#backup):
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -1,0 +1,89 @@
+---
+title: "Backup and Recovery: Single-Server Streaming - Running a Base Backup"
+description: "Running a full backup using Barman"
+navTitle: "Base Backup"
+product: barman
+platform: ubuntu
+tags:
+    - ubuntu
+    - barman
+    - postgresql
+    - streaming-replication
+    - live-demo
+katacodaPanel:
+    scenario: ubuntu:2004
+    initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step03-backup/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it -u barman backup /bin/bash
+    codelanguages: shell, sql, ini
+iconName: tutorial
+---
+
+With [the Barman server configured in our last step](step02-backup-setup), we can run a full backup (or "base backup").
+
+This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+
+<KatacodaPanel />
+
+To run a full backup, we use [Barman's `backup` command](http://docs.pgbarman.org/release/2.12/#backup):
+
+```shell
+barman backup pg --wait
+__OUTPUT__
+Starting backup using postgres method for server pg in /var/lib/barman/pg/base/20210226T003857
+Backup start at LSN: 0/23EA6C0 (000000010000000000000002, 003EA6C0)
+Starting backup copy via pg_basebackup for 20210226T003857
+Copy done (time: 1 second)
+Finalising the backup.
+This is the first backup for server pg
+WAL segments preceding the current backup have been found:
+        000000010000000000000002 from server pg has been removed
+Backup size: 38.5 MiB
+Backup end at LSN: 0/4000000 (000000010000000000000003, 00000000)
+Backup completed (start time: 2021-02-26 00:38:57.535973, elapsed time: 2 seconds)
+Waiting for the WAL file 000000010000000000000003 from server 'pg'
+Processing xlog segments from streaming for pg
+        000000010000000000000002
+        000000010000000000000003
+```
+
+This will wait to recieve the next WAL file to ensure the backup is complete before the command returns.
+
+Verify that it completed by listing backups for the server:
+
+```shell
+barman list-backup pg
+__OUTPUT__
+pg 20210226T003857 - Fri Feb 26 00:38:59 2021 - Size: 54.5 MiB - WAL Size: 0 B
+```
+(the timestamps will be different for you)
+
+<!-- This needs barman-cli on the database server - which means I can't use the std postgresql image. TODO!
+
+Of course, we've configured streaming backups - so we shouldn't need to depend on having a base backup for every change made to the database. Let's make a small modification to the data and verify that it arrives. 
+
+First, log into the database (we'll use our barman user for convenience in this demonstration):
+
+```shell
+psql -h pg -d pagila -U barman
+```
+
+Then make a modifications, and view the results:
+
+```sql
+Update actor Set first_name='ALOYSIUS' where actor_id=23;
+Select * From actor Where last_name='KILMER';
+/q
+```
+
+Ok, let's see if it showed up:
+
+```shell
+grep 'ALOYSIUS' pg/streaming/*
+```
+
+There it is! The current WAL segment hasn't been rotated yet, but we have the most recent data in the *partial* WAL streamed to Barman. So in theory, nothing would be lost of something *terrible* happened to the database right now... 
+
+--->
+
+Now, the crucial question with backups is always the same: "can you get the data *back?*"
+
+We'll answer this in [Step #4: Restoring a Backup](step04-restore).

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -19,9 +19,17 @@ iconName: tutorial
 
 In the previous step, [we created a full backup of the example database](step03-backup). But it's not a real backup until we've successfully restored it - so let's end with that. 
 
-This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
 
 <KatacodaPanel />
+
+!!! Note
+    The button above will load a Docker Compose application with two container images representing a 
+    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server running Ubuntu from which we'll restore the backup.
+
+    You will see a `barman@backup` prompt once the application has loaded; then you can follow the steps below.
+
 
 Something terrible has happened to our example database! This should list all the tables:
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -14,7 +14,7 @@ katacodaPanel:
     scenario: ubuntu:2004
     initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step04-restore/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it -u barman backup /bin/bash
     codelanguages: shell, sql, ini
-iconName: tutorial
+iconName: coffee
 ---
 
 In the previous step, [we created a full backup of the example database](step03-backup). But it's not a real backup until we've successfully restored it - so let's end with that. 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -23,7 +23,7 @@ This demo is interactive. You can follow along right in your browser, using Kata
 
 !!! Note
     When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
-    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `barman@backup` prompt, you can follow the steps below.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -24,12 +24,11 @@ This is an interactive demonstration. You can follow along right in your browser
 <KatacodaPanel />
 
 !!! Note
-    The button above will load a Docker Compose application with two container images representing a 
-    PostgreSQL 12 server with the [Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
-    and a backup server running Ubuntu from which we'll restore the backup.
-
-    You will see a `barman@backup` prompt once the application has loaded; then you can follow the steps below.
-
+    The interactive demo loads a Docker Compose application with two container images representing a
+    PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
+    and a backup server for Barman.    
+    
+    Once you see a `barman@backup` prompt, you can follow the steps below.
 
 Something terrible has happened to our example database! This should list all the tables:
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -19,16 +19,16 @@ iconName: tutorial
 
 In the previous step, [we created a full backup of the example database](step03-backup). But it's not a real backup until we've successfully restored it - so let's end with that. 
 
-This is an interactive demonstration. You can follow along right in your browser, using Katacoda, by clicking the button below:
-
-<KatacodaPanel />
+This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    The interactive demo loads a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
     PostgreSQL 12 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
     Once you see a `barman@backup` prompt, you can follow the steps below.
+
+<KatacodaPanel />
 
 Something terrible has happened to our example database! This should list all the tables:
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -1,0 +1,127 @@
+---
+title: "Backup and Recovery: Single-Server Streaming - Recovery"
+description: "Recovering from data loss by using Barman to restore a full backup remotely"
+navTitle: "Restore"
+product: barman
+platform: ubuntu
+tags:
+    - ubuntu
+    - barman
+    - postgresql
+    - streaming-replication
+    - live-demo
+katacodaPanel:
+    scenario: ubuntu:2004
+    initializeCommand: wget -q https://raw.githubusercontent.com/josh-heyer/barmantutorial/main/step04-restore/docker-compose.yaml ; docker-compose up -d ; clear ; docker exec -it -u barman backup /bin/bash
+    codelanguages: shell, sql, ini
+iconName: tutorial
+---
+
+In the previous step, [we created a full backup of the example database](step03-backup). But it's not a real backup until we've successfully restored it - so let's end with that. 
+
+This tutorial is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below:
+
+<KatacodaPanel />
+
+Something terrible has happened to our example database! This should list all the tables:
+
+```shell
+psql -h pg -d pagila -U barman -c '\dt'
+__OUTPUT__
+Did not find any relations.
+```
+
+All the data is gone! 
+
+Ok, I just didn't populate the data for this step, in order to demonstrate a total loss. Fortunately, we still have a backup!
+
+```shell
+barman list-backup pg
+```
+
+Let's instruct Barman to ssh into the database server and restore the backup. 
+
+1. Connect to pg and shut down the database cluster:
+
+    ```shell
+    ssh postgres@pg /usr/lib/postgresql/13/bin/pg_ctl \
+        --pgdata=/var/lib/postgresql/data stop
+    ```
+
+2. Use [Barman's recover command](http://docs.pgbarman.org/release/2.12/#recover) to connect to pg and restore the latest backup 
+
+    ```shell
+    barman recover --remote-ssh-command 'ssh postgres@pg' \
+            pg latest \
+            /var/lib/postgresql/data
+    ```
+
+    Barman handles connecting to the destination server, but we do have to provide a valid path *on* that server. In this example, the PostgreSQL cluster lives in /var/lib/postgresql/data and we're asking Barman to overwrite it with the backup.
+
+3. Restart the server:
+
+    ```shell
+    ssh postgres@pg /usr/lib/postgresql/13/bin/pg_ctl \
+        --pgdata=/var/lib/postgresql/data start 
+    ```
+
+    (Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> after that completes to regain control in the terminal)
+
+Now we should be able to reconnect to the database:
+
+```shell
+psql -h pg -d pagila -U barman
+__OUTPUT__
+psql (13.2 (Ubuntu 13.2-1.pgdg20.04+1))
+Type "help" for help.
+
+pagila=#
+```
+
+...And re-run the query we started out with:
+
+```sql
+select * from actor where last_name='KILMER';
+__OUTPUT__
+ actor_id | first_name | last_name |      last_update       
+----------+------------+-----------+------------------------
+       23 | SANDRA     | KILMER    | 2020-02-15 09:34:33+00
+       45 | REESE      | KILMER    | 2020-02-15 09:34:33+00
+       55 | FAY        | KILMER    | 2020-02-15 09:34:33+00
+      153 | MINNIE     | KILMER    | 2020-02-15 09:34:33+00
+      162 | OPRAH      | KILMER    | 2020-02-15 09:34:33+00
+(5 rows)
+```
+
+<!-- This needs barman-cli on the database server - which means I can't use the std postgresql image. TODO!
+
+Ok, so far so good - but, we're missing the update we wrote to this data! Remember, that wasn't in the base backup, it was in a partial WAL file... Fortunately, Barman still has it and knows how to use it. 
+
+Let's try this recovery process again:
+
+1. Connect to pg and shut down the database cluster:
+
+    ```shell
+    ssh postgres@pg /usr/lib/postgresql/13/bin/pg_ctl \
+        --pgdata=/var/lib/postgresql/data stop
+    ```
+
+2. Instruct Barman to connect to pg and restore the latest backup 
+    ```shell
+    barman recover --remote-ssh-command 'ssh postgres@pg' \
+            --get-wal \
+            pg latest \
+            /var/lib/postgresql/data
+    ```
+
+3. Restart the server:
+
+    ```shell
+    ssh postgres@pg /usr/lib/postgresql/13/bin/pg_ctl \
+        --pgdata=/var/lib/postgresql/data start &
+    ```
+-->
+
+## Conclusion
+
+This walk-through barely scratches the surface of what is possible with Barman, but hopefully it has provided you with a taste of its capabilities! For more details, visit https://pgbarman.org/

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -22,7 +22,7 @@ In the previous step, [we created a full backup of the example database](step03-
 This demo is interactive. You can follow along right in your browser, using Katacoda, by clicking the button below.
 
 !!! Note
-    When you click "Start Now," Katacoda will load a Docker Compose application with two container images representing a
+    When you click "Start Now," Katacoda will load a Docker Compose environment with two container images representing a
     PostgreSQL 13 server with [the Pagila database](https://github.com/devrimgunduz/pagila) loaded (named `pg`)
     and a backup server for Barman.    
     
@@ -131,4 +131,4 @@ Let's try this recovery process again:
 
 ## Conclusion
 
-This walk-through barely scratches the surface of what is possible with Barman, but hopefully it has provided you with a taste of its capabilities! For more details, visit https://pgbarman.org/
+This demonstration barely scratches the surface of what is possible with Barman, but hopefully it has provided you with a taste of its capabilities! For more details, visit https://pgbarman.org/

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -90,6 +90,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             katacodaPanel {
               scenario
               account
+              initializeCommand
               codelanguages
             }
             directoryDefaults {

--- a/src/components/code-block.js
+++ b/src/components/code-block.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from 'react-bootstrap';
 
-const childToString = child => {
+const childToString = (child) => {
   if (typeof child === 'string') {
     return child; // hit string, unroll
   } else if (child && child.props) {
@@ -11,7 +11,7 @@ const childToString = child => {
   return '';
 };
 
-const popExtraNewLines = code => {
+const popExtraNewLines = (code) => {
   while (
     code.length - 1 > 0 &&
     childToString(code[code.length - 1]).trim() === ''
@@ -20,7 +20,7 @@ const popExtraNewLines = code => {
   }
 };
 
-const splitChildrenIntoCodeAndOutput = rawChildren => {
+const splitChildrenIntoCodeAndOutput = (rawChildren) => {
   if (!rawChildren) {
     return [[], []];
   }
@@ -60,7 +60,7 @@ const splitChildrenIntoCodeAndOutput = rawChildren => {
 const CodePre = ({ className, content, runnable }) => {
   const codeRef = React.createRef();
   const [copyButtonText, setCopyButtonText] = useState('Copy');
-  const copyClick = e => {
+  const copyClick = (e) => {
     const text = codeRef.current && codeRef.current.textContent;
     navigator.clipboard.writeText(text).then(() => {
       setCopyButtonText('Copied!');
@@ -72,13 +72,13 @@ const CodePre = ({ className, content, runnable }) => {
   };
 
   const [wrap, setWrap] = useState(false);
-  const wrapClick = e => {
+  const wrapClick = (e) => {
     setWrap(!wrap);
     e.target.blur();
   };
 
   const [canRun, setCanRun] = useState(true);
-  const runClick = e => {
+  const runClick = (e) => {
     const text = codeRef.current && codeRef.current.textContent;
     window.katacoda.write(text);
     setCanRun(false);
@@ -141,7 +141,9 @@ const CodeBlock = ({ children, katacodaPanelData, ...otherProps }) => {
     : 'text';
 
   const execLanguages = katacodaPanelData
-    ? ['shell'].concat(katacodaPanelData.codelanguages)
+    ? ['shell'].concat(
+        katacodaPanelData.codelanguages?.split(',')?.map((l) => l.trim()),
+      )
     : [];
 
   if (codeContent.length > 0) {

--- a/src/components/katacoda-panel.js
+++ b/src/components/katacoda-panel.js
@@ -114,6 +114,7 @@ const KatacodaPanel = ({ katacodaPanelData }) => {
   }
   const account = katacodaPanelData.account;
   const scenario = katacodaPanelData.scenario;
+  const command = katacodaPanelData.initializeCommand;
 
   const [isShown, setShown] = useState(false);
   const scenarioId = account ? [account, scenario].join('/') : scenario;
@@ -146,6 +147,7 @@ const KatacodaPanel = ({ katacodaPanelData }) => {
         className={`katacoda-panel${isShown ? '' : ' d-none'}`}
         data-katacoda-id={scenarioId}
         data-katacoda-ui="panel"
+        data-katacoda-command={command}
         data-katacoda-color="e94621"
         data-katacoda-ondemand="true"
       />
@@ -160,7 +162,7 @@ const useAdjustLayoutCloseDetection = (isShown, panelElementId, setShown) => {
       document.documentElement.classList.add('katacoda-panel-active');
 
       // detect when katacoda is closed via the internal button
-      const handler = e => {
+      const handler = (e) => {
         if (
           e.data.type === 'close-panel' &&
           (e.data.data || { target: null }).target === panelElementId
@@ -180,7 +182,7 @@ const useAdjustLayoutCloseDetection = (isShown, panelElementId, setShown) => {
 
 // adapted from Katacoda src to patch over http to https redirect issues
 // when testing locally - remove once Katacoda has this fixed
-const katacodaHttpsWriter = cmd => {
+const katacodaHttpsWriter = (cmd) => {
   let target = document.querySelectorAll('[data-katacoda-env]');
   if (target.length === 0)
     target = document.querySelectorAll('[data-katacoda-id]');

--- a/src/styles/_docs.scss
+++ b/src/styles/_docs.scss
@@ -123,7 +123,11 @@ label.link-label {
 
 // Katacoda in panel display mode adds a fixed-position console with this height
 .katacoda-panel-active body {
-  margin-bottom: 40vh;
+  margin-bottom: max(40vh, 320px);
+}
+
+#katacoda-panel-container {
+  min-height: 320px !important;
 }
 
 .katacoda-exec-button {


### PR DESCRIPTION
Revised #975 in response to feedback, this version breaks the steps up into 4 sections, and builds on docker compose environments running within Katacoda vs. Katacoda directly.

Lots of small changes, but of particular note:

- backup and pg are logically different machines
- reverted to using a superuser for barman access vs. replication user + assigned roles and permissions
- demonstrates remote restore
- overall hews a bit closer to the approaches demonstrated in the Barman manual

Future work:
- demonstrating partial WAL recovery (had this nearly working, but will need to rebuild the pg on a different base)
- link to git repo used to build images as an option for experimentation
- slim down images a bit somehow

Some potential issues:

- Even broken up, this is still pretty heavy, and may strain Katacoda's resources at times.
- Related to above, might be some timing issues with initialization (I've added delays in spots to avoid this, but that's always sketchy).
