### PR TITLE
Revert "Revert "ensure that Katacoda won't try to load before the page content""

### DIFF
--- a/src/components/katacoda-panel.js
+++ b/src/components/katacoda-panel.js
@@ -133,7 +133,10 @@ const KatacodaPanel = ({ katacodaPanelData }) => {
   return (
     <>
       <Helmet>
-        <script src="https://katacoda.com/embed.js" />
+        <script
+          src="https://katacoda.com/embed.js"
+          data-katacoda-ondemand="true"
+        />
       </Helmet>
 
       {isShown ? (


### PR DESCRIPTION
Reverts EnterpriseDB/docs#1093

Wasn't causing the issue, so want this back!