### PR TITLE
ensure that Katacoda won't try to load before the page content

### DIFF
--- a/src/components/katacoda-panel.js
+++ b/src/components/katacoda-panel.js
@@ -133,7 +133,10 @@ const KatacodaPanel = ({ katacodaPanelData }) => {
   return (
     <>
       <Helmet>
-        <script src="https://katacoda.com/embed.js" />
+        <script
+          src="https://katacoda.com/embed.js"
+          data-katacoda-ondemand="true"
+        />
       </Helmet>
 
       {isShown ? (


### PR DESCRIPTION
## What Changed?

Finally figured this out with @matt-edb's help: Katacoda is supposed to delay load (that is, the script doesn't try to initialize until we've actually displayed the panel) - if it loads too early and the panel is hidden, then it sets up some constants wrong and never fully loads. 

This is supposed to be triggered by a `data-katacoda-ondemand` attribute on the panel wrapper div. But, sometimes the script would load before the panel was in place. 

This was frustrating because it wouldn't break *every* time - heavily dependent on script load time, when Gatsby decided to refresh the pre-rendered content, and how quickly you click the "Start Now" button after the page loads.

So, gonna cheat just slightly here & put the attribute on the script tag itself: should be then that if the script is loaded it WILL find that attribute (and do nothing until `katacoda.init()` is called later on).