### PR TITLE
directoryDefault aware algolia indexing

### DIFF
--- a/advocacy_docs/supported-open-source/barman/index.mdx
+++ b/advocacy_docs/supported-open-source/barman/index.mdx
@@ -2,7 +2,6 @@
 title: Barman
 navTitle: Barman
 description: EDB supports Barman.
-product: barman
 tags:
     - barman
     - backup
@@ -12,6 +11,7 @@ tags:
     - postgresql
 directoryDefaults:
   iconName: coffee
+  product: barman
 ---
 
 Barman (Backup and Recovery Manager) is an open-source administration tool for remote backups and disaster recovery of PostgreSQL servers in business-critical environments. It relies on PostgreSQL’s robust and reliable Point In Time Recovery technology, allowing DBAs to remotely manage a complete catalogue of backups and the recovery phase of multiple remote servers – all from one location. Barman is distributed under GNU GPL 3 and maintained by EDB.

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/index.mdx
@@ -2,8 +2,6 @@
 title: "Backup and Recovery: Single-Server Streaming with Barman"
 description: "A quick demonstration of Barman installation, configuration, and basic backup and restore operations"
 navTitle: "Demo: Single-Server Streaming"
-product: barman
-platform: ubuntu
 tags:
     - ubuntu
     - barman
@@ -12,6 +10,7 @@ tags:
     - live-demo
 iconName: coffee
 directoryDefaults:
+  platform: ubuntu
   prevNext: true
 ---
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -2,8 +2,6 @@
 title: "Backup and Recovery: Single-Server Streaming - Installing and Configuring Barman"
 description: "Installing Barman on an Ubuntu-based backup server, creating a configuration file and testing the connection"
 navTitle: "Barman Installation & Configuration"
-product: barman
-platform: ubuntu
 tags:
     - ubuntu
     - barman

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -2,8 +2,6 @@
 title: "Backup and Recovery: Single-Server Streaming - Running a Base Backup"
 description: "Running a full backup using Barman"
 navTitle: "Base Backup"
-product: barman
-platform: ubuntu
 tags:
     - ubuntu
     - barman

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -2,8 +2,6 @@
 title: "Backup and Recovery: Single-Server Streaming - Recovery"
 description: "Recovering from data loss by using Barman to restore a full backup remotely"
 navTitle: "Restore"
-product: barman
-platform: ubuntu
 tags:
     - ubuntu
     - barman

--- a/advocacy_docs/supported-open-source/pgadmin/index.mdx
+++ b/advocacy_docs/supported-open-source/pgadmin/index.mdx
@@ -2,9 +2,9 @@
 title: pgAdmin
 navTitle: pgAdmin
 description: EDB supports pgAdmin.
-product: pgAdmin
 directoryDefaults:
   iconName: postgresql
+  product: pgAdmin
 ---
 
 pgAdmin is an open source, multi-platform console for PostgreSQL management and administration.

--- a/advocacy_docs/supported-open-source/pgbackrest/02-installation.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/02-installation.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Installation'
 description: 'Instructions for installing pgBackRest on supported systems, including EDB Postgres Advanced Server'
-product: 'pgBackRest'
 tags:
   - installation
   - EPAS

--- a/advocacy_docs/supported-open-source/pgbackrest/03-quick_start.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/03-quick_start.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Quick Start'
 description: "A walkthrough: configuring pgBackRest, then running, examining and restoring a backup of a database cluster"
-product: 'pgBackRest'
 tags:
   - configuration
   - backup

--- a/advocacy_docs/supported-open-source/pgbackrest/04-recommended_settings.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/04-recommended_settings.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Recommended Settings'
 description: "Recommendations & rationale for pgBackRest configuration settings"
-product: 'pgBackRest'
 ---
 
 This section walks you through the recommended settings while using pgBackRest.

--- a/advocacy_docs/supported-open-source/pgbackrest/05-retention_policy.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/05-retention_policy.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Retention Policy'
 description: "Configuration options and considerations for the removal of obsolete backups and WAL archives"
-product: 'pgBackRest'
 ---
 
 Setting retention policy options allows to remove obsolete backups. Those settings will then be a trade-off between saving space and data retention.

--- a/advocacy_docs/supported-open-source/pgbackrest/06-use_case_1.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/06-use_case_1.mdx
@@ -2,7 +2,6 @@
 title: 'Use Case 1: Running pgBackRest Locally on the Database Host'
 navTitle: 'Use Case 1'
 description: "Examines a configuration used to run pgBackRest locally, on the database host"
-product: 'pgBackRest'
 tags:
   - configuration
   - pgBackRest

--- a/advocacy_docs/supported-open-source/pgbackrest/07-use_case_2.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/07-use_case_2.mdx
@@ -2,7 +2,6 @@
 title: 'Use Case 2: Running pgBackRest from a Dedicated Repository Host'
 navTitle: 'Use Case 2'
 description: "Examines a configuration used to run pgBackRest from a dedicated repository host"
-product: 'pgBackRest'
 tags:
   - configuration
   - pgBackRest

--- a/advocacy_docs/supported-open-source/pgbackrest/98-appendix.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/98-appendix.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Appendix'
 description: "Definitions for terms and concepts used in this guide, along with notes on configuration terminology"
-product: 'pgBackRest'
 ---
 
 ### Concepts

