### PR TITLE
Add partial WAL recovery to Barman demo

### DIFF
--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -28,11 +28,31 @@ This demo is interactive. You can follow along right in your browser, using Kata
 
 <KatacodaPanel />
 
-We'll start by configuring the database itself to allow streaming replication. For this, we need two things:
+For Barman to back up this server, a few things need to be done to prepare it:
 
-1. A dedicated superuser for Barman to connect as
-2. A dedicated streaming user with the replication attribute and remote login permissions
-3. Free replication slots
+1. Installing the Barman CLI tools
+2. Creating a dedicated superuser for Barman to connect as
+3. Creating a dedicated streaming user with the replication attribute and remote login permissions
+4. Ensuring there are free replication slots
+
+### Barman CLI installation
+
+We'll start by installing the barman-cli package: this contains the `barman-wal-archive` and `barman-wal-restore` commands that will be used to transmit data to and from our backup server.
+
+Since PostgreSQL is already installed, the PostgreSQL apt repository is already configured and we can just request the package:
+
+```shell
+sudo apt-get update
+sudo apt-get -y install barman-cli
+__OUTPUT__
+...
+Setting up barman-cli-cloud (2.12-1.pgdg100+1) ...
+Processing triggers for ca-certificates (20200601~deb10u2) ...
+Updating certificates in /etc/ssl/certs...
+0 added, 0 removed; done.
+Running hooks in /etc/ca-certificates/update.d...
+done.
+```
 
 ### User provisioning
 
@@ -110,6 +130,7 @@ Before we end, let's query some data - this is what we're going to back up!
 
 ```sql
 select * from actor where last_name='KILMER';
+\q
 __OUTPUT__
  actor_id | first_name | last_name |      last_update       
 ----------+------------+-----------+------------------------

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step01-db-setup.mdx
@@ -37,9 +37,9 @@ For Barman to back up this server, a few things need to be done to prepare it:
 
 ### Barman CLI installation
 
-We'll start by installing the barman-cli package: this contains the `barman-wal-archive` and `barman-wal-restore` commands that will be used to transmit data to and from our backup server.
+We'll start by installing the barman-cli package: this contains the [`barman-wal-archive`](http://docs.pgbarman.org/release/2.12/barman-wal-archive.1.html) and [`barman-wal-restore`](http://docs.pgbarman.org/release/2.12/barman-wal-restore.1.html) commands that will be used to transmit data to and from our backup server.
 
-Since PostgreSQL is already installed, the PostgreSQL apt repository is already configured and we can just request the package:
+Since PostgreSQL is already installed, [the PostgreSQL apt repository](https://wiki.postgresql.org/wiki/Apt) is already configured and we can just request the package:
 
 ```shell
 sudo apt-get update
@@ -53,6 +53,9 @@ Updating certificates in /etc/ssl/certs...
 Running hooks in /etc/ca-certificates/update.d...
 done.
 ```
+
+!!! Tip Further reading
+    For more details on this package and installation instructions for other supported platforms, see: [the Barman client utilities section in the Barman guide](http://docs.pgbarman.org/release/2.12/index.html#barman-client-utilities-barman-cli).
 
 ### User provisioning
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -60,7 +60,7 @@ This demonstration uses an Ubuntu environment, so the first step is to configure
     Reading package lists... Done
     ```
 
