### PR TITLE
Revert "ensure that Katacoda won't try to load before the page content"

### DIFF
--- a/src/components/katacoda-panel.js
+++ b/src/components/katacoda-panel.js
@@ -133,10 +133,7 @@ const KatacodaPanel = ({ katacodaPanelData }) => {
   return (
     <>
       <Helmet>
-        <script
-          src="https://katacoda.com/embed.js"
-          data-katacoda-ondemand="true"
-        />
+        <script src="https://katacoda.com/embed.js" />
       </Helmet>
 
       {isShown ? (


### PR DESCRIPTION
Reverts EnterpriseDB/docs#1090

Not sure why, but build is failing since this was merged. Seems unrelated, but ... !