### PR TITLE
Cleanup gatsby-config, upgrade algolia

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -126,14 +126,6 @@ const indexQuery = `
 `;
 
 /********** Gatsby config *********/
-const netlifyHeaders = () => {
-  if (isProduction) return {};
-
-  return {
-    '/*': ['X-Robots-Tag: noindex'],
-  };
-};
-
 module.exports = {
   flags: {
     PRESERVE_WEBPACK_CACHE: true,
@@ -159,7 +151,9 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-netlify',
       options: {
-        headers: netlifyHeaders(),
+        headers: {
+          '/*': isProduction ? [] : ['X-Robots-Tag: noindex'],
+        },
       },
     },
     // 'gatsby-plugin-remove-fingerprints', // speeds up Netlify, see https://github.com/narative/gatsby-plugin-remove-fingerprints

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,9 @@
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
 });
-const utf8Truncate = require('truncate-utf8-bytes');
 const gracefulFs = require('graceful-fs');
+
+const algoliaTransformer = require('./src/constants/algolia-indexing.js');
 
 const ANSI_BLUE = '\033[34m';
 const ANSI_GREEN = '\033[32m';
@@ -124,173 +125,7 @@ const indexQuery = `
 }
 `;
 
-const transformNodeForAlgolia = (node) => {
-  let newNode = node;
-  newNode['title'] = node.frontmatter.title;
-  newNode['path'] = node.fields.path;
-  newNode['type'] = 'guide';
-  if (node.frontmatter.product) {
-    newNode['product'] = node.frontmatter.product;
-  }
-  if (node.frontmatter.platform) {
-    newNode['platform'] = node.frontmatter.platform;
-  }
-
-  if (node.fields.docType == 'doc') {
-    newNode['product'] = node.fields.product;
-    newNode['version'] = node.fields.version;
-    newNode['productVersion'] =
-      node.fields.product + ' > ' + node.fields.version;
-    newNode['type'] = 'doc';
-  }
-
-  delete newNode['frontmatter'];
-  delete newNode['fields'];
-  return newNode;
-};
-
-const makePathDictionary = (nodes) => {
-  let dictionary = {};
-  for (let node of nodes) {
-    dictionary[node.fields.path] = node.frontmatter.title;
-  }
-  return dictionary;
-};
-
-const makeBreadcrumbs = (node, dictionary, advocacy = false) => {
-  let depth = advocacy ? 3 : 4;
-  let trail = '';
-  const path = node.fields.path;
-  const pathPieces = path.split('/');
-  for (let i = depth; i < pathPieces.length; i++) {
-    let parentPath = pathPieces.slice(0, i).join('/');
-    trail += dictionary[parentPath] + ' / ';
-  }
-  return trail;
-};
-
-const addBreadcrumbsToNodes = (nodes) => {
-  const pathDictionary = makePathDictionary(nodes);
-  let newNodes = [];
-  for (let node of nodes) {
-    let newNode = node;
-    const advocacy = !node.fields.product;
-    newNode['breadcrumb'] = makeBreadcrumbs(node, pathDictionary, advocacy);
-    newNodes.push(newNode);
-  }
-  return newNodes;
-};
-
-const mdxTreeToSearchNodes = (rootNode) => {
-  rootNode.depth = 0;
-  const stack = [rootNode];
-  const searchNodes = [];
-  const initialSearchNode = { text: '', heading: '' };
-
-  let parseState = {
-    attribute: 'text',
-    nextAttribute: null,
-    transitionDepth: null,
-  };
-  const nextParseStateIfDepth = (depth) => {
-    if (!parseState.transitionDepth || depth > parseState.transitionDepth)
-      return;
-    parseState = {
-      attribute: parseState.nextAttribute,
-      nextAttribute: null,
-      transitionDepth: null,
-    };
-  };
-  const setHeadingParseState = (depth) => {
-    parseState = {
-      attribute: 'heading',
-      nextAttribute: 'text',
-      transitionDepth: depth,
-    };
-  };
-
-  let searchNode = { ...initialSearchNode };
-  let node = null;
-  while (stack.length > 0) {
-    node = stack.pop();
-    nextParseStateIfDepth(node.depth);
-
-    if (['import', 'export'].includes(node.type)) {
-      // skip these nodes
-      continue;
-    }
-
-    if (node.type === 'heading') {
-      // break on headings
-      if (searchNode.text.length > 0) {
-        searchNodes.push(searchNode);
-      }
-      searchNode = { ...initialSearchNode };
-      setHeadingParseState(node.depth);
-    }
-
-    if (node.value && !['html', 'jsx'].includes(node.type)) {
-      searchNode[parseState.attribute] += ` ${node.value}`;
-    } else {
-      (node.children || [])
-        .slice()
-        .reverse()
-        .forEach((child) => {
-          child.depth = node.depth + 1;
-          stack.push(child);
-        });
-    }
-  }
-  if (searchNode.text.length > '') {
-    searchNodes.push(searchNode);
-  }
-
-  return searchNodes;
-};
-
-const trimSpaces = (str) => {
-  return str.replace(/\s+/g, ' ').trim();
-};
-
-const splitNodeContent = (nodes) => {
-  const result = [];
-  for (const node of nodes) {
-    // skip indexing this content for now
-    if (
-      node.path.includes('/postgresql_journey/') ||
-      node.path.includes('/playground/')
-    ) {
-      console.log(`skipped indexing ${node.path}`);
-      continue;
-    }
-
-    const searchNodes = mdxTreeToSearchNodes(node.mdxAST);
-
-    searchNodes.forEach((searchNode, i) => {
-      let newNode = { ...node };
-      delete newNode['mdxAST'];
-
-      newNode.id = `${newNode.path}-${i + 1}`;
-      newNode.heading = trimSpaces(searchNode.heading);
-      newNode.excerpt = utf8Truncate(
-        trimSpaces(`${searchNode.heading}: ${searchNode.text}`),
-        8000,
-      );
-      if (searchNode.heading.length > 0) {
-        const anchor = newNode.heading
-          .split(' ')
-          .join('-')
-          .toLowerCase()
-          .replace('/', '');
-        newNode.path = `${newNode.path}#${anchor}`;
-      }
-
-      result.push(newNode);
-    });
-  }
-  return result;
-};
-
+/********** Gatsby config *********/
 const netlifyHeaders = () => {
   if (isProduction) return {};
 
@@ -299,7 +134,6 @@ const netlifyHeaders = () => {
   };
 };
 
