### PR TITLE
Update image paths in EPRS 6.2 to not break pandoc

### DIFF
--- a/product_docs/docs/eprs/6.2/02_overview/02_replication_concepts_and_definitions/02_publications_and_subscriptions.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/02_replication_concepts_and_definitions/02_publications_and_subscriptions.mdx
@@ -33,21 +33,21 @@ The preceding diagram illustrates that a table that has been created as a member
 
 The following diagram illustrates a multi-master replication system with three primary nodes.
 
-![Publications in one database replicating to subscriptions in another database](/../../images/image3.png)
+![Publications in one database replicating to subscriptions in another database](../../images/image3.png)
 
 **Publications in one database replicating to subscriptions in another database**
 
 
 
-![Publications replicating to two subscription databases](/../../images/image4.png)
+![Publications replicating to two subscription databases](../../images/image4.png)
 
 **Publications replicating to two subscription databases**
 
-![*Publications in two databases replicating to one subscription database*](/../../images/image5.png)
+![*Publications in two databases replicating to one subscription database*](../../images/image5.png)
 
 **Publications in two databases replicating to one subscription database**
 
-![*Cascading Replication: Tables used in both a subscription and a publication*](/../../images/image6.png)
+![*Cascading Replication: Tables used in both a subscription and a publication*](../../images/image6.png)
 
 **Cascading Replication: Tables used in both a subscription and a publication**
 
@@ -55,6 +55,6 @@ The preceding diagram illustrates that a table that has been created as a member
 
 The following diagram illustrates a multi-master replication system with three primary nodes.
 
-![*Multi-master replication system*](/../../images/image7.png)
+![*Multi-master replication system*](../../images/image7.png)
 
 **Multi-master replication system**

--- a/product_docs/docs/eprs/6.2/02_overview/02_replication_concepts_and_definitions/03_smr_replication.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/02_replication_concepts_and_definitions/03_smr_replication.mdx
@@ -10,6 +10,6 @@ Generally, changes must not be made to the definitions of the publication tables
 
 Changes must not be made to the rows of the subscription tables. If such changes are made, they are not propagated back to the publication. If changes are made to the subscription table rows, it is fairly likely that the rows will no longer match their publication counterparts. There is also a risk that future replication attempts may fail.
 
-![Single-Master (Primary-to-secondary) replication](/../../images/image8.png)
+![Single-Master (Primary-to-secondary) replication](../../images/image8.png)
 
 **Single-Master (Primary-to-secondary) replication**

