### PR TITLE
link-rewrite uses semver-compare

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "remark-frontmatter": "^2.0.0",
     "remark-mdx": "^1.6.22",
     "remark-stringify": "^8.1.1",
+    "semver-compare": "^1.0.0",
     "to-vfile": "^6.1.0",
     "typescript": "^4.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12545,6 +12545,11 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
 semver-diff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz#05f77ce59f325e00e2706afd67bb506ddb1ca32b"


### PR DESCRIPTION
## What Changed?

This was used by scripts/normalize/lib/relativelinks.js to do product comparisons, but... Apparently I never actually added it as a dev dependency? 

Figures; I don't run these for a bit and they just rot.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
