### PR TITLE
fix: adjust Pandoc CSS to use specified coding font

### DIFF
--- a/scripts/pdf/pdf-styles.css
+++ b/scripts/pdf/pdf-styles.css
@@ -77,27 +77,27 @@ img {
 
 
 /* Code */
-code {
-  border-radius: .2rem;
+pre, code {
+  font-family: Source Code Pro;
+  font-weight: normal;
   padding: .3rem;
+  border-radius: .2rem;
+}
+
+code {
   color: #457a00;
   background-color: #f0f4f7;
-  white-space: pre-wrap;
+  white-space: pre-wrap !important; /* SourceCode pandoc will override otherwise */
+}
+
+pre {
+  background-color: #f8f8f8; /* match SourceCode pandoc highlighting colors */
+  margin-bottom: 2rem;
 }
 
 pre code {
   color: black;
   background-color: #f8f8f8; /* match SourceCode pandoc highlighting colors */
-  white-space: pre-wrap !important; /* SourceCode pandoc will override otherwise */
-}
-
-pre {
-  font-family: Source Code Pro;
-  font-weight: normal;
-  background-color: #f8f8f8; /* match SourceCode pandoc highlighting colors */
-  border-radius: .2rem;
-  padding: .3rem;
-  margin-bottom: 2rem;
 }
 
 


### PR DESCRIPTION
## What Changed?

- Fixed coding font spec in Pandoc CSS. I assume we want to use the specified font of `Source Code Pro` for both `pre` and `code`, right?