--- a/product_docs/docs/eprs/6.2/02_overview/02_replication_concepts_and_definitions/04_mmr_replication.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/02_replication_concepts_and_definitions/04_mmr_replication.mdx
@@ -23,6 +23,6 @@ Once the multi-master replication system is defined, changes (inserts, updates, 
 
 Generally, changes must not be made to the table definitions in any of the primary nodes including the primary definition node. If such changes are made, they are not propagated to other nodes in the multi-master replication system unless they are made using the DDL change replication feature described in [Replicating DDL Changes](../../07_common_operations/08_replicating_ddl_changes/#replicating_ddl_changes). If changes are made to tables without using the DDL change replication feature, there is a risk that future replication attempts may fail.
 
-![In a multi-master replication system, table rows can be updated at any primary node](/../../images/image9.png)
+![In a multi-master replication system, table rows can be updated at any primary node](../../images/image9.png)
 
 **In a multi-master replication system, table rows can be updated at any primary node**

--- a/product_docs/docs/eprs/6.2/02_overview/03_replication_server_components_and_architecture/01_physical_components.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/03_replication_server_components_and_architecture/01_physical_components.mdx
@@ -8,13 +8,13 @@ xDB Replication Server is not a single, executable program, but rather a set of 
 
 The following diagram illustrates the components of xDB Replication Server and how they are used to form a complete, basic, single-master replication system.
 
-![xDB Replication Server - physical view (single-master replication system)](/../../images/image10.png)
+![xDB Replication Server - physical view (single-master replication system)](../../images/image10.png)
 
 **Figure 2-8: xDB Replication Server - physical view (single-master replication system)**
 
 The following diagram illustrates the components of xDB Replication Server and how they are used to form a complete, basic, multi-master replication system.
 
-![xDB Replication Server - physical view (multi-master replication system)](/../../images/image11.png)
+![xDB Replication Server - physical view (multi-master replication system)](../../images/image11.png)
 
 **Figure 2 9: xDB Replication Server - physical view (multi-master replication system)**
 
@@ -183,7 +183,7 @@ The xDB Replication Console is the graphical user interface program you can use 
 
 Through a single xDB Replication Console, you can configure and operate a replication system running on the same host on which the xDB Replication Console is installed, or you can configure and operate replication systems where the xDB Replication Server components are distributed on different hosts in a networked environment.
 
-![xDB Replication Consoles accessing multiple hosts](/../../images/image12.png)
+![xDB Replication Consoles accessing multiple hosts](../../images/image12.png)
 
 In the preceding figure, there are two Postgres installations running on two networked hosts, each with its own xDB Replication Server installation. Each host is running a publication server and a subscription server.
 

--- a/product_docs/docs/eprs/6.2/02_overview/03_replication_server_components_and_architecture/03_xdb_replication_system_examples.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/03_replication_server_components_and_architecture/03_xdb_replication_system_examples.mdx
@@ -12,7 +12,7 @@ In the accompanying diagrams, the logical components, represented by nodes in th
 
 The following is an illustration of a basic Oracle to PostgreSQL or Advanced Server single-master replication system. A single publication in Oracle contains tables from two schemas that are replicated to a database residing in either PostgreSQL or Advanced Server.
 
-![Oracle to PostgreSQL or Advanced Server replication](/../../images/image13.png)
+![Oracle to PostgreSQL or Advanced Server replication](../../images/image13.png)
 
 **Figure 2-11: Oracle to PostgreSQL or Advanced Server replication**
 
@@ -26,7 +26,7 @@ The following describes the logical components in the preceding diagram: \* The 
 
 The following screen capture shows how the logical components of this replication system appear in the xDB Replication Console replication tree.
 
-![Oracle to Postgres replication tree](/../../images/image14.png)
+![Oracle to Postgres replication tree](../../images/image14.png)
 
 **Figure 2-12: Oracle to Postgres replication tree**
 
@@ -38,7 +38,7 @@ See Chapter [Introduction to the xDB Replication Console](../../04_intro_xdb_con
 
 The following is an illustration of a basic SQL Server to PostgreSQL or Advanced Server single-master replication system. A single publication in SQL Server contains tables from two schemas that are replicated to a database residing in either PostgreSQL or Advanced Server.
 
-![SQL Server to PostgreSQL or Advanced Server replication](/../../images/image15.png)
+![SQL Server to PostgreSQL or Advanced Server replication](../../images/image15.png)
 
 **Figure 2-13: SQL Server to PostgreSQL or Advanced Server replication**
 
@@ -53,7 +53,7 @@ The following describes the logical components in the preceding diagram:
 
 The following screen capture shows how the logical components of this replication system appear in the xDB Replication Console replication tree.
 
-![SQL Server to Postgres replication tree](/../../images/image16.png)
+![SQL Server to Postgres replication tree](../../images/image16.png)
 
 **Figure 2-14: SQL Server to Postgres replication tree**
 
@@ -63,7 +63,7 @@ See Chapter [Introduction to the xDB Replication Console](../../04_intro_xdb_con
 
 The following is an illustration of a basic Advanced Server to Oracle single-master replication system. A single publication in an Advanced Server database contains tables from two schema that are replicated to an Oracle database.
 
-![Advanced Server to Oracle replication](/../../images/image17.png)
+![Advanced Server to Oracle replication](../../images/image17.png)
 
 **Figure 2-15: Advanced Server to Oracle replication**
 
@@ -78,7 +78,7 @@ The following describes the logical components in the preceding diagram:
 
 The following screen capture shows how the logical components of this replication system appear in the xDB Replication Console replication tree.
 
-![Advanced Server to Oracle replication tree](/../../images/image18.png)
+![Advanced Server to Oracle replication tree](../../images/image18.png)
 
 **Figure 2-16: Advanced Server to Oracle replication tree**
 
@@ -89,7 +89,7 @@ See Chapter [Introduction to the xDB Replication Console](../../04_intro_xdb_con
 
 The following is an illustration of a basic PostgreSQL to Oracle single-master replication system. A single publication in a PostgreSQL database contains tables from two schemas that are replicated to an Oracle database. WAL based method as well as trigger-based method is supported in this type of replication.
 
-![PostgreSQL to Oracle replication](/../../images/PG_to_oracle.png)
+![PostgreSQL to Oracle replication](../../images/PG_to_oracle.png)
 
 **Figure 2-16: PostgreSQL to Oracle replication**
 
@@ -104,7 +104,7 @@ The following describes the logical components in the preceding diagram:
 
 The following screen capture shows how the logical components of this replication system appear in the xDB Replication Console replication tree.
 
-![PostgreSQL to Oracle replication tree](/../../images/PG_to_oracle_sc.png)
+![PostgreSQL to Oracle replication tree](../../images/PG_to_oracle_sc.png)
 
 **Figure 2-17: PostgreSQL to Oracle replication tree**
 
@@ -112,7 +112,7 @@ The following screen capture shows how the logical components of this replicatio
 
 The following is an illustration of a basic PostgreSQL or Advanced Server to SQL Server single-master replication system. A single publication in a PostgreSQL or Advanced Server database contains tables from two schemas that are replicated to a SQL Server database.
 
-![PostgreSQL or Advanced Server to SQL Server replication](/../../images/image19.png)
+![PostgreSQL or Advanced Server to SQL Server replication](../../images/image19.png)
 
 **Figure 2-18: PostgreSQL or Advanced Server to SQL Server replication**
 
@@ -127,7 +127,7 @@ The following describes the logical components in the preceding diagram:
 
 The following screen capture shows how the logical components of this replication system appear in the xDB Replication Console replication tree.
 
-![Postgres to SQL Server replication tree](/../../images/image20.png)
+![Postgres to SQL Server replication tree](../../images/image20.png)
 
 **Figure 2-19: Postgres to SQL Server replication tree**
 
@@ -137,7 +137,7 @@ See [Introduction to the xDB Replication Console](../../04_intro_xdb_console/#in
 
 The following is an illustration of a basic Postgres multi-master replication system. A publication in a Postgres primary definition node contains tables from two schemas that are initially replicated to two other Postgres primary nodes. The tables in all three primary nodes can then be updated and synchronized with each other.
 
-![Postgres multi-master replication system](/../../images/image21.png)
+![Postgres multi-master replication system](../../images/image21.png)
 
 **Figure 2-20: Postgres multi-master replication system**
 
@@ -152,7 +152,7 @@ The following describes the logical components in the preceding diagram:
 
 The following screen capture shows how the logical components of this replication system appear in the xDB Replication Console replication tree.
 
-![Postgres multi-master replication tree](/../../images/image22.png)
+![Postgres multi-master replication tree](../../images/image22.png)
 
 **Figure 2-21: Postgres multi-master replication tree**
 

--- a/product_docs/docs/eprs/6.2/02_overview/04_design_replication_system/05_distributed_replication.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/04_design_replication_system/05_distributed_replication.mdx
@@ -18,7 +18,7 @@ The simplest implementation of a replication system is when all replication comp
 
 The Postgres publication or subscription database as the case may be, can reside in the initial database cluster that is created when Postgres is installed on the host.
 
-![Single host replication system](/../../images/image23.png)
+![Single host replication system](../../images/image23.png)
 
 **Figure 2-22: Single host replication system**
 
@@ -37,7 +37,7 @@ The disadvantages of a single host replication system are the following:
 
 xDB Replication Server allows you to build a replication system with either or both of the publication database and the subscription database on separate hosts. This is illustrated in the following diagram:
 
-![Oracle database server on distributed host](/../../images/image24.png)
+![Oracle database server on distributed host](../../images/image24.png)
 
 **Figure 2-23: Oracle database server on distributed host**
 
@@ -60,6 +60,6 @@ The disadvantages of a distributed host replication system are the following:
 
 In a multi-master replication system, the Postgres database servers running the primary nodes can be running on a single or multiple hosts. The following example illustrates two primary nodes running on database servers on separate hosts as well as a primary node running on the same database server as the publication server.
 
-![Multi-master replication on distributed hosts](/../../images/image25.png)
+![Multi-master replication on distributed hosts](../../images/image25.png)
 
 Figure 2-24: Multi-master replication on distributed hosts

--- a/product_docs/docs/eprs/6.2/03_installation/01_installing_with_stackbuilder.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/01_installing_with_stackbuilder.mdx
@@ -24,19 +24,19 @@ Follow the directions for your host operating system to install Java runtime.
 
 **Step 2:** From the host’s application menu, open the Postgres menu and choose `Stack Builder` or `StackBuilder Plus`.
 
-![Postgres application menu](/../images/image26.png)
+![Postgres application menu](../images/image26.png)
 
 **Figure 3-1: Postgres application menu**
 
 **Step 3 (For Linux only):** Depending upon your Linux host, a dialog box or a prompt appears requesting the root account’s password. Enter the root password and click the `OK` button.
 
-![Enter root account password](/../images/image27.png)
+![Enter root account password](../images/image27.png)
 
 **Figure 3-2: Enter root account password**
 
 **Step 4:** The StackBuilder Plus welcome screen appears. Select your `Postgres` installation from the drop-down list and click the `Next` button.
 
-![StackBuilder Plus welcome screen](/../images/image28.png)
+![StackBuilder Plus welcome screen](../images/image28.png)
 
 **Figure 3-3: StackBuilder Plus welcome screen**
 
@@ -45,17 +45,17 @@ Follow the directions for your host operating system to install Java runtime.
 !!! Note
     Though the following ../images show Replication Server v6.0, use the same process for Replication Server v6.2.
 
-![StackBuilder Plus applications](/../images/image29.png)
+![StackBuilder Plus applications](../images/image29.png)
 
 **Figure 3-4: StackBuilder Plus applications**
 
 **Step 5 (For PostgreSQL):** Expand the Registration-Required and Trial Products node, and then expand the EnterpriseDB Tools node. Check the box for `Replication Server` under the `EnterpriseDB Tools` list and click the `Next` button.
 
-![Stack Builder applications](/../images/image30.png)
+![Stack Builder applications](../images/image30.png)
 
 **Figure 3-5: Stack Builder applications**
 
-![EnterpriseDB Tools for PostgreSQL](/../images/image31.png)
+![EnterpriseDB Tools for PostgreSQL](../images/image31.png)
 
 **Figure 3-6: EnterpriseDB Tools for PostgreSQL**
 
@@ -64,19 +64,19 @@ Follow the directions for your host operating system to install Java runtime.
 !!! Note
     (For PostgreSQL only): Proceed to Step 7. If you are using PostgreSQL, account registration occurs later in the process.
 
-![EnterpriseDB account registration](/../images/image32.png)
+![EnterpriseDB account registration](../images/image32.png)
 
 **Figure 3-7: EnterpriseDB account registration**
 
 **Step 7:** Verify that Replication Server appears in the list of selected packages. Click the `Next` button.
 
-![Selected packages](/../images/image33.png)
+![Selected packages](../images/image33.png)
 
 **Figure 3-8: Selected packages**
 
 An information box appears showing the download progress of the Replication Server package. This may take a few minutes.
 
-![Downloading progress](/../images/image34.png)
+![Downloading progress](../images/image34.png)
 
 **Figure 3-9: Downloading progress**
 
@@ -85,44 +85,44 @@ An information box appears showing the download progress of the Replication Serv
 !!! Note
     You can check the Skip Installation box if you wish to install xDB Replication Server some other time.
 
-![Start installation](/../images/image35.png)
+![Start installation](../images/image35.png)
 
 **Figure 3-10: Start installation**
 
 **Step 9:** Select the installation language and click the `OK` button.
 
-![Installation language](/../images/image36.png)
+![Installation language](../images/image36.png)
 
 **Figure 3-11: Installation language**
 
 **Step 10:** In the Setup xDB Replication Server screen, click the `Next` button.
 
-![Installation language](/../images/image37.png)
+![Installation language](../images/image37.png)
 
 **Figure 3-12: Setup xDB Replication Server**
 
 **Step 11:** Read the license agreement. If you accept the agreement, select the accept radio button and click the `Next` button.
 
-![Installation language](/../images/image38.png)
+![Installation language](../images/image38.png)
 
 **Figure 3-13: License agreement**
 
 **Step 12:** Browse to a directory where you want the xDB Replication Server components installed, or allow it to install the components in the default location shown. Click the `Next` button.
 
-![Installation directory](/../images/image39.png)
+![Installation directory](../images/image39.png)
 
 **Figure 3-14: Installation directory**
 
 **Step 13:** If you do not want a particular xDB Replication Server component installed on this particular host, uncheck the box `Next` to the component name. Click the `Next` button.
 
-![Select components](/../images/image40.png)
+![Select components](../images/image40.png)
 
 **Figure 3-15: Select components**
 
 
 **Step 14:** In the Account Registration screen select the radio button that applies to you. Click the `Next` button.
 
-![Account registration](/../images/image41.png)
+![Account registration](../images/image41.png)
 
 **Figure 3-16: Account registration**
 
@@ -130,7 +130,7 @@ If you do not have an EnterpriseDB user account, you will be directed to the reg
 
 If you already have an EnterpriseDB user account, enter the email address and password for your EnterpriseDB user account as shown in the following screen. Click the `Next` button.
 
-![My EnterpriseDB account](/../images/image42.png)
+![My EnterpriseDB account](../images/image42.png)
 
 **Figure 3-17: My EnterpriseDB account**
 
@@ -144,7 +144,7 @@ Enter values for the following fields:
 -   `Admin User.` The xDB administrator user name to authenticate certain usage of the xDB Replication Server such as registering a publication server or a subscription server running on this host. Any alphanumeric string may be entered for the admin user name. The default admin user name is admin.
 -   `Admin Password.` Password of your choice for the xDB administrator given in the Admin User field.
 
-![xDB admin user information](/../images/image43.png)
+![xDB admin user information](../images/image43.png)
 
 **Figure 3-18: xDB admin user information**
 
@@ -152,43 +152,43 @@ The admin user and the admin password (in encrypted form) are saved to the xDB R
 
 **Step 16 (Only if publication server is a selected component):** Enter an available port on which the publication server will run. Default port number is 9051. Click the `Next` button.
 
-![xDB admin user information](/../images/image44.png)
+![xDB admin user information](../images/image44.png)
 
 **Figure 3-19: Publication server details**
 
 **Step 17 (Only if subscription server is a selected component):** Enter an available port on which the subscription server will run. Default port number is 9052. Click the `Next` button.
 
-![Subscription server details](/../images/image45.png)
+![Subscription server details](../images/image45.png)
 
 **Figure 3-20: Subscription server details**
 
 **Step 18:** For the operating system account under which the publication server or subscription server is to run, enter `postgres` (`enterprisedb` if you are using Advanced Server installed in Oracle compatible configuration mode).
 
-![Publication/subscription server operating system account](/../images/image46.png)
+![Publication/subscription server operating system account](../images/image46.png)
 
 **Figure 3-21: Publication/subscription server operating system account**
 
 **Step 19:** On the Ready to Install screen, click the `Next` button.
 
-![Ready to install](/../images/image47.png)
+![Ready to install](../images/image47.png)
 
 **Figure 3-22: Ready to install**
 
 An information box appears showing the installation progress of the xDB Replication Server selected components. This may take a few minutes.
 
-![Installation progress](/../images/image48.png)
+![Installation progress](../images/image48.png)
 
 **Figure 3-23: Installation progress**
 
 **Step 20:** When installation has completed the following screen appears. Click the Finish button.
 
-![xDB Replication Server installation completion](/../images/image49.png)
+![xDB Replication Server installation completion](../images/image49.png)
 
 **Figure 3-24: xDB Replication Server installation completion**
 
 **Step 21:** On the `StackBuilder Plus Installation Complete` screen, click the `Finish` button.
 
-![StackBuilder Plus installation complete](/../images/image50.png)
+![StackBuilder Plus installation complete](../images/image50.png)
 
 **Figure 3-25: StackBuilder Plus installation complete**
 

--- a/product_docs/docs/eprs/6.2/03_installation/06_uninstalling_xdb_replication_server.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/06_uninstalling_xdb_replication_server.mdx
@@ -27,13 +27,13 @@ $ ./uninstall-xdbreplicationserver
 
 **Step 2:** Click the `Yes` button to confirm uninstallation of xDB Replication Server.
 
-![Confirm xDB Replication Server uninstallation](/../images/image51.png)
+![Confirm xDB Replication Server uninstallation](../images/image51.png)
 
 **Figure 3-26: Confirm xDB Replication Server uninstallation**
 
 **Step 3:** The `Uninstallation Completed` dialog box appears when the process has completed. Click the `OK` button.
 
-![Uninstallation completed](/../images/image52.png)
+![Uninstallation completed](../images/image52.png)
 
 **Figure 3-27: Uninstallation completed**
 
@@ -41,26 +41,26 @@ $ ./uninstall-xdbreplicationserver
 
 **Step 1:** From the `Windows Control Panel`, select `Uninstall a Program`.
 
-![Uninstall a program](/../images/image53.png)
+![Uninstall a program](../images/image53.png)
 
 **Figure 3-28: Uninstall a program**
 
 **Step 2:** Select the xDB Replication Server product in the list of programs to uninstall or change. Click the `Uninstall/Change` button.
 
-![Uninstall or change a program](/../images/image54.png)
+![Uninstall or change a program](../images/image54.png)
 
 **Figure 3-29: Uninstall or change a program**
 
 
 **Step 3:** Click the `Yes` button to confirm uninstallation of xDB Replication Server.
 
-![Confirm xDB Replication Server uninstallation](/../images/image55.png)
+![Confirm xDB Replication Server uninstallation](../images/image55.png)
 
 **Figure 3-30: Confirm xDB Replication Server uninstallation**
 
 **Step 4:** The `Uninstallation Completed` dialog box appears when the process has completed. Click the `OK` button.
 
-![Uninstallation completed](/../images/image56.png)
+![Uninstallation completed](../images/image56.png)
 
 **Figure 3-31: Uninstallation completed**
 

--- a/product_docs/docs/eprs/6.2/04_intro_xdb_console.mdx
+++ b/product_docs/docs/eprs/6.2/04_intro_xdb_console.mdx
@@ -13,7 +13,7 @@ The xDB Replication Console window consists of the following main areas:
 -   `Replication Tree.` Replication system components represented as nodes in an inverted tree
 -   `Information Window.` Tabbed window with information about a highlighted node in the replication tree
 
-![xDB Replication Console window](/images/image57.png)
+![xDB Replication Console window](images/image57.png)
 
 **Figure 4-1: xDB Replication Console window**
 
@@ -32,7 +32,7 @@ This section describes when the various tool bar icons are activated. The operat
 
 The `Refresh` icon is always activated. Click the `Refresh` icon if the replication tree or information window does not appear to display the latest information after performing an operation. Clicking the `Refresh` icon ensures that the latest information is shown in the replication tree and in the information window.
 
-![Refresh icon](/images/image58.png)
+![Refresh icon](images/image58.png)
 
 **Figure 4-2: Refresh icon**
 
@@ -40,7 +40,7 @@ The `Refresh` icon is always activated. Click the `Refresh` icon if the replicat
 
 The `Create Publication` icon is activated when a Publication Database node is highlighted in the replication tree.
 
-![Create Publication icon](/images/image59.png)
+![Create Publication icon](images/image59.png)
 
 **Figure 4-3: Create Publication icon**
 
@@ -48,7 +48,7 @@ The `Create Publication` icon is activated when a Publication Database node is h
 
 The `Remove Publication` icon, `Add Publication Tables` icon, and `Remove Publication Tables` icon are activated when a Publication node is highlighted in the replication tree.
 
-![Remove Publication, Add Publication Tables, and Remove Publication Tables icons](/images/image60.png)
+![Remove Publication, Add Publication Tables, and Remove Publication Tables icons](images/image60.png)
 
 **Figure 4-4: Remove Publication, Add Publication Tables, and Remove Publication Tables icons**
 
@@ -56,7 +56,7 @@ The `Remove Publication` icon, `Add Publication Tables` icon, and `Remove Public
 
 The `Create Subscription` icon is activated when a Subscription Database node is highlighted in the replication tree.
 
-![Create Subscription icon](/images/image61.png)
+![Create Subscription icon](images/image61.png)
 
 **Figure 4-5: Create Subscription icon**
 
@@ -65,7 +65,7 @@ The `Create Subscription` icon is activated when a Subscription Database node is
 
 The `Remove Subscription` icon, `Snapshot` icon, `Synchronize` icon, `Configure Schedule` icon, and `Remove Schedule` icon are activated when a Subscription node is highlighted in the replication tree.
 
-![Remove Subscription, Snapshot, Synchronize, Configure Schedule, and Remove Schedule icons](/images/image62.png)
+![Remove Subscription, Snapshot, Synchronize, Configure Schedule, and Remove Schedule icons](images/image62.png)
 
 **Figure 4-6: Remove Subscription, Snapshot, Synchronize, Configure Schedule, and Remove Schedule icons**
 
@@ -85,7 +85,7 @@ The following shows the Register Publication Server dialog box where the option 
 
 The values for User Name and Password that you enter are validated against the admin user name and password in the xDB Replication Configuration file residing on host `192.168.2.22`, in this case. The admin user name and password must successfully authenticate before registration of the publication server and saving of the publication server’s login information in the server login file occur. See [xDB Replication Configuration File](02_overview/03_replication_server_components_and_architecture/01_physical_components/#xdb_replication_conf_file) for information on the xDB Replication Configuration file.
 
-![Save login information option for a publication server](/images/image63.png)
+![Save login information option for a publication server](images/image63.png)
 
 **Figure 4-7: Save login information option for a publication server**
 
@@ -93,7 +93,7 @@ See [Registering a Publication Server](05_smr_operation/02_creating_publication/
 
 The following shows the Register Subscription Server dialog box. In this example `192.168.2.22` entered in the Host field, `9052` entered in the Port field, admin entered in the User Name field, and an encrypted form of the password entered in the Password field are saved in the server login file for this subscription server if the admin user name and password validation are successful.
 
-![Save login information option for a subscription server](/images/image64.png)
+![Save login information option for a subscription server](images/image64.png)
 
 **Figure 4-8: Save login information option for a subscription server**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/02_creating_publication/01_registering_publication_server.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/02_creating_publication/01_registering_publication_server.mdx
@@ -59,7 +59,7 @@ Similarly, use the stop option to stop the publication server.
 
 **For Windows only:** Open Control Panel, System and Security, Administrative Tools, and then Services. The publication server runs as a service named Publication Service for xDB Replication Server.
 
-![Windows publication service](/../../images/image65.png)
+![Windows publication service](../../images/image65.png)
 
 **Figure 5-1: Windows publication service**
 
@@ -69,11 +69,11 @@ If the publication server fails to start, see [Publication and Subscription Serv
 
 Step 2: Register the publication server. Open the xDB Replication Console from the system’s application menu. For xDB Replication Server installed from an xDB RPM package, the xDB Replication Console is started by invoking the script `XDB_HOME/bin/runRepConsole.sh`.
 
-![xDB Replication Console menu option](/../../images/image66.png)
+![xDB Replication Console menu option](../../images/image66.png)
 
 **Figure 5-2: xDB Replication Console menu option**
 
-![xDB Replication Console](/../../images/image67.png)
+![xDB Replication Console](../../images/image67.png)
 
 **Figure 5-3: xDB Replication Console**
 
@@ -90,13 +90,13 @@ Enter the values you supplied during the installation of xDB Replication Server 
 !!! Note
     The user name and password combination you enter is authenticated against the admin user name and password in the xDB Replication Configuration file residing on the host with the IP address you enter in the Host field.
 
-![Register Publication Server dialog box](/../../images/image63.png)
+![Register Publication Server dialog box](../../images/image63.png)
 
 **Figure 5-4: Register Publication Server dialog box**
 
 Click the `Register` button after you have filled in the fields. A Publication Server node appears in the replication tree of the xDB Replication Console. Expand the Publication Server node to expose the SMR and MMR type nodes.
 
-![Replication tree after registering a publication server](/../../images/image68.png)
+![Replication tree after registering a publication server](../../images/image68.png)
 
 **Figure 5-5: Replication tree after registering a publication server**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/02_creating_publication/02_adding_pub_database.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/02_creating_publication/02_adding_pub_database.mdx
@@ -26,7 +26,7 @@ You must enter database connection information such as the database server netwo
 -   `URL Options (For SSL connectivity).` Enter the URL options to establish SSL connectivity to the publication database. See [Using Secure Sockets Layer (SSL) Connections](../../07_common_operations/11_using_ssl_connections/#using_ssl_connections) for information on using SSL connections.
 -   `Changeset Logging (For Postgres).` Select Table Triggers to use the trigger-based method of synchronization replication. Select WAL Stream to use the log-based method of synchronization replication. See [Synchronization Replication with the Trigger-Based Method](../../02_overview/02_replication_concepts_and_definitions/09_sync_replication_trigger_based/#sync_replication_trigger_based) for information on the trigger-based method. See [Synchronization Replication with the Log-Based Method](../../02_overview/02_replication_concepts_and_definitions/10_sync_replication_log_based/#sync_replication_log_based) for information on the log-based method.
 
-![Publication Service - Add Database dialog box](/../../images/image69.png)
+![Publication Service - Add Database dialog box](../../images/image69.png)
 
 **Figure 5-6: Publication Service - Add Database dialog box**
 
@@ -35,13 +35,13 @@ You must enter database connection information such as the database server netwo
 
 The following is the Publication Service – Add Database dialog box for a Postgres database that shows the `Changeset Logging` option for selecting either the trigger-based method or the log-based method of synchronization replication.
 
-![Publication Service - Add Database dialog box for Postgres](/../../images/image70.png)
+![Publication Service - Add Database dialog box for Postgres](../../images/image70.png)
 
 **Figure 5-7: Publication Service - Add Database dialog box for Postgres**
 
 **Step 4:** Click the `Test` button. If Test Result: Success appears, click the `OK` button, then click the `Save` button.
 
-![Successful publication database test](/../../images/image71.png)
+![Successful publication database test](../../images/image71.png)
 
 **Figure 5-8: Successful publication database test**
 
@@ -49,7 +49,7 @@ If an error message appears investigate the cause of the error, correct the prob
 
 When the publication database definition is successfully saved, a Publication Database node is added to the replication tree under the Publication Server node.
 
-![Replication tree after adding a publication database](/../../images/image72.png)
+![Replication tree after adding a publication database](../../images/image72.png)
 
 **Figure 5-9: Replication tree after adding a publication database**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/02_creating_publication/03_adding_publication.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/02_creating_publication/03_adding_publication.mdx
@@ -16,7 +16,7 @@ Subordinate to a publication database definition, you create publications that c
 -   `Select All.` Check this box if you want to include all tables and views in the Available Tables list in the publication.
 -   `Use Wildcard Selection.` Click this button to use the wildcard selector to choose tables for the publication. See [Selecting Tables with the Wildcard Selector](../../07_common_operations/01_select_tables_wildcard_selector/#select_tables_wildcard_selector) for information on the wildcard selector.
 
-![Create Publication dialog box](/../../images/image73.png)
+![Create Publication dialog box](../../images/image73.png)
 
 **Figure 5-10: Create Publication dialog box**
 
@@ -46,19 +46,19 @@ In the `Filter` dialog box, enter a descriptive filter name and the filter claus
 
 In the following example a filter rule is defined on the `DEPT` table so only rows where the `deptno` column contains 10, 20, or 30 are included in replications. All other rows are excluded from replication.
 
-![Adding a filter rule for the DEPT table](/../../images/image74.png)
+![Adding a filter rule for the DEPT table](../../images/image74.png)
 
 **Figure 5-11: Adding a filter rule for the DEPT table**
 
 The following shows a rule added to the `EMP` table by choosing `EDB.EMP` from the Table/View drop-down list and then entering the selection criteria for only rows with deptno containing 10 in the Filter dialog box.
 
-![Adding a filter rule for the EMP table](/../../images/image75.png)
+![Adding a filter rule for the EMP table](../../images/image75.png)
 
 **Figure 5-12: Adding a filter rule for the EMP table**
 
 Repeating this process, additional filter rules can be added for the EMP table. The following shows the complete set of available filter rules defined for the `DEPT` and `EMP` tables.
 
-![Set of all available filter rules](/../../images/image76.png)
+![Set of all available filter rules](../../images/image76.png)
 
 **Figure 5-13: Set of all available filter rules**
 
@@ -70,12 +70,12 @@ When creating a subscription, you may selectively enable these table filters on 
 
 **Step 4:** Click the `Create` button. If Publication Created Successfully appears, click the `OK` button, otherwise investigate the error and make the necessary corrections.
 
-![Publication created successfully](/../../images/image77.png)
+![Publication created successfully](../../images/image77.png)
 
 **Figure 5-14: Publication created successfully**
 
 Upon successful publication creation, a Publication node is added to the replication tree.
 
-![Replication tree after adding a publication](/../../images/image78.png)
+![Replication tree after adding a publication](../../images/image78.png)
 
 **Figure 5-15: Replication tree after adding a publication**

--- a/product_docs/docs/eprs/6.2/05_smr_operation/03_creating_subscription/01_registering_subscription_server.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/03_creating_subscription/01_registering_subscription_server.mdx
@@ -17,7 +17,7 @@ It is important that you record the login information for the subscription serve
 
 **For Windows only:** Open Control Panel, System and Security, Administrative Tools, and then Services. Use the Start or Restart link for the service named Subscription Service for xDB Replication Server.
 
-![Windows subscription service](/../../images/image79.png)
+![Windows subscription service](../../images/image79.png)
 
 **Figure 5-16: Windows subscription service**
 
@@ -38,12 +38,12 @@ Enter the values you supplied during the installation of xDB Replication Server 
 !!! Note
     The user name and password combination you enter is authenticated against the admin user name and password in the xDB Replication Configuration file residing on the host with the IP address you enter in the Host field.
 
-![Register Subscription Server dialog box](/../../images/image64.png)
+![Register Subscription Server dialog box](../../images/image64.png)
 
 **Figure 5-17: Register Subscription Server dialog box**
 
 Click the Register button after you have filled in the fields. A Subscription Server node appears in the replication tree of the xDB Replication Console.
 
-![Replication tree after registering a subscription server](/../../images/image80.png)
+![Replication tree after registering a subscription server](../../images/image80.png)
 
 **Figure 5-18: Replication tree after registering a subscription server**

--- a/product_docs/docs/eprs/6.2/05_smr_operation/03_creating_subscription/02_adding_subscription_database.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/03_creating_subscription/02_adding_subscription_database.mdx
@@ -41,13 +41,13 @@ Note the following restriction on the subscription database:
 -   `Database (For Postgres or SQL Server)`. Enter the Postgres or SQL Server database name.
 -   `URL Options (For SSL connectivity)`. Enter the URL options to establish SSL connectivity to the subscription database. See [Using Secure Sockets Layer (SSL) Connections](../../07_common_operations/11_using_ssl_connections/#using_ssl_connections) for information on using SSL connections.
 
-![Subscription Service - Add Database dialog box](/../../images/image81.png)
+![Subscription Service - Add Database dialog box](../../images/image81.png)
 
 **Figure 5-19: Subscription Service - Add Database dialog box**
 
 **Step 4:** Click the `Test` button. If Test Result: Success appears, click the OK button, then click the Save button.
 
-![Successful subscription database test](/../../images/image82.png)
+![Successful subscription database test](../../images/image82.png)
 
 **Figure 5-20: Successful subscription database test**
 
@@ -55,6 +55,6 @@ If an error message appears investigate the cause of the error, correct the prob
 
 When the subscription database definition is successfully saved, a Subscription Database node is added to the replication tree under the Subscription Server node.
 
-![Replication tree after adding a subscription database](/../../images/image83.png)
+![Replication tree after adding a subscription database](../../images/image83.png)
 
 **Figure 5-21: Replication tree after adding a subscription database**

--- a/product_docs/docs/eprs/6.2/05_smr_operation/03_creating_subscription/03_adding_subscription.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/03_creating_subscription/03_adding_subscription.mdx
@@ -17,7 +17,7 @@ Subordinate to a subscription database definition, you create subscriptions. A s
 -   `Password`. Password of the admin user. This is the same value entered in the Password field in Step 3 of [Registering a Publication Server](../02_creating_publication/01_registering_publication_server/#registering_publication_server).
 -   `Publication Name`. Click the `Load` button to get a list of available publications. Select the publication to which to subscribe.
 
-![Create Subscription dialog box](/../../images/image84.png)
+![Create Subscription dialog box](../../images/image84.png)
 
 **Figure 5-22: Create Subscription dialog box**
 
@@ -27,24 +27,24 @@ Click the Filter Rules tab to enable one or more filter rules on the subscriptio
 
 In the following example the filter named `dept_10_20_30` is enabled on the dept table and the filter named dept_30 is enabled on the `emp` table of this subscription.
 
-![Enabling filter rules on a subscription](/../../images/image85.png)
+![Enabling filter rules on a subscription](../../images/image85.png)
 
 **Figure 5-23: Enabling filter rules on a subscription**
 
 **Step 4:** Click the `Create` button. If `Subscription Created Successfully` appears, click the `OK` button, otherwise investigate the error and make the necessary corrections.
 
-![Subscription created successfully](/../../images/image86.png)
+![Subscription created successfully](../../images/image86.png)
 
 **Figure 5-24: Subscription created successfully**
 
 Upon successful subscription creation, a Subscription node is added to the replication tree.
 
-![Replication tree after adding a subscription](/../../images/image87.png)
+![Replication tree after adding a subscription](../../images/image87.png)
 
 **Figure 5-25: Replication tree after adding a subscription**
 
 The tables and views from the publication are created in the subscription database, but without any rows. Rows are populated into the subscription tables when the first snapshot replication occurs.
 
-![Table definitions in the subscription database](/../../images/image88.png)
+![Table definitions in the subscription database](../../images/image88.png)
 
 **Figure 5-26: Table definitions in the subscription database**

--- a/product_docs/docs/eprs/6.2/05_smr_operation/04_on_demand_replication/01_perform_replication.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/04_on_demand_replication/01_perform_replication.mdx
@@ -8,7 +8,7 @@ The very first replication must be performed using snapshot replication. After t
 
 **Step 1:** Select the Subscription node of the subscription for which you wish to perform snapshot replication.
 
-![Selecting a subscription for an on demand snapshot](/../../images/image89.png)
+![Selecting a subscription for an on demand snapshot](../../images/image89.png)
 
 **Figure 5-27: Selecting a subscription for an on demand snapshot**
 
@@ -18,13 +18,13 @@ The very first replication must be performed using snapshot replication. After t
 -   Click the secondary mouse button on the Subscription node and choose `Snapshot`.
 -   Click the primary mouse button on the Snapshot icon.
 
-![Opening the Snapshot dialog box](/../../images/image90.png)
+![Opening the Snapshot dialog box](../../images/image90.png)
 
 **Figure 5-28: Opening the Snapshot dialog box**
 
 **Step 3:** Select the `Verbose Output` check box only if you want to display the output from the snapshot in the dialog box. This option should be left unchecked in a network address translation (NAT) environment as a large amount of output from the snapshot may delay the response from the Snapshot dialog box. Click the Snapshot button to start snapshot replication.
 
-![Snapshot dialog box](/../../images/image91.png)
+![Snapshot dialog box](../../images/image91.png)
 
 **Figure 5-29: Snapshot dialog box**
 
@@ -42,7 +42,7 @@ The status messages of each snapshot are saved in the Migration Toolkit log file
 
 `POSTGRES_HOME` is the home directory of the Windows postgres account (enterprisedb account for Advanced Server installed in Oracle compatible configuration mode). The specific location of `POSTGRES_HOME` is dependent upon your version of Windows. The xDB Replication Server version number is represented by `x.x`.
 
-![Successful on demand snapshot](/../../images/image92.png)
+![Successful on demand snapshot](../../images/image92.png)
 
 **Figure 5-30: Successful on demand snapshot**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/04_on_demand_replication/02_perform_sync_replication.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/04_on_demand_replication/02_perform_sync_replication.mdx
@@ -10,7 +10,7 @@ After the first snapshot replication, subsequent replications can be performed u
 
 When the log-based method of synchronization replication is in use, select the Subscription node of any subscription. For the log-based method, the synchronization replication will be performed on all subscriptions regardless of which one is selected.
 
-![Selecting a subscription for an on demand synchronization](/../../images/image89.png)
+![Selecting a subscription for an on demand synchronization](../../images/image89.png)
 
 **Figure 5-31: Selecting a subscription for an on demand synchronization**
 
@@ -20,19 +20,19 @@ When the log-based method of synchronization replication is in use, select the S
 -   Click the secondary mouse button on the Subscription node and choose Synchronize.
 -   Click the primary mouse button on the `Synchronize` icon.
 
-![Opening the Synchronize dialog box](/../../images/image93.png)
+![Opening the Synchronize dialog box](../../images/image93.png)
 
 **Figure 5-32: Opening the Synchronize dialog box**
 
 **Step 3:** Click the `Synchronize` button to start synchronization replication.
 
-![Synchronize dialog box](/../../images/image91.png)
+![Synchronize dialog box](../../images/image91.png)
 
 **Figure 5-33: Synchronize dialog box**
 
 **Step 4:** `Subscription Synchronized Successfully` appears if the synchronization was successful. Click the `OK` button. If the synchronization was not successful, scroll through the messages in the Synchronize dialog box window.
 
-![Successful on demand synchronization](/../../images/image94.png)
+![Successful on demand synchronization](../../images/image94.png)
 
 **Figure 5-34: Successful on demand synchronization**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/01_updating_subscription_server.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/01_updating_subscription_server.mdx
@@ -10,7 +10,7 @@ The steps described in this section show you how to update the subscription serv
 
 It is assumed that the xDB Replication Console is open on your computer and the subscription server whose login information you wish to alter in the server login file, appears as a Subscription Server node in the xDB Replication Console’s replication tree.
 
-![Subscription Server node](/../../images/image95.png)
+![Subscription Server node](../../images/image95.png)
 
 **Figure 5-35: Subscription Server node**
 
@@ -27,7 +27,7 @@ The subscription server whose login information you want to save, change, or del
 
 **Step 2:** Click the secondary mouse button on the Subscription Server node and choose Update. The Update Subscription Server dialog box appears.
 
-![Update Subscription Server dialog box](/../../images/image96.png)
+![Update Subscription Server dialog box](../../images/image96.png)
 
 **Figure 5-36: Update Subscription Server dialog box**
 
@@ -37,7 +37,7 @@ The subscription server whose login information you want to save, change, or del
 -   If you want to delete previously saved login information, make sure the network location shown in the dialog box is still correct. Re-enter the admin user name and password saved in the xDB Replication Configuration file that resides on the host identified by the IP address in the Host field. Leave the Save Login Information box unchecked. Access to the subscription server is available for this session, but subsequent sessions will require you to register the subscription server again.
 -   If you want to save the current login information shown in the dialog box, make sure the network location shown in the dialog box is correct. Re-enter the admin user name and password saved in the xDB Replication Configuration file that resides on the host identified by the IP address in the Host field. Check the Save Login Information box.
 
-![Updated subscription server location](/../../images/image97.png)
+![Updated subscription server location](../../images/image97.png)
 
 **Figure 5-37: Updated subscription server location**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/02_updating_subscription_database.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/02_updating_subscription_database.mdx
@@ -30,7 +30,7 @@ Attributes you may change include the following:
 
 **Step 3:** Select the Subscription Database node corresponding to the subscription database definition that you wish to update.
 
-![Selecting a subscription database definition for update](/../../images/image98.png)
+![Selecting a subscription database definition for update](../../images/image98.png)
 
 **Figure 5-38: Selecting a subscription database definition for update**
 
@@ -38,13 +38,13 @@ Attributes you may change include the following:
 
 **Step 5:** Enter the desired changes. See Step 3 of Section [Adding a Subscription Database](../03_creating_subscription/02_adding_subscription_database/#adding_subscription_database) for the precise meanings of the fields.
 
-![Update Database Source dialog box](/../../images/image99.png)
+![Update Database Source dialog box](../../images/image99.png)
 
 **Figure 5-39: Update Database Source dialog box**
 
 **Step 6:** Click the `Test` button. If Test Result: Success appears, click the `OK` button, then click the `Save` button.
 
-![Successful subscription database test](/../../images/image100.png)
+![Successful subscription database test](../../images/image100.png)
 
 **Figure 5-40: Successful subscription database test**
 
@@ -52,6 +52,6 @@ If an error message appears investigate the cause of the error, correct the prob
 
 **Step 7:** Click the `Refresh` icon in the xDB Replication Console tool bar to show the updated Subscription Database node and any of its subscriptions.
 
-![Updated subscription database](/../../images/image101.png)
+![Updated subscription database](../../images/image101.png)
 
 **Figure 5-41: Updated subscription database**

--- a/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/03_updating_subscription.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/03_updating_subscription.mdx
@@ -17,19 +17,19 @@ The following directions show how to update the publication server network IP ad
 
 **Step 2:** Select the Subscription node whose attributes you wish to update.
 
-![Selecting a subscription to update](/../../images/image102.png)
+![Selecting a subscription to update](../../images/image102.png)
 
 **Figure 5-42: Selecting a subscription to update**
 
 **Step 3:** From the `Subscription` menu, choose `Update` Subscription. Alternatively, click the secondary mouse button on the Subscription node and choose Update Subscription. The `Update Subscription` dialog box appears.
 
-![Update Subscription dialog box](/../../images/image103.png)
+![Update Subscription dialog box](../../images/image103.png)
 
 **Figure 5-43: Update Subscription dialog box**
 
 **Step 4:** If the publication server now runs on a host with a different IP address or port number than what is shown in the dialog box, enter the correct information. You must also enter the admin user name and password saved in the xDB Replication Configuration file that resides on the host on which the publication server is running. Click the `Update` button.
 
-![Subscription successfully updated](/../../images/image104.png)
+![Subscription successfully updated](../../images/image104.png)
 
 **Figure 5-44: Subscription successfully updated**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/04_enable_filters_on_subscription.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/04_enable_filters_on_subscription.mdx
@@ -12,7 +12,7 @@ The following are the steps for enabling or disabling table filters on an existi
 
 **Step 2:** Select the Subscription node of the subscription on which you wish to enable or disable individual filter rules.
 
-![Selecting a subscription on which to enable or disable filter rules](/../../images/image89.png)
+![Selecting a subscription on which to enable or disable filter rules](../../images/image89.png)
 
 **Figure 5-45: Selecting a subscription on which to enable or disable filter rules**
 
@@ -22,13 +22,13 @@ The following are the steps for enabling or disabling table filters on an existi
 -   Choose `Update Filter Rule` from the `Subscription` menu.
 -   Click the secondary mouse button on the Subscription node and choose `Update Filter Rule`.
 
-![Opening the Filter Rules tab on a subscription](/../../images/image105.png)
+![Opening the Filter Rules tab on a subscription](../../images/image105.png)
 
 **Figure 5-46: Opening the Filter Rules tab on a subscription**
 
 **Step 4:** In the `Filter Rules` tab check or uncheck the boxes to specify the filter rules to enable or disable on the subscription. At most one filter rule may be enabled any given subscription table. Click the `Update` button.
 
-![Filter Rules tab](/../../images/image106.png)
+![Filter Rules tab](../../images/image106.png)
 
 **Figure 5-47: Filter Rules tab**
 
@@ -36,13 +36,13 @@ The following are the steps for enabling or disabling table filters on an existi
 
 Click the `Ok` button in the confirmation box to proceed with the update to the filter rule selections. Click the `Cancel` button to return to the `Filter Rules` tab if you wish to modify your filter rule selections.
 
-![Change filter rule confirmation](/../../images/image107.png)
+![Change filter rule confirmation](../../images/image107.png)
 
 **Figure 5-48: Change filter rule confirmation**
 
 **Step 6:** If you clicked the `Ok` button in the preceding step, the `Filter Rules updated successfully` confirmation message appears if the update was successful.
 
-![Successful update of filter rules](/../../images/image108.png)
+![Successful update of filter rules](../../images/image108.png)
 
 **Figure 5-49: Successful update of filter rules**
 

--- a/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/05_removing_subscription.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/05_removing_subscription.mdx
@@ -12,7 +12,7 @@ Removing a subscription does not delete the subscription tables in the subscript
 
 **Step 2:** Select the Subscription node of the subscription that you wish to remove.
 
-![Selecting a subscription to remove](/../../images/image89.png)
+![Selecting a subscription to remove](../../images/image89.png)
 
 **Figure 5-50: Selecting a subscription to remove**
 
@@ -22,18 +22,18 @@ Removing a subscription does not delete the subscription tables in the subscript
 -   Click the secondary mouse button on the Subscription node and choose `Remove Subscription`.
 -   Click the primary mouse button on the `Remove Subscription` icon.
 
-![Removing the subscription using the toolbar](/../../images/image109.png)
+![Removing the subscription using the toolbar](../../images/image109.png)
 
 **Figure 5-51: Removing the subscription using the toolbar**
 
 **Step 4:** In the Remove Subscription confirmation box, click the `Yes` button.
 
-![Remove Subscription confirmation](/../../images/image110.png)
+![Remove Subscription confirmation](../../images/image110.png)
 
 **Figure 5-52: Remove Subscription confirmation**
 
 The Subscription node no longer appears under the Subscription Database node.
 
-![Replication tree after removing a subscription](/../../images/image111.png)
+![Replication tree after removing a subscription](../../images/image111.png)
 
 **Figure 5-53: Replication tree after removing a subscription**

--- a/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/06_removing_subscription_database.mdx
+++ b/product_docs/docs/eprs/6.2/05_smr_operation/05_managing_subscription/06_removing_subscription_database.mdx
@@ -12,7 +12,7 @@ Removing a Subscription Database node does not delete the physical database from
 
 **Step 2:** Select the Subscription Database node that you wish to remove.
 
-![Selecting a subscription database definition for removal](/../../images/image98.png)
+![Selecting a subscription database definition for removal](../../images/image98.png)
 
 **Figure 5-54: Selecting a subscription database definition for removal**
 
@@ -20,12 +20,12 @@ Removing a Subscription Database node does not delete the physical database from
 
 **Step 4:** In the `Remove Subscription Database` confirmation box, click the `Yes` button.
 
-![Remove Subscription Database confirmation](/../../images/image112.png)
+![Remove Subscription Database confirmation](../../images/image112.png)
 
 **Figure 5-55: Remove Subscription Database confirmation**
 
 The Subscription Database node no longer appears under the Subscription Server node.
 
-![Replication tree after removal of a subscription database](/../../images/image113.png)
+![Replication tree after removal of a subscription database](../../images/image113.png)
 
 **Figure 5-56: Replication tree after removal of a subscription database**

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/02_creating_publication_mmr.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/02_creating_publication_mmr.mdx
@@ -17,7 +17,7 @@ Creating a publication requires the following steps:
 
 Registering a publication server is done in a manner identical to single-master replication. See [Registering a Publication Server](../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions on registering a publication server.
 
-![Replication tree after registering a publication server](/../images/image68.png)
+![Replication tree after registering a publication server](../images/image68.png)
 
 After you have successfully registered a publication server, the replication tree of the xDB Replication Console displays a Publication Server node under which are the SMR and MMR type nodes.
 
@@ -49,17 +49,17 @@ You must enter database connection information such as the database server netwo
 -   `Changeset Logging (For Postgres)`. Select Table Triggers to use the trigger-based method of synchronization replication. Select WAL Stream to use the log-based method of synchronization replication. See [Synchronization Replication with the Trigger-Based Method](../02_overview/02_replication_concepts_and_definitions/09_sync_replication_trigger_based/#sync_replication_trigger_based) for information on the trigger-based method. See [Synchronization Replication with the Log-Based Method](../02_overview/02_replication_concepts_and_definitions/10_sync_replication_log_based/#sync_replication_log_based) for information on the log-based method.
 -   `Node Priority Level`. An integer from 1 to 10, which is the priority level assigned to this primary node for conflict resolution based on node priority. The highest priority is 1 while the lowest is 10. See [Conflict Resolution Strategies](06_conflict_resolution/04_conflict_resolution_strategies/#conflict_resolution_strategies) for information on conflict resolution strategies. The default is 1 for the primary definition node.
 
-![Publication Service - Add Database dialog box for the primary definition node](/../images/image114.png)
+![Publication Service - Add Database dialog box for the primary definition node](../images/image114.png)
 
 **Step 4:** Click the `Test` button. If `Test Result: Success` appears, click the `OK` button, then click the `Save` button.
 
-![Successful primary definition node test](/../images/image115.png)
+![Successful primary definition node test](../images/image115.png)
 
 If an error message appears investigate the cause of the error, correct the problem, and repeat steps 1 through 4.
 
 When the publication database definition is successfully saved, a Publication Database node is added to the replication tree under the MMR type node of the Publication Server node.
 
-![Replication tree after adding the primary definition node](/../images/image116.png)
+![Replication tree after adding the primary definition node](../images/image116.png)
 
 The label `PDN` appears at the end of the node in the replication tree and in addition, the `PDN` field is set to Yes in the Property window to indicate this is the primary definition node.
 
@@ -78,7 +78,7 @@ Subordinate to the primary definition node, you create a publication that contai
 -   `Select All`. Check this box if you want to include all tables in the Available Tables list in the publication.
 -   `Use Wildcard Selection`. Click this button to use the wildcard selector to choose tables for the publication. See [Selecting Tables with the Wildcard Selector](../07_common_operations/01_select_tables_wildcard_selector/#select_tables_wildcard_selector) for information on the wildcard selector.
 
-![Create Publication dialog box](/../images/image117.png)
+![Create Publication dialog box](../images/image117.png)
 
 If you wish to use table filters during replications between primary nodes in this multi-master replication system, follow the directions in the next step to define the initial set of available table filters, otherwise go on to Step 4.
 
@@ -106,15 +106,15 @@ In the `Filter` dialog box, enter a descriptive filter name and the filter claus
 
 In the following example a filter rule is defined on the dept table so only rows where the `deptno` column contains `10, 20,` or `30` are included in replications. All other rows are excluded from replication.
 
-![Adding a filter rule for the dept table](/../images/image118.png)
+![Adding a filter rule for the dept table](../images/image118.png)
 
 The following shows a rule added to the `emp` table by choosing `edb.emp` from the Table/View drop-down list and then entering the selection criteria for only rows with `deptno` containing 10 in the Filter dialog box.
 
-![Adding a filter rule for the emp table](/../images/image119.png)
+![Adding a filter rule for the emp table](../images/image119.png)
 
 Repeating this process, additional filter rules can be added for the `emp` table. The following shows the complete set of available filter rules defined for the `dept` and `emp` tables.
 
-![Set of all available filter rules](/../images/image120.png)
+![Set of all available filter rules](../images/image120.png)
 
 To remove a filter rule, click the primary mouse button on the filter rule you wish to remove so the entry is highlighted and then click the `Remove Filter` button.
 
@@ -131,7 +131,7 @@ If you wish to change the conflict resolution options from their default setting
 
 **Step 4 (Optional):** If you want to modify or see the current conflict resolution options, click the `Conflict Resolution Options` tab. For each table, you can select the primary conflict resolution strategy and a standby strategy by clicking the primary mouse button over the appropriate box to expose a drop-down list of choices.
 
-![Conflict Resolution Options tab](/../images/image121.png)
+![Conflict Resolution Options tab](../images/image121.png)
 
 If during synchronization replication, conflicting changes are pending against the same row from different primary nodes, the conflict resolution strategy determines which of the conflicting changes is accepted and replicated to all primary nodes. The conflicting changes that are not accepted are discarded.
 
@@ -153,8 +153,8 @@ See [Conflict Resolution Strategies](06_conflict_resolution/04_conflict_resoluti
 
 **Step 6:** Click the `Create` button. If `Publication Created Successfully` appears, click the `OK` button, otherwise investigate the error and make the necessary corrections.
 
-![Publication created successfully](/../images/image122.png)
+![Publication created successfully](../images/image122.png)
 
 Upon successful publication creation, a Publication node is added to the replication tree.
 
-![Replication tree after adding a publication](/../images/image123.png)
+![Replication tree after adding a publication](../images/image123.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/03_creating_primary_nodes.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/03_creating_primary_nodes.mdx
@@ -30,14 +30,14 @@ You must enter database connection information such as the database server netwo
 -   `Replicate Publication Schema.` Check this box if you want the publication server to create the publication table definitions in the new primary node by copying the definitions from the primary definition node. If you do not check this box, it is assumed that you have already created the table definitions in the primary node. If you are using the offline snapshot technique to create this primary node, do not check this box. See <span class="title-ref">Loading Tables From an External Data Source (Offline Snapshot) &lt;offline_snapshot></span>) for information on using an offline snapshot.
 -   `Perform Initial Snapshot.` Check this box if you want the publication server to perform a snapshot from the primary definition node to this primary node when you click the Save button. If you do not check this box, the tables on the primary node will not be loaded until you perform a replication at some later time. If you are using the offline snapshot technique to create this primary node, you should have already loaded the table rows. Therefore do not check this box unless you want to reload the data. See <span class="title-ref">Loading Tables From an External Data Source (Offline Snapshot) &lt;offline_snapshot></span> for information on using an offline snapshot.
 
-![Publication Service - Add Database dialog box for an additional primary node](/../images/image124.png)
+![Publication Service - Add Database dialog box for an additional primary node](../images/image124.png)
 
 !!! Note
     Unless you intend to use the offline snapshot technique (see <span class="title-ref">Loading Tables From an External Data Source (Offline Snapshot) &lt;offline_snapshot></span>), it is suggested that you check the Perform Initial Snapshot box. An initial snapshot replication must be performed from the primary definition node to every other primary node before performing synchronization replications on demand (see [Performing Synchronization Replication](05_on_demand_replication_mmr/#perform_synchronization_replication_mmr)) or by a schedule (see [Creating a Schedule](../07_common_operations/02_creating_schedule/#creating_schedule)). If a newly added primary node did not undergo an initial snapshot, any subsequent synchronization replication may fail to apply the transactions to that primary node. The initial snapshot can also be taken by performing an on demand snapshot (see [Performing Snapshot Replication](05_on_demand_replication_mmr/#perform_snapshot_replication_mmr)).
 
 **Step 4:** Click the `Test` button. If `Test Result: Success` appears, click the `OK` button.
 
-![Successful primary node test](/../images/image125.png)
+![Successful primary node test](../images/image125.png)
 
 If an error message appears investigate the cause of the error, correct the problem, and repeat steps 1 through 4.
 
@@ -50,7 +50,7 @@ Click the `Filter Rules` tab to apply one or more filter rules to the primary no
 
 In the following example the filter named `dept_10_20_30` is enabled on the dept table and the filter named dept_30 is enabled on the `emp` table of this primary node.
 
-![Enabling filter rules on a primary node](/../images/image126.png)
+![Enabling filter rules on a primary node](../images/image126.png)
 
 **Step 6:** Check the Perform Initial Snapshot box if you want the publication server to perform a snapshot from the primary definition node to this primary node when you click the Save button. If you do not check this box, the tables on the primary node will not be loaded until you perform a replication at some later time.
 
@@ -58,11 +58,11 @@ If you are using the offline snapshot technique to create this primary node, you
 
 If you do check the Perform Initial Snapshot check box, the Verbose Output check box appears as shown by the following:
 
-![Initial snapshot with verbose output option](/../images/image127.png)
+![Initial snapshot with verbose output option](../images/image127.png)
 
 If you skipped the enabling of table filters as described in Step 5, and you checked the `Perform Initial Snapshot` check box after Step 4, the `Verbose Output` check box is displayed as well:
 
-![Initial snapshot with verbose output option](/../images/image128.png)
+![Initial snapshot with verbose output option](../images/image128.png)
 
 Select the `Verbose Output` check box only if you want to display the output from the snapshot in the dialog box. This option should be left unchecked in a network address translation (NAT) environment as a large amount of output from the snapshot may delay the response from the Snapshot dialog box.
 
@@ -70,7 +70,7 @@ Click the `Save` button.
 
 When the publication database definition is successfully saved, a Publication Database node is added to the replication tree under the MMR type node of the Publication Server node.
 
-![Replication tree after adding an additional primary node](/../images/image129.png)
+![Replication tree after adding an additional primary node](../images/image129.png)
 
 Unlike the primary definition node, the label PDN does not appear at the end of the node in the replication tree. The PDN field is set to No in the Property window to indicate this is not the primary definition node.
 
@@ -78,7 +78,7 @@ In addition, a Publication node appears under the newly added primary node. This
 
 If in Step 6, you checked the `Perform Initial Snapshot` check box, an initial snapshot replication is performed. If you checked the `Verbose Output` check box, the log of the snapshot is displayed as well.
 
-![- Adding a primary node with an initial snapshot](/../images/image130.png)
+![- Adding a primary node with an initial snapshot](../images/image130.png)
 
 If the snapshot is successful, the replicated tables in the primary node are loaded with the rows from the publication tables of the primary definition node.
 

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/05_on_demand_replication_mmr.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/05_on_demand_replication_mmr.mdx
@@ -21,18 +21,18 @@ When you create a primary node for the first time, you have the option of perfor
 
 **Step 1:** Select the Publication node under the primary node for which you wish to perform snapshot replication.
 
-![Selecting a primary node publication for an on demand snapshot](/../images/image131.png)
+![Selecting a primary node publication for an on demand snapshot](../images/image131.png)
 
 **Step 2:** Open the `Snapshot` dialog box in any of the following ways:
 
 -   Click the secondary mouse button on the Publication node and choose Snapshot.
 -   Click the primary mouse button on the Snapshot icon.
 
-![Opening the Snapshot dialog box](/../images/image132.png)
+![Opening the Snapshot dialog box](../images/image132.png)
 
 **Step 3:** Select the `Verbose Output` check box only if you want to display the output from the snapshot in the dialog box. This option should be left unchecked in a network address translation (NAT) environment as a large amount of output from the snapshot may delay the response from the Snapshot dialog box. Click the `Snapshot` button to start snapshot replication.
 
-![Snapshot dialog box](/../images/image133.png)
+![Snapshot dialog box](../images/image133.png)
 
 **Step 4:** `Snapshot Taken` Successfully appears if the snapshot was successful. Click the `OK` button. If the snapshot was not successful, scroll through the messages in the Snapshot dialog box window if Verbose Output was selected or check the log files.
 
@@ -48,7 +48,7 @@ The status messages of each snapshot are saved in the Migration Toolkit log file
 
 `POSTGRES_HOME` is the home directory of the Windows postgres account (enterprisedb account for Advanced Server installed in Oracle compatible configuration mode). The specific location of POSTGRES_HOME is dependent upon your version of Windows. The xDB Replication Server version number is represented by `x.x`.
 
-![Successful on demand snapshot](/../images/image134.png)
+![Successful on demand snapshot](../images/image134.png)
 
 The publication has now been replicated from the primary definition node to the selected primary node. A record of the snapshot is maintained in the replication history. See [Viewing Replication History](../07_common_operations/04_view_replication_history/#view_replication_history) for information on how to view replication history.
 
@@ -76,22 +76,22 @@ The following steps describe how to initiate on demand synchronization replicati
 
 **Step 1:** Select the Publication node under any primary node. Regardless of the primary node chosen, synchronization is applied to every primary node pair in the replication system.
 
-![Selecting a primary node publication for an on demand synchronization](/../images/image131.png)
+![Selecting a primary node publication for an on demand synchronization](../images/image131.png)
 
 **Step 2:** Open the `Synchronize` dialog box in any of the following ways:
 
 -   Click the secondary mouse button on the Publication node and choose `Synchronize`.
 -   Click the primary mouse button on the Synchronize icon.
 
-![Opening the Synchronize dialog box](/../images/image135.png)
+![Opening the Synchronize dialog box](../images/image135.png)
 
 **Step 3:** Click the `Synchronize` button to start synchronization replication.
 
-![Synchronize dialog box](/../images/image136.png)
+![Synchronize dialog box](../images/image136.png)
 
 **Step 4:** `Publication Synchronized Successfully(())` appears if the synchronization was successful. Click the `OK` button. If the synchronization was not successful, an error message is displayed.
 
-![Successful on demand synchronization](/../images/image137.png)
+![Successful on demand synchronization](../images/image137.png)
 
 The operations that were applied to the publication tables can be seen in the replication history. See [Viewing Replication History](../07_common_operations/04_view_replication_history/#view_replication_history) for information on how to view replication history.
 

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/06_conflict_prevention_mmr_ready/02_mmr_ready_example.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/06_conflict_prevention_mmr_ready/02_mmr_ready_example.mdx
@@ -129,7 +129,7 @@ The multi-master replication system is created with the Replicate Publication Sc
 
 The resulting primary nodes are shown in the xDB Replication Console.
 
-![Publication table with MMR-ready sequence](/../../../images/image138.png)
+![Publication table with MMR-ready sequence](../../../images/image138.png)
 
 !!! Note
     The Default Value property of the id column uses the `MMR_sequence_nextval` function.

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/08_custom_conflict_handling/02_adding_custom_conflict_handling_function.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/08_custom_conflict_handling/02_adding_custom_conflict_handling_function.mdx
@@ -17,18 +17,18 @@ CREATE FUNCTION
 
 **Step 3:** Open the `Conflict Resolution Options` tab in any of the following ways:
 
-![Opening the Conflict Resolution Options tab](/../../../images/image139.png)
+![Opening the Conflict Resolution Options tab](../../../images/image139.png)
 
 -   From the `Publication` menu, choose `Update Publication`, then `Conflict Resolution Options`.
 -   Click the secondary mouse button on the Publication node, choose `Update Publication`, and then choose `Conflict Resolution Options`.
 
 **Step 4:** For the table on which you want to use custom conflict handling, select Custom from the appropriate drop-down list. In the Custom Handler text box, enter the schema and function name used in the `CREATE FUNCTION` statement.
 
-![Setting conflict resolution to custom conflict handling](/../../../images/image140.png)
+![Setting conflict resolution to custom conflict handling](../../../images/image140.png)
 
 **Step 5:** Click the `Update` button, and then click `OK` in response to the `Conflict Resolution Options Updated Successfully` confirmation message.
 
-![Successfully updated conflict resolution options](/../../../images/image141.png)
+![Successfully updated conflict resolution options](../../../images/image141.png)
 
 !!! Note
     If the multi-master replication system uses custom conflict handling, and you subsequently switch the role of the primary definition node to another primary node, you must re-add the functions to the new primary definition node. That is, you must repeat Step 2 on the new primary definition node.

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/08_custom_conflict_handling/03_custom_conflict_handling_examples.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/08_custom_conflict_handling/03_custom_conflict_handling_examples.mdx
@@ -44,7 +44,7 @@ MMRnode=# SELECT * FROM dept;
 
 After a synchronization replication, the update/update conflict is detected and resolved as shown in the Conflict History tab:
 
-![Conflict resolved by custom conflict handling](/../../../images/image142.png)
+![Conflict resolved by custom conflict handling](../../../images/image142.png)
 
 In the source primary node the `loc` column of department 50 loses the value set in its UPDATE statement. The column is reset to the value from the target primary node.
 

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/01_find_conflict.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/01_find_conflict.mdx
@@ -6,13 +6,13 @@ title: "Finding Conflicts"
 
 Conflicts can be found using the `Conflict History` tab as described in Section [Viewing Conflict History](../../07_view_conflict_history/#view_conflict_history). The following is an example of the Conflict History tab. Click the Refresh button to reveal all of the latest conflicts.
 
-![Conflict History tab for trigger-based method](/../../../images/image143.png)
+![Conflict History tab for trigger-based method](../../../images/image143.png)
 
 The `Source DB` and `Target DB` columns provide the IP address and database names of the source and target primary nodes involved in the conflict.
 
 Click the `View Data link` to show the details of the transactions involved in a particular conflict as shown by the following:
 
-![Conflict Details window](/../../../images/image144.png)
+![Conflict Details window](../../../images/image144.png)
 
 You can also obtain this information from a SQL query rather than from the xDB Replication Console graphical user interface. The following query can be run from a primary node to display information regarding pending (unresolved) conflicts:
 

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/03_overview_correction_strategies.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/03_overview_correction_strategies.mdx
@@ -107,7 +107,7 @@ MMRnode_c=# SELECT * FROM dept;
 
 The Conflict History tab shows the following entry:
 
-![Conflict History tab with a uniqueness conflict](/../../../images/image145.png)
+![Conflict History tab with a uniqueness conflict](../../../images/image145.png)
 
 The following is the output from the SQL query described in Section [Finding Conflicts](01_find_conflict/#find_conflict).
 

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/04_manual_publication_table_correction.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/04_manual_publication_table_correction.mdx
@@ -182,13 +182,13 @@ rrep_tx_conflict_status | P
 
 The following shows the `rrep_tx_conflict_status` column marked `P` (pending) in the Postgres Enterprise Manager Client.
 
-![Shadow table entry with pending conflict](/../../../images/image146.png)
+![Shadow table entry with pending conflict](../../../images/image146.png)
 
 Modify column `rrep_tx_conflict_status` by changing the value to `D` (discarded) to show that the pending conflict has been resolved. A value of D also ensures that the shadow table entry will not be replicated during any future synchronization replications.
 
 Make this change to the shadow tables in both `MMRnode_a` and `MMRnode_b`.
 
-![Discarded shadow table entry](/../../../images/image147.png)
+![Discarded shadow table entry](../../../images/image147.png)
 
 Be sure to qualify the row with the correct `rrep_sync_id` value if you perform the update using a SQL statement such as in the following:
 
@@ -216,7 +216,7 @@ Note the following points regarding the `xdb_conflicts` table:
 
 The following shows the Conflict History tab prior to updating the `xdb_conflicts` table.
 
-![Pending uniqueness conflict](/../../../images/image145.png)
+![Pending uniqueness conflict](../../../images/image145.png)
 
 The conflict entry for synchronization from `MMRnode_a` to `MMRnode_b` can be located in xdb_conflicts with the following query for this example:
 
@@ -317,7 +317,7 @@ target_rrep_sync_id | 0
 
 These entries appear in the Postgres Enterprise Manager Client as shown by the following:
 
-![Pending conflict in xdb_conflicts](/../../../images/image147.png)
+![Pending conflict in xdb_conflicts](../../../images/image147.png)
 
 Change the value in column resolution_status from P (pending) to C (completed) to indicate this conflict has been resolved. The value in winning_db_id is changed to 4 to indicate primary node `MMRnode_b` contains the winning transaction. The value in `winning_rrep_sync_id` is changed to the value of rrep_sync_id for the shadow table entry of the transaction in `MMRnode_b` since this is the one deemed to be correct.
 
@@ -361,8 +361,8 @@ WHERE pk_value = 'deptno=50'
 
 The following are the updated xdb_conflicts entries:
 
-![Resolved conflict in xdb_conflicts](/../../../images/image149.png)
+![Resolved conflict in xdb_conflicts](../../../images/image149.png)
 
 When viewed in the Conflict History tab, the entries now show Resolved instead of Pending in the Resolution Status column, and the Winning DB column shows the address of primary node `MMRnode_b`.
 
-![Resolved uniqueness conflict](/../../../images/image150.png)
+![Resolved uniqueness conflict](../../../images/image150.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/05_correction_using_new_txn.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/05_correction_using_new_txn.mdx
@@ -166,17 +166,17 @@ Change the `rrep_tx_conflict_status` column from `P` (pending) to `D` (discarded
 
 The resulting change for the shadow table on `MMRnode_a` is as follows.
 
-![Discarded shadow table entry](/../../../images/image151.png)
+![Discarded shadow table entry](../../../images/image151.png)
 
 !!! Note
     The second entry for the accepted transaction you ran in Step 2 where `rrep_tx_conflict_status` is set to null indicating there was no conflict.
 
 The resulting change for the shadow table on `MMRnode_b` is as follows.
 
-![Discarded shadow table entry](/../../../images/image152.png)
+![Discarded shadow table entry](../../../images/image152.png)
 
 There is no shadow table entry in `MMRnode_c`, since an insert transaction was not performed in that primary node by the application.
 
 **Step 5:** In the control schema of the publication database currently designated as the controller database, modify the entries in the `xdb_conflicts` table to indicate the conflict has been resolved as in Step 3 of Section [Manual Publication Table Correction](04_manual_publication_table_correction/#manual_publication_table_correction).
 
-![Resolved conflict in xdb_conflicts](/../../../images/image153.png)
+![Resolved conflict in xdb_conflicts](../../../images/image153.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/06_correction_using_shadow_table_txn.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/09_manual_conflict_resolution_trigger_based_method/06_correction_using_shadow_table_txn.mdx
@@ -151,7 +151,7 @@ MMRnode_c=# SELECT * FROM emp WHERE empno = 9001;
 
 Change the `rrep_tx_conflict_status` column from `P` (pending) to `D` (discarded) on the losing node, `MMRnode_b` as shown by the following:
 
-![Losing shadow table entry](/../../../images/image154.png)
+![Losing shadow table entry](../../../images/image154.png)
 
 **Step 3:** On winning node `MMRnode_c`, inspect the shadow table for the `emp` publication table.
 
@@ -159,19 +159,19 @@ The objective is to use the shadow table entries for the insert and three update
 
 The leftmost columns of the shadow table appear as follows:
 
-![Shadow table with multiple transactions](/../../../images/image155.png)
+![Shadow table with multiple transactions](../../../images/image155.png)
 
 Make note of the `rrep_sync_id` values for these four entries, which are 1, 2, 3, and 4 in this example.
 
 The following shows the rightmost columns of the shadow table from the prior figure. Note the contents of column `rrep_tx_conflict_status` furthest to the right.
 
-![Shadow table with multiple transactions (continued)](/../../../images/image156.png)
+![Shadow table with multiple transactions (continued)](../../../images/image156.png)
 
 Make sure the `rrep_tx_conflict_status` column is null for these four entries. In this case, for the insert transaction, you will need to change the `P` (pending) value to null.
 
 The resulting change for the `rrep_tx_conflict_status` column in the shadow table on `MMRnode_c` is shown by the following:
 
-![Shadow table transactions set to replicate](/../../../images/image157.png)
+![Shadow table transactions set to replicate](../../../images/image157.png)
 
 **Step 4:** In order to replicate these four shadow table entries during the next synchronization, one or more entries must be added to the control schema table `_edb_replicator_pub.rrep_MMR_txset` on `MMRnode_c` to indicate pending status for synchronization to the target primary nodes (`MMRnode_a` and `MMRnode_b`) of the four shadow table entries identified by the rrep_sync_id values of 1, 2, 3, and 4 noted in Step 3.
 
@@ -356,4 +356,4 @@ WHERE pk_value = 'empno=9001'
 
 When viewed in the Conflict History tab, the entry now shows Resolved in the Resolution Status column, and the Winning DB column shows the address of primary node `MMRnode_c`.
 
-![Resolved uniqueness conflict](/../../../images/image158.png)
+![Resolved uniqueness conflict](../../../images/image158.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/01_finding_conflict.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/01_finding_conflict.mdx
@@ -6,7 +6,7 @@ title: "Finding Conflicts"
 
 Conflicts can be found using the `Conflict History` tab as described in Section [Viewing Conflict History](../../07_view_conflict_history/#view_conflict_history). The following is an example of the Conflict History tab. Click the `Refresh` button to reveal all of the latest conflicts.
 
-![Conflict History tab for log-based method](/../../../images/image159.png)
+![Conflict History tab for log-based method](../../../images/image159.png)
 
 !!! Note
     The `View Data link and Conflict Details` window displayed for multi-master replication systems configured with the trigger-based method of synchronization replication are not available for multi-master replication systems configured with the log-based method of synchronization replication.

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/03_overview_correction_strategies_log_based.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/03_overview_correction_strategies_log_based.mdx
@@ -94,7 +94,7 @@ MMRnode_c=# SELECT * FROM dept;
 
 The Conflict History tab shows the following entry:
 
-![Conflict History tab with a uniqueness conflict](/../../../images/image160.png)
+![Conflict History tab with a uniqueness conflict](../../../images/image160.png)
 
 The following is the output from the SQL query described in Section [Finding Conflicts](../09_manual_conflict_resolution_trigger_based_method/01_find_conflict/#find_conflict).
 

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/04_manual_publication_table_correction_log_based.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/04_manual_publication_table_correction_log_based.mdx
@@ -113,7 +113,7 @@ Note the following points regarding the `xdb_conflicts` table:
 
 The following shows the **Conflict History** tab prior to updating the `xdb_conflicts` table.
 
-![Pending uniqueness conflict](/../../../images/image160.png)
+![Pending uniqueness conflict](../../../images/image160.png)
 
 The entry for the pending insert/insert conflict on the deptno primary key value of 50 can be located in xdb_conflicts with the following query for this example:
 
@@ -142,7 +142,7 @@ pk_value            | deptno=50
 
 This entry appears in the Postgres Enterprise Manager Client as shown by the following:
 
-![Pending conflict in xdb_conflicts](/../../../images/image161.png)
+![Pending conflict in xdb_conflicts](../../../images/image161.png)
 
 Change the value in column resolution_status from P (pending) to C (completed) to indicate this conflict has been resolved. The value in winning_db_id is changed to 22 to indicate primary node `MMRnode_b` contains the winning transaction.
 
@@ -159,8 +159,8 @@ WHERE pk_value = 'deptno=50'
 
 The following is the updated xdb_conflicts entry:
 
-![Resolved conflict in xdb_conflicts](/../../../images/image162.png)
+![Resolved conflict in xdb_conflicts](../../../images/image162.png)
 
 When viewed in the **Conflict History** tab, the entry now shows Resolved instead of `Pending` in the **Resolution Status** column, and the **Winning DB** column shows the address of primary node `MMRnode_b`.
 
-![Resolved uniqueness conflict](/../../../images/image163.png)
+![Resolved uniqueness conflict](../../../images/image163.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/05_correction_using_new_txn_log_based.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/06_conflict_resolution/10_manual_conflict_resolution_log_based_method/05_correction_using_new_txn_log_based.mdx
@@ -143,4 +143,4 @@ MMRnode_c=# SELECT * FROM dept;
 
 **Step 4:** In the control schema of the publication database currently designated as the controller database, modify the entry in the `xdb_conflicts` table to indicate the conflict has been resolved as in Step 2 of Section [Conflict Resolution Concept for the Log-Based Method](02_conflict_resolution_for_log_based/#conflict_resolution_for_log_based).
 
-![Resolved conflict in xdb_conflicts](/../../../images/image164.png)
+![Resolved conflict in xdb_conflicts](../../../images/image164.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/07_view_conflict_history.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/07_view_conflict_history.mdx
@@ -22,19 +22,19 @@ The following steps describe how to view the conflict history.
 
 **Step 1:** Select any Publication node under a Database node representing a primary node. Tabs labeled `General, Realtime Monitor, Replication History`, and `Conflict History` appear.
 
-![Selecting a publication on which to view conflict history](/../images/image165.png)
+![Selecting a publication on which to view conflict history](../images/image165.png)
 
 **Step 2:** Click the `Conflict History` tab to show conflict history. Click `Refresh` to ensure all the conflicts are listed.
 
-![Conflict History tab](/../images/image166.png)
+![Conflict History tab](../images/image166.png)
 
 **Step 3:** Use the `Conflict Display` Criteria drop-down list to display only conflicts of the chosen status.
 
-![Selecting conflict history by status](/../images/image167.png)
+![Selecting conflict history by status](../images/image167.png)
 
 **Step 4:** Click the `View Data` link to show the details of a particular conflict.
 
 !!! Note
     The `View Data` link and `Conflict Details` window are available only for multi-primary replication systems configured with the trigger-based method of synchronization replication. There is no `View Data` link or `Conflict Details` window for multi-primary replication systems configured with the log-based method of synchronization replication.
 
-![Conflict Details window](/../images/image168.png)
+![Conflict Details window](../images/image168.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/08_update_conflict_resolution_options.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/08_update_conflict_resolution_options.mdx
@@ -10,19 +10,19 @@ A current conflict resolution option on a publication table can be changed. See 
 
 **Step 2:** Select the Publication node under the Publication Database node representing the primary definition node.
 
-![Selecting a publication in which to update conflict resolution options](/../images/image169.png)
+![Selecting a publication in which to update conflict resolution options](../images/image169.png)
 
 **Step 3:** Open the `Conflict Resolution Options` dialog box in any of the following ways:
 
 -   From the `Publication` menu, choose `Update Publication`, then `Conflict Resolution Options`.
 -   Click the secondary mouse button on the `Publication` node, choose `Update Publication`, and then choose `Conflict Resolution Options`.
 
-![Opening the Conflict Resolution Options dialog box](/../images/image170.png)
+![Opening the Conflict Resolution Options dialog box](../images/image170.png)
 
 **Step 4:** For each table, you can select the primary conflict resolution strategy and a standby strategy by clicking the master mouse button over the appropriate box to expose a drop-down list of choices.
 
-![Updating conflict resolution strategies](/../images/image171.png)
+![Updating conflict resolution strategies](../images/image171.png)
 
 **Step 5:** Click the `Update` button, and then click `OK` in response to Conflict Resolution Options Updated Successfully.
 
-![Successfully updated conflict resolution options](/../images/image172.png)
+![Successfully updated conflict resolution options](../images/image172.png)

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/09_enable_disable_table_filters.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/09_enable_disable_table_filters.mdx
@@ -15,11 +15,11 @@ The following are the steps for enabling or disabling table filters on an existi
 
 **Step 2:** Select the Publication Database node corresponding to the primary node on which you wish to enable or disable individual filter rules.
 
-![Selecting a primary node on which to enable or disable filter rules](/../images/image173.png)
+![Selecting a primary node on which to enable or disable filter rules](../images/image173.png)
 
 **Step 3:** Click the secondary mouse button on the Publication Database node and choose `Update Filter Rule`.
 
-![Opening the Filter Rules tab on a primary node](/../images/image174.png)
+![Opening the Filter Rules tab on a primary node](../images/image174.png)
 
 !!! Note
     If you wish to enable or disable filter rules on the current primary definition node, you must first switch the role of the primary definition node to another primary node in order to expose the Update Filter Rule option in the primary node context menu. See Section [Switching the Primary definition node](10_switching_pdn/#switching_pdn) for directions on switching the primary definition node.
@@ -28,17 +28,17 @@ The primary node you choose as the new primary definition node should contain a 
 
 **Step 4:** In the `Filter Rules` tab check or uncheck the boxes to specify the filter rules to enable or disable on the primary node. At most one filter rule may be enabled on any given table. Click the `Save` button.
 
-![Filter Rules tab](/../images/image175.png)
+![Filter Rules tab](../images/image175.png)
 
 **Step 5:** A confirmation box appears presenting a warning message and a recommendation to perform a snapshot replication to any primary node on which you changed the filtering criteria.
 
 Click the `Ok` button in the confirmation box to proceed with the update to the filter rule selections. Click the Cancel button to return to the Filter Rules tab if you wish to modify your filter rule selections.
 
-![Change filter rule confirmation](/../images/image176.png)
+![Change filter rule confirmation](../images/image176.png)
 
 **Step 6:** If you clicked the `Ok` button in the preceding step, the Filter Rules updated successfully confirmation message appears if the update was successful.
 
-![Successful update of filter rules](/../images/image177.png)
+![Successful update of filter rules](../images/image177.png)
 
 If you clicked the `Cancel` button in the preceding step, the Filter Rules tab reopens. You can modify your filter rule selections by repeating Step 4, or you can click the `Cancel` button in the Filter Rules tab to abort the filter rule updates on the primary node.
 

--- a/product_docs/docs/eprs/6.2/06_mmr_operation/10_switching_pdn.mdx
+++ b/product_docs/docs/eprs/6.2/06_mmr_operation/10_switching_pdn.mdx
@@ -10,26 +10,26 @@ After the multi-master replication system is created, you can switch the role of
 
 **Step 2:** Select the Publication Database node corresponding to the primary node that you wish to set as the primary definition node.
 
-![Selecting the primary node to set as the master definition node](/../images/image178.png)
+![Selecting the primary node to set as the master definition node](../images/image178.png)
 
 **Step 3:** Click the secondary mouse button on the Publication Database node and choose `Set as PDN`.
 
-![Setting the master definition node](/../images/image179.png)
+![Setting the master definition node](../images/image179.png)
 
 **Step 4:** In the `Set as PDN` confirmation box, click the `Yes` button.
 
-![Set as PDN confirmation](/../images/image180.png)
+![Set as PDN confirmation](../images/image180.png)
 
 **Step 5:** The selected master node is now the master definition node.
 
-![Database promoted to master definition node](/../images/image181.png)
+![Database promoted to master definition node](../images/image181.png)
 
 **Step 6:** The value `Yes` in the PDN field of the Property window indicates this database is the primary definition node.
 
 !!! Note
     The new primary definition node is moved to the top of the replication tree in the xDB Replication Console.
 
-![Master definition node (PDN) indicated by ‘Yes’ in the Property window](/../images/image182.png)
+![Master definition node (PDN) indicated by ‘Yes’ in the Property window](../images/image182.png)
 
 !!! Note
     You should now perform a synchronization replication to ensure that the new primary definition node is synchronized with the other primary nodes. See [Performing Synchronization Replication](05_on_demand_replication_mmr/#perform_synchronization_replication_mmr) for directions on performing a synchronization replication.

--- a/product_docs/docs/eprs/6.2/07_common_operations/01_select_tables_wildcard_selector.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/01_select_tables_wildcard_selector.mdx
@@ -37,7 +37,7 @@ Interpretation of pattern characters is described by the following:
 
 The wildcard pattern definitions and examples can be seen from a help screen displayed by clicking the secondary mouse button on the Filter Pattern text field of the Wildcard Selector dialog box:
 
-![Filter Pattern Help screen](/../images/image183.png)
+![Filter Pattern Help screen](../images/image183.png)
 
 The following section describes the basic steps for using the wildcard selector.
 
@@ -61,27 +61,27 @@ The tables that you have preselected are included in the local list used by the 
 
 For example, the following is the Create Publication dialog box from which the wildcard selector can be used:
 
-![Invoking the wildcard selector from a calling dialog box](/../images/image184.png)
+![Invoking the wildcard selector from a calling dialog box](../images/image184.png)
 
 **Step 2:** The Available Tables field displays the filtered list matching the pattern used in the Filter Pattern text field.
 
 When the Wildcard Selector dialog box is initially opened, the default filter pattern is the percent sign (`%`), which returns all eligible, unselected tables.
 
-![Wildcard Selector dialog box](/../images/image185.png)
+![Wildcard Selector dialog box](../images/image185.png)
 
 **Step 3:** Enter a pattern in the `Filter Pattern` text field to narrow down your desired table selection. Click the `Filter List` button to display the tables that match the pattern.
 
-![Tables matching a filter pattern](/../images/image186.png)
+![Tables matching a filter pattern](../images/image186.png)
 
 **Step 4:** Select tables from the `Available Tables` list that you want to add to the local list by placing a check mark in each such table’s check box. You can also click the Select `All` check box to select all tables and then individually deselect certain tables by removing its check mark.
 
-![Tables selected for the local list](/../images/image187.png)
+![Tables selected for the local list](../images/image187.png)
 
 **Step 5:** Click the `Apply Selections to Local List button` to add the selected tables to the local list.
 
 The following example shows that the selected tables have been removed from the Available Tables list after the Apply Selections to Local List button was clicked since they are no longer unselected.
 
-![Selected tables added to the local list](/../images/image188.png)
+![Selected tables added to the local list](../images/image188.png)
 
 !!! Note
     You can click the `Cancel` button at any time to terminate the wildcard selector without applying the local list changes to the table list of the calling dialog box.
@@ -90,41 +90,41 @@ The following example shows that the selected tables have been removed from the 
 
 The following example shows a second filter pattern and the returned filter list.
 
-![Tables matching a second filter pattern](/../images/image189.png)
+![Tables matching a second filter pattern](../images/image189.png)
 
 All tables are then selected from this filtered list by clicking the `Select All` check box.
 
-![Select all tables](/../images/image190.png)
+![Select all tables](../images/image190.png)
 
 The `Apply Selections to Local List` button is clicked to add all tables to the local list. After applying the selections, there are no unselected tables remaining that match the filter pattern.
 
-![All filter list tables added to the local list](/../images/image191.png)
+![All filter list tables added to the local list](../images/image191.png)
 
 By using the asterisk after the pattern, you can display previously selected tables comprising the local list. Each selected table has a check mark its check box.
 
-![Display selected and unselected tables matching the filter pattern](/../images/image192.png)
+![Display selected and unselected tables matching the filter pattern](../images/image192.png)
 
 You can remove selected tables from the local list by clicking on each such table’s check box to remove the check mark.
 
 The following filter pattern includes the tables to be removed from the local list.
 
-![List selected tables to be removed](/../images/image193.png)
+![List selected tables to be removed](../images/image193.png)
 
 The check marks are removed from the selected tables to be removed from the local list.
 
-![Deselect tables to be removed from the local list](/../images/image194.png)
+![Deselect tables to be removed from the local list](../images/image194.png)
 
 The removal of the deselected tables from the local list occurs along with the addition of any newly selected tables when you click the `Apply Selections to Local List` button.
 
-![Deselected tables removed from the local list now shown as unselected](/../images/image195.png)
+![Deselected tables removed from the local list now shown as unselected](../images/image195.png)
 
 The deselected tables still appear in the Available Tables list since they still match the pattern, but as unselected tables (that is, with no check mark in each such table’s check box).
 
 **Step 7:** When the local list contains all of your desired, selected tables, click the Done button. The Wildcard Selector dialog box closes, and the local list becomes the list of selected tables displayed by the calling dialog box.
 
-![Create Publication calling dialog box with applied local list](/../images/image196.png)
+![Create Publication calling dialog box with applied local list](../images/image196.png)
 
-![Create Publication calling dialog box with applied local list (continued)](/../images/image197.png)
+![Create Publication calling dialog box with applied local list (continued)](../images/image197.png)
 
 Alternatively, if you decide that you do not wish to apply the local list, click the `Cancel` button. The local list changes are discarded and the table list of the calling dialog box remains unchanged.
 
@@ -132,10 +132,10 @@ Alternatively, if you decide that you do not wish to apply the local list, click
 
 The following example verifies that if you were to invoke the wildcard selector a second time, the local list includes the table list created from the prior closure of the wildcard selector.
 
-![Local list includes selected tables from the calling dialog box table list](/../images/image198.png)
+![Local list includes selected tables from the calling dialog box table list](../images/image198.png)
 
 **Step 9:** When the calling dialog box contains the complete list of your desired tables, click the appropriate button of the calling dialog box to complete the operation with the selected tables.
 
 The following shows the publication created from the selected tables.
 
-![Publication created with the selected tables](/../images/image199.png)
+![Publication created with the selected tables](../images/image199.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/02_creating_schedule.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/02_creating_schedule.mdx
@@ -32,15 +32,15 @@ For snapshot replications, skipped, scheduled replications present no problem si
 
 **Step 1 (For SMR only):** Select the Subscription node of the subscription for which you wish to create a schedule.
 
-![Selecting a subscription on which to set a schedule](/../images/image109.png)
+![Selecting a subscription on which to set a schedule](../images/image109.png)
 
 **Step 1 (For MMR only):** Select the Publication Database node designated as the controller database. (The Controller database field in the Property window is set to Yes for the controller database.)
 
-![Selecting the controller database on which to set a schedule](/../images/image200.png)
+![Selecting the controller database on which to set a schedule](../images/image200.png)
 
 **Step 2 (For SMR only):** Open the Scheduled Task Wizard dialog box in any of the following ways:
 
-![Opening the Scheduled Task Wizard dialog box on a subscription](/../images/image201.png)
+![Opening the Scheduled Task Wizard dialog box on a subscription](../images/image201.png)
 
 -   From the `Subscription` menu, choose `Schedule`, then `Configure Schedule`.
 -   Click the secondary mouse button on the Subscription node and choose `Configure Schedule`.
@@ -51,7 +51,7 @@ For snapshot replications, skipped, scheduled replications present no problem si
 -   Click the secondary mouse button on the Publication Database node and choose `Configure Schedule`.
 -   Click the primary mouse button on the `Configure Schedule icon`.
 
-![Opening the Scheduled Task Wizard dialog box on a subscription](/../images/image202.png)
+![Opening the Scheduled Task Wizard dialog box on a subscription](../images/image202.png)
 
 **Step 3:** In the `Scheduled Task Wizard` dialog box, select the radio button for either synchronization replication or snapshot replication.
 
@@ -61,7 +61,7 @@ For snapshot replications, skipped, scheduled replications present no problem si
 !!! Note
     In a multi-master replication system, only Synchronize may be chosen.
 
-![Scheduled Task Wizard dialog box](/../images/image203.png)
+![Scheduled Task Wizard dialog box](../images/image203.png)
 
 **Step 4:** Step 4: Select the radio button for the scheduled replication frequency, or select `Cron Expression` to write your own cron expression. The frequency choices have the following meanings:
 
@@ -73,14 +73,14 @@ For snapshot replications, skipped, scheduled replications present no problem si
 
 The following example shows the selection of a weekly schedule.
 
-![Selecting a weekly schedule](/../images/image204.png)
+![Selecting a weekly schedule](../images/image204.png)
 
 **Step 5:** After completing the `Scheduled Task Wizard` dialog box, click the `Next` button.
 
 **Step 6:** Your selected schedule will appear. Click the `Finish` button to accept the schedule.
 
-![Scheduled Task Wizard summary](/../images/image205.png)
+![Scheduled Task Wizard summary](../images/image205.png)
 
 If you click the `Refresh` icon, you will see the schedule properties in the `General` tab.
 
-![Information window with the replication schedule](/../images/image206.png)
+![Information window with the replication schedule](../images/image206.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/03_managing_schedule.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/03_managing_schedule.mdx
@@ -18,11 +18,11 @@ The following steps illustrate how to change an existing schedule.
 
 **Step 2 (For SMR only):** Select the Subscription node of the subscription for which you wish to update the schedule.
 
-![Selecting a subscription whose schedule is to be updated](/../images/image207.png)
+![Selecting a subscription whose schedule is to be updated](../images/image207.png)
 
 **Step 2 (For MMR only):** Select the Publication Database node designated as the controller database for which you wish to update the schedule.
 
-![Selecting the controller database whose schedule is to be updated](/../images/image208.png)
+![Selecting the controller database whose schedule is to be updated](../images/image208.png)
 
 **Step 3 (For SMR only):** Open the `Scheduled Task Wizard` dialog box in any of the following ways:
 
@@ -35,15 +35,15 @@ The following steps illustrate how to change an existing schedule.
 -   Click the secondary mouse button on the Publication Database node and choose `Configure Schedule`.
 -   Click the primary mouse button on the `Configure Schedule` icon.
 
-![Opening the Scheduled Task Wizard dialog box from the tool bar](/../images/image209.png)
+![Opening the Scheduled Task Wizard dialog box from the tool bar](../images/image209.png)
 
 **Step 4:** The `Configure Scheduler` confirmation box appears. Click the `Yes` button.
 
-![Configure Scheduler confirmation](/../images/image210.png)
+![Configure Scheduler confirmation](../images/image210.png)
 
 **Step 5:** In the Scheduled Task Wizard dialog box, create the new schedule. See Step 3 of Section [Creating a Schedule](02_creating_schedule/#creating_schedule) for details on how to create a new schedule.
 
-![Scheduled Task Wizard dialog box](/../images/image211.png)
+![Scheduled Task Wizard dialog box](../images/image211.png)
 
 <div id="remove_schedule" class="registered_link"></div>
 
@@ -57,11 +57,11 @@ If you no longer wish replication to take place automatically, you must remove t
 
 **Step 2 (For SMR only):** Select the Subscription node of the subscription for which you wish to remove the schedule.
 
-![Selecting a subscription for removal of a schedule](/../images/image207.png)
+![Selecting a subscription for removal of a schedule](../images/image207.png)
 
 **Step 2 (For MMR only):** Select the Publication Database node designated as the controller database for which you wish to remove the schedule.
 
-![Selecting the controller database for removal of a schedule](/../images/image208.png)
+![Selecting the controller database for removal of a schedule](../images/image208.png)
 
 **Step 3 (For SMR only):** Remove the schedule in any of the following ways:
 
@@ -71,12 +71,12 @@ If you no longer wish replication to take place automatically, you must remove t
 
 **Step 3 (For MMR only):** Remove the schedule in any of the following ways: \* Click the secondary mouse button on the Publication Database node and choose Remove Schedule. \* Click the primary mouse button on the Remove Schedule icon.
 
-![Removing the schedule](/../images/image212.png)
+![Removing the schedule](../images/image212.png)
 
 **Step 4:** In the Removing Schedule confirmation box, click the `Yes` button.
 
-![Removing Schedule confirmation](/../images/image213.png)
+![Removing Schedule confirmation](../images/image213.png)
 
 If you click the `Refresh` icon in the tool bar, you will notice that schedule information no longer appears in the information window.
 
-![- Information window after schedule removal](/../images/image214.png)
+![- Information window after schedule removal](../images/image214.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/04_view_replication_history.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/04_view_replication_history.mdx
@@ -24,15 +24,15 @@ The following steps describe how to view the replication history of the events i
 
 **Step 1 (For SMR only):** Select the node beneath the Subscription node. Tabs labeled `General, Realtime Monitor`, and `Replication History` appear.
 
-![Selecting a subscription on which to view replication history](/../images/image215.png)
+![Selecting a subscription on which to view replication history](../images/image215.png)
 
 **Step 1 (For MMR only):** Select any Publication node under a Database node representing a primary node. Tabs labeled `General, Realtime Monitor, Replication History`, and `Conflict History` appear.
 
-![Selecting a publication on which to view replication history](/../images/image216.png)
+![Selecting a publication on which to view replication history](../images/image216.png)
 
 **Step 2:** Click the `Replication History` tab to show a history of replications.
 
-![Selecting a publication on which to view replication history](/../images/image217.png)
+![Selecting a publication on which to view replication history](../images/image217.png)
 
 !!! Note
     Every snapshot replication and each synchronization replication with at least one update produces a history record that is maintained in replication history tables in the control schema. Over time the size of the replication history tables will grow. Replication history records can be periodically deleted. See Section [Cleaning Up Replication History](05_managing_history/#clean_up_replication_history) for information on cleaning up replication history.
@@ -41,13 +41,13 @@ The following steps describe how to view the replication history of the events i
 
 You may notice synchronization replications with transaction counts of zero. These records indicate that there were no changes to synchronize at the time the replication occurred. For scheduled replications that occur frequently, this may result in a large number of lines in the `Replication History` tab, thus obscuring the more meaningful replications with non-zero transaction counts as shown below.
 
-![Replication history with zero transaction counts](/../images/image218.png)
+![Replication history with zero transaction counts](../images/image218.png)
 
 While viewing the `Replication History` tab, you can hide the records with zero transaction counts as follows:
 
 **Step 1:** Check the `Show History With Transactions Count > 0` check box located at the bottom of the `Replication History` tab.
 
-![Setting replication history to hide zero transaction count records](/../images/image219.png)
+![Setting replication history to hide zero transaction count records](../images/image219.png)
 
 **Step 2:** The next time the `Replication History` tab refreshes, only the replications with non-zero transaction counts appear in the `Replication History`.
 
@@ -66,11 +66,11 @@ Expanding the nodes under the Subscription node of a single-master replication s
 
 Step 1: Select a table to reveal tabs that contain general information about the table and the replication history of the table. Expand a Table node to reveal the columns in the table.
 
-![Table properties and columns](/../images/image220.png)
+![Table properties and columns](../images/image220.png)
 
 Step 2: Click the `Replication History` tab to show a history of replications for this table.
 
-![Table replication history tab](/../images/image221.png)
+![Table replication history tab](../images/image221.png)
 
 **Step 3:** Click the `View Data` link to show a list of each change made to the table during the synchronization replication. The `Synchronize History` window shows two update operations followed by one insert operation against the `emp` target table that correspond to the following set of SQL statements executed on the `emp` source table:
 
@@ -79,7 +79,7 @@ UPDATE emp SET hiredate = TO_DATE('07-JUN-15'), mgr = 7698 WHERE empno IN (9001,
 INSERT INTO emp (empno, ename, job, mgr, deptno) VALUES (9003, 'JOHNSON', 'SALESMAN', 7698, 30);
 ```
 
-![Synchronize History window](/../images/image222.png)
+![Synchronize History window](../images/image222.png)
 
 !!! Note
     Since all insert, update, and delete operations on all source tables are recorded in shadow tables, the size of the shadow tables may grow considerably over time for volatile source tables. The rows shown in the Synchronize History window are obtained from these shadow tables. Rows in the shadow tables can be periodically deleted. See [Cleaning Up Shadow Table History](../08_xdb_cli/03_xdb_cli_commands/49_clean_shadow_table_history/#clean_shadow_table_history) for information on cleaning up the shadow tables.

--- a/product_docs/docs/eprs/6.2/07_common_operations/05_managing_history.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/05_managing_history.mdx
@@ -55,15 +55,15 @@ The following steps show how to alter the default setting.
 
 **Step 2:** Select the Publication Database node for which you want to set the cleanup scheduling preference.
 
-![Selecting the publication database for cleanup scheduling](/../images/image223.png)
+![Selecting the publication database for cleanup scheduling](../images/image223.png)
 
 **Step 3:** From the `Publication` menu, choose `Preferences`. Alternatively, click the secondary mouse button on the Publication Database node and choose `Preferences`. The `Publication Server Preferences` dialog box appears.
 
-![Publication Server Preferences dialog box](/../images/image224.png)
+![Publication Server Preferences dialog box](../images/image224.png)
 
 **Step 4:** In the `Publication Server Preferences` dialog box, uncheck the box if you do not want to run a scheduled shadow table history cleanup job. Click the `OK` button and skip the remaining steps.
 
-![Disabled schedule for shadow table history cleanup](/../images/image225.png)
+![Disabled schedule for shadow table history cleanup](../images/image225.png)
 
 **Step 5:** If you want to schedule shadow table history cleanup, make sure the Run Cleanup Job check box is selected. Select the radio button for the cleanup frequency. The frequency choices have the following meanings:
 
@@ -75,7 +75,7 @@ The following steps show how to alter the default setting.
 !!! Note
     A configuration option is available to force shadow table history cleanup after every synchronization replication. See [Forcing Immediate Shadow Table Cleanup](../10_appendix/04_miscellaneous_xdb_processing_topics/01_publications_and_subscriptions_server_conf_options/09_forcing_shadow_table_cleanup/#forcing_shadow_table_cleanup) for information on this option.
 
-![Cleanup Job dialog box](/../images/image226.png)
+![Cleanup Job dialog box](../images/image226.png)
 
 **Step 6:** Click the `OK` button to accept the schedule.
 
@@ -106,23 +106,23 @@ The following are the steps to run shadow table history cleanup on demand for a 
 
 **Step 2:** Select the Publication node of the publication for which you want to clean up the shadow table history.
 
-![Selecting a publication for shadow table history cleanup](/../images/image227.png)
+![Selecting a publication for shadow table history cleanup](../images/image227.png)
 
 **Step 3:** From the `Publication` menu, choose `Cleanup Shadow Table History`. Alternatively, click the secondary mouse button on the Publication node and choose `Cleanup Shadow Table History`. The `Cleanup Synchronization History` confirmation box appears.
 
-![Cleaning up shadow table history](/../images/image228.png)
+![Cleaning up shadow table history](../images/image228.png)
 
 **Step 4:** Click the `Yes` button in the `Cleanup Synchronization History` confirmation box.
 
-![Cleanup Synchronization History confirmation](/../images/image229.png)
+![Cleanup Synchronization History confirmation](../images/image229.png)
 
 **Step 5:** Click the `Yes` button in response to `Shadow Table’s Transaction History Removed Successfully`.
 
-![Successful cleanup of shadow table history](/../images/image230.png)
+![Successful cleanup of shadow table history](../images/image230.png)
 
 After shadow table history cleanup, if you click the `View Data` link of the `Replication History` tab, an information message appears stating that there is no synchronization history to view.
 
-![View Data link after shadow table history cleanup](/../images/image231.png)
+![View Data link after shadow table history cleanup](../images/image231.png)
 
 <div id="clean_up_replication_history" class="registered_link"></div>
 
@@ -139,23 +139,23 @@ The following are the steps to run replication history cleanup for a chosen publ
 
 **Step 2:** Select the Publication node of the publication for which you want to clean up replication history.
 
-![Selecting a publication for replication history cleanup](/../images/image227.png)
+![Selecting a publication for replication history cleanup](../images/image227.png)
 
 **Step 3:** From the `Publication` menu, choose `Cleanup Replication History`. Alternatively, click the secondary mouse button on the Publication node and choose Cleanup Replication History. The `Cleanup Replication History` confirmation box appears.
 
-![Cleaning up replication history](/../images/image232.png)
+![Cleaning up replication history](../images/image232.png)
 
 **Step 4:** Click the `Yes` button in the Cleanup Replication History confirmation box.
 
-![Cleanup Replication History confirmation](/../images/image233.png)
+![Cleanup Replication History confirmation](../images/image233.png)
 
 **Step 5:** Click the `Yes` button in response to Replication History Has Been Removed.
 
-![Successful cleanup of replication history](/../images/image234.png)
+![Successful cleanup of replication history](../images/image234.png)
 
 After replication history cleanup, if you click the `Replication History` tab, no history records appear.
 
-![Successful cleanup of replication history](/../images/image235.png)
+![Successful cleanup of replication history](../images/image235.png)
 
 <div id="clean_event_history" class="registered_link"></div>
 

--- a/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/01_updating_publication_server.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/01_updating_publication_server.mdx
@@ -19,7 +19,7 @@ The steps described in this section show you how to update the publication serve
 
 It is assumed that the xDB Replication Console is open on your computer and the publication server whose login information you wish to alter in the server login file, appears as a Publication Server node in the xDB Replication Console’s replication tree.
 
-![Publication Server node](/../../images/image236.png)
+![Publication Server node](../../images/image236.png)
 
 You can perform the following actions on the server login file:
 
@@ -33,7 +33,7 @@ The following steps change only the content of the server login file residing on
 
 **Step 2:** Click the secondary mouse button on the Publication Server node and choose Update. The `Update Publication Server` dialog box appears.
 
-![Update Publication Server dialog box](/../../images/image237.png)
+![Update Publication Server dialog box](../../images/image237.png)
 
 **Step 3:** Complete the fields in the dialog box according to your purpose for updating the server login file:
 
@@ -41,7 +41,7 @@ The following steps change only the content of the server login file residing on
 -   If you want to delete previously saved login information, make sure the network location shown in the dialog box is still correct. Re-enter the admin user name and password saved in the xDB Replication Configuration file that resides on the host identified by the IP address in the Host field. Leave the Save Login Information box unchecked. Access to the publication server is available for this session, but subsequent sessions will require you to register the publication server again.
 -   If you want to save the current login information shown in the dialog box, make sure the network location shown in the dialog box is correct. Re-enter the admin user name and password saved in the xDB Replication Configuration file that resides on the host identified by the IP address in the Host field. Check the Save Login Information box.
 
-![Updated publication server location](/../../images/image238.png)
+![Updated publication server location](../../images/image238.png)
 
 **Step 4:** Click the `Update` button. If the dialog box closes, then the update to the server login file was successful. Click the `Refresh` icon in the xDB Replication Console tool bar to show the updated Publication Server node.
 
@@ -60,7 +60,7 @@ This network information enables the publication server to communicate with the 
 
 If the network location of a subscription server changes after subscriptions have been created, the publication server metadata must be updated with the new network location, otherwise a communication failure occurs between the publication server and the subscription server that is made apparent by the following message that appears when you open the xDB Replication Console.
 
-![Subscription server connection failure](/../../images/image239.png)
+![Subscription server connection failure](../../images/image239.png)
 
 The following are the steps to update the subscription server network location within a publication server’s metadata.
 
@@ -71,11 +71,11 @@ The following are the steps to update the subscription server network location w
 !!! Note
     If the error message box reappears, click the `OK` button and repeat Step 2.
 
-![Update Subscription Servers dialog box](/../../images/image240.png)
+![Update Subscription Servers dialog box](../../images/image240.png)
 
 **Step 3:** Enter the new network location for each subscription server in the list whose network location has changed.
 
-![Updated subscription server location](/../../images/image241.png)
+![Updated subscription server location](../../images/image241.png)
 
 **Step 4:** Click the `Update` button. If the dialog box closes, then the update to the publication server’s metadata was successful.
 

--- a/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/02_updating_pub_database.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/02_updating_pub_database.mdx
@@ -29,22 +29,22 @@ Attributes you may change include the following:
 
 **Step 3:** Select the Publication Database node corresponding to the publication database definition that you wish to update.
 
-![Selecting a publication database definition for update](/../../images/image242.png)
+![Selecting a publication database definition for update](../../images/image242.png)
 
 **Step 4:** From the `Publication` menu, choose `Publication Database`, and then choose `Update Database`. Alternatively, click the secondary mouse button on the Publication Database node and choose Update Database. The `Update Database Source` dialog box appears.
 
 **Step 5:** Enter the desired changes. See Step 3 of [Adding a Publication Database](../../05_smr_operation/02_creating_publication/02_adding_pub_database/#adding_pub_database) for the precise meanings of the fields for a single-master replication system. See sections [Adding the Primary definition node](../../06_mmr_operation/02_creating_publication_mmr/#adding_pdn) and [Creating Additional Primary nodes](../../06_mmr_operation/03_creating_primary_nodes/#creating_primary_nodes) for a multi-master replication system.
 
-![Update Database Source dialog box for a single-master replication system](/../../images/image243.png)
+![Update Database Source dialog box for a single-master replication system](../../images/image243.png)
 
 **Step 6:** Click the `Test` button. If `Test Result: Success` appears, click the `OK` button, then click the `Save` button.
 
 If an error message appears investigate the cause of the error, correct the problem, and repeat steps 1 through 6.
 
-![Successful publication database test](/../../images/image244.png)
+![Successful publication database test](../../images/image244.png)
 
 **Step 7:** Restart the publication server. See [Registering a Publication Server](../../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions on restarting the publication server.
 
 **Step 8:** Click the `Refresh` icon in the xDB Replication Console tool bar to show the updated Publication Database node and any of its publications.
 
-![Updated publication database](/../../images/image245.png)
+![Updated publication database](../../images/image245.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/03_updating_pub.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/03_updating_pub.mdx
@@ -24,7 +24,7 @@ The following are the steps to add tables to an existing publication.
 
 **Step 2 (For MMR only):** Select the Publication node under the Publication Database node representing the primary definition node.
 
-![Selecting a publication to which to add tables](/../../images/image246.png)
+![Selecting a publication to which to add tables](../../images/image246.png)
 
 **Step 3:** Open the Add Tables dialog box in any of the following ways:
 
@@ -32,7 +32,7 @@ The following are the steps to add tables to an existing publication.
 -   Click the secondary mouse button on the Publication node, choose Update Publication, and then choose Add Tables.
 -   Click the primary mouse button on the Add Publication Tables icon.
 
-![Opening the Add Tables dialog box](/../../images/image247.png)
+![Opening the Add Tables dialog box](../../images/image247.png)
 
 **Step 4:** Fill in the following fields in the Add Tables tab of the Add Tables dialog box:
 
@@ -40,7 +40,7 @@ The following are the steps to add tables to an existing publication.
 -   Select All. Check this box if you want to include all tables and views in the Available Tables list in the publication.
 -   Use Wildcard Selection. Click this button to use the wildcard selector to choose tables for the publication. See [Selecting Tables with the Wildcard Selector](../01_select_tables_wildcard_selector/#select_tables_wildcard_selector) for information on the wildcard selector.
 
-![Add Tables dialog box](/../../images/image248.png)
+![Add Tables dialog box](../../images/image248.png)
 
 If you wish to omit certain rows of the publication tables or views from being replicated follow the directions in the next step to create a filter, otherwise go on to Step 6.
 
@@ -52,7 +52,7 @@ For a multi-master replication system, see [Adding a Publication](../../06_mmr_o
 
 **Step 6 (For SMR only):** Click the `Add Tables` button. If Publication Updated Successfully appears, click the `OK` button, otherwise investigate the error and make the necessary corrections.
 
-![Successfully added tables to publication](/../../images/image249.png)
+![Successfully added tables to publication](../../images/image249.png)
 
 **Step 6 (For MMR only):** Click the `Add Tables` button. The `Data Sync Check` dialog box appears warning you that synchronization replication is performed before the table is added.
 
@@ -60,11 +60,11 @@ If you wish to perform synchronization at some later point in time then add the 
 
 If you wish to proceed, click the `Yes` button. If Publication Updated Successfully appears, click the `OK` button, otherwise investigate the error and make the necessary corrections.
 
-![Data Sync Check dialog box](/../../images/image250.png)
+![Data Sync Check dialog box](../../images/image250.png)
 
 **Step 7:** The replication tree appears as follows with the newly added table under the Publication node. Click the `Refresh` icon. The newly added table appears under the Subscription nodes of a single-master replication system or the additional primary nodes of a multi-master replication system.
 
-![Publication and subscription with added table](/../../images/image251.png)
+![Publication and subscription with added table](../../images/image251.png)
 
 **Step 8 (For MMR only):** If you want to modify or see the default conflict resolution options assigned to the newly added table, follow the directions in Section [Updating the Conflict Resolution Options](../../06_mmr_operation/08_update_conflict_resolution_options/#update_conflict_resolution_options).
 
@@ -82,7 +82,7 @@ You can remove one or more tables from a publication, but only if the following 
 
 -   The tables to be removed are not parent tables referenced by foreign key constraints of child tables that are not selected for removal as well.
 
-![Entity relationship diagram of tables with foreign key constraints](/../../images/image252.png)
+![Entity relationship diagram of tables with foreign key constraints](../../images/image252.png)
 
 In the preceding entity relationship diagram, the `emp` table has a foreign key constraint referencing the dept table, and the `jobhist` table has two foreign key constraints. One constraint references the `emp` table and the other references the `dept` table.
 
@@ -97,7 +97,7 @@ If all three tables are in the publication, then you can remove the following co
 
 **Step 2 (For MMR only):** Select the Publication node under the Publication Database node representing the primary definition node.
 
-![Selecting a publication from which to remove tables](/../../images/image253.png)
+![Selecting a publication from which to remove tables](../../images/image253.png)
 
 **Step 3:** Open the `Remove Tables` dialog box in any of the following ways:
 
@@ -105,23 +105,23 @@ If all three tables are in the publication, then you can remove the following co
 -   Click the secondary mouse button on the Publication node, choose `Update Publication`, and then choose `Remove Tables`.
 -   Click the primary mouse button on the `Remove Publication Tables` icon.
 
-![Opening the Remove Tables dialog box by clicking the toolbar icon](/../../images/image254.png)
+![Opening the Remove Tables dialog box by clicking the toolbar icon](../../images/image254.png)
 
 **Step 4:** Use the `Remove Tables` dialog box as follows:
 
-![Remove Tables dialog box](/../../images/image255.png)
+![Remove Tables dialog box](../../images/image255.png)
 
 -   Remove. Check the boxes next to the table names from the Available Tables list that are to be removed from the publication. If the publication is a snapshot-only publication, then views would appear in the Available Tables list as well. Alternatively or in addition, click the `Use Wildcard Selection` button to use wildcard pattern matching for selecting tables to be removed from the publication.
 -   Use Wildcard Selection. Click this button to use the wildcard selector to choose tables to remove from the publication. See [Selecting Tables with the Wildcard Selector](../01_select_tables_wildcard_selector/#select_tables_wildcard_selector) for information on the wildcard selector.
 
 **Step 5:** Click the `Remove` button, then click the `Yes` button of the confirmation box.
 
-![Remove Tables dialog box](/../../images/image256.png)
+![Remove Tables dialog box](../../images/image256.png)
 
 **Step 6:** Click the `OK` button in response to Tables Removed Successfully.
 
-![Successfully removed tables from publication](/../../images/image257.png)
+![Successfully removed tables from publication](../../images/image257.png)
 
 The replication tree appears as follows without the removed table under the Publication node.
 
-![Publication minus removed table](/../../images/image258.png)
+![Publication minus removed table](../../images/image258.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/04_updating_table_filters_in_pub.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/04_updating_table_filters_in_pub.mdx
@@ -25,18 +25,18 @@ The following are the steps to update the set of available filter rules in a pub
 
 **Step 2 (For MMR only):** Select the Publication node under the Publication Database node representing the primary definition node.
 
-![Selecting a publication in which to update the set of available table filters](/../../images/image259.png)
+![Selecting a publication in which to update the set of available table filters](../../images/image259.png)
 
 **Step 3:** Open the **Update Filters** dialog box in any of the following ways:
 
 -   From the **Publication** menu, choose **Update Publication**, then **Update Filters**.
 -   Click the secondary mouse button on the Publication node, choose **Update Publication**, and then choose **Update Filters**.
 
-![Opening the Update Filters dialog box](/../../images/image260.png)
+![Opening the Update Filters dialog box](../../images/image260.png)
 
 **Step 4:** The set of all available filter rules defined in the publication are listed under the **Table Filters** tab.
 
-![- Set of all available filter rules](/../../images/image261.png)
+![- Set of all available filter rules](../../images/image261.png)
 
 To add a new filter rule, from the Table/View drop-down list select the table or view for which you wish to add a filter and click the Add Filter button. Fill in the information in the dialog box that appears. (See [Adding a Publication](../../05_smr_operation/02_creating_publication/03_adding_publication/#adding_publication) for more details on adding individual filter rules in a single-master replication system. See [Adding a Publication](../../06_mmr_operation/02_creating_publication_mmr/#add_pub_mmr) for a multi-master replication system.)
 
@@ -48,6 +48,6 @@ When you are satisfied with the updated set of available table filters, click th
 
 Click the **Ok** button in the confirmation box to proceed with the update to the filter rules. Click the **Cancel** button to return to the **Filter Rules** tab if you wish to modify your filter rule updates.
 
-![Change filter rule confirmation](/../../images/image262.png)
+![Change filter rule confirmation](../../images/image262.png)
 
 **Step 6:** You may selectively enable any new filter rules to the corresponding tables of the associated subscriptions or primary nodes. See <span class="title-ref">Enabling/Disabling Table Filters on a Subscription &lt;enable_filters_on_subscription></span> for information on enabling table filters on a subscription. See <span class="title-ref">Enabling/Disabling Table Filters on a Primary node &lt;enable_disable_table_filters></span> for enabling table filters on a primary node.

--- a/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/05_validating_publication.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/05_validating_publication.mdx
@@ -78,11 +78,11 @@ The following steps show how to validate a single publication:
 
 **Step 3:** From the `Publication` menu, choose `Validate Publication`. Alternatively, click the secondary mouse button on the Publication node and choose `Validate Publication`.
 
-![Validating a selected publication](/../../images/image263.png)
+![Validating a selected publication](../../images/image263.png)
 
 **Step 4:** If All Schema of Published Tables in Publication 'publication_name' Are Up-To-Date appears, click the `OK` button. If an error appears, determine which tables were changed and what changes were made to the table definitions. These issues need to be resolved on a case by case basis as discussed earlier in this section.
 
-![Successful validation of all tables in the selected publication](/../../images/image264.png)
+![Successful validation of all tables in the selected publication](../../images/image264.png)
 
 <div id="validate_all_pub" class="registered_link"></div>
 
@@ -104,12 +104,12 @@ All publications under a single Publication Database node can be validated in on
 
 **Step 3:** From the `Publication` menu, choose `Validate All Publications`. Alternatively, click the secondary mouse button on the Publication Database node and choose `Validate All Publications`.
 
-![Validating all publications subordinate to a selected publication database](/../../images/image265.png)
+![Validating all publications subordinate to a selected publication database](../../images/image265.png)
 
 **Step 4:** If there were no modified tables, click the `OK` button.
 
-![Successful validation of all tables in all publications subordinate to a selected publication database](/../../images/image266.png)
+![Successful validation of all tables in all publications subordinate to a selected publication database](../../images/image266.png)
 
 If there were modified tables, a list of publications that contain the modified tables is displayed. Determine which tables were changed and what changes were made to the table definitions. These issues need to be resolved on a case by case basis as discussed earlier in this section.
 
-![List of publications with modified tables](/../../images/image267.png)
+![List of publications with modified tables](../../images/image267.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/06_removing_pub.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/06_removing_pub.mdx
@@ -18,7 +18,7 @@ The publication database user name is also left intact along with some of the xD
 
 **Step 2 (For MMR only):** Select the Publication node under the Publication Database node representing the primary definition node.
 
-![Selecting a publication to remove](/../../images/image268.png)
+![Selecting a publication to remove](../../images/image268.png)
 
 **Step 3:** Remove the publication in any of the following ways:
 
@@ -26,12 +26,12 @@ The publication database user name is also left intact along with some of the xD
 -   Click the secondary mouse button on the Publication node and choose **Remove Publication**.
 -   Click the primary mouse button on the **Remove Publication** icon.
 
-![Removing the publication using the menu bar](/../../images/image269.png)
+![Removing the publication using the menu bar](../../images/image269.png)
 
 **Step 4:** In the **Remove Publication** confirmation box, click the **Yes** button.
 
-![Remove Publication confirmation](/../../images/image270.png)
+![Remove Publication confirmation](../../images/image270.png)
 
 The Publication node no longer appears under the Publication Database node.
 
-![Replication tree after removing a publication](/../../images/image271.png)
+![Replication tree after removing a publication](../../images/image271.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/07_removing_pub_database.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/06_managing_publication/07_removing_pub_database.mdx
@@ -40,14 +40,14 @@ The following are the steps to remove the Publication Database node and equivale
 
 **Step 2:** Select the Publication Database node that you wish to remove.
 
-![Selecting a publication to remove](/../../images/image271.png)
+![Selecting a publication to remove](../../images/image271.png)
 
 **Step 3:** From the Publication menu, choose Publication Database, then Remove Database. Alternatively, click the secondary mouse button on the Publication Database node and choose Remove Database. The **Remove Publication** Database confirmation box appears.
 
 **Step 4:** In the **Remove Publication Database** confirmation box, click the **Yes** button.
 
-![Remove Publication confirmation](/../../images/image273.png)
+![Remove Publication confirmation](../../images/image273.png)
 
 The Publication Database node no longer appears under the Publication Server node.
 
-![Replication tree after removing a publication database](/../../images/image274.png)
+![Replication tree after removing a publication database](../../images/image274.png)

--- a/product_docs/docs/eprs/6.2/07_common_operations/07_switching_controller_db.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/07_switching_controller_db.mdx
@@ -25,23 +25,23 @@ The following are the steps to set another publication database as the controlle
 
 **Step 2:** Select the Publication Database node corresponding to the publication database that you wish to set as the controller database.
 
-![Selecting the publication database to set as the controller database](/../images/image275.png)
+![Selecting the publication database to set as the controller database](../images/image275.png)
 
 Step 3: Click the secondary mouse button on the Publication Database node and choose Set as Controller database.
 
-![Setting the controller database](/../images/image276.png)
+![Setting the controller database](../images/image276.png)
 
 Step 4: In the Set as Controller database confirmation box, click the `Yes` button.
 
-![Set as Controller database confirmation](/../images/image277.png)
+![Set as Controller database confirmation](../images/image277.png)
 
 Step 5: The selected publication database has now been set as the controller database.
 
-![Publication database promoted to controller database](/../images/image278.png)
+![Publication database promoted to controller database](../images/image278.png)
 
 Step 6: The value <span class="title-ref">Yes</span> in the Controller database field of the `Property` window indicates this database is the controller database.
 
-![Controller database indicated by Yes in the Property window](/../images/image279.png)
+![Controller database indicated by Yes in the Property window](../images/image279.png)
 
 The following shows the xDB Replication Configuration file after the controller database has been switched to the primary node database `MMRnode_b`.
 

--- a/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/02_ddl_change_replication_using_xdb_console.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/02_ddl_change_replication_using_xdb_console.mdx
@@ -14,19 +14,19 @@ Alternatively, you can copy and paste, or directly type in the `ALTER TABLE` sta
 
 **Step 3:** Under the publication database of a single-master replication system, or under the primary definition node of a multi-master replication system, open the Alter Publication Table dialog box by clicking the secondary mouse button on the Table node of the table to be modified and choose Alter Table.
 
-![Selecting a table to alter](/../../images/image280.png)
+![Selecting a table to alter](../../images/image280.png)
 
 **Step 4:** In the `Alter Publication Table` dialog box, if you saved the `ALTER TABLE` statements in a text file, make sure the DDL Script File option is selected, browse for this file, and click the `OK` button.
 
-![Alter Publication Table dialog box with DDL script file](/../../images/image281.png)
+![Alter Publication Table dialog box with DDL script file](../../images/image281.png)
 
 Alternatively, if you are directly entering the `ALTER TABLE` statements, select the DDL Script option instead of the DDL Script File option. Directly type in, or copy and paste the ALTER TABLE statements from your source into the text box. Click the `OK` button.
 
-![Alter Publication Table dialog box with copy and paste](/../../images/image282.png)
+![Alter Publication Table dialog box with copy and paste](../../images/image282.png)
 
 **Step 5:** If the `DDL replicated successfully message` box appears, the DDL change was successful across all databases. Click the `OK` button.
 
-![DDL replicated successfully](/../../images/image283.png)
+![DDL replicated successfully](../../images/image283.png)
 
 If DDL replication was not successful, the problem must be investigated and resolved on a case by case basis. Factors to look for include the following:
 

--- a/product_docs/docs/eprs/6.2/07_common_operations/10_replicating_postgres_partitioned_tables.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/10_replicating_postgres_partitioned_tables.mdx
@@ -278,17 +278,17 @@ Follow the directions in Section [Creating a Publication](../06_mmr_operation/02
 
 When creating the publication you must select the parent table along with the child tables.
 
-![Creating a publication for a Postgres 9.x partitioned table](/../images/image284.png)
+![Creating a publication for a Postgres 9.x partitioned table](../images/image284.png)
 
 The following shows the resulting replication tree for the partitioned table in the primary definition node:
 
-![Publication containing a Postgres 9.x partitioned table](/../images/image285.png)
+![Publication containing a Postgres 9.x partitioned table](../images/image285.png)
 
 Create additional primary nodes as described in Section [Creating Additional Primary nodes](../06_mmr_operation/03_creating_primary_nodes/#creating_primary_nodes). (For a single-master replication system, create the subscription database and subscription according to the directions in Section [Creating a Subscription](../05_smr_operation/03_creating_subscription/#creating_subscription).)
 
 The following shows the resulting multi-master replication system after you have added an additional primary node.
 
-![MMR system with a Postgres 9.x partitioned table](/../images/image286.png)
+![MMR system with a Postgres 9.x partitioned table](../images/image286.png)
 
 The partitioned table can now be kept synchronized on the primary nodes of the multi-master replication system.
 
@@ -311,16 +311,16 @@ Follow the directions in Section [Creating a Publication](../06_mmr_operation/02
 
 When creating the publication, only the parent table appears and is selected.
 
-![Creating a publication for a Postgres 10 or later partitioned table](/../images/image287.png)
+![Creating a publication for a Postgres 10 or later partitioned table](../images/image287.png)
 
 The following shows the resulting replication tree for the partitioned table in the primary definition node:
 
-![Publication containing a Postgres 10 or later partitioned table](/../images/image288.png)
+![Publication containing a Postgres 10 or later partitioned table](../images/image288.png)
 
 Create additional primary nodes as described in Section [Creating Additional Primary nodes](../06_mmr_operation/03_creating_primary_nodes/#creating_primary_nodes). (For a single-master replication system, create the subscription database and subscription according to the directions in Section [Creating a Subscription](../05_smr_operation/03_creating_subscription/#creating_subscription).)
 
 The following shows the resulting multi-master replication system after you have added an additional primary node.
 
-![MMR system with a Postgres 10 or later partitioned table](/../images/image289.png)
+![MMR system with a Postgres 10 or later partitioned table](../images/image289.png)
 
 The partitioned table can now be kept synchronized on the primary nodes of the multi-master replication system.

--- a/product_docs/docs/eprs/6.2/07_common_operations/11_using_ssl_connections.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/11_using_ssl_connections.mdx
@@ -348,7 +348,7 @@ For publication, subscription, and primary node databases, in the URL Options fi
 
 The following is an example of the Add Database dialog box with the `ssl=true` URL option.
 
-![Add Database with SSL URL option](/../images/image290.png)
+![Add Database with SSL URL option](../images/image290.png)
 
 !!! Note
     If you no longer wish to use an SSL connection to an xDB Replication Server database, you must completely delete the `ssl=true` text from the URL Options field of the Add Database or Update Database dialog box. Simply changing true to false does not have the effect of disabling the SSL option.

--- a/product_docs/docs/eprs/6.2/09_data_validator/02_perform_datavalidation.mdx
+++ b/product_docs/docs/eprs/6.2/09_data_validator/02_perform_datavalidation.mdx
@@ -438,7 +438,7 @@ The log file contains the same content as displayed when the Data Validator is i
 
 The following is the diff file as displayed in a text editor:
 
-![Data Validator diff file](/../images/image291.png)
+![Data Validator diff file](../images/image291.png)
 
 The following example includes only tables `dept` and `emp` with the `-it` option when comparing the Oracle EDB schema against the Advanced Server public schema.
 

--- a/product_docs/docs/eprs/6.2/10_appendix/02_upgrading_to_xdb6_2/02_upgrading_with_gui_installer.mdx
+++ b/product_docs/docs/eprs/6.2/10_appendix/02_upgrading_to_xdb6_2/02_upgrading_with_gui_installer.mdx
@@ -14,15 +14,15 @@ Perform the following steps to upgrade to xDB Replication Server 6.2 using the g
 
 **Step 4:** Following the acceptance of the license agreement in Step 11 of Section [Installing With Stack Builder or StackBuilder Plus](../../03_installation/01_installing_with_stackbuilder/#installing_with_stackbuilder), the Select Components screen appears, but with the entries grayed out. The old xDB Replication Server components are replaced by the new ones in the old xDB Replication Server’s directory location. Click the `Next` button.
 
-![Select components](/../../images/image292.png)
+![Select components](../../images/image292.png)
 
 **Step 5:** The Existing Installation screen confirms that an existing xDB Replication Server installation was found. Click the `Next` button to proceed with the upgrade.
 
-![Existing installation](/../../images/image293.png)
+![Existing installation](../../images/image293.png)
 
 **Step 6:** On the `Ready to Install` screen, click the `Next` button.
 
-![Ready to install](/../../images/image294.png)
+![Ready to install](../../images/image294.png)
 
 **Step 7:** The remaining screens that appear confirm completion of the installation process and allow you to exit from Stack Builder or StackBuilder Plus.
 

--- a/product_docs/docs/eprs/6.2/10_appendix/03_resolving_problems/04_troubleshooting_areas.mdx
+++ b/product_docs/docs/eprs/6.2/10_appendix/03_resolving_problems/04_troubleshooting_areas.mdx
@@ -62,7 +62,7 @@ In the following example, the SMR publication database edb as well as the three 
 
 The control schema must be removed from all four publication databases if it is determined that the control schema is corrupted in any of the four publication databases.
 
-![Publication databases with shared controller database](/../../images/image295.png)
+![Publication databases with shared controller database](../../images/image295.png)
 
 Finally, the subscription databases of SMR systems contain a control schema object, which must be deleted as well.
 
@@ -409,7 +409,7 @@ admin_user=enterprisedb
 
 **Step 12:** In the replication tree you should see the following:
 
-![Replication tree after removal of all control schema objects](/../../images/image296.png)
+![Replication tree after removal of all control schema objects](../../images/image296.png)
 
 All the nodes under the SMR and MMR type nodes beneath the Publication Server node, and under the Subscription Server node no longer appear.
 

--- a/product_docs/docs/eprs/6.2/10_appendix/04_miscellaneous_xdb_processing_topics/04_disable_foreign_key_constraints_for_snapshot_replication.mdx
+++ b/product_docs/docs/eprs/6.2/10_appendix/04_miscellaneous_xdb_processing_topics/04_disable_foreign_key_constraints_for_snapshot_replication.mdx
@@ -13,8 +13,8 @@ No user (not even a superuser) is allowed to directly modify the data in a Postg
 
 To verify that a user has the privilege to update the system catalog tables, select the user name under the Login Roles node in pgAdmin (Postgres Enterprise Manager Client in Advanced Server). The Update Catalogs property should be set to Yes.
 
-![User with privilege to update system catalogs](/../../images/image297.png)
+![User with privilege to update system catalogs](../../images/image297.png)
 
 If the Update Catalogs property is set to No, click the secondary mouse button on the user name in the Object Browser and choose Properties from the menu. Select the Role Privileges tab, check the **Can Modify Catalog Directly** box, and click the **OK** button.
 
-![Granting system catalog update privilege](/../../images/image298.png)
+![Granting system catalog update privilege](../../images/image298.png)

--- a/product_docs/docs/eprs/6.2/10_appendix/04_miscellaneous_xdb_processing_topics/06_replicating_sql_server_sql_variant_data_type.mdx
+++ b/product_docs/docs/eprs/6.2/10_appendix/04_miscellaneous_xdb_processing_topics/06_replicating_sql_server_sql_variant_data_type.mdx
@@ -61,4 +61,4 @@ At the bottom of the following Object Browser window, note the presence of the s
 
 > `CREATE TABLE MyTable …` would result in an object identifier name of mytable.
 >
-> ![Subscription table with sql_variant column](/../../images/image299.png)
+> ![Subscription table with sql_variant column](../../images/image299.png)


### PR DESCRIPTION
## What Changed?

The previous image paths used in EPRS 6.2 started with a slash, making them absolute paths technically? Either way, pandoc was not happy with this. Seemed safest to find and replace versus trying to replace the image paths automatically.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
