### PR TITLE
Re-enable cache on github builds

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -26,16 +26,16 @@ jobs:
       env:
         NODE_ENV: ${{ secrets.NODE_ENV }}
 
-    # - name: Checking Gatsby cache
-    #   id: gatsby-cache-build
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: |
-    #       public
-    #       .cache
-    #     key: ${{ runner.os }}-gatsby-build-develop-${{ github.run_id }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-gatsby-build-develop-
+    - name: Checking Gatsby cache
+      id: gatsby-cache-build
+      uses: actions/cache@v2
+      with:
+        path: |
+          public
+          .cache
+        key: ${{ runner.os }}-gatsby-build-develop-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-gatsby-build-develop-
 
     - name: Fix mtimes
       run: yarn fix-mtimes --force

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -26,16 +26,16 @@ jobs:
       env:
         NODE_ENV: ${{ secrets.NODE_ENV }}
 
-    # - name: Checking Gatsby cache
-    #   id: gatsby-cache-build
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: |
-    #       public
-    #       .cache
-    #     key: ${{ runner.os }}-gatsby-build-main-${{ github.run_id }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-gatsby-build-main-
+    - name: Checking Gatsby cache
+      id: gatsby-cache-build
+      uses: actions/cache@v2
+      with:
+        path: |
+          public
+          .cache
+        key: ${{ runner.os }}-gatsby-build-main-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-gatsby-build-main-
 
     - name: Fix mtimes
       run: yarn fix-mtimes --force

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -143,7 +143,7 @@ module.exports = {
     siteUrl: 'https://enterprisedb.com/docs',
     algoliaIndex: algoliaIndex,
     isDevelopment: !isBuild,
-    cacheBuster: 2, // for busting gh actions cache if needed
+    cacheBuster: 1, // for busting gh actions cache if needed
   },
   plugins: [
     'gatsby-plugin-sass',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -251,6 +251,14 @@ const createDoc = (navTree, prevNext, doc, productVersions, actions) => {
 
   const template = doc.frontmatter.productStub ? 'doc-stub.js' : 'doc.js';
   const path = isLatest ? replacePathVersion(doc.fields.path) : doc.fields.path;
+
+  // workaround for https://github.com/gatsbyjs/gatsby/issues/26520
+  actions.createPage({
+    path: path,
+    component: require.resolve(`./src/templates/${template}`),
+    context: {},
+  });
+
   actions.createPage({
     path: path,
     component: require.resolve(`./src/templates/${template}`),
@@ -300,6 +308,13 @@ const createAdvocacy = (navTree, prevNext, doc, learn, actions) => {
   const githubIssuesLink = `${advocacyDocsRepoUrl}/issues/new?title=Regarding%20${encodeURIComponent(
     fileUrlSegment,
   )}`;
+
+  // workaround for https://github.com/gatsbyjs/gatsby/issues/26520
+  actions.createPage({
+    path: doc.fields.path,
+    component: require.resolve('./src/templates/learn-doc.js'),
+    context: {},
+  });
 
   actions.createPage({
     path: doc.fields.path,


### PR DESCRIPTION
## What Changed?
 - add workaround to fix stale cache issue with page deletion
 - re-enable gatsby cache for github builds

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
