### PR TITLE
Indent body of admonition

### DIFF
--- a/product_docs/docs/pem/8.0/pem_inst_guide_linux/02_pem_hardware_software_requirements.mdx
+++ b/product_docs/docs/pem/8.0/pem_inst_guide_linux/02_pem_hardware_software_requirements.mdx
@@ -18,16 +18,16 @@ Additional disk space is required for data storage. Please note that resource us
 
 ## Software Prerequisites
 
-**Platforms and Versions Support**
+### Platforms and Versions Support
 
 For information about the platforms and versions supported by PEM, visit the EnterpriseDB website at:
 
 <https://www.enterprisedb.com/services-support/edb-supported-products-and-platforms>
 
 !!! note Please note:
-PEM 8.0 is no longer supported on CentOS/RHEL/OEL 6.x platforms. It is strongly recommended that EDB products running on these platforms be migrated to a supported platform.
+    PEM 8.0 is no longer supported on CentOS/RHEL/OEL 6.x platforms. It is strongly recommended that EDB products running on these platforms be migrated to a supported platform.
 
-**Modifying the pg_hba.conf File**
+### Modifying the pg_hba.conf File
 
 The `pg_hba.conf` file manages connections for the Postgres server. You must ensure that the `pg_hba.conf` file on each monitored server allows connections from the PEM server, the monitoring PEM Agent, and the host of the PEM-HTTPD server.
 
@@ -39,10 +39,10 @@ Information about managing authentication is also available in the Postgres core
 
 <https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html>
 
-**Firewall Restrictions**
+### Firewall Restrictions
 
 Please note that you must adjust your firewall to allow communication between PEM components.
 
-**Supported Locales**
+### Supported Locales
 
 Currently, the PEM server and web interface support a locale of `English(US) en_US` and use of a period (.) as a language separator character. Using an alternate locale, or a separator character other than a period may result in errors.


### PR DESCRIPTION
## What Changed?

Fix bug whereby admonition body wasn't indented, and thus interpreted as a "fenced" admonition with no closing, causing it to eat the rest of the page (including some frontmatter!)

Also use real headers instead of bold text, which would've avoided *some* of the issue if it'd been done originally.

Fixes #1089

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
