### PR TITLE
DB-1088 Enable core dumps, reviewed by Rohit

### DIFF
--- a/product_docs/docs/epas/13/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
@@ -897,7 +897,7 @@ By default, data files reside under `/var/lib/edb/as13/data` directory. To use a
     systemctl start edb-as-13
     ```
 
-### Configuring SELinux Policy to Change the Data Directory Location on CentOS or Redhat 7.x
+### Configuring SELinux Policy to Change the Data Directory Location on CentOS or Redhat 7.x | 8.x
 
 By default, the data files resides under `/var/lib/edb/as13/data` directory. To change the default data directory location depending on individual environment preferences, you must configure the SELinux policy and perform the following steps:
 
@@ -976,6 +976,233 @@ By default, the data files resides under `/var/lib/edb/as13/data` directory. To 
     ```text
     systemctl start edb-as-13
     ```
+
+## Enabling Core Dumps
+
+You can use core dumps to diagnose or debug errors. A core dump is a file containing a process's address space (memory) when the process terminates unexpectedly. Core dumps may be produced on-demand (such as by a debugger) or automatically upon termination.
+
+**Enabling Core Dumps on a CentOS or RHEL Host**
+
+On a CentOS or RHEL 7.x or 8.x, core file creation is disabled by default. To enable the core file generation, follow the following commands:
+
+-   Identify the system's current limit using the `ulimit -c` or `ulimit -a` command. `0` indicates that core file generation is disabled.
+
+    ```text
+    # ulimit -c
+    0
+
+    # ulimit -a
+    core file size          (blocks, -c) 0
+    data seg size           (kbytes, -d) unlimited
+    scheduling priority             (-e) 0
+    file size               (blocks, -f) unlimited
+    pending signals                 (-i) 3756
+    max locked memory       (kbytes, -l) 64
+    max memory size         (kbytes, -m) unlimited
+    open files                      (-n) 1024
+    pipe size            (512 bytes, -p) 8
+    POSIX message queues     (bytes, -q) 819200
+    real-time priority              (-r) 0
+    stack size              (kbytes, -s) 8192
+    cpu time               (seconds, -t) unlimited
+    max user processes              (-u) 3756
+    virtual memory          (kbytes, -v) unlimited
+    file locks                      (-x) unlimited
+    ```
+
+-   Create a new directory to store the core dumps and modify `kernel.core_pattern` to store the dumps in a specified directory:
+
+    ```text
+    mkdir -p /var/coredumps
+    chmod a+w /var/coredumps
+
+    sysctl kernel.core_pattern=/var/coredumps/core-%e-%p
+    kernel.core_pattern = /var/coredumps/core-%e-%p
+    ```
+
+-   Use the following command to persist the `kernel.core_pattern` setting across reboots:
+
+    ```text
+    echo 'kernel.core_pattern=/var/coredumps/core-%e-%p' >> /etc/sysctl.conf
+    ```
+
+-   Enable core dumps in `/etc/security/limits.conf` to allow a user to create core files. Each line describes a limit for a user in the following form:
+
+    ```text
+    <domain>  <type>  <item>  <value>
+       *       soft    core    unlimited
+    ```
+
+    Use `*` to enable the core dump size to unlimited.
+
+-   Set the limit of core file size to `UNLIMITED` by using the following command:
+
+    ```text
+    ulimit -c unlimited
+
+    ulimit -c
+    unlimited
+    ```
+
+-   To set a core limit for the services, add the following setting in `/usr/lib/systemd/system/edb-as-13.service`.
+
+    ```text
+    [Service]
+    LimitCore=Infinity
+    ```
+
+-   Reload the service configuration:
+
+    ```text
+    systemctl daemon-reload
+    ```
+
+-   Modify the global default limit using `systemd`, add the following setting in `/etc/systemd/system.conf`.
+
+    ```
+    DefaultLimitCORE=Infinity
+    ```
+
+-   Restart the `systemd`:
+
+    ```text
+    systemctl daemon-reexec
+    ```
+
+-   Stop and then start Advanced Server:
+
+   ```text
+   systemctl stop edb-as-13
+   systemctl start edb-as-13
+   ```
+
+-   Now, the core dumps are enabled, install the `gdb` tool and debug packages using the following command:   
+
+    ```text
+    yum install gdb
+    debuginfo-install edb-as13 edb-as13-server-contrib edb-as13-server edb-as13-libs
+    ```
+
+-   Replace the path to a core dump file before proceeding to get a backtrace using the `bt` command to analyze output:
+
+    ```text
+    gdb /usr/edb/as13/bin /var/coredumps/core-edb-postgres-65499
+    (gdb) bt full
+    ```
+
+**Enabling Core Dumps on a Debian or Ubuntu Host**
+
+On Debian 9, 10 or Ubuntu 18, 20, core file creation is disabled by default. To enable the core file generation, follow the following commands:
+
+-   Identify the system's current limit using the `ulimit -c` or `ulimit -a` command. `0` indicates that core file generation is disabled.
+
+    ```text
+    # ulimit -c
+    0
+
+    # ulimit -a
+    core file size          (blocks, -c) 0
+    data seg size           (kbytes, -d) unlimited
+    scheduling priority             (-e) 0
+    file size               (blocks, -f) unlimited
+    pending signals                 (-i) 7617
+    max locked memory       (kbytes, -l) 65536
+    max memory size         (kbytes, -m) unlimited
+    open files                      (-n) 1024
+    pipe size            (512 bytes, -p) 8
+    POSIX message queues     (bytes, -q) 819200
+    real-time priority              (-r) 0
+    stack size              (kbytes, -s) 8192
+    cpu time               (seconds, -t) unlimited
+    max user processes              (-u) 7617
+    virtual memory          (kbytes, -v) unlimited
+    file locks                      (-x) unlimited
+    ```
+
+-   Create a new directory to store the core dumps and modify `kernel.core_pattern` to store the dumps in a specified directory:
+
+    ```text
+    mkdir -p /var/coredumps
+    chmod a+w /var/coredumps
+
+    sysctl kernel.core_pattern=/var/coredumps/core-%e-%p
+    kernel.core_pattern = /var/coredumps/core-%e-%p
+    ```
+
+-   Use the following command to persist the `kernel.core_pattern` setting across reboots:
+
+    ```text
+    echo 'kernel.core_pattern=/var/coredumps/core-%e-%p' >> /etc/sysctl.conf
+    ```
+
+-   Enable core dumps in `/etc/security/limits.conf` to allow a user to create core files. Each line describes a limit for a user in the following form:
+
+    ```text
+    <domain>  <type>  <item>  <value>
+       *       soft    core    unlimited
+    ```
+
+    Use `*` to enable the core dump size to unlimited.
+
+-   Set the limit of core file size to `UNLIMITED` by using the following command:
+
+    ```text
+    ulimit -c unlimited
+
+    ulimit -c
+    unlimited
+    ```
+
+-   To set a core limit for the services, add the following setting in `/lib/systemd/system/edb-as@.service`.
+
+    ```text
+    [Service]
+    LimitCore=Infinity
+    ```
+
+-   Reload the service configuration:
+
+    ```text
+    systemctl daemon-reload
+    ```
+
+-   Modify the global default limit using `systemd`, add the following setting in `/etc/systemd/system.conf`.
+
+    ```
+    DefaultLimitCORE=Infinity
+    ```
+
+-   Restart the `systemd`:
+
+    ```text
+    systemctl daemon-reexec
+    ```
+
+-   Stop and then start Advanced Server:
+
+   ```text
+   systemctl stop edb-as@13.service
+   systemctl start edb-as@13.service
+   ```
+
+-   Now, the core dumps are enabled, install the `gdb` tool and debug symbols using the following command:   
+
+    ```text
+    apt-get install gdb
+    apt-get install edb-as13 edb-as-contrib edb-as13-server edb-debugger-dbgsym
+    ```
+    
+-   Replace the path to a core dump file before proceeding to get a backtrace using the `bt` command to analyze output:
+
+    ```text
+    gdb /usr/lib/edb-as/13/bin /var/coredumps/core-edb-postgres-21638
+    (gdb) bt full
+    ```
+
+!!! Note
+    -   The debug info packages name on a Debian or Ubuntu host may vary and include `-dbgsym` or `-dbg` suffix. For more information about setting `sources.list` and installing the debug info packages, visit Debian or Ubuntu wiki at <https://wiki.debian.org/HowToGetABacktrace> or <https://wiki.ubuntu.com/Debug%20Symbol%20Packages> respectively.
+    -   The core files can be huge depending on the memory usage, enabling the core dumps on a system may fill up its mass storage over time.
+
 
 ## Starting Multiple Postmasters with Different Clusters
 

--- a/product_docs/docs/epas/13/epas_inst_linux/05_managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/05_managing_an_advanced_server_installation.mdx
@@ -16,14 +16,14 @@ A service is a program that runs in the background and requires no user interact
 
 The following table lists the names of the services that control Advanced Server and services that control Advanced Server supporting components:
 
-| Advanced Server Component Name | Linux Service Name       | Debian Service Name                     |
-| ------------------------------ | ------------------------ | --------------------------------------- |
-| Advanced Server                | edb-as-13                | [edb-as@13-main](mailto:edb-as@13-main) |
-| pgAgent                        | edb-pgagent-13           | edb-as13-pgagent                        |
-| PgBouncer                      | edb-pgbouncer-1.14       | edb-pgbouncer114                        |
-| pgPool-II                      | edb-pgpool-4.1           | edb-pgpool41                            |
-| Slony                          | edb-slony-replication-13 | edb-as13-slony-replication              |
-| EFM                            | edb-efm-4.0              | edb-efm-4.0                             |
+| Advanced Server Component Name | Linux Service Name       | Debian Service Name        |
+| ------------------------------ | ------------------------ | -------------------------- |
+| Advanced Server                | edb-as-13                | edb-as@13-main             |
+| pgAgent                        | edb-pgagent-13           | edb-as13-pgagent           |
+| PgBouncer                      | edb-pgbouncer-1.14       | edb-pgbouncer114           |
+| pgPool-II                      | edb-pgpool-4.1           | edb-pgpool41               |
+| Slony                          | edb-slony-replication-13 | edb-as13-slony-replication |
+| EFM                            | edb-efm-4.0              | edb-efm-4.0                |
 
 You can use the Linux command line to control Advanced Server's database server and the services of Advanced Server's supporting components. The commands that control the Advanced Server service on a Linux platform are host specific.
 
@@ -50,7 +50,7 @@ Where:
 
 ### Controlling a Service on Debian 9.x | 10.x or Ubuntu 18.04 | 20.04
 
-If your installation of Advanced Server resides on version 9x of Debian or 18.04 of Ubuntu, assume superuser privileges and invoke the following commands (using bundled scripts) to manage the service. Use the following commands to:
+If your installation of Advanced Server resides on version 9.x or 10.x of Debian or 18.04 or 20.04 of Ubuntu, assume superuser privileges and invoke the following commands (using bundled scripts) to manage the service. Use the following commands to:
 
 -   Discover the current status of a service:
 


### PR DESCRIPTION
## What Changed?

Feature enhancement: Enabling Core Dumps for RHEL/CentOS and Debian/Ubuntu host documented.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