-With the repository configured, we can use apt to install the PostgreSQL client software and Barman:
+With the repository configured, we can use apt to install Barman and its dependencies:
 
 ```shell
 apt-get -y install barman
@@ -115,7 +115,16 @@ For more details on configuration files, see: [Configuration](http://docs.pgbarm
 
 ### Verifying the configuration
 
-Now that the configuration is done, we can use Barman's check command to verify that it works:
+During installation, Barman will have installed a cron service that runs every minute to maintenance tasks. Since we only just gave it a configuration, let's make sure those tasks have run before continuing: 
+
+```shell
+barman cron
+__OUTPUT__
+Starting WAL archiving for server pg
+Starting streaming archiver for server pg
+```
+
+Now that the configuration is done and initialization has been performed, we can use Barman's check command to verify that it works:
 
 ```shell
 barman check pg

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -70,7 +70,8 @@ Processing triggers for systemd (245.4-4ubuntu3.4) ...
 Processing triggers for libc-bin (2.31-0ubuntu9.1) ...
 ```
 
-For more details on installation (including instructions for other supported operating systems), see [the Installation section in the Barman guide](http://docs.pgbarman.org/release/2.12/#installation).
+!!! Tip Further reading
+    For more details on installation (including instructions for other supported operating systems), see [the Installation section in the Barman guide](http://docs.pgbarman.org/release/2.12/#installation).
 
 ## Configuration
 
@@ -111,11 +112,12 @@ chmod 0600 ~/.pgpass
 
 Note the change in permissions - this is necessary to protect the visibility of the file, and PostgreSQL will not use it unless permissions are restricted.
 
-For more details on configuration files, see: [Configuration](http://docs.pgbarman.org/release/2.12/#configuration) in the pgBarman guide.
+!!! Tip Further reading
+    For more details on configuration files, see: [the Configuration section in the Barman guide](http://docs.pgbarman.org/release/2.12/#configuration).
 
 ### Verifying the configuration
 
-During installation, Barman will have installed a cron service that runs every minute to maintenance tasks. Since we only just gave it a configuration, let's make sure those tasks have run before continuing: 
+During installation, [Barman will have installed a cron service](http://docs.pgbarman.org/release/2.12/index.html#cron) that runs every minute to maintenance tasks. Since we only just gave it a configuration, let's make sure those tasks have run before continuing: 
 
 ```shell
 barman cron
@@ -164,7 +166,7 @@ Processing xlog segments from streaming for pg
         000000010000000000000002
 ```
 This forces WAL rotation and (with the `--archive` option) waits for the WAL to arrive. We'll give it 60 seconds (with the `--archive-timeout` option) to complete; 
-if it doesn't complete within that amount of time, try again. For more detail on these commands and their options, refer to [the Barman man page](https://docs.pgbarman.org/release/2.12/barman.1.html#commands).
+if it doesn't complete within that amount of time, try again. For more detail on these commands and their options, refer to [the Barman manual](https://docs.pgbarman.org/release/2.12/barman.1.html#commands).
 
 Once switch-wal has completed successfully, run the check again and you should see all checks passing:
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -33,35 +33,35 @@ To run a full backup, we use [Barman's `backup` command](http://docs.pgbarman.or
 ```shell
 barman backup pg --wait
 __OUTPUT__
-Starting backup using postgres method for server pg in /var/lib/barman/pg/base/20210226T003857
-Backup start at LSN: 0/23EA6C0 (000000010000000000000002, 003EA6C0)
-Starting backup copy via pg_basebackup for 20210226T003857
+Starting backup using postgres method for server pg in /var/lib/barman/pg/base/20210329T235157
+Backup start at LSN: 0/3000000 (000000010000000000000002, 00000000)
+Starting backup copy via pg_basebackup for 20210329T235157
 Copy done (time: 1 second)
 Finalising the backup.
 This is the first backup for server pg
 WAL segments preceding the current backup have been found:
         000000010000000000000002 from server pg has been removed
-Backup size: 38.5 MiB
+Backup size: 38.3 MiB
 Backup end at LSN: 0/4000000 (000000010000000000000003, 00000000)
-Backup completed (start time: 2021-02-26 00:38:57.535973, elapsed time: 2 seconds)
+Backup completed (start time: 2021-03-29 23:51:57.146435, elapsed time: 2 seconds)
 Waiting for the WAL file 000000010000000000000003 from server 'pg'
 Processing xlog segments from streaming for pg
-        000000010000000000000002
         000000010000000000000003
 ```
 
-This will wait to recieve the next WAL file to ensure the backup is complete before the command returns.
+The `--wait` option causes Barman to wait for arrival and processing of the WAL file corresponding to the end of the backup, to ensure the backup is complete before the command returns. 
+
+!!! Note: 
+    Since the cron job is doing this periodically in the background, the WAL segments you see listed may be different than the output listed above!
 
 Verify that it completed by listing backups for the server:
 
 ```shell
 barman list-backup pg
 __OUTPUT__