-/********** Gatsby config *********/
 module.exports = {
   flags: {
     PRESERVE_WEBPACK_CACHE: true,
@@ -438,32 +272,24 @@ module.exports = {
         whereToIncludeRedirects: '', // defaults to: "server"
       },
     },
+    {
+      // This plugin must be placed last in your list of plugins to ensure that it can query all the GraphQL data
+      resolve: `gatsby-plugin-algolia`,
+      options: {
+        appId: process.env.ALGOLIA_APP_ID,
+        apiKey: process.env.ALGOLIA_API_KEY,
+        indexName: algoliaIndex,
+        queries: [
+          {
+            query: indexQuery,
+            transformer: algoliaTransformer,
+            indexName: algoliaIndex,
+          },
+        ],
+        chunkSize: 1000,
+        enablePartialUpdates: false,
+        skipIndexing: process.env.INDEX_ON_BUILD !== 'true',
+      },
+    },
   ],
 };
-
-if (process.env.INDEX_ON_BUILD && process.env.INDEX_ON_BUILD !== 'false') {
-  module.exports['plugins'].push({
-    // This plugin must be placed last in your list of plugins to ensure that it can query all the GraphQL data
-    resolve: `gatsby-plugin-algolia`,
-    options: {
-      appId: process.env.ALGOLIA_APP_ID,
-      apiKey: process.env.ALGOLIA_API_KEY,
-      indexName: algoliaIndex,
-      queries: [
-        {
-          query: indexQuery,
-          transformer: ({ data }) =>
-            splitNodeContent(
-              addBreadcrumbsToNodes(data.allMdx.nodes).map((node) =>
-                transformNodeForAlgolia(node),
-              ),
-            ),
-          indexName: algoliaIndex,
-        },
-      ],
-      chunkSize: 1000, // default: 1000,
-      enablePartialUpdates: false,
-      skipIndexing: !process.env.INDEX_ON_BUILD, // useless on plugin version 0.13.0, just for posterity
-    },
-  });
-}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gatsby": "^2.31.1",
     "gatsby-cli": "^2.12.93",
     "gatsby-image": "^2.4.1",
