### PR TITLE
PDF generator fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "serve-build": "gatsby serve --prefix-paths",
     "update-icons": "git submodule update --init --remote && node scripts/createIconTypes.js && node scripts/createIconNames.js",
     "build-pdf": "python3 scripts/pdf/generate_pdf.py",
-    "build-all-pdfs": "for i in product_docs/docs/**/*/ ; do echo \"$i\"; python3 scripts/pdf/generate_pdf.py ${i%}; done",
+    "build-all-pdfs": "for i in product_docs/docs/**/*/ ; do echo \"$i\"; python3 scripts/pdf/generate_pdf.py ${i%} || exit 1; done",
     "fix-mtimes": "python3 scripts/source/git-restore-mtime.py",
     "count": "find product_docs/docs/ advocacy_docs/ external_sources/ -name '*.mdx' | wc -l",
     "heroku-postbuild": "gatsby build",

--- a/product_docs/docs/pem/8.0.1/pem_online_help/03_toc_pem_client/01_pem_browser_window.mdx
+++ b/product_docs/docs/pem/8.0.1/pem_online_help/03_toc_pem_client/01_pem_browser_window.mdx
@@ -6,7 +6,7 @@ title: "PEM Main Browser Window"
 
 The PEM client features a menu bar and a window divided into two panes: the `Browser` tree control in the left pane, and a tabbed browser in the right pane.
 
