### PR TITLE
strip nginx legacy redirects from netlify _redirects

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -23,6 +23,8 @@ const {
   findPrevNextNavNodes,
   configureRedirects,
   configureLegacyRedirects,
+  readFile,
+  writeFile,
 } = require('./src/constants/gatsby-node-utils.js');
 
 const isBuild = process.env.NODE_ENV === 'production';
@@ -411,4 +413,19 @@ exports.onPreBootstrap = () => {
 |_____||____/ |_____|  |____/ |___||___||___|
                                                                                                                    
   `);
+};
+
+exports.onPostBuild = async ({ reporter, pathPrefix }) => {
+  const originalRedirects = await readFile('public/_redirects');
+
+  // filter out legacyRedirects that are loaded via nginx, not netlify
+  let filteredRedirects = originalRedirects
+    .split('\n')
+    .filter((line) => !line.startsWith(`${pathPrefix}/edb-docs/`))
+    .join('\n');
+
+  await writeFile(
+    'public/_redirects',
+    `${filteredRedirects}\n\n# Netlify pathPrefix path rewrite\n${pathPrefix}/*  /:splat  200`,
+  );
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -424,6 +424,10 @@ exports.onPostBuild = async ({ reporter, pathPrefix }) => {
     .filter((line) => !line.startsWith(`${pathPrefix}/edb-docs/`))
     .join('\n');
 
+  if (filteredRedirects.length === originalRedirects.length) {
+    reporter.warn('no redirects were filtered out, did something change?');
+  }
+
   await writeFile(
     'public/_redirects',
     `${filteredRedirects}\n\n# Netlify pathPrefix path rewrite\n${pathPrefix}/*  /:splat  200`,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "develop": "gatsby develop",
     "config-sources": "python3 scripts/source/config_sources.py",
     "format": "prettier --write src/**/*.js gatsby-*.js",
-    "build": "gatsby build --prefix-paths && bash scripts/post-build.sh",
+    "build": "gatsby build --prefix-paths",
     "serve-build": "gatsby serve --prefix-paths",
     "update-icons": "git submodule update --init --remote && node scripts/createIconTypes.js && node scripts/createIconNames.js",
     "build-pdf": "python3 scripts/pdf/generate_pdf.py",

--- a/scripts/post-build.sh
+++ b/scripts/post-build.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-echo "post-build script starting"
-if test -f "public/_redirects"; then
-  echo "writing path prefix to public/_redirects"
-  printf "\n\n/docs/*  /:splat  200" >> public/_redirects
-fi
-echo "post-build script complete"

--- a/src/constants/gatsby-node-utils.js
+++ b/src/constants/gatsby-node-utils.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 const sortVersionArray = (versions) => {
   return versions
     .map((version) => version.replace(/\d+/g, (n) => +n + 100000))
@@ -308,6 +310,20 @@ const configureLegacyRedirects = ({
   });
 };
 
+const readFile = (filePath) =>
+  new Promise(function (resolve, reject) {
+    fs.readFile(filePath, 'utf8', function (err, data) {
+      err ? reject(err) : resolve(data);
+    });
+  });
+
+const writeFile = (filePath, data) =>
+  new Promise(function (resolve, reject) {
+    fs.writeFile(filePath, data, function (err) {
+      err ? reject(err) : resolve();
+    });
+  });
+
 module.exports = {
   sortVersionArray,
   replacePathVersion,
@@ -325,4 +341,6 @@ module.exports = {
   findPrevNextNavNodes,
   configureRedirects,
   configureLegacyRedirects,
+  readFile,
+  writeFile,
 };


### PR DESCRIPTION
also move post-build.sh into `onPostBuild` gatsby hook