### PR TITLE
Tweaks to CNP demo location

### DIFF
--- a/advocacy_docs/kubernetes/cloud_native_postgresql/index.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/index.mdx
@@ -15,7 +15,7 @@ navigation:
   - architecture
   - installation
   - quickstart
-  - interactive
+  - interactive_demo
   - cloud_setup
   - bootstrap
   - resource_management

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/interactive_demo.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/interactive_demo.mdx
@@ -14,6 +14,8 @@ katacodaPanel:
   scenario: minikube
   codelanguages: shell, yaml
 showInteractiveBadge: true
+legacyRedirects:
+ - "/kubernetes/cloud_native_postgresql/interactive/installation_and_deployment"
 ---
 
 Want to see what it takes to get the Cloud Native PostgreSQL Operator up and running? This section will demonstrate the following:

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/quickstart.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/quickstart.mdx
@@ -12,7 +12,7 @@ using Cloud Native PostgreSQL on a local Kubernetes cluster in
 !!! Tip "Live demonstration"
     Don't want to install anything locally just yet? Try a demonstration directly in your browser:
 
-    [Cloud Native PostgreSQL Operator Interactive Quickstart](interactive/installation_and_deployment/)
+    [Cloud Native PostgreSQL Operator Interactive Quickstart](interactive_demo)
 
 RedHat OpenShift Container Platform users can test the certified operator for
 Cloud Native PostgreSQL on the [Red Hat CodeReady Containers (CRC)](https://developers.redhat.com/products/codeready-containers/overview)

--- a/src/components/tree-node.js
+++ b/src/components/tree-node.js
@@ -14,7 +14,7 @@ const SubList = ({ children, collapsed }) => {
   }
 };
 
-// const KatacodaBadge = () => <span className="new-thing">Demos</span>;
+const KatacodaBadge = () => <span className="new-thing">Demo</span>;
 
 const TreeNode = ({ node, path, hideIfEmpty }) => {
   if (!node.path) {
@@ -43,7 +43,7 @@ const TreeNode = ({ node, path, hideIfEmpty }) => {
           }`}
         >
           <Title node={node} />
-          {/* {node.interactive && <KatacodaBadge />} */}
+          {node.interactive && <KatacodaBadge />}
         </Link>
       </div>
       {node.items.length > 0 && (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -181,10 +181,10 @@ const Page = () => (
               Cloud Native PostgreSQL Operator
             </IndexCardLink>
             <IndexCardLink
-              to="/kubernetes/cloud_native_postgresql/interactive/installation_and_deployment/"
+              to="/kubernetes/cloud_native_postgresql/interactive_demo/"
               className="nested-link"
             >
-              Installation and Deployment
+              Install, Configure, Deploy
               <span
                 className="new-thing"
                 title="Walk through an interactive demo in Katacoda"


### PR DESCRIPTION
## What Changed?

Per team discussion on April 14, moving CNP installation demo to be on the same hierarchical level as other content. Added back in the Demo badge for sidebar links.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