-![PEM browser window](/../images/pem_browser_window.png)
+![PEM browser window](../images/pem_browser_window.png)
 
 [Menus](03_pem_menu_bar/#pem_menu_bar) displayed across the top of the browser window provide quick, context-sensitive access to PEM features and functionality.
 

--- a/product_docs/docs/pem/8.0.1/pem_online_help/03_toc_pem_client/02_pem_toolbar.mdx
+++ b/product_docs/docs/pem/8.0.1/pem_online_help/03_toc_pem_client/02_pem_toolbar.mdx
@@ -6,7 +6,7 @@ title: "Browser Toolbar"
 
 The browser toolbar provides shortcut buttons for frequently used features like View Data and the Query Tool which are most frequently used in PEM. This toolbar is visible on the Browser panel. Buttons get enabled/disabled based on the selected browser node.
 
-![Browser Toolbar](/../images/pem_toolbar.png)
+![Browser Toolbar](../images/pem_toolbar.png)
 
 -   Use the [Query Tool](05_keyboard_shortcuts/#query-tool) button to open the Query Tool in the current database context.
 -   Use the [View Data](../08_toc_pem_developer_tools/04_editgrid/#editgrid) button to view/edit the data stored in a selected table.

--- a/product_docs/docs/pem/8.0.1/pem_online_help/03_toc_pem_client/03_pem_menu_bar.mdx
+++ b/product_docs/docs/pem/8.0.1/pem_online_help/03_toc_pem_client/03_pem_menu_bar.mdx
@@ -14,7 +14,7 @@ Context-sensitive menus across the top of the PEM web interface allow you to cus
 
 **The File Menu**
 
-![PEM File menu](/../images/pem_file_menu.png)
+![PEM File menu](../images/pem_file_menu.png)
 
 Use the `File` menu to access the following options:
 
@@ -27,7 +27,7 @@ Use the `File` menu to access the following options:
 
 **The Object Menu**
 
-![PEM Object menu](/../images/pem_object_menu.png)
+![PEM Object menu](../images/pem_object_menu.png)
 
 The `Object` menu is context-sensitive. Use the `Object` menu to access the following options:
 
@@ -55,7 +55,7 @@ The `Object` menu is context-sensitive. Use the `Object` menu to access the foll
 
 **The Management Menu**
 
-![PEM Management menu](/../images/pem_management_menu.png)
+![PEM Management menu](../images/pem_management_menu.png)
 
 Use the `Management` menu to access the following PEM features:
 
@@ -78,7 +78,7 @@ Use the `Management` menu to access the following PEM features:
 
 **The Dashboards Menu**
 
-![PEM Dashboards menu](/../images/pem_dashboards_menu.png)
+![PEM Dashboards menu](../images/pem_dashboards_menu.png)
 
 The `Dashboards` menu is context-sensitive; use the `Dashboards` menu to access the following options:
 
@@ -102,7 +102,7 @@ The `Dashboards` menu is context-sensitive; use the `Dashboards` menu to access 
 
 **The Tools Menu**
 
-![PEM Tools menu](/../images/pem_tool_menu.png)
+![PEM Tools menu](../images/pem_tool_menu.png)
 
 Use the `Tools` menu to access the following options:
 

--- a/product_docs/docs/pem/8.0/pem_online_help/03_toc_pem_client/01_pem_browser_window.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/03_toc_pem_client/01_pem_browser_window.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 The PEM client features a menu bar and a window divided into two panes: the `Browser` tree control in the left pane, and a tabbed browser in the right pane.
 
-![PEM browser window](/../images/pem_browser_window.png)
+![PEM browser window](../images/pem_browser_window.png)
 
 [Menus](03_pem_menu_bar/#pem_menu_bar) displayed across the top of the browser window provide quick, context-sensitive access to PEM features and functionality.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/03_toc_pem_client/02_pem_toolbar.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/03_toc_pem_client/02_pem_toolbar.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 The browser toolbar provides shortcut buttons for frequently used features like View Data and the Query Tool which are most frequently used in PEM. This toolbar is visible on the Browser panel. Buttons get enabled/disabled based on the selected browser node.
 
-![Browser Toolbar](/../images/pem_toolbar.png)
+![Browser Toolbar](../images/pem_toolbar.png)
 
 -   Use the [Query Tool](05_keyboard_shortcuts/#query-tool) button to open the Query Tool in the current database context.
 -   Use the [View Data](../08_toc_pem_developer_tools/04_editgrid/#editgrid) button to view/edit the data stored in a selected table.

--- a/product_docs/docs/pem/8.0/pem_online_help/03_toc_pem_client/03_pem_menu_bar.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/03_toc_pem_client/03_pem_menu_bar.mdx
@@ -18,7 +18,7 @@ Context-sensitive menus across the top of the PEM web interface allow you to cus
 
 **The File Menu**
 
-![PEM File menu](/../images/pem_file_menu.png)
+![PEM File menu](../images/pem_file_menu.png)
 
 Use the `File` menu to access the following options:
 
@@ -31,7 +31,7 @@ Use the `File` menu to access the following options:
 
 **The Object Menu**
 
-![PEM Object menu](/../images/pem_object_menu.png)
+![PEM Object menu](../images/pem_object_menu.png)
 
 The `Object` menu is context-sensitive. Use the `Object` menu to access the following options:
 
@@ -59,7 +59,7 @@ The `Object` menu is context-sensitive. Use the `Object` menu to access the foll
 
 **The Management Menu**
 
-![PEM Management menu](/../images/pem_management_menu.png)
+![PEM Management menu](../images/pem_management_menu.png)
 
 Use the `Management` menu to access the following PEM features:
 
@@ -82,7 +82,7 @@ Use the `Management` menu to access the following PEM features:
 
 **The Dashboards Menu**
 
-![PEM Dashboards menu](/../images/pem_dashboards_menu.png)
+![PEM Dashboards menu](../images/pem_dashboards_menu.png)
 
 The `Dashboards` menu is context-sensitive; use the `Dashboards` menu to access the following options:
 
@@ -106,7 +106,7 @@ The `Dashboards` menu is context-sensitive; use the `Dashboards` menu to access 
 
 **The Tools Menu**
 
-![PEM Tools menu](/../images/pem_tool_menu.png)
+![PEM Tools menu](../images/pem_tool_menu.png)
 
 Use the `Tools` menu to access the following options:
 

--- a/scripts/pdf/generate_pdf.py
+++ b/scripts/pdf/generate_pdf.py
@@ -6,6 +6,12 @@ import pathlib
 
 basePath = pathlib.Path(__file__).parent.absolute()
 
+ANSI_STOP = '\033[0m'
+ANSI_BLUE = '\033[34m'
+ANSI_GREEN = '\033[32m'
+ANSI_YELLOW = '\033[33m'
+ANSI_RED = '\033[31m'
+
 # magic snippet for inline repl
 # import code; code.interact(local=dict(globals(), **locals()))
 
@@ -102,6 +108,8 @@ def main():
         guide + '_' if guide else ''
     )
 
+    print(ANSI_BLUE + 'building {}'.format(pdfFilePath) + ANSI_STOP)
+
     if not os.path.exists(dirName):
         raise Exception('directory does not exist')
 
@@ -159,6 +167,7 @@ def main():
 
     title = getTitle(dirName) or product
 
+    print('generating docs html')
     os.system(
     "pandoc {0} " \
     "-f gfm " \
@@ -176,10 +185,11 @@ def main():
     if html:
         os.system("open " + htmlFilePath)
     else:
+        print('generating cover page')
         os.system(
         "sed " \
-        "-e 's/\[PRODUCT\]/{1}/' " \
-        "-e 's/\[VERSION\]/{2}/' " \
+        "-e \"s/\[PRODUCT\]/{1}/\" " \
+        "-e \"s/\[VERSION\]/{2}/\" " \
         "scripts/pdf/cover.html " \
         "> {0}" \
         "".format(coverFilePath, title, version)
@@ -196,10 +206,11 @@ def main():
         "--footer-font-size 8 " \
         "--footer-spacing 7 ".format(datetime.datetime.now().year)
 
+        print('converting html to pdf')
         os.system(
         "wkhtmltopdf " \
         "--log-level error " \
-        "--title '{3}' " \
+        "--title \"{3}\" " \
         "--margin-top 15mm " \
         "--margin-bottom 15mm " \
         "{0} " \


### PR DESCRIPTION
- Change `yarn build-all-pdfs` to fail as soon as a PDF fails to build (which should fail the github action)
- Fix some images paths in PEM 8.0 and 8.0.1 online help. The images were displaying in the browser (and still do), but pandoc wasn't happy about them when trying to generate the html for the pdf generator.
- Wrap titles with `"` instead of `'` so that title frontmatter without quotes (but possibly with a `'`) doesn't cause a problem when passing the title into system commands
- Add a bit more logging to the output of the generation script