-    "gatsby-plugin-algolia": "^0.13.0",
+    "gatsby-plugin-algolia": "^0.16.3",
     "gatsby-plugin-catch-links": "^2.6.0",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-google-tagmanager": "^2.10.0",

--- a/src/constants/algolia-indexing.js
+++ b/src/constants/algolia-indexing.js
@@ -1,0 +1,177 @@
+const utf8Truncate = require('truncate-utf8-bytes');
+
+const transformNodeForAlgolia = (node) => {
+  let newNode = node;
+  newNode['title'] = node.frontmatter.title;
+  newNode['path'] = node.fields.path;
+  newNode['type'] = 'guide';
+  if (node.frontmatter.product) {
+    newNode['product'] = node.frontmatter.product;
+  }
+  if (node.frontmatter.platform) {
+    newNode['platform'] = node.frontmatter.platform;
+  }
+
+  if (node.fields.docType == 'doc') {
+    newNode['product'] = node.fields.product;
+    newNode['version'] = node.fields.version;
+    newNode['productVersion'] =
+      node.fields.product + ' > ' + node.fields.version;
+    newNode['type'] = 'doc';
+  }
+
+  delete newNode['frontmatter'];
+  delete newNode['fields'];
+  return newNode;
+};
+
+const makePathDictionary = (nodes) => {
+  let dictionary = {};
+  for (let node of nodes) {
+    dictionary[node.fields.path] = node.frontmatter.title;
+  }
+  return dictionary;
+};
+
+const makeBreadcrumbs = (node, dictionary, advocacy = false) => {
+  let depth = advocacy ? 3 : 4;
+  let trail = '';
+  const path = node.fields.path;
+  const pathPieces = path.split('/');
+  for (let i = depth; i < pathPieces.length; i++) {
+    let parentPath = pathPieces.slice(0, i).join('/');
+    trail += dictionary[parentPath] + ' / ';
+  }
+  return trail;
+};
+
+const addBreadcrumbsToNodes = (nodes) => {
+  const pathDictionary = makePathDictionary(nodes);
+  let newNodes = [];
+  for (let node of nodes) {
+    let newNode = node;
+    const advocacy = !node.fields.product;
+    newNode['breadcrumb'] = makeBreadcrumbs(node, pathDictionary, advocacy);
+    newNodes.push(newNode);
+  }
+  return newNodes;
+};
+
+const mdxTreeToSearchNodes = (rootNode) => {
+  rootNode.depth = 0;
+  const stack = [rootNode];
+  const searchNodes = [];
+  const initialSearchNode = { text: '', heading: '' };
+
+  let parseState = {
+    attribute: 'text',
+    nextAttribute: null,
+    transitionDepth: null,
+  };
+  const nextParseStateIfDepth = (depth) => {
+    if (!parseState.transitionDepth || depth > parseState.transitionDepth)
+      return;
+    parseState = {
+      attribute: parseState.nextAttribute,
+      nextAttribute: null,
+      transitionDepth: null,
+    };
+  };
+  const setHeadingParseState = (depth) => {
+    parseState = {
+      attribute: 'heading',
+      nextAttribute: 'text',
+      transitionDepth: depth,
+    };
+  };
+
+  let searchNode = { ...initialSearchNode };
+  let node = null;
+  while (stack.length > 0) {
+    node = stack.pop();
+    nextParseStateIfDepth(node.depth);
+
+    if (['import', 'export'].includes(node.type)) {
+      // skip these nodes
+      continue;
+    }
+
+    if (node.type === 'heading') {
+      // break on headings
+      if (searchNode.text.length > 0) {
+        searchNodes.push(searchNode);
+      }
+      searchNode = { ...initialSearchNode };
+      setHeadingParseState(node.depth);
+    }
+
+    if (node.value && !['html', 'jsx'].includes(node.type)) {
+      searchNode[parseState.attribute] += ` ${node.value}`;
+    } else {
+      (node.children || [])
+        .slice()
+        .reverse()
+        .forEach((child) => {
+          child.depth = node.depth + 1;
+          stack.push(child);
+        });
+    }
+  }
+  if (searchNode.text.length > '') {
+    searchNodes.push(searchNode);
+  }
+
+  return searchNodes;
+};
+
+const trimSpaces = (str) => {
+  return str.replace(/\s+/g, ' ').trim();
+};
+
+const splitNodeContent = (nodes) => {
+  const result = [];
+  for (const node of nodes) {
+    // skip indexing this content for now
+    if (
+      node.path.includes('/postgresql_journey/') ||
+      node.path.includes('/playground/')
+    ) {
+      console.log(`skipped indexing ${node.path}`);
+      continue;
+    }
+
+    const searchNodes = mdxTreeToSearchNodes(node.mdxAST);
+
+    searchNodes.forEach((searchNode, i) => {
+      let newNode = { ...node };
+      delete newNode['mdxAST'];
+
+      newNode.id = `${newNode.path}-${i + 1}`;
+      newNode.heading = trimSpaces(searchNode.heading);
+      newNode.excerpt = utf8Truncate(
+        trimSpaces(`${searchNode.heading}: ${searchNode.text}`),
+        8000,
+      );
+      if (searchNode.heading.length > 0) {
+        const anchor = newNode.heading
+          .split(' ')
+          .join('-')
+          .toLowerCase()
+          .replace('/', '');
+        newNode.path = `${newNode.path}#${anchor}`;
+      }
+
+      result.push(newNode);
+    });
+  }
+  return result;
+};
+
+const algoliaTransformer = ({ data }) =>
+  splitNodeContent(
+    addBreadcrumbsToNodes(data.allMdx.nodes).map((node) =>
+      transformNodeForAlgolia(node),
+    ),
+  );
+
+module.exports = algoliaTransformer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6741,10 +6741,10 @@ gatsby-page-utils@^0.9.0:
     lodash "^4.17.20"
     micromatch "^4.0.2"
 
-gatsby-plugin-algolia@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-algolia/-/gatsby-plugin-algolia-0.13.0.tgz#d73ba83f5a449313356c1897c2d2ecf0d8efa21c"
-  integrity sha512-hx+J9IfHuuxxENtz/GlBQxbiMPCu71dWI32EKVvas0T57SIZES1YO2Xcck1TEJpDHjU59tO/cLFJ/3EJTUBl6Q==
+gatsby-plugin-algolia@^0.16.3:
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-algolia/-/gatsby-plugin-algolia-0.16.3.tgz#f455cdc30d9b10ee3d417a9052167339109f0793"
+  integrity sha512-1ErBAsPtDL/uvUpweBCNpzkMFamXnYYUVdhFnpx488PFAl7N26I0Jsk+TcoHCMTTp9GGRahF8w7VBvv7jtKUAQ==
   dependencies:
     algoliasearch "^3.24.5"
     gatsby-cli "^1.1.58"


### PR DESCRIPTION
- Move algolia related functions into new `algolia-indexing` file to cleanup `gatsby-config` a bit
- Upgrade `gatsby-plugin-algolia` so that we can use the `skipIndexing` option and simplify the setup there
- Change the way the `noindex` header is being set - I think the previous method was busting the cache each time