--- a/advocacy_docs/supported-open-source/pgbackrest/99-faq.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/99-faq.mdx
@@ -2,7 +2,6 @@
 title: 'Frequently Asked Questions'
 navTitle: 'FAQ'
 description: 'Answers to Frequently Asked Questions'
-product: 'pgBackRest'
 ---
 
 - Why do we have to specify the `--stanza` option even if only one stanza is defined in the configuration file?

--- a/advocacy_docs/supported-open-source/pgbackrest/index.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'pgBackRest'
 description: 'Introduction to pgBackRest, a reliable PostgreSQL backup & restore tool'
-product: 'pgBackRest'
 tags:
   - backup
   - restore
@@ -10,6 +9,7 @@ tags:
 indexCards: simple
 directoryDefaults:
   iconName: 'postgressupport'
+  product: 'pgBackRest'
 ---
 
 pgBackRest is an easy-to-use backup and restore tool that aims to enable your organization to implement disaster recovery solutions for PostgreSQL databases. 

--- a/advocacy_docs/supported-open-source/postgresql/index.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/index.mdx
@@ -2,9 +2,9 @@
 title: PostgreSQL
 navTitle: PostgreSQL
 description: EDB supports PostgreSQL.
-product: PostgreSQL
 directoryDefaults:
   iconName: postgresql
+  product: PostgreSQL
 ---
 
 PostgreSQL is a popular, free, open-source relational database management system (RDBMS). It has earned a reputation for reliability, performance, and extensibility, with a robust feature set to securely store and scale even the most complex workloads.

--- a/advocacy_docs/supported-open-source/postgresql/installer/01_requirements_overview.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/01_requirements_overview.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Requirements Overview"
-product: PostgreSQL
 legacyRedirects:
   - "/edb-docs/d/postgresql/installation-getting-started/installation-guide/13.0/requirements_overview.html"
 ---

--- a/advocacy_docs/supported-open-source/postgresql/installer/02_installing_postgresql_with_the_graphical_installation_wizard/01_invoking_the_graphical_installer.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/02_installing_postgresql_with_the_graphical_installation_wizard/01_invoking_the_graphical_installer.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Invoking the Graphical Installer"
-product: PostgreSQL
 legacyRedirects:
   - "/edb-docs/d/postgresql/installation-getting-started/installation-guide/13.0/invoking_the_graphical_installer.html"
 ---

--- a/advocacy_docs/supported-open-source/postgresql/installer/02_installing_postgresql_with_the_graphical_installation_wizard/index.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/02_installing_postgresql_with_the_graphical_installation_wizard/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Installing PostgreSQL with the Graphical Installation Wizard"
-product: PostgreSQL
 legacyRedirects:
   - "/edb-docs/d/postgresql/installation-getting-started/installation-guide/13.0/installing_postgresql_with_the_graphical_installation_wizard.html"
 ---

--- a/advocacy_docs/supported-open-source/postgresql/installer/03_using_stackbuilder.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/03_using_stackbuilder.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Using Stack Builder"
-product: PostgreSQL
 legacyRedirects:
   - "/edb-docs/d/postgresql/installation-getting-started/installation-guide/13.0/using_stackbuilder.html"
 ---

--- a/advocacy_docs/supported-open-source/postgresql/installer/04_installation_troubleshooting.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/04_installation_troubleshooting.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Installation Troubleshooting"
-product: PostgreSQL
 legacyRedirects:
   - "/edb-docs/d/postgresql/installation-getting-started/installation-guide/13.0/installation_troubleshooting.html"
 ---

--- a/advocacy_docs/supported-open-source/postgresql/installer/05_uninstalling_postgresql.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/05_uninstalling_postgresql.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Uninstalling PostgreSQL"
-product: PostgreSQL
 legacyRedirects:
   - "/edb-docs/d/postgresql/installation-getting-started/installation-guide/13.0/uninstalling_postgresql.html"
 ---

--- a/advocacy_docs/supported-open-source/postgresql/installer/index.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: "EDB Installers"
 description: "The PostgreSQL installers created by EnterpriseDB are designed to make it quick and simple to install PostgreSQL on your computer."
-product: PostgreSQL
 ---
 
 The PostgreSQL installers created by EnterpriseDB are designed to make it quick and simple to install PostgreSQL on your computer. The installer provides:

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ const ANSI_STOP = '\033[0m';
 
 const isBuild = process.env.NODE_ENV === 'production';
 const isProduction = process.env.APP_ENV === 'production';
-const algoliaIndex = process.env.ALGOLIA_INDEX_NAME || 'edb-docs-staging';
+const algoliaIndex = process.env.ALGOLIA_INDEX_NAME || 'edb-docs-test';
 
 /******** Sourcing *********/
 const sourceFilename = isBuild ? 'build-sources.json' : 'dev-sources.json';
@@ -111,6 +111,10 @@ const indexQuery = `
         product
         platform
         tags
+        directoryDefaults {
+          product
+          platform
+        }
       }
       id
       fields {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -104,6 +104,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
               description
               prevNext
               iconName
+              product
+              platform
             }
           }
           fields {


### PR DESCRIPTION
## What Changed?

Changed the algolia indexing code to build up a content tree (the same way gatsby-node does) in order to compute the frontmatter for each doc. This lets us use `directoryDefaults` in the search indexing. I converted all of the docs in `supported-open-source` to use `directoryDefaults` for `product` and `platform` as a test. I also did a little more cleanup of the search indexing code, though I think there is a little more work to be done.

Going to test this more to ensure the indexing didn't change, but looking good so far.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