-pg 20210226T003857 - Fri Feb 26 00:38:59 2021 - Size: 54.5 MiB - WAL Size: 0 B
+pg 20210329T235157 - Mon Mar 29 23:51:59 2021 - Size: 54.3 MiB - WAL Size: 0 B
 ```
 (the timestamps will be different for you)
-
-<!-- This needs barman-cli on the database server - which means I can't use the std postgresql image. TODO!
 
 Of course, we've configured streaming backups - so we shouldn't need to depend on having a base backup for every change made to the database. Let's make a small modification to the data and verify that it arrives. 
 
@@ -69,6 +69,9 @@ First, log into the database (we'll use our barman user for convenience in this 
 
 ```shell
 psql -h pg -d pagila -U barman
+__OUTPUT__
+psql (13.2 (Ubuntu 13.2-1.pgdg20.04+1))
+Type "help" for help.
 ```
 
 Then make a modifications, and view the results:
@@ -76,18 +79,28 @@ Then make a modifications, and view the results:
 ```sql
 Update actor Set first_name='ALOYSIUS' where actor_id=23;
 Select * From actor Where last_name='KILMER';
-/q
+\q
+__OUTPUT__
+UPDATE 1
+ actor_id | first_name | last_name |          last_update          
+----------+------------+-----------+-------------------------------
+       45 | REESE      | KILMER    | 2020-02-15 09:34:33+00
+       55 | FAY        | KILMER    | 2020-02-15 09:34:33+00
+      153 | MINNIE     | KILMER    | 2020-02-15 09:34:33+00
+      162 | OPRAH      | KILMER    | 2020-02-15 09:34:33+00
+       23 | ALOYSIUS   | KILMER    | 2021-03-29 23:53:22.302271+00
+(5 rows)
 ```
 
 Ok, let's see if it showed up:
 
 ```shell
