### PR TITLE
DB-733 default_with_rowids not supported with partitioned table, reviewed by Suraj

### DIFF
--- a/product_docs/docs/epas/13/epas_compat_table_partitioning/02_selecting_a_partition_type/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_table_partitioning/02_selecting_a_partition_type/index.mdx
@@ -12,6 +12,9 @@ When you create a partitioned table, you specify `LIST, RANGE`, or `HASH` partit
 
 Advanced Server can also use the partitioning rules to enforce partition pruning, improving performance when responding to user queries. When selecting a partitioning type and partitioning keys for a table, you should take into consideration how the data that is stored within a table will be queried, and include often-queried columns in the partitioning rules.
 
+!!! Note
+    Advanced Server does not support the creation of partitioned tables when using `default_with_rowids` set to `ON`. 
+
 **List Partitioning**
 
 When you create a list-partitioned table, you specify a single partitioning key column. When adding a row to the table, the server compares the key values specified in the partitioning rule to the corresponding column within the row. If the column value matches a value in the partitioning rule, the row is stored in the partition named in the rule.


### PR DESCRIPTION
## What Changed?

Doc is updated with DB-733 i.e default_with_rowids not supported with partitioned table.

**Examples**
- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [x ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