-grep 'ALOYSIUS' pg/streaming/*
+grep 'ALOYSIUS' ~/pg/streaming/*
+__OUTPUT__
+Binary file /var/lib/barman/pg/streaming/000000010000000000000004.partial matches
 ```
 
 There it is! The current WAL segment hasn't been rotated yet, but we have the most recent data in the *partial* WAL streamed to Barman. So in theory, nothing would be lost of something *terrible* happened to the database right now... 
-
---->
 
 Now, the crucial question with backups is always the same: "can you get the data *back?*"
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step03-backup.mdx
@@ -51,7 +51,7 @@ Processing xlog segments from streaming for pg
 
 The `--wait` option causes Barman to wait for arrival and processing of the WAL file corresponding to the end of the backup, to ensure the backup is complete before the command returns. 
 
-!!! Note: 
+!!! Note
     Since the cron job is doing this periodically in the background, the WAL segments you see listed may be different than the output listed above!
 
 Verify that it completed by listing backups for the server:

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -159,7 +159,7 @@ Let's try this recovery process again:
     server stopped
     ```
 
-3. Instruct Barman to connect to pg and restore the latest backup 
+3. Instruct Barman to connect to pg and restore the latest backup *with the `--get-wal` option* - this triggers WAL fetching, including partial WAL files, during the recovery process.
     ```shell
     barman recover --remote-ssh-command 'ssh postgres@pg' \
             --get-wal \

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -51,26 +51,64 @@ Let's instruct Barman to ssh into the database server and restore the backup.
     ```shell
     ssh postgres@pg /usr/lib/postgresql/13/bin/pg_ctl \
         --pgdata=/var/lib/postgresql/data stop
+    __OUTPUT__
+    waiting for server to shut down.... done
+    server stopped
     ```
 
-2. Use [Barman's recover command](http://docs.pgbarman.org/release/2.12/#recover) to connect to pg and restore the latest backup 
+2. Back up the corrupt data directory, just in case something goes wrong. Then delete the corrupt data.
+
+    ```shell
+    ssh postgres@pg "cp -a /var/lib/postgresql/data \
+        /var/lib/postgresql/old_data \
+        && rm -rf /var/lib/postgresql/data/*"
+    ```
+
+3. Use [Barman's recover command](http://docs.pgbarman.org/release/2.12/#recover) to connect to pg and restore the latest backup 
 
     ```shell
     barman recover --remote-ssh-command 'ssh postgres@pg' \
             pg latest \
             /var/lib/postgresql/data
+    __OUTPUT__
+    Starting remote restore for server pg using backup 20210330T040549
+    Destination directory: /var/lib/postgresql/data
+    Remote command: ssh postgres@pg
+    Using safe horizon time for smart rsync copy: 2021-03-30 04:05:58+00:00
+    Copying the base backup.
+    Copying required WAL segments.
+    Generating archive status files
+    Identify dangerous settings in destination directory.
+
+    Recovery completed (start time: 2021-03-31 02:29:23.555186, elapsed time: 1 second)
+
+    Your PostgreSQL server has been successfully prepared for recovery!
     ```
 
     Barman handles connecting to the destination server, but we do have to provide a valid path *on* that server. In this example, the PostgreSQL cluster lives in /var/lib/postgresql/data and we're asking Barman to overwrite it with the backup.
 
-3. Restart the server:
+4. Restart the server:
 
     ```shell
-    ssh postgres@pg /usr/lib/postgresql/13/bin/pg_ctl \
-        --pgdata=/var/lib/postgresql/data start 
+    ssh postgres@pg "/usr/lib/postgresql/13/bin/pg_ctl \
+        --pgdata=/var/lib/postgresql/data \
+        -l /var/log/postgresql/pg.log \
+        start \
+        ; tail /var/log/postgresql/pg.log"
+    __OUTPUT__
+    waiting for server to start.... done
+    server started
+    2021-03-31 02:29:12.761 UTC [2201] LOG:  database system is shut down
+    2021-03-31 02:30:13.156 UTC [2515] LOG:  starting PostgreSQL 13.2 (Debian 13.2-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
+    2021-03-31 02:30:13.157 UTC [2515] LOG:  listening on IPv4 address "0.0.0.0", port 5432
+    2021-03-31 02:30:13.157 UTC [2515] LOG:  listening on IPv6 address "::", port 5432
+    2021-03-31 02:30:13.160 UTC [2515] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
+    2021-03-31 02:30:13.164 UTC [2516] LOG:  database system was interrupted; last known up at 2021-03-30 04:05:58 UTC
+    2021-03-31 02:30:13.337 UTC [2516] LOG:  redo starts at 0/4000028
+    2021-03-31 02:30:13.337 UTC [2516] LOG:  consistent recovery state reached at 0/4000138
+    2021-03-31 02:30:13.337 UTC [2516] LOG:  redo done at 0/4000138
+    2021-03-31 02:30:13.363 UTC [2515] LOG:  database system is ready to accept connections
     ```
-
-    (Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> after that completes to regain control in the terminal)
 
 Now we should be able to reconnect to the database:
 
@@ -87,6 +125,7 @@ pagila=#
 
 ```sql
 select * from actor where last_name='KILMER';
+\q
 __OUTPUT__
  actor_id | first_name | last_name |      last_update       
 ----------+------------+-----------+------------------------
@@ -97,8 +136,6 @@ __OUTPUT__
       162 | OPRAH      | KILMER    | 2020-02-15 09:34:33+00
 (5 rows)
 ```
-
-<!-- This needs barman-cli on the database server - which means I can't use the std postgresql image. TODO!
 
 Ok, so far so good - but, we're missing the update we wrote to this data! Remember, that wasn't in the base backup, it was in a partial WAL file... Fortunately, Barman still has it and knows how to use it. 
 
@@ -111,21 +148,86 @@ Let's try this recovery process again:
         --pgdata=/var/lib/postgresql/data stop
     ```
 
-2. Instruct Barman to connect to pg and restore the latest backup 
+2. Back up the corrupt data directory, just in case something goes wrong. Then delete the corrupt data.
+
+    ```shell
+    ssh postgres@pg "cp -a /var/lib/postgresql/data \
+        /var/lib/postgresql/old_data \
+        && rm -rf /var/lib/postgresql/data/*"
+    __OUTPUT__
+    waiting for server to shut down.... done
+    server stopped
+    ```
+
+3. Instruct Barman to connect to pg and restore the latest backup 
     ```shell
     barman recover --remote-ssh-command 'ssh postgres@pg' \
             --get-wal \
             pg latest \
             /var/lib/postgresql/data
+    __OUTPUT__
+    Starting remote restore for server pg using backup 20210330T040549
+    Destination directory: /var/lib/postgresql/data
+    Remote command: ssh postgres@pg
+    Copying the base backup.
+    Generating recovery configuration
+    Identify dangerous settings in destination directory.
+
+    WARNING: 'get-wal' is in the specified 'recovery_options'.
+    Before you start up the PostgreSQL server, please review the postgresql.auto.conf file
+    inside the target directory. Make sure that 'restore_command' can be executed by the PostgreSQL user.
+
+    Recovery completed (start time: 2021-03-31 00:47:46.722740, elapsed time: 1 second)
+
+    Your PostgreSQL server has been successfully prepared for recovery!
     ```
 
-3. Restart the server:
+4. Restart the server:
 
     ```shell
-    ssh postgres@pg /usr/lib/postgresql/13/bin/pg_ctl \
-        --pgdata=/var/lib/postgresql/data start &
+    ssh postgres@pg "/usr/lib/postgresql/13/bin/pg_ctl \
+        --pgdata=/var/lib/postgresql/data \
+        -l /var/log/postgresql/pg.log \
+        start \
+        ; tail /var/log/postgresql/pg.log"
+    __OUTPUT__
+    waiting for server to start..... done
+    server started
+    2021-03-31 00:47:52.278 UTC [250] LOG:  listening on IPv6 address "::", port 5432
+    2021-03-31 00:47:52.282 UTC [250] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
+    2021-03-31 00:47:52.286 UTC [251] LOG:  database system was interrupted; last known up at 2021-03-30 04:05:58 UTC
+    ERROR: WAL file '00000002.history' not found in server 'pg' (SSH host: 192.168.80.2)
+    ERROR: Remote 'barman get-wal' command has failed!
+    2021-03-31 00:47:52.863 UTC [251] LOG:  starting archive recovery
+    2021-03-31 00:47:53.350 UTC [251] LOG:  restored log file "000000010000000000000004" from archive
+    2021-03-31 00:47:53.362 UTC [251] LOG:  redo starts at 0/4000028
+    2021-03-31 00:47:53.362 UTC [251] LOG:  consistent recovery state reached at 0/4000138
+    2021-03-31 00:47:53.363 UTC [250] LOG:  database system is ready to accept read only connections    
     ```
--->
+
+!!! Note about those errors...
+    You may notice two lines starting with "ERROR:" mid-way through the recovery log. They're fine - that's just PostgreSQL scanning to make sure it has the most recent timeline.
+    By going through this recovery, we've actually created a *new* timeline - in fact, if you were to run through the four steps above again, you'd see that now `00000002.history` is found and PostgreSQL goes looking for `00000003.history`... Try it!
+
+    For more on PostgreSQL backup timelines, see [Continuous Archiving in the PostgreSQL documentation](https://www.postgresql.org/docs/current/continuous-archiving.html#BACKUP-TIMELINES).
+
+Now check the data again:
+
+```shell
+psql -h pg -d pagila -U barman -c \
+    "select * from actor where last_name='KILMER'"
+__OUTPUT__
+ actor_id | first_name | last_name |          last_update          
+----------+------------+-----------+-------------------------------
+       45 | REESE      | KILMER    | 2020-02-15 09:34:33+00
+       55 | FAY        | KILMER    | 2020-02-15 09:34:33+00
+      153 | MINNIE     | KILMER    | 2020-02-15 09:34:33+00
+      162 | OPRAH      | KILMER    | 2020-02-15 09:34:33+00
+       23 | ALOYSIUS   | KILMER    | 2021-03-30 04:06:55.101099+00
+(5 rows)
+```
+
+Good ol' Aloysius is back!
 
 ## Conclusion
 

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step04-restore.mdx
@@ -229,6 +229,9 @@ __OUTPUT__
 
 Good ol' Aloysius is back!
 
+!!! Tip Further Reading
+    For more details on recovery of partial WAL files, see: [Limitations of partial WAL files with recovery in the Barman guide](http://docs.pgbarman.org/release/2.12/index.html#limitations-of-partial-wal-files-with-recovery).
+
 ## Conclusion
 
 This demonstration barely scratches the surface of what is possible with Barman, but hopefully it has provided you with a taste of its capabilities! For more details, visit https://pgbarman.org/


### PR DESCRIPTION
Critical areas for review:

- Step 1: installing barman-cli (pretty trivial)
- Step 3: triggering an update without a WAL rotation
- Step 4: doing a restore both *without* and then *with* WAL recovery to demonstrate the difference

## What Changed?

- Addresses #1062
- Adds more links to documentation, sample output, and explanations for output that may seem incongruous
- Backed by copious stability updates to the underlying containers

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
