### PR TITLE
Normalize markdown & links in Foreign Data Wrapper conversions

### DIFF
--- a/product_docs/docs/hadoop_data_adapter/2.0.7/05_installing_the_hadoop_data_adapter.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/05_installing_the_hadoop_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Installing the Hadoop Foreign Data Wrapper"
 
 <div id="installing_the_hadoop_data_adapter" class="registered_link"></div>
 
-
 The Hadoop Foreign Data Wrapper can be installed with an RPM package. During the installation process, the installer will satisfy software prerequisites.
 
 <div id="using_an_rpm_package_to_install_the_data_adapter" class="registered_link"></div>
@@ -26,13 +25,13 @@ Before installing the Hadoop Foreign Data Wrapper, you must install the followin
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 > ```
 
 Enable the optional, extras, and HA repositories:
 
-> ``` text
+> ```text
 > subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"  --enable "rhel-ha-for-rhel-*-server-rpms"
 > ```
 
@@ -50,7 +49,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -60,7 +59,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -73,7 +72,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following commands to install the Hadoop Foreign Data Wrapper:
 
-> ``` 
+> ```
 > yum install edb-as<xx>-hdfs_fdw
 > ```
 
@@ -87,19 +86,17 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On RHEL 8
 
-
-
 Before installing the Hadoop Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 > ```
 
 Enable the `codeready-builder-for-rhel-8-\*-rpms` repository:
 
-> ``` text
+> ```text
 > ARCH=$( /bin/arch )
 > subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
 > ```
@@ -118,7 +115,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > dnf -y https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -128,7 +125,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -141,7 +138,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the below command to install the Hadoop Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > dnf install edb-as<xx>-hdfs_fdw
 > ```
 
@@ -153,27 +150,16 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On CentOS 7
 
-
-
 Before installing the Hadoop Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 > ```
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
-
-</div>
+!!! Note
+    You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
@@ -189,7 +175,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -199,7 +185,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -212,7 +198,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the Hadoop Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > yum install edb-as<xx>-hdfs_fdw
 > ```
 
@@ -226,19 +212,17 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On CentOS 8
 
-
-
 Before installing the Hadoop Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 > ```
 
 Enable the `PowerTools` repository:
 
-> ``` text
+> ```text
 > dnf config-manager --set-enabled PowerTools
 > ```
 
@@ -256,7 +240,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -266,7 +250,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -279,7 +263,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the Hadoop Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > dnf install edb-as<xx>-hdfs_fdw
 > ```
 
@@ -291,17 +275,13 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ## Installing the Hadoop Foreign Data Wrapper on a Debian or Ubuntu Host
 
-
-
-
-
 To install the Hadoop Foreign Data Wrapper on a Debian or Ubuntu host, you must have credentials that allow access to the EDB repository. To request credentials for the repository, visit the [EDB website](https://www.enterprisedb.com/repository-access-request/).
 
 The following steps will walk you through on using the EDB apt repository to install a Debian package. When using the commands, replace the `username` and `password` with the credentials provided by EDB.
 
 1.  Assume superuser privileges:
 
-    ``` text
+    ```text
     sudo su –
     ```
 
@@ -309,7 +289,7 @@ The following steps will walk you through on using the EDB apt repository to ins
 
     On Debian 9 and Ubuntu:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "deb https://username:password@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
     > ```
 
@@ -317,38 +297,38 @@ The following steps will walk you through on using the EDB apt repository to ins
 
     1.  Set up the EDB repository:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "deb [arch=amd64] https://apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
     > ```
 
     1.  Substitute your EDB credentials for the `username` and `password` in the following command:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "machine apt.enterprisedb.com login <username> password <password>" > /etc/apt/auth.conf.d/edb.conf'
     > ```
 
 3.  Add support to your system for secure APT repositories:
 
-    ``` text
+    ```text
     apt-get install apt-transport-https
     ```
 
 4.  Add the EDB signing key:
 
-    ``` text
+    ```text
     wget -q -O - https://username:password
     @apt.enterprisedb.com/edb-deb.gpg.key | apt-key add -
     ```
 
 5.  Update the repository metadata:
 
-    ``` text
+    ```text
     apt-get update
     ```
 
 6.  Install the package:
 
-    ``` text
+    ```text
     apt-get install edb-as<xx>-hdfs-fdw
     ```
 

--- a/product_docs/docs/hadoop_data_adapter/2.0.7/06_updating_the_hadoop_data_adapter.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/06_updating_the_hadoop_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Updating the Hadoop Foreign Data Wrapper"
 
 <div id="updating_the_hadoop_data_adapter" class="registered_link"></div>
 
-
 **Updating an RPM Installation**
 
 If you have an existing RPM installation of Hadoop Foreign Data Wrapper, you can use yum or dnf to upgrade your repository configuration file and update to a more recent product version. To update the `edb.repo` file, assume superuser privileges and enter:

--- a/product_docs/docs/hadoop_data_adapter/2.0.7/07_features_of_hdfs_fdw.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/07_features_of_hdfs_fdw.mdx
@@ -4,7 +4,6 @@ title: "Features of the Hadoop Foreign Data Wrapper"
 
 <div id="features_of_hdfs_fdw" class="registered_link"></div>
 
-
 The key features of the Hadoop Foreign Data Wrapper are listed below:
 
 ## Where Clause Push-down

--- a/product_docs/docs/hadoop_data_adapter/2.0.7/08_configuring_the_hadoop_data_adapter.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/08_configuring_the_hadoop_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Configuring the Hadoop Foreign Data Wrapper"
 
 <div id="configuring_the_hadoop_data_adapter" class="registered_link"></div>
 
-
 Before creating the extension and the database objects that use the extension, you must modify the Postgres host, providing the location of the supporting libraries.
 
 After installing Postgres, modify the `postgresql.conf` located in:
@@ -13,24 +12,15 @@ After installing Postgres, modify the `postgresql.conf` located in:
 
 Modify the configuration file with your editor of choice, adding the `hdfs_fdw.jvmpath` parameter to the end of the configuration file, and setting the value to specify the location of the Java virtual machine (`libjvm.so`). Set the value of `hdfs_fdw.classpath` to indicate the location of the java class files used by the adapter; use a colon (:) as a delimiter between each path. For example:
 
-> ``` text
+> ```text
 > hdfs_fdw.classpath=
 > '/usr/edb/as12/lib/HiveJdbcClient-1.0.jar:/home/edb/Projects/hadoop_fdw/hadoop/share/hadoop/common/hadoop-common-2.6.4.jar:/home/edb/Projects/hadoop_fdw/apache-hive-1.0.1-bin/lib/hive-jdbc-1.0.1-standalone.jar'
 > ```
 >
-> <div class="note">
+> !!! Note
+>     The jar files (hive-jdbc-1.0.1-standalone.jar and hadoop-common-2.6.4.jar) mentioned in the above example should be copied from respective Hive and Hadoop sources or website to PostgreSQL instance where Hadoop Foreign Data Wrapper is installed.
 >
-> <div class="title">
->
-> Note
->
-> </div>
->
-> The jar files (hive-jdbc-1.0.1-standalone.jar and hadoop-common-2.6.4.jar) mentioned in the above example should be copied from respective Hive and Hadoop sources or website to PostgreSQL instance where Hadoop Foreign Data Wrapper is installed.
->
-> If you are using EDB Advanced Server and have a `DATE` column in your database, you must set `edb_redwood_date = OFF` in the `postgresql.conf` file.
->
-> </div>
+>     If you are using EDB Advanced Server and have a `DATE` column in your database, you must set `edb_redwood_date = OFF` in the `postgresql.conf` file.
 
 After setting the parameter values, restart the Postgres server. For detailed information about controlling the service on an Advanced Server host, see the EDB Postgres Advanced Server Installation Guide, available at:
 
@@ -38,10 +28,10 @@ After setting the parameter values, restart the Postgres server. For detailed in
 
 Before using the Hadoop Foreign Data Wrapper, you must:
 
-> 1.  Use the [CREATE EXTENSION](#create_extension) command to create the extension on the Postgres host.
-> 2.  Use the [CREATE SERVER](#create_server) command to define a connection to the Hadoop file system.
-> 3.  Use the [CREATE USER MAPPING](#create_user_mapping) command to define a mapping that associates a Postgres role with the server.
-> 4.  Use the [CREATE FOREIGN TABLE](#create_foreign_table) command to define a table in the Advanced Server database that corresponds to a database that resides on the Hadoop cluster.
+> 1.  Use the [CREATE EXTENSION](#create-extension) command to create the extension on the Postgres host.
+> 2.  Use the [CREATE SERVER](#create-server) command to define a connection to the Hadoop file system.
+> 3.  Use the [CREATE USER MAPPING](#create-user-mapping) command to define a mapping that associates a Postgres role with the server.
+> 4.  Use the [CREATE FOREIGN TABLE](#create-foreign-table) command to define a table in the Advanced Server database that corresponds to a database that resides on the Hadoop cluster.
 
 <div id="create_extension" class="registered_link"></div>
 
@@ -49,7 +39,7 @@ Before using the Hadoop Foreign Data Wrapper, you must:
 
 Use the `CREATE EXTENSION` command to create the `hdfs_fdw` extension. To invoke the command, use your client of choice (for example, psql) to connect to the Postgres database from which you will be querying the Hive or Spark server, and invoke the command:
 
-``` text
+```text
 CREATE EXTENSION [IF NOT EXISTS] hdfs_fdw [WITH] [SCHEMA schema_name];
 ```
 
@@ -79,7 +69,7 @@ For more information about using the foreign data wrapper `CREATE EXTENSION` com
 
 Use the `CREATE SERVER` command to define a connection to a foreign server. The syntax is:
 
-``` text
+```text
 CREATE SERVER server_name FOREIGN DATA WRAPPER hdfs_fdw
     [OPTIONS (option 'value' [, ...])]
 ```
@@ -100,13 +90,23 @@ The role that defines the server is the owner of the server; use the `ALTER SERV
 
 > Use the `OPTIONS` clause of the `CREATE SERVER` command to specify connection information for the foreign server. You can include:
 
-<table><thead><tr class="header"><th>Option</th><th>Description</th></tr></thead><tbody><tr class="odd"><td>host</td><td>The address or hostname of the Hadoop cluster. The default value is `localhost`.</td></tr><tr class="even"><td>port</td><td>The port number of the Hive Thrift Server or Spark Thrift Server. The default is `10000`.</td></tr><tr class="odd"><td>client_type</td><td>Specify hiveserver2 or spark as the client type. To use the ANALYZE statement on Spark, you must specify a value of spark; if you do not specify a value for client_type, the default value is hiveserver2.</td></tr><tr class="even"><td><p>auth_type</p></td><td><p>The authentication type of the client; specify LDAP or NOSASL. If you do not specify an auth_type, the data wrapper will decide the auth_type value on the basis of the user mapping:</p><ul><li>If the user mapping includes a user name and password, the data wrapper will use LDAP authentication.</li><li>If the user mapping does not include a user name and password, the data wrapper will use NOSASL authentication.</li></ul></td></tr><tr class="odd"><td>connect_timeout</td><td>The length of time before a connection attempt times out. The default value is `300` seconds.</td></tr><tr class="even"><td>fetch_size</td><td>A user-specified value that is provided as a parameter to the JDBC API setFetchSize. The default value is `10,000`.</td></tr><tr class="odd"><td>log_remote_sql</td><td>If true, logging will include SQL commands executed on the remote hive server and the number of times that a scan is repeated. The default is `false`.</td></tr><tr class="even"><td>query_timeout</td><td>Use query_timeout to provide the number of seconds after which a request will timeout if it is not satisfied by the Hive server. Query timeout is not supported by the Hive JDBC driver.</td></tr><tr class="odd"><td>use_remote_estimate</td><td>Include the use_remote_estimate to instruct the server to use EXPLAIN commands on the remote server when estimating processing costs. By default, use_remote_estimate is false, and remote tables are assumed to have `1000` rows.</td></tr></tbody></table>
+| Option              | Description                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| host                | The address or hostname of the Hadoop cluster. The default value is \`localhost\`.                                                                                                                                                                                                                                                                                                                                                       |
+| port                | The port number of the Hive Thrift Server or Spark Thrift Server. The default is \`10000\`.                                                                                                                                                                                                                                                                                                                                              |
+| client_type         | Specify hiveserver2 or spark as the client type. To use the ANALYZE statement on Spark, you must specify a value of spark; if you do not specify a value for client_type, the default value is hiveserver2.                                                                                                                                                                                                                              |
+| auth_type<br />     | The authentication type of the client; specify LDAP or NOSASL. If you do not specify an auth_type, the data wrapper will decide the auth_type value on the basis of the user mapping:-   If the user mapping includes a user name and password, the data wrapper will use LDAP authentication.     <br /> -   If the user mapping does not include a user name and password, the data wrapper will use NOSASL authentication.     <br /> |
+| connect_timeout     | The length of time before a connection attempt times out. The default value is \`300\` seconds.                                                                                                                                                                                                                                                                                                                                          |
+| fetch_size          | A user-specified value that is provided as a parameter to the JDBC API setFetchSize. The default value is \`10,000\`.                                                                                                                                                                                                                                                                                                                    |
+| log_remote_sql      | If true, logging will include SQL commands executed on the remote hive server and the number of times that a scan is repeated. The default is \`false\`.                                                                                                                                                                                                                                                                                 |
+| query_timeout       | Use query_timeout to provide the number of seconds after which a request will timeout if it is not satisfied by the Hive server. Query timeout is not supported by the Hive JDBC driver.                                                                                                                                                                                                                                                 |
+| use_remote_estimate | Include the use_remote_estimate to instruct the server to use EXPLAIN commands on the remote server when estimating processing costs. By default, use_remote_estimate is false, and remote tables are assumed to have \`1000\` rows.                                                                                                                                                                                                     |
 
 **Example**
 
 The following command creates a foreign server named `hdfs_server` that uses the `hdfs_fdw` foreign data wrapper to connect to a host with an IP address of `170.11.2.148`:
 
-``` text
+```text
 CREATE SERVER hdfs_server FOREIGN DATA WRAPPER hdfs_fdw OPTIONS (host '170.11.2.148', port '10000', client_type 'hiveserver2', auth_type 'LDAP', connect_timeout '10000', query_timeout '10000');
 ```
 
@@ -122,7 +122,7 @@ For more information about using the `CREATE SERVER` command, see:
 
 Use the `CREATE USER MAPPING` command to define a mapping that associates a Postgres role with a foreign server:
 
-``` text
+```text
 CREATE USER MAPPING FOR role_name SERVER server_name
        [OPTIONS (option 'value' [, ...])];
 ```
@@ -159,7 +159,7 @@ The following command creates a user mapping for a role named `enterprisedb`; th
 
 If the database host uses LDAP authentication, provide connection credentials when creating the user mapping:
 
-``` text
+```text
 CREATE USER MAPPING FOR enterprisedb SERVER hdfs_server OPTIONS (username 'alice', password '1safepwd');
 ```
 
@@ -175,7 +175,7 @@ For detailed information about the `CREATE USER MAPPING` command, see:
 
 A foreign table is a pointer to a table that resides on the Hadoop host. Before creating a foreign table definition on the Postgres server, connect to the Hive or Spark server and create a table; the columns in the table will map to to columns in a table on the Postgres server. Then, use the `CREATE FOREIGN TABLE` command to define a table on the Postgres server with columns that correspond to the table that resides on the Hadoop host. The syntax is:
 
-``` text
+```text
 CREATE FOREIGN TABLE [ IF NOT EXISTS ] table_name ( [
   { column_name data_type [ OPTIONS ( option 'value' [, ... ] ) ] [ COLLATE collation ] [ column_constraint [ ... ] ]
     | table_constraint }
@@ -187,14 +187,14 @@ CREATE FOREIGN TABLE [ IF NOT EXISTS ] table_name ( [
 
 where `column_constraint` is:
 
-``` text
+```text
 [ CONSTRAINT constraint_name ]
 { NOT NULL | NULL | CHECK (expr) [ NO INHERIT ] | DEFAULT default_expr }
 ```
 
 and `table_constraint` is:
 
-``` text
+```text
 [ CONSTRAINT constraint_name ] CHECK (expr) [ NO INHERIT ]
 ```
 
@@ -254,16 +254,16 @@ and `table_constraint` is:
 >
 > Use the `OPTIONS` clause to specify the following `options` and their corresponding values:
 
-| option      | value                                                                                   |
-|-------------|-----------------------------------------------------------------------------------------|
-| dbname      | The name of the database on the Hive server; the database name is required.             |
-| table\_name | The name of the table on the Hive server; the default is the name of the foreign table. |
+| option     | value                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------- |
+| dbname     | The name of the database on the Hive server; the database name is required.             |
+| table_name | The name of the table on the Hive server; the default is the name of the foreign table. |
 
 **Example**
 
 To use data that is stored on a distributed file system, you must create a table on the Postgres host that maps the columns of a Hadoop table to the columns of a Postgres table. For example, for a Hadoop table with the following definition:
 
-``` text
+```text
 CREATE TABLE weblogs (
  client_ip           STRING,
  full_request_date   STRING,
@@ -287,7 +287,7 @@ fields terminated by '\t';
 
 You should execute a command on the Postgres server that creates a comparable table on the Postgres server:
 
-``` text
+```text
 CREATE FOREIGN TABLE weblogs
 (
  client_ip                TEXT,
@@ -322,7 +322,7 @@ For more information about using the `CREATE FOREIGN TABLE` command, see:
 When using the foreign data wrapper, you must create a table on the Postgres server that mirrors the table that resides on the Hive server. The Hadoop data wrapper will automatically convert the following Hive data types to the target Postgres type:
 
 | **Hive**    | **Postgres**     |
-|-------------|------------------|
+| ----------- | ---------------- |
 | BIGINT      | BIGINT/INT8      |
 | BOOLEAN     | BOOL/BOOLEAN     |
 | BINARY      | BYTEA            |
@@ -341,7 +341,7 @@ When using the foreign data wrapper, you must create a table on the Postgres ser
 
 Use the `DROP EXTENSION` command to remove an extension. To invoke the command, use your client of choice (for example, psql) to connect to the Postgres database from which you will be dropping the Hadoop server, and run the command:
 
-``` text
+```text
 DROP EXTENSION [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ];
 ```
 
@@ -377,7 +377,7 @@ For more information about using the foreign data wrapper `DROP EXTENSION` comma
 
 Use the `DROP SERVER` command to remove a connection to a foreign server. The syntax is:
 
-``` text
+```text
 DROP SERVER [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 ```
 
@@ -415,7 +415,7 @@ For more information about using the `DROP SERVER` command, see:
 
 Use the `DROP USER MAPPING` command to remove a mapping that associates a Postgres role with a foreign server. You must be the owner of the foreign server to remove a user mapping for that server.
 
-``` text
+```text
 DROP USER MAPPING [ IF EXISTS ] FOR { user_name | USER | CURRENT_USER | PUBLIC } SERVER server_name;
 ```
 
@@ -447,7 +447,7 @@ For detailed information about the `DROP USER MAPPING` command, see:
 
 A foreign table is a pointer to a table that resides on the Hadoop host. Use the `DROP FOREIGN TABLE` command to remove a foreign table. Only the owner of the foreign table can drop it.
 
-``` text
+```text
 DROP FOREIGN TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 ```
 
@@ -471,7 +471,7 @@ DROP FOREIGN TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 
 **Example**
 
-``` text
+```text
 DROP FOREIGN TABLE warehouse;
 ```
 

--- a/product_docs/docs/hadoop_data_adapter/2.0.7/09_using_the_hadoop_data_adapter.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/09_using_the_hadoop_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Using the Hadoop Foreign Data Wrapper"
 
 <div id="using_the_hadoop_data_adapter" class="registered_link"></div>
 
-
 You can use the Hadoop Foreign Data Wrapper either through the Apache Hive or the Apache Spark. Both Hive and Spark store metadata in the configured metastore, where databases and tables are created using HiveQL.
 
 ## Using HDFS FDW with Apache Hive on Top of Hadoop
@@ -13,25 +12,16 @@ You can use the Hadoop Foreign Data Wrapper either through the Apache Hive or th
 
 There are two versions of Hive - `HiveServer1` and `HiveServer2` which can be downloaded from the [Apache Hive website](https://hive.apache.org/downloads.html).
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-The Hadoop Foreign Data Wrapper supports only `HiveServer2`.
-
-</div>
+!!! Note
+    The Hadoop Foreign Data Wrapper supports only `HiveServer2`.
 
 To use HDFS FDW with Apache Hive on top of Hadoop:
 
-Step 1: Download [weblogs\_parse](http://wiki.pentaho.com/download/attachments/23531451/weblogs_parse.zip?version=1&modificationDate=1327096242000/) and follow the instructions at the [Wiki Pentaho website](https://wiki.pentaho.com/display/BAD/Transforming+Data+within+Hive/).
+Step 1: Download [weblogs_parse](http://wiki.pentaho.com/download/attachments/23531451/weblogs_parse.zip?version=1&modificationDate=1327096242000/) and follow the instructions at the [Wiki Pentaho website](https://wiki.pentaho.com/display/BAD/Transforming+Data+within+Hive/).
 
 Step 2: Upload `weblog_parse.txt` file using these commands:
 
-``` text
+```text
 hadoop fs -mkdir /weblogs
 hadoop fs -mkdir /weblogs/parse
 hadoop fs -put weblogs_parse.txt /weblogs/parse/part-00000
@@ -39,19 +29,19 @@ hadoop fs -put weblogs_parse.txt /weblogs/parse/part-00000
 
 Step 3: Start `HiveServer`, if not already running, using following command:
 
-``` text
+```text
 $HIVE_HOME/bin/hiveserver2
 ```
 
 or
 
-``` text
+```text
 $HIVE_HOME/bin/hive --service hiveserver2
 ```
 
 Step 4: Connect to `HiveServer2` using the hive `beeline` client. For example:
 
-``` text
+```text
 $ beeline
 Beeline version 1.0.1 by Apache Hive
 beeline> !connect jdbc:hive2://localhost:10000/default;auth=noSasl
@@ -59,7 +49,7 @@ beeline> !connect jdbc:hive2://localhost:10000/default;auth=noSasl
 
 Step 5: Create a table in Hive. The example creates a table named `weblogs`"
 
-``` text
+```text
 CREATE TABLE weblogs (
     client_ip           STRING,
     full_request_date   STRING,
@@ -83,13 +73,13 @@ fields terminated by '\t';
 
 Step 6: Load data into the table.
 
-``` text
+```text
 hadoop fs -cp /weblogs/parse/part-00000 /user/hive/warehouse/weblogs/
 ```
 
 Step 7: Access your data from Postgres; you can now use the `weblog` table. Once you are connected using psql, follow the below steps:
 
-``` text
+```text
 -- set the GUC variables appropriately, e.g. :
 hdfs_fdw.jvmpath='/home/edb/Projects/hadoop_fdw/jdk1.8.0_111/jre/lib/amd64/server/'
 hdfs_fdw.classpath='/usr/local/edbas/lib/postgresql/HiveJdbcClient-1.0.jar:/home/edb/Projects/hadoop_fdw/hadoop/share/hadoop/common/hadoop-common-2.6.4.jar:/home/edb/Projects/hadoop_fdw/apache-hive-1.0.1-bin/lib/hive-jdbc-1.0.1-standalone.jar'
@@ -165,7 +155,7 @@ Step 1: Download and install Apache Spark in local mode.
 
 Step 2: In the folder `$SPARK_HOME/conf` create a file `spark-defaults.conf` containing the following line:
 
-``` text
+```text
 spark.sql.warehouse.dir hdfs://localhost:9000/user/hive/warehouse
 ```
 
@@ -173,7 +163,7 @@ By default, Spark uses `derby` for both the meta data and the data itself (calle
 
 Step 3: Start the Spark Thrift Server.
 
-``` text
+```text
 ./start-thriftserver.sh
 ```
 
@@ -181,7 +171,7 @@ Step 4: Make sure the Spark Thrift server is running and writing to a log file.
 
 Step 5: Create a local file (`names.txt`) that contains the following entries:
 
-``` text
+```text
 $ cat /tmp/names.txt
 1,abcd
 2,pqrs
@@ -193,7 +183,7 @@ $ cat /tmp/names.txt
 
 Step 6: Connect to Spark Thrift Server2 using the Spark `beeline` client. For example:
 
-``` text
+```text
 $ beeline
 Beeline version 1.2.1.spark2 by Apache Hive
 beeline> !connect jdbc:hive2://localhost:10000/default;auth=noSasl org.apache.hive.jdbc.HiveDriver
@@ -201,7 +191,7 @@ beeline> !connect jdbc:hive2://localhost:10000/default;auth=noSasl org.apache.hi
 
 Step 7: Prepare the sample data on Spark. Run the following commands in the `beeline` command line tool:
 
-``` text
+```text
 ./beeline
 Beeline version 1.2.1.spark2 by Apache Hive
 beeline> !connect jdbc:hive2://localhost:10000/default;auth=noSasl org.apache.hive.jdbc.HiveDriver
@@ -253,7 +243,7 @@ No rows selected (0.33 seconds)
 
 The following commands list the corresponding files in Hadoop:
 
-``` text
+```text
 $ hadoop fs -ls /user/hive/warehouse/
 Found 1 items
 drwxrwxrwx   - org.apache.hive.jdbc.HiveDriver supergroup 0 2020-06-12 17:03 /user/hive/warehouse/my_test_db.db
@@ -265,7 +255,7 @@ drwxrwxrwx   - org.apache.hive.jdbc.HiveDriver supergroup 0 2020-06-12 17:03 /us
 
 Step 8: Access your data from Postgres using psql:
 
-``` text
+```text
 -- set the GUC variables appropriately, e.g. :
 hdfs_fdw.jvmpath='/home/edb/Projects/hadoop_fdw/jdk1.8.0_111/jre/lib/amd64/server/'
 hdfs_fdw.classpath='/usr/local/edbas/lib/postgresql/HiveJdbcClient-1.0.jar:/home/edb/Projects/hadoop_fdw/hadoop/share/hadoop/common/hadoop-common-2.6.4.jar:/home/edb/Projects/hadoop_fdw/apache-hive-1.0.1-bin/lib/hive-jdbc-1.0.1-standalone.jar'
@@ -308,14 +298,5 @@ EXPLAIN (verbose, costs off) SELECT name FROM f_names_tab WHERE a > 3;
 (3 rows)
 ```
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-The same port was being used while creating foreign server because the Spark Thrift Server is compatible with the Hive Thrift Server. Applications using Hiveserver2 would work with Spark except for the behaviour of the `ANALYZE` command and the connection string in the case of `NOSASL`. We recommend using `ALTER SERVER` and changing the `client_type` option if Hive is to be replaced with Spark.
-
-</div>
+!!! Note
+    The same port was being used while creating foreign server because the Spark Thrift Server is compatible with the Hive Thrift Server. Applications using Hiveserver2 would work with Spark except for the behaviour of the `ANALYZE` command and the connection string in the case of `NOSASL`. We recommend using `ALTER SERVER` and changing the `client_type` option if Hive is to be replaced with Spark.

--- a/product_docs/docs/hadoop_data_adapter/2.0.7/10_identifying_data_adapter_version.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/10_identifying_data_adapter_version.mdx
@@ -4,16 +4,15 @@ title: "Identifying the Hadoop Foreign Data Wrapper Version"
 
 <div id="identifying_data_adapter_version" class="registered_link"></div>
 
-
 The Hadoop Foreign Data Wrapper includes a function that you can use to identify the currently installed version of the `.so` file for the data wrapper. To use the function, connect to the Postgres server, and enter:
 
-``` text
+```text
 SELECT hdfs_fdw_version();
 ```
 
 The function returns the version number:
 
-``` text
+```text
 hdfs_fdw_version
 -----------------
 <xxxxx>

--- a/product_docs/docs/hadoop_data_adapter/2.0.7/11_uninstalling_the_hadoop_data_adapter.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/11_uninstalling_the_hadoop_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Uninstalling the Hadoop Foreign Data Wrapper"
 
 <div id="uninstalling_the_hadoop_data_adapter" class="registered_link"></div>
 
-
 **Uninstalling an RPM Package**
 
 You can use the `yum remove` or `dnf remove` command to remove a package installed by `yum` or `dnf`. To remove a package, open a terminal window, assume superuser privileges, and enter the command:

--- a/product_docs/docs/hadoop_data_adapter/2.0.7/index.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.0.7/index.mdx
@@ -2,8 +2,6 @@
 title: "Hadoop Foreign Data Wrapper Guide"
 ---
 
-
-
 The Hadoop Foreign Data Wrapper (`hdfs_fdw`) is a Postgres extension that allows you to access data that resides on a Hadoop file system from EDB Postgres Advanced Server. The foreign data wrapper makes the Hadoop file system a read-only data source that you can use with Postgres functions and utilities, or in conjunction with other data that resides on a Postgres host.
 
 The Hadoop Foreign Data Wrapper can be installed with an RPM package. You can download an installer from the [EDB website](https://www.enterprisedb.com/software-downloads-postgres/).
@@ -12,6 +10,6 @@ This guide uses the term `Postgres` to refer to an instance of EDB Postgres Adva
 
 <div class="toctree" maxdepth="4">
 
-whats\_new requirements\_overview architecture\_overview supported\_authentication\_methods installing\_the\_hadoop\_data\_adapter updating\_the\_hadoop\_data\_adapter features\_of\_hdfs\_fdw configuring\_the\_hadoop\_data\_adapter using\_the\_hadoop\_data\_adapter identifying\_data\_adapter\_version uninstalling\_the\_hadoop\_data\_adapter conclusion
+whats_new requirements_overview architecture_overview supported_authentication_methods installing_the_hadoop_data_adapter updating_the_hadoop_data_adapter features_of_hdfs_fdw configuring_the_hadoop_data_adapter using_the_hadoop_data_adapter identifying_data_adapter_version uninstalling_the_hadoop_data_adapter conclusion
 
 </div>

--- a/product_docs/docs/mongo_data_adapter/5.2.8/01_whats_new.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/01_whats_new.mdx
@@ -4,7 +4,6 @@ title: "What’s New"
 
 <div id="whats_new" class="registered_link"></div>
 
-
 The following features are added to create MongoDB Foreign Data Wrapper `5.2.8`:
 
 -   Support for EDB Postgres Advanced Server 13.

--- a/product_docs/docs/mongo_data_adapter/5.2.8/02_requirements_overview.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/02_requirements_overview.mdx
@@ -2,17 +2,11 @@
 title: "Requirements Overview"
 ---
 
-
-
 ## Supported Versions
-
-
 
 The MongoDB Foreign Data Wrapper is certified with EDB Postgres Advanced Server 9.6 and above.
 
 ## Supported Platforms
-
-
 
 The MongoDB Foreign Data Wrapper is supported on the following platforms:
 

--- a/product_docs/docs/mongo_data_adapter/5.2.8/03_architecture_overview.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/03_architecture_overview.mdx
@@ -4,7 +4,6 @@ title: "Architecture Overview"
 
 <div id="architecture_overview" class="registered_link"></div>
 
-
 The MongoDB data wrapper provides an interface between a MongoDB server and a Postgres database. It transforms a Postgres statement (`SELECT`/`INSERT`/`DELETE`/`UPDATE`) into a query that is understood by the MongoDB database.
 
 ![Using MongoDB FDW with Postgres](images/mongo_server_with_postgres.png)

--- a/product_docs/docs/mongo_data_adapter/5.2.8/04_installing_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/04_installing_the_mongo_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Installing the MongoDB Foreign Data Wrapper"
 
 <div id="installing_the_mongo_data_adapter" class="registered_link"></div>
 
-
 The MongoDB Foreign Data Wrapper can be installed with an RPM package. During the installation process, the installer will satisfy software prerequisites.
 
 <div id="using_an_rpm_package_to_install_the_data_adapter" class="registered_link"></div>
@@ -26,13 +25,13 @@ Before installing the MongoDB Foreign Data Wrapper, you must install the followi
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 > ```
 
 Enable the optional, extras, and HA repositories:
 
-> ``` text
+> ```text
 > subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"  --enable "rhel-ha-for-rhel-*-server-rpms"
 > ```
 
@@ -50,7 +49,7 @@ After receiving your repository credentials:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -60,7 +59,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -73,7 +72,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
-> ``` 
+> ```
 > yum install edb-as<xx>-mongo_fdw
 > ```
 
@@ -87,19 +86,17 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On RHEL 8
 
-
-
 Before installing the MongoDB Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 > ```
 
 Enable the `codeready-builder-for-rhel-8-\*-rpms` repository:
 
-> ``` text
+> ```text
 > ARCH=$( /bin/arch )
 > subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
 > ```
@@ -118,7 +115,7 @@ After receiving your repository credentials:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > dnf -y https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -128,7 +125,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -141,7 +138,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > dnf install edb-as<xx>-mongo_fdw
 > ```
 
@@ -153,27 +150,16 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On CentOS 7
 
-
-
 Before installing the MongoDB Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 > ```
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
-
-</div>
+!!! Note
+    You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
@@ -189,7 +175,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -199,7 +185,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -212,7 +198,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > yum install edb-as<xx>-mongo_fdw
 > ```
 
@@ -226,19 +212,17 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On CentOS 8
 
-
-
 Before installing the MongoDB Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 > ```
 
 Enable the `PowerTools` repository:
 
-> ``` text
+> ```text
 > dnf config-manager --set-enabled PowerTools
 > ```
 
@@ -256,7 +240,7 @@ After receiving your repository credentials:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -266,7 +250,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -279,7 +263,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the MongoDB Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > dnf install edb-as<xx>-mongo_fdw
 > ```
 
@@ -291,17 +275,13 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ## Installing the MongoDB Foreign Data Wrapper on a Debian or Ubuntu Host
 
-
-
-
-
 To install the MongoDB Foreign Data Wrapper on a Debian or Ubuntu host, you must have credentials that allow access to the EDB repository. To request credentials for the repository, visit the [EDB website](https://www.enterprisedb.com/repository-access-request/).
 
 The following steps will walk you through using the EDB apt repository to install a Debian package. When using the commands, replace the `username` and `password` with the credentials provided by EDB.
 
 1.  Assume superuser privileges:
 
-    > ``` text
+    > ```text
     > sudo su –
     > ```
 
@@ -309,7 +289,7 @@ The following steps will walk you through using the EDB apt repository to instal
 
     On Debian 9 and Ubuntu:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "deb https://username:password@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
     > ```
 
@@ -317,37 +297,37 @@ The following steps will walk you through using the EDB apt repository to instal
 
     1.  Set up the EDB repository:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "deb [arch=amd64] https://apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
     > ```
 
     1.  Substitute your EDB credentials for the `username` and `password` in the following command:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "machine apt.enterprisedb.com login <username> password <password>" > /etc/apt/auth.conf.d/edb.conf'
     > ```
 
 3.  Add support to your system for secure APT repositories:
 
-    > ``` text
+    > ```text
     > apt-get install apt-transport-https
     > ```
 
 4.  Add the EDB signing key:
 
-    > ``` text
+    > ```text
     > wget -q -O - https://<username>:<password>@apt.enterprisedb.com/edb-deb.gpg.key | apt-key add -
     > ```
 
 5.  Update the repository metadata:
 
-    > ``` text
+    > ```text
     > apt-get update
     > ```
 
 6.  Install the Debian package:
 
-    > ``` text
+    > ```text
     > apt-get install edb-as<xx>-mongo-fdw
     > ```
 

--- a/product_docs/docs/mongo_data_adapter/5.2.8/05_updating_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/05_updating_the_mongo_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Updating the MongoDB Foreign Data Wrapper"
 
 <div id="updating_the_mongo_data_adapter" class="registered_link"></div>
 
-
 **Updating an RPM Installation**
 
 If you have an existing RPM installation of MongoDB Foreign Data Wrapper, you can use yum or dnf to upgrade your repository configuration file and update to a more recent product version. To update the `edb.repo` file, assume superuser privileges and enter:

--- a/product_docs/docs/mongo_data_adapter/5.2.8/06_features_of_mongo_fdw.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/06_features_of_mongo_fdw.mdx
@@ -4,16 +4,15 @@ title: "Features of the MongoDB Foreign Data Wrapper"
 
 <div id="features_of_mongo_fdw" class="registered_link"></div>
 
-
 The key features of the MongoDB Foreign Data Wrapper are listed below:
 
 ## Writable FDW
 
 The MongoDB Foreign Data Wrapper allows you to modify data on a MongoDB server. Users can `INSERT`, `UPDATE` and `DELETE` data in the remote MongoDB collections by inserting, updating and deleting data locally in foreign tables. See also:
 
-[Example: Using the MongoDB Foreign Data Wrapper](#example_using_the_mongo_data_adapter)
+[Example: Using the MongoDB Foreign Data Wrapper](08_example_using_the_mongo_data_adapter/#example_using_the_mongo_data_adapter)
 
-[Data Type Mappings](#data_type_mappings)
+[Data Type Mappings](07_configuring_the_mongo_data_adapter/#data-type-mappings)
 
 ## Where Clause Push-down
 
@@ -21,7 +20,7 @@ MongoDB Foreign Data Wrapper allows the push-down of `WHERE` clause only when cl
 
 ## Connection Pooling
 
-Mongo\_FDW establishes a connection to a foreign server during the first query that uses a foreign table associated with the foreign server. This connection is kept and reused for subsequent queries in the same session.
+Mongo_FDW establishes a connection to a foreign server during the first query that uses a foreign table associated with the foreign server. This connection is kept and reused for subsequent queries in the same session.
 
 ## Automated Cleanup
 
@@ -41,7 +40,7 @@ You can retrieve all available fields in a collection residing in MongoDB Foreig
 
 The collection in MongoDB Foreign Data Wrapper:
 
-``` text
+```text
 > db.warehouse.find();
 { "_id" : ObjectId("58a1ebbaf543ec0b90545859"), "warehouse_id" : 1, "warehouse_name" : "UPS", "warehouse_created" : ISODate("2014-12-12T07:12:10Z") }
 { "_id" : ObjectId("58a1ebbaf543ec0b9054585a"), "warehouse_id" : 2, "warehouse_name" : "Laptop", "warehouse_created" : ISODate("2015-11-11T08:13:10Z") }
@@ -51,19 +50,19 @@ Steps for retrieving the document:
 
 1.  Create foreign table with a column name `__doc`. The type of the column could be json, jsonb, text or varchar.
 
-``` text
+```text
 CREATE FOREIGN TABLE test_json(__doc json) SERVER mongo_server OPTIONS (database 'testdb', collection 'warehouse');
 ```
 
 1.  Retrieve the document.
 
-``` text
+```text
 SELECT * FROM test_json ORDER BY __doc::text COLLATE "C";
 ```
 
 The output:
 
-``` text
+```text
 edb=#SELECT * FROM test_json ORDER BY __doc::text COLLATE "C";
                                                                       __doc                                                                  ---------------------------------------------------------------------------------------------------------------------------------------------------------
 { "_id" : { "$oid" : "58a1ebbaf543ec0b90545859" }, "warehouse_id" : 1, "warehouse_name" : "UPS", "warehouse_created" : { "$date" : 1418368330000 } }

--- a/product_docs/docs/mongo_data_adapter/5.2.8/07_configuring_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/07_configuring_the_mongo_data_adapter.mdx
@@ -4,13 +4,12 @@ title: "Configuring the MongoDB Foreign Data Wrapper"
 
 <div id="configuring_the_mongo_data_adapter" class="registered_link"></div>
 
-
 Before using the MongoDB Foreign Data Wrapper, you must:
 
-> 1.  Use the [CREATE EXTENSION](#create_extension) command to create the MongoDB Foreign Data Wrapper extension on the Postgres host.
-> 2.  Use the [CREATE SERVER](#create_server) command to define a connection to the MongoDB server.
-> 3.  Use the [CREATE USER MAPPING](#create_user_mapping) command to define a mapping that associates a Postgres role with the server.
-> 4.  Use the [CREATE FOREIGN TABLE](#create_foreign_table) command to define a table in the Postgres database that corresponds to a database that resides on the MongoDB cluster.
+> 1.  Use the [CREATE EXTENSION](#create-extension) command to create the MongoDB Foreign Data Wrapper extension on the Postgres host.
+> 2.  Use the [CREATE SERVER](#create-server) command to define a connection to the MongoDB server.
+> 3.  Use the [CREATE USER MAPPING](#create-user-mapping) command to define a mapping that associates a Postgres role with the server.
+> 4.  Use the [CREATE FOREIGN TABLE](#create-foreign-table) command to define a table in the Postgres database that corresponds to a database that resides on the MongoDB cluster.
 
 <div id="create_extension" class="registered_link"></div>
 
@@ -18,7 +17,7 @@ Before using the MongoDB Foreign Data Wrapper, you must:
 
 Use the `CREATE EXTENSION` command to create the `mongo_fdw` extension. To invoke the command, use your client of choice (for example, psql) to connect to the Postgres database from which you will be querying the MongoDB server, and invoke the command:
 
-``` text
+```text
 CREATE EXTENSION [IF NOT EXISTS] mongo_fdw [WITH] [SCHEMA schema_name];
 ```
 
@@ -48,7 +47,7 @@ For more information about using the foreign data wrapper `CREATE EXTENSION` com
 
 Use the `CREATE SERVER` command to define a connection to a foreign server. The syntax is:
 
-``` text
+```text
 CREATE SERVER server_name FOREIGN DATA WRAPPER mongo_fdw
     [OPTIONS (option 'value' [, ...])]
 ```
@@ -69,24 +68,24 @@ The role that defines the server is the owner of the server; use the `ALTER SERV
 
 > Use the `OPTIONS` clause of the `CREATE SERVER` command to specify connection information for the foreign server object. You can include:
 
-| **Option**               | **Description**                                                                                                                                                                                                                 |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| address                  | The address or hostname of the Mongo server. The default value is `127.0.0.1`.                                                                                                                     |
-| port                     | The port number of the Mongo Server. Valid range is 0 to 65535. The default value is `27017`.                                                                                                      |
-| authentication\_database | The database against which user will be authenticated. This option is only valid with password based authentication.                                                                                                            |
-| ssl                      | Requests an authenticated, encrypted SSL connection. By default, the value is set to `false`. Set the value to `true` to enable ssl. See <http://mongoc.org/libmongoc/current/mongoc_ssl_opt_t.html> to understand the options. |
-| pem\_file                | SSL option                                                                                                                                                                                                                      |
-| pem\_pwd                 | SSL option.                                                                                                                                                                                                                     |
-| ca\_file                 | SSL option                                                                                                                                                                                                                      |
-| ca\_dir                  | SSL option                                                                                                                                                                                                                      |
-| crl\_file                | SSL option                                                                                                                                                                                                                      |
-| weak\_cert\_validation   | SSL option                                                                                                                                                                                                                      |
+| **Option**              | **Description**                                                                                                                                                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| address                 | The address or hostname of the Mongo server. The default value is `127.0.0.1`.                                                                                                                                                  |
+| port                    | The port number of the Mongo Server. Valid range is 0 to 65535. The default value is `27017`.                                                                                                                                   |
+| authentication_database | The database against which user will be authenticated. This option is only valid with password based authentication.                                                                                                            |
+| ssl                     | Requests an authenticated, encrypted SSL connection. By default, the value is set to `false`. Set the value to `true` to enable ssl. See <http://mongoc.org/libmongoc/current/mongoc_ssl_opt_t.html> to understand the options. |
+| pem_file                | SSL option                                                                                                                                                                                                                      |
+| pem_pwd                 | SSL option.                                                                                                                                                                                                                     |
+| ca_file                 | SSL option                                                                                                                                                                                                                      |
+| ca_dir                  | SSL option                                                                                                                                                                                                                      |
+| crl_file                | SSL option                                                                                                                                                                                                                      |
+| weak_cert_validation    | SSL option                                                                                                                                                                                                                      |
 
 **Example**
 
 The following command creates a foreign server named `mongo_server` that uses the `mongo_fdw` foreign data wrapper to connect to a host with an IP address of `127.0.0.1`:
 
-``` text
+```text
 CREATE SERVER mongo_server FOREIGN DATA WRAPPER mongo_fdw OPTIONS (host '127.0.0.1', port '27017');
 ```
 
@@ -102,7 +101,7 @@ For more information about using the `CREATE SERVER` command, see:
 
 Use the `CREATE USER MAPPING` command to define a mapping that associates a Postgres role with a foreign server:
 
-``` text
+```text
 CREATE USER MAPPING FOR role_name SERVER server_name
        [OPTIONS (option 'value' [, ...])];
 ```
@@ -135,7 +134,7 @@ The following command creates a user mapping for a role named `enterprisedb`; th
 
 If the database host uses secure authentication, provide connection credentials when creating the user mapping:
 
-``` text
+```text
 CREATE USER MAPPING FOR enterprisedb SERVER mongo_server OPTIONS (username 'mongo_user', password 'mongo_pass');
 ```
 
@@ -151,7 +150,7 @@ For detailed information about the `CREATE USER MAPPING` command, see:
 
 A foreign table is a pointer to a table that resides on the MongoDB host. Before creating a foreign table definition on the Postgres server, connect to the MongoDB server and create a collection; the columns in the table will map to columns in a table on the Postgres server. Then, use the `CREATE FOREIGN TABLE` command to define a table on the Postgres server with columns that correspond to the collection that resides on the MongoDB host. The syntax is:
 
-``` text
+```text
 CREATE FOREIGN TABLE [ IF NOT EXISTS ] table_name ( [
   { column_name data_type [ OPTIONS ( option 'value' [, ... ] ) ] [ COLLATE collation ] [ column_constraint [ ... ] ]
     | table_constraint }
@@ -163,14 +162,14 @@ CREATE FOREIGN TABLE [ IF NOT EXISTS ] table_name ( [
 
 where `column_constraint` is:
 
-``` text
+```text
 [ CONSTRAINT constraint_name ]
 { NOT NULL | NULL | CHECK (expr) [ NO INHERIT ] | DEFAULT default_expr }
 ```
 
 and `table_constraint` is:
 
-``` text
+```text
 [ CONSTRAINT constraint_name ] CHECK (expr) [ NO INHERIT ]
 ```
 
@@ -231,7 +230,7 @@ and `table_constraint` is:
 > Use the `OPTIONS` clause to specify the following `options` and their corresponding values:
 
 | option     | value                                                                             |
-|------------|-----------------------------------------------------------------------------------|
+| ---------- | --------------------------------------------------------------------------------- |
 | database   | The name of the database to query. The default value is `test`.                   |
 | collection | The name of the collection to query. The default value is the foreign table name. |
 
@@ -239,7 +238,7 @@ and `table_constraint` is:
 
 To use data that is stored on MongoDB server, you must create a table on the Postgres host that maps the columns of a MongoDB collection to the columns of a Postgres table. For example, for a MongoDB collection with the following definition:
 
-``` text
+```text
 db.warehouse.find
 (
         {
@@ -256,7 +255,7 @@ db.warehouse.find
 
 You should execute a command on the Postgres server that creates a comparable table on the Postgres server:
 
-``` text
+```text
 CREATE FOREIGN TABLE warehouse
 (
  _id               NAME,
@@ -276,17 +275,8 @@ For more information about using the `CREATE FOREIGN TABLE` command, see:
 
 > <https://www.postgresql.org/docs/current/static/sql-createforeigntable.html>
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-MongoDB foreign data wrapper supports the write capability feature.
-
-</div>
+!!! Note
+    MongoDB foreign data wrapper supports the write capability feature.
 
 <div id="data_type_mappings" class="registered_link"></div>
 
@@ -294,21 +284,21 @@ MongoDB foreign data wrapper supports the write capability feature.
 
 When using the foreign data wrapper, you must create a table on the Postgres server that mirrors the table that resides on the MongoDB server. The MongoDB data wrapper will automatically convert the following MongoDB data types to the target Postgres type:
 
-| **MongoDB (BSON Type)**       | **Postgres**                             |
-|-------------------------------|------------------------------------------|
-| ARRAY JSON BOOL BOOL          |                                          |
-| BINARY BYTE                   | A                                        |
-| DATE\_TIME DATE DOCUMENT JSON | /TIMESTAMP/TIMESTAMPTZ                   |
-| DOUBLE FLOA                   | T/FLOAT4/FLOAT8/DOUBLE PRECISION/NUMERIC |
-| INT32 SMAL                    | LINT/INT2/INT/INTEGER/INT4               |
-| INT64 BIGI OID NAME           | NT/INT8                                  |
-| UTF8 BPCH                     | AR/VARCHAR/CHARCTER VARYING/TEXT         |
+| **MongoDB (BSON Type)**      | **Postgres**                             |
+| ---------------------------- | ---------------------------------------- |
+| ARRAY JSON BOOL BOOL         |                                          |
+| BINARY BYTE                  | A                                        |
+| DATE_TIME DATE DOCUMENT JSON | /TIMESTAMP/TIMESTAMPTZ                   |
+| DOUBLE FLOA                  | T/FLOAT4/FLOAT8/DOUBLE PRECISION/NUMERIC |
+| INT32 SMAL                   | LINT/INT2/INT/INTEGER/INT4               |
+| INT64 BIGI OID NAME          | NT/INT8                                  |
+| UTF8 BPCH                    | AR/VARCHAR/CHARCTER VARYING/TEXT         |
 
 ## DROP EXTENSION
 
 Use the `DROP EXTENSION` command to remove an extension. To invoke the command, use your client of choice (for example, psql) to connect to the Postgres database from which you will be dropping the MongoDB server, and run the command:
 
-``` text
+```text
 DROP EXTENSION [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ];
 ```
 
@@ -344,7 +334,7 @@ For more information about using the foreign data wrapper `DROP EXTENSION` comma
 
 Use the `DROP SERVER` command to remove a connection to a foreign server. The syntax is:
 
-``` text
+```text
 DROP SERVER [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 ```
 
@@ -382,7 +372,7 @@ For more information about using the `DROP SERVER` command, see:
 
 Use the `DROP USER MAPPING` command to remove a mapping that associates a Postgres role with a foreign server. You must be the owner of the foreign server to remove a user mapping for that server.
 
-``` text
+```text
 DROP USER MAPPING [ IF EXISTS ] FOR { user_name | USER | CURRENT_USER | PUBLIC } SERVER server_name;
 ```
 
@@ -414,7 +404,7 @@ For detailed information about the `DROP USER MAPPING` command, see:
 
 A foreign table is a pointer to a table that resides on the MongoDB host. Use the `DROP FOREIGN TABLE` command to remove a foreign table. Only the owner of the foreign table can drop it.
 
-``` text
+```text
 DROP FOREIGN TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 ```
 
@@ -438,7 +428,7 @@ DROP FOREIGN TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 
 **Example**
 
-``` text
+```text
 DROP FOREIGN TABLE warehouse;
 ```
 

--- a/product_docs/docs/mongo_data_adapter/5.2.8/08_example_using_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/08_example_using_the_mongo_data_adapter.mdx
@@ -4,10 +4,9 @@ title: "Example: Using the MongoDB Foreign Data Wrapper"
 
 <div id="example_using_the_mongo_data_adapter" class="registered_link"></div>
 
-
 Before using the MongoDB foreign data wrapper, you must connect to your database with a client application. The following examples demonstrate using the wrapper with the psql client. After connecting to psql, you can follow the steps in the example below:
 
-``` text
+```text
 -- load extension first time after install
 CREATE EXTENSION mongo_fdw;
 

--- a/product_docs/docs/mongo_data_adapter/5.2.8/09_identifying_data_adapter_version.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/09_identifying_data_adapter_version.mdx
@@ -4,16 +4,15 @@ title: "Identifying the MongoDB Foreign Data Wrapper Version"
 
 <div id="identifying_data_adapter_version" class="registered_link"></div>
 
-
 The MongoDB Foreign Data Wrapper includes a function that you can use to identify the currently installed version of the `.so` file for the data wrapper. To use the function, connect to the Postgres server, and enter:
 
-``` text
+```text
 SELECT mongo_fdw_version();
 ```
 
 The function returns the version number:
 
-``` text
+```text
 mongo_fdw_version
 -----------------
 <xxxxx>

--- a/product_docs/docs/mongo_data_adapter/5.2.8/10_limitations.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/10_limitations.mdx
@@ -4,7 +4,6 @@ title: "Limitations"
 
 <div id="limitations" class="registered_link"></div>
 
-
 The following limitations apply to MongoDB Foreign Data Wrapper:
 
 -   If the BSON document key contains uppercase letters or occurs within a nested document, MongoDB Foreign Data Wrapper requires the corresponding column names to be declared in double quotes.

--- a/product_docs/docs/mongo_data_adapter/5.2.8/11_uninstalling_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/11_uninstalling_the_mongo_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Uninstalling the MongoDB Foreign Data Wrapper"
 
 <div id="uninstalling_the_mongo_data_adapter" class="registered_link"></div>
 
-
 **Uninstalling an RPM Package**
 
 You can use the `yum remove` or `dnf remove` command to remove a package installed by `yum` or `dnf`. To remove a package, open a terminal window, assume superuser privileges, and enter the command:

--- a/product_docs/docs/mongo_data_adapter/5.2.8/index.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.2.8/index.mdx
@@ -2,8 +2,6 @@
 title: "MongoDB Foreign Data Wrapper Guide"
 ---
 
-
-
 The MongoDB Foreign Data Wrapper (`mongo_fdw`) is a Postgres extension that allows you to access data that resides on a MongoDB database from EDB Postgres Advanced Server. It is a writable foreign data wrapper that you can use with Postgres functions and utilities, or in conjunction with other data that resides on a Postgres host.
 
 The MongoDB Foreign Data Wrapper can be installed with an RPM package. You can download an installer from the [EDB website](https://www.enterprisedb.com/software-downloads-postgres/).
@@ -12,6 +10,6 @@ This guide uses the term `Postgres` to refer to an instance of EDB Postgres Adva
 
 <div class="toctree" maxdepth="4">
 
-whats\_new requirements\_overview architecture\_overview installing\_the\_mongo\_data\_adapter updating\_the\_mongo\_data\_adapter features\_of\_mongo\_fdw configuring\_the\_mongo\_data\_adapter example\_using\_the\_mongo\_data\_adapter identifying\_data\_adapter\_version limitations uninstalling\_the\_mongo\_data\_adapter conclusion
+whats_new requirements_overview architecture_overview installing_the_mongo_data_adapter updating_the_mongo_data_adapter features_of_mongo_fdw configuring_the_mongo_data_adapter example_using_the_mongo_data_adapter identifying_data_adapter_version limitations uninstalling_the_mongo_data_adapter conclusion
 
 </div>

--- a/product_docs/docs/mysql_data_adapter/2.5.5/01_whats_new.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/01_whats_new.mdx
@@ -4,7 +4,6 @@ title: "What’s New"
 
 <div id="whats_new" class="registered_link"></div>
 
-
 The following features are added to create MySQL Foreign Data Wrapper `2.5.5`:
 
 -   Support for EDB Postgres Advanced Server 13.

--- a/product_docs/docs/mysql_data_adapter/2.5.5/02_requirements_overview.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/02_requirements_overview.mdx
@@ -2,17 +2,11 @@
 title: "Requirements Overview"
 ---
 
-
-
 ## Supported Versions
-
-
 
 The MySQL Foreign Data Wrapper is certified with EDB Postgres Advanced Server 9.6 and above.
 
 ## Supported Platforms
-
-
 
 The MySQL Foreign Data Wrapper is supported on the following platforms:
 

--- a/product_docs/docs/mysql_data_adapter/2.5.5/03_architecture_overview.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/03_architecture_overview.mdx
@@ -4,7 +4,6 @@ title: "Architecture Overview"
 
 <div id="architecture_overview" class="registered_link"></div>
 
-
 The MySQL data wrapper provides an interface between a MySQL server and a Postgres database. It transforms a Postgres statement (`SELECT`/`INSERT`/`DELETE`/`UPDATE`) into a query that is understood by the MySQL database.
 
 ![Using mysql_fdw with Postgres](images/mysql_server_with_postgres.png)

--- a/product_docs/docs/mysql_data_adapter/2.5.5/04_installing_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/04_installing_the_mysql_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Installing the MySQL Foreign Data Wrapper"
 
 <div id="installing_the_mysql_data_adapter" class="registered_link"></div>
 
-
 The MySQL Foreign Data Wrapper can be installed with an RPM package. During the installation process, the installer will satisfy software prerequisites.
 
 <div id="using_an_rpm_package_to_install_the_data_adapter" class="registered_link"></div>
@@ -26,13 +25,13 @@ Before installing the MySQL Foreign Data Wrapper, you must install the following
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 > ```
 
 Enable the optional, extras, and HA repositories:
 
-> ``` text
+> ```text
 > subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"  --enable "rhel-ha-for-rhel-*-server-rpms"
 > ```
 
@@ -50,7 +49,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -60,7 +59,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -73,7 +72,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the MySQL Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > yum install edb-as<xx>-mysql<x>_fdw
 > ```
 
@@ -81,17 +80,8 @@ where `xx` is the server version number, and `x` is the supported release versio
 
 > `yum install edb-as<xx>-mysql5_fdw`
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-MySQL 8.0 and MySQL 5.0 RPMs are available for RHEL 7 platform.
-
-</div>
+!!! Note
+    MySQL 8.0 and MySQL 5.0 RPMs are available for RHEL 7 platform.
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
 
@@ -101,19 +91,17 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On RHEL 8
 
-
-
 Before installing the MySQL Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 > ```
 
 Enable the `codeready-builder-for-rhel-8-\*-rpms` repository:
 
-> ``` text
+> ```text
 > ARCH=$( /bin/arch )
 > subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
 > ```
@@ -132,7 +120,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > dnf -y https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -142,7 +130,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -155,7 +143,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the below command to install the MySQL Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > dnf install edb-as<xx>-mysql8_fdw
 > ```
 
@@ -167,27 +155,16 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On CentOS 7
 
-
-
 Before installing the MySQL Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 > ```
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
-
-</div>
+!!! Note
+    You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
@@ -203,7 +180,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -213,7 +190,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -226,7 +203,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the MySQL Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > yum install edb-as<xx>-mysql<x>_fdw
 > ```
 
@@ -234,17 +211,8 @@ where `xx` is the server version number, and `x` is the supported release versio
 
 > `yum install edb-as<xx>-mysql5_fdw`
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-MySQL 8.0 and MySQL 5.0 RPMs are available for CentOS 7 platform.
-
-</div>
+!!! Note
+    MySQL 8.0 and MySQL 5.0 RPMs are available for CentOS 7 platform.
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
 
@@ -254,19 +222,17 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ### On CentOS 8
 
-
-
 Before installing the MySQL Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
 
 Install the `epel-release` package:
 
-> ``` text
+> ```text
 > dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 > ```
 
 Enable the `PowerTools` repository:
 
-> ``` text
+> ```text
 > dnf config-manager --set-enabled PowerTools
 > ```
 
@@ -284,7 +250,7 @@ After receiving your repository credentials you can:
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-> ``` text
+> ```text
 > dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 > ```
 
@@ -294,7 +260,7 @@ The repository configuration file is named `edb.repo`. The file resides in `/etc
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-> ``` text
+> ```text
 > [edb]
 > name=EnterpriseDB RPMs $releasever - $basearch
 > baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -307,7 +273,7 @@ After creating the `edb.repo` file, use your choice of editor to ensure that the
 
 After saving your changes to the configuration file, use the following command to install the MySQL Foreign Data Wrapper:
 
-> ``` text
+> ```text
 > dnf install edb-as<xx>-mysql8_fdw
 > ```
 
@@ -319,17 +285,13 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 
 ## Installing the MySQL Foreign Data Wrapper on a Debian or Ubuntu Host
 
-
-
-
-
 To install the MySQL Foreign Data Wrapper on a Debian or Ubuntu host, you must have credentials that allow access to the EDB repository. To request credentials for the repository, visit the [EDB website](https://www.enterprisedb.com/repository-access-request/).
 
 The following steps will walk you through on using the EDB apt repository to install a DEB package. When using the commands, replace the `username` and `password` with the credentials provided by EDB.
 
 1.  Assume superuser privileges:
 
-``` text
+```text
 sudo su –
 ```
 
@@ -337,7 +299,7 @@ sudo su –
 
     On Debian 9:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "deb https://username:password@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
     > ```
 
@@ -345,38 +307,38 @@ sudo su –
 
     1.  Set up the EDB repository:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "deb [arch=amd64] https://apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
     > ```
 
     1.  Substitute your EDB credentials for the `username` and `password` in the following command:
 
-    > ``` text
+    > ```text
     > sh -c 'echo "machine apt.enterprisedb.com login <username> password <password>" > /etc/apt/auth.conf.d/edb.conf'
     > ```
 
 2.  Add support to your system for secure APT repositories:
 
-``` text
+```text
 apt-get install apt-transport-https
 ```
 
 1.  Add the EBD signing key:
 
-``` text
+```text
 wget -q -O - https://username:password
 @apt.enterprisedb.com/edb-deb.gpg.key | apt-key add -
 ```
 
 1.  Update the repository metadata:
 
-``` text
+```text
 apt-get update
 ```
 
 1.  Install DEB package:
 
-``` text
+```text
 apt-get install edb-as<xx>-mysql-fdw
 ```
 

--- a/product_docs/docs/mysql_data_adapter/2.5.5/05_updating_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/05_updating_the_mysql_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Updating the MySQL Foreign Data Wrapper"
 
 <div id="updating_the_mysql_data_adapter" class="registered_link"></div>
 
-
 **Updating an RPM Installation**
 
 If you have an existing RPM installation of MySQL Foreign Data Wrapper, you can use yum or dnf to upgrade your repository configuration file and update to a more recent product version. To update the `edb.repo` file, assume superuser privileges and enter:

--- a/product_docs/docs/mysql_data_adapter/2.5.5/06_features_of_mysql_fdw.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/06_features_of_mysql_fdw.mdx
@@ -4,34 +4,24 @@ title: "Features of the MySQL Foreign Data Wrapper"
 
 <div id="features_of_mysql_fdw" class="registered_link"></div>
 
-
 The key features of the MySQL Foreign Data Wrapper are listed below:
 
 ## Writable FDW
 
 MySQL Foreign Data Wrapper provides the write capability. Users can insert, update and delete data in the remote MySQL tables by inserting, updating and deleting the data locally in the foreign tables. MySQL foreign data wrapper uses the Postgres type casting mechanism to provide opposite type casting between MySQL and Postgres data types.
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-The first column of MySQL table must have unique/primary key for DML to work.
-
-</div>
+!!! Note
+    The first column of MySQL table must have unique/primary key for DML to work.
 
 See also:
 
-[Example: Using the MySQL Foreign Data Wrapper](#example_using_the_mysql_data_adapter)
+[Example: Using the MySQL Foreign Data Wrapper](08_example_using_the_mysql_data_adapter/#example_using_the_mysql_data_adapter)
 
-[Data Type Mappings](#data_type_mappings)
+[Data Type Mappings](07_configuring_the_mysql_data_adapter/#data-type-mappings)
 
 ## Connection Pooling
 
-MySQL\_FDW establishes a connection to a foreign server during the first query that uses a foreign table associated with the foreign server. This connection is kept and reused for subsequent queries in the same session.
+MySQL_FDW establishes a connection to a foreign server during the first query that uses a foreign table associated with the foreign server. This connection is kept and reused for subsequent queries in the same session.
 
 ## Where Clause Push-down
 
@@ -51,7 +41,7 @@ MySQL Foreign Data Wrapper supports Import Foreign Schema which enables the loca
 
 See also:
 
-[Example: Import Foreign Schema](#example_import_foreign_schema)
+[Example: Import Foreign Schema](09_example_import_foreign_schema/#example_import_foreign_schema)
 
 ## Automated Cleanup
 
@@ -65,19 +55,10 @@ For more information, see [DROP EXTENSION](https://www.postgresql.org/docs/curre
 
 MySQL Foreign Data Wrapper supports join push-down. It pushes the joins between two foreign tables from the same remote MySQL server to a remote server, thereby enhancing the performance.
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
--   Currently, joins involving only relational and arithmetic operators in join-clauses are pushed down to avoid any potential join failure.
--   Only the INNER and LEFT/RIGHT OUTER joins are supported.
-
-</div>
+!!! Note
+    -   Currently, joins involving only relational and arithmetic operators in join-clauses are pushed down to avoid any potential join failure.
+    -   Only the INNER and LEFT/RIGHT OUTER joins are supported.
 
 See also:
 
-[Example: Join Push-down](#example_join_push_down)
+[Example: Join Push-down](10_example_join_push_down/#example_join_push_down)

--- a/product_docs/docs/mysql_data_adapter/2.5.5/07_configuring_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/07_configuring_the_mysql_data_adapter.mdx
@@ -4,13 +4,12 @@ title: "Configuring the MySQL Foreign Data Wrapper"
 
 <div id="configuring_the_mysql_data_adapter" class="registered_link"></div>
 
-
 Before using the MySQL Foreign Data Wrapper, you must:
 
-> 1.  Use the [CREATE EXTENSION](#create_extension) command to create the MySQL Foreign Data Wrapper extension on the Postgres host.
-> 2.  Use the [CREATE SERVER](#create_server) command to define a connection to the MySQL server.
-> 3.  Use the [CREATE USER MAPPING](#create_user_mapping) command to define a mapping that associates a Postgres role with the server.
-> 4.  Use the [CREATE FOREIGN TABLE](#create_foreign_table) command to define a single table in the Postgres database that corresponds to a table that resides on the MySQL server or use the [IMPORT FOREIGN SCHEMA](#import_foreign_schema) command to import multiple remote tables in the local schema.
+> 1.  Use the [CREATE EXTENSION](#create-extension) command to create the MySQL Foreign Data Wrapper extension on the Postgres host.
+> 2.  Use the [CREATE SERVER](#create-server) command to define a connection to the MySQL server.
+> 3.  Use the [CREATE USER MAPPING](#create-user-mapping) command to define a mapping that associates a Postgres role with the server.
+> 4.  Use the [CREATE FOREIGN TABLE](#create-foreign-table) command to define a single table in the Postgres database that corresponds to a table that resides on the MySQL server or use the [IMPORT FOREIGN SCHEMA](#import-foreign-schema) command to import multiple remote tables in the local schema.
 
 <div id="create_extension" class="registered_link"></div>
 
@@ -18,7 +17,7 @@ Before using the MySQL Foreign Data Wrapper, you must:
 
 Use the `CREATE EXTENSION` command to create the `mysql_fdw` extension. To invoke the command, use your client of choice (for example, psql) to connect to the Postgres database from which you will be querying the MySQL server, and invoke the command:
 
-``` text
+```text
 CREATE EXTENSION [IF NOT EXISTS] mysql_fdw [WITH] [SCHEMA schema_name];
 ```
 
@@ -48,7 +47,7 @@ For more information about using the foreign data wrapper `CREATE EXTENSION` com
 
 Use the `CREATE SERVER` command to define a connection to a foreign server. The syntax is:
 
-``` text
+```text
 CREATE SERVER server_name FOREIGN DATA WRAPPER mysql_fdw
     [OPTIONS (option 'value' [, ...])]
 ```
@@ -69,24 +68,24 @@ The role that defines the server is the owner of the server; use the `ALTER SERV
 
 > Use the `OPTIONS` clause of the `CREATE SERVER` command to specify connection information for the foreign server. You can include:
 
-| Option                | Description                                                                                                                                                                         |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| host                  | The address or hostname of the MySQL server. The default value is `127.0.0.1`.                                                                         |
-| port                  | The port number of the MySQL Server. The default is `3306`.                                                                                            |
-| secure\_auth          | Use to enable or disable secure authentication. The default value is `true`.                                                                           |
-| init\_command         | The SQL statement to execute when connecting to the MySQL server.                                                                                                                   |
-| ssl\_key              | The path name of the client private key file.                                                                                                                                       |
-| ssl\_cert             | The path name of the client public key certificate file.                                                                                                                            |
-| ssl\_ca               | The path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the same certificate used by the server.                                       |
-| ssl\_capath           | The path name of the directory that contains trusted SSL CA certificate files.                                                                                                      |
-| ssl\_cipher           | The list of permissible ciphers for SSL encryption.                                                                                                                                 |
-| use\_remote\_estimate | Include the use\_remote\_estimate to instruct the server to use EXPLAIN commands on the remote server when estimating processing costs. By default, use\_remote\_estimate is false. |
+| Option              | Description                                                                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| host                | The address or hostname of the MySQL server. The default value is `127.0.0.1`.                                                                                                  |
+| port                | The port number of the MySQL Server. The default is `3306`.                                                                                                                     |
+| secure_auth         | Use to enable or disable secure authentication. The default value is `true`.                                                                                                    |
+| init_command        | The SQL statement to execute when connecting to the MySQL server.                                                                                                               |
+| ssl_key             | The path name of the client private key file.                                                                                                                                   |
+| ssl_cert            | The path name of the client public key certificate file.                                                                                                                        |
+| ssl_ca              | The path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the same certificate used by the server.                                   |
+| ssl_capath          | The path name of the directory that contains trusted SSL CA certificate files.                                                                                                  |
+| ssl_cipher          | The list of permissible ciphers for SSL encryption.                                                                                                                             |
+| use_remote_estimate | Include the use_remote_estimate to instruct the server to use EXPLAIN commands on the remote server when estimating processing costs. By default, use_remote_estimate is false. |
 
 **Example**
 
 The following command creates a foreign server named `mysql_server` that uses the `mysql_fdw` foreign data wrapper to connect to a host with an IP address of `127.0.0.1`:
 
-``` text
+```text
 CREATE SERVER mysql_server FOREIGN DATA WRAPPER mysql_fdw OPTIONS (host '127.0.0.1', port '3306');
 ```
 
@@ -102,7 +101,7 @@ For more information about using the `CREATE SERVER` command, see:
 
 Use the `CREATE USER MAPPING` command to define a mapping that associates a Postgres role with a foreign server:
 
-``` text
+```text
 CREATE USER MAPPING FOR role_name SERVER server_name
        [OPTIONS (option 'value' [, ...])];
 ```
@@ -135,7 +134,7 @@ The following command creates a user mapping for a role named `enterprisedb`; th
 
 If the database host uses secure authentication, provide connection credentials when creating the user mapping:
 
-``` text
+```text
 CREATE USER MAPPING FOR public SERVER mysql_server OPTIONS (username 'foo', password 'bar');
 ```
 
@@ -151,7 +150,7 @@ For detailed information about the `CREATE USER MAPPING` command, see:
 
 A foreign table is a pointer to a table that resides on the MySQL host. Before creating a foreign table definition on the Postgres server, connect to the MySQL server and create a table; the columns in the table will map to columns in a table on the Postgres server. Then, use the `CREATE FOREIGN TABLE` command to define a table on the Postgres server with columns that correspond to the table that resides on the MySQL host. The syntax is:
 
-``` text
+```text
 CREATE FOREIGN TABLE [ IF NOT EXISTS ] table_name ( [
   { column_name data_type [ OPTIONS ( option 'value' [, ... ] ) ] [ COLLATE collation ] [ column_constraint [ ... ] ]
     | table_constraint }
@@ -163,14 +162,14 @@ CREATE FOREIGN TABLE [ IF NOT EXISTS ] table_name ( [
 
 where `column_constraint` is:
 
-``` text
+```text
 [ CONSTRAINT constraint_name ]
 { NOT NULL | NULL | CHECK (expr) [ NO INHERIT ] | DEFAULT default_expr }
 ```
 
 and `table_constraint` is:
 
-``` text
+```text
 [ CONSTRAINT constraint_name ] CHECK (expr) [ NO INHERIT ]
 ```
 
@@ -230,17 +229,17 @@ and `table_constraint` is:
 >
 > Use the `OPTIONS` clause to specify the following `options` and their corresponding values:
 
-| option          | value                                                                                    |
-|-----------------|------------------------------------------------------------------------------------------|
-| dbname          | The name of the database on the MySQL server; the database name is required.             |
-| table\_name     | The name of the table on the MySQL server; the default is the name of the foreign table. |
-| max\_blob\_size | The maximum blob size to read without truncation.                                        |
+| option        | value                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| dbname        | The name of the database on the MySQL server; the database name is required.             |
+| table_name    | The name of the table on the MySQL server; the default is the name of the foreign table. |
+| max_blob_size | The maximum blob size to read without truncation.                                        |
 
 **Example**
 
 To use data that is stored on MySQL server, you must create a table on the Postgres host that maps the columns of a MySQL table to the columns of a Postgres table. For example, for a MySQL table with the following definition:
 
-``` text
+```text
 CREATE TABLE warehouse (
  warehouse_id      INT PRIMARY KEY,
  warehouse_name    TEXT,
@@ -249,7 +248,7 @@ CREATE TABLE warehouse (
 
 You should execute a command on the Postgres server that creates a comparable table on the Postgres server:
 
-``` text
+```text
 CREATE FOREIGN TABLE warehouse
 (
  warehouse_id      INT,
@@ -266,17 +265,8 @@ For more information about using the `CREATE FOREIGN TABLE` command, see:
 
 > <https://www.postgresql.org/docs/current/static/sql-createforeigntable.html>
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-MySQL foreign data wrapper supports the write capability feature.
-
-</div>
+!!! Note
+    MySQL foreign data wrapper supports the write capability feature.
 
 <div id="data_type_mappings" class="registered_link"></div>
 
@@ -285,7 +275,7 @@ MySQL foreign data wrapper supports the write capability feature.
 When using the foreign data wrapper, you must create a table on the Postgres server that mirrors the table that resides on the MySQL server. The MySQL data wrapper will automatically convert the following MySQL data types to the target Postgres type:
 
 | **MySQL**   | **Postgres**                 |
-|-------------|------------------------------|
+| ----------- | ---------------------------- |
 | BIGINT      | BIGINT/INT8                  |
 | BOOLEAN     | SMALLINT                     |
 | BLOB        | BYTEA                        |
@@ -299,21 +289,12 @@ When using the foreign data wrapper, you must create a table on the Postgres ser
 | TIMESTAMP   | TIMESTAMP                    |
 | VARCHAR()   | VARCHAR()/CHARCTER VARYING() |
 
-<div class="note">
+!!! Note
+    For `ENUM` data type:
 
-<div class="title">
+    MySQL accepts `enum` value in string form. You must create exactly same `enum` listing on Advanced Server as that is present on MySQL server. Any sort of inconsistency will result in an error while fetching rows with values not known on the local server.
 
-Note
-
-</div>
-
-For `ENUM` data type:
-
-MySQL accepts `enum` value in string form. You must create exactly same `enum` listing on Advanced Server as that is present on MySQL server. Any sort of inconsistency will result in an error while fetching rows with values not known on the local server.
-
-Also, when the given `enum` value is not present at MySQL side but present at Postgres/Advanced Server side, an empty string (`''`) is inserted as a value at MySQL side for the `enum` column. To select from such a table having enum value as `''`, create an `enum` type at Postgres side with all valid values and `''`.
-
-</div>
+    Also, when the given `enum` value is not present at MySQL side but present at Postgres/Advanced Server side, an empty string (`''`) is inserted as a value at MySQL side for the `enum` column. To select from such a table having enum value as `''`, create an `enum` type at Postgres side with all valid values and `''`.
 
 <div id="import_foreign_schema" class="registered_link"></div>
 
@@ -321,7 +302,7 @@ Also, when the given `enum` value is not present at MySQL side but present at Po
 
 Use the `IMPORT FOREIGN SCHEMA` command to import table definitions on the Postgres server from the MySQL server. The new foreign tables are created with the same column definitions as that of remote tables in the existing local schema. The syntax is:
 
-``` text
+```text
 IMPORT FOREIGN SCHEMA remote_schema
     [ { LIMIT TO | EXCEPT } ( table_name [, ...] ) ]
     FROM SERVER server_name
@@ -361,16 +342,16 @@ IMPORT FOREIGN SCHEMA remote_schema
 > >
 > > </div>
 > >
-> > | **Option**        | **Description**                                                                                                                                                                                                   |
-> > |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | import\_default   | Controls whether column `DEFAULT` expressions are included in the definitions of foreign tables imported from a foreign server. The default is `false`. |
-> > | import\_not\_null | Controls whether column `NOT NULL` constraints are included in the definitions of foreign tables imported from a foreign server. The default is `true`. |
+> > | **Option**      | **Description**                                                                                                                                         |
+> > | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+> > | import_default  | Controls whether column `DEFAULT` expressions are included in the definitions of foreign tables imported from a foreign server. The default is `false`. |
+> > | import_not_null | Controls whether column `NOT NULL` constraints are included in the definitions of foreign tables imported from a foreign server. The default is `true`. |
 
 **Example**
 
 For a MySQL table created in the `edb` database with the following definition:
 
-``` text
+```text
 CREATE TABLE color(cid INT PRIMARY KEY, cname TEXT);
 INSERT INTO color VALUES (1, 'Red');
 INSERT INTO color VALUES (2, 'Green');
@@ -383,7 +364,7 @@ INSERT INTO fruit VALUES (2, 'Mango');
 
 You should execute a command on the Postgres server that imports a comparable table on the Postgres server:
 
-``` text
+```text
 IMPORT FOREIGN SCHEMA edb FROM SERVER mysql_server INTO public;
 
 SELECT * FROM color;
@@ -414,7 +395,7 @@ For more information about using the `IMPORT FOREIGN SCHEMA` command, see:
 
 Use the `DROP EXTENSION` command to remove an extension. To invoke the command, use your client of choice (for example, psql) to connect to the Postgres database from which you will be dropping the MySQL server, and run the command:
 
-``` text
+```text
 DROP EXTENSION [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ];
 ```
 
@@ -450,7 +431,7 @@ For more information about using the foreign data wrapper `DROP EXTENSION` comma
 
 Use the `DROP SERVER` command to remove a connection to a foreign server. The syntax is:
 
-``` text
+```text
 DROP SERVER [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 ```
 
@@ -488,7 +469,7 @@ For more information about using the `DROP SERVER` command, see:
 
 Use the `DROP USER MAPPING` command to remove a mapping that associates a Postgres role with a foreign server. You must be the owner of the foreign server to remove a user mapping for that server.
 
-``` text
+```text
 DROP USER MAPPING [ IF EXISTS ] FOR { user_name | USER | CURRENT_USER | PUBLIC } SERVER server_name;
 ```
 
@@ -520,7 +501,7 @@ For detailed information about the `DROP USER MAPPING` command, see:
 
 A foreign table is a pointer to a table that resides on the MySQL host. Use the `DROP FOREIGN TABLE` command to remove a foreign table. Only the owner of the foreign table can drop it.
 
-``` text
+```text
 DROP FOREIGN TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 ```
 
@@ -544,7 +525,7 @@ DROP FOREIGN TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 
 **Example**
 
-``` text
+```text
 DROP FOREIGN TABLE warehouse;
 ```
 

--- a/product_docs/docs/mysql_data_adapter/2.5.5/08_example_using_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/08_example_using_the_mysql_data_adapter.mdx
@@ -4,10 +4,9 @@ title: "Example: Using the MySQL Foreign Data Wrapper"
 
 <div id="example_using_the_mysql_data_adapter" class="registered_link"></div>
 
-
 Access data from Advanced Server and connect to psql. Once you are connected to psql, follow the below steps:
 
-``` text
+```text
 -- load extension first time after install
 CREATE EXTENSION mysql_fdw;
 

--- a/product_docs/docs/mysql_data_adapter/2.5.5/09_example_import_foreign_schema.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/09_example_import_foreign_schema.mdx
@@ -4,10 +4,9 @@ title: "Example: Import Foreign Schema"
 
 <div id="example_import_foreign_schema" class="registered_link"></div>
 
-
 Access data from Advanced Server and connect to psql. Once you are connected to psql, follow the below steps:
 
-``` text
+```text
 -- load extension first time after install
 CREATE EXTENSION mysql_fdw;
 

--- a/product_docs/docs/mysql_data_adapter/2.5.5/10_example_join_push_down.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/10_example_join_push_down.mdx
@@ -4,12 +4,11 @@ title: "Example: Join Push-down"
 
 <div id="example_join_push_down" class="registered_link"></div>
 
-
 The following example shows join push-down between a table on MySQL server and Postgres server:
 
 Table on MySQL server:
 
-``` text
+```text
 CREATE TABLE warehouse
 (
 warehouse_id      INT PRIMARY KEY,
@@ -26,7 +25,7 @@ qty           INT
 
 Table on Postgres server:
 
-``` text
+```text
 CREATE EXTENSION mysql_fdw;
 CREATE SERVER mysql_server FOREIGN DATA WRAPPER mysql_fdw OPTIONS (host '127.0.0.1', port '3306');
 CREATE USER MAPPING FOR public SERVER mysql_server OPTIONS (username 'edb', password 'edb');
@@ -55,7 +54,7 @@ INSERT INTO sales_records values (3, 200);
 
 The output:
 
-``` text
+```text
 --inner join
 edb=# EXPLAIN VERBOSE SELECT t1.warehouse_name, t2.qty FROM warehouse t1 INNER JOIN sales_records t2 ON (t1.warehouse_id = t2.warehouse_id);
                                                                              QUERY PLAN

--- a/product_docs/docs/mysql_data_adapter/2.5.5/11_identifying_data_adapter_version.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/11_identifying_data_adapter_version.mdx
@@ -4,16 +4,15 @@ title: "Identifying the MySQL Foreign Data Wrapper Version"
 
 <div id="identifying_data_adapter_version" class="registered_link"></div>
 
-
 The MySQL Foreign Data Wrapper includes a function that you can use to identify the currently installed version of the `.so` file for the data wrapper. To use the function, connect to the Postgres server, and enter:
 
-``` text
+```text
 SELECT mysql_fdw_version();
 ```
 
 The function returns the version number:
 
-``` text
+```text
 mysql_fdw_version
 -----------------
 <xxxxx>

--- a/product_docs/docs/mysql_data_adapter/2.5.5/12_uninstalling_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/12_uninstalling_the_mysql_data_adapter.mdx
@@ -4,7 +4,6 @@ title: "Uninstalling the MySQL Foreign Data Wrapper"
 
 <div id="uninstalling_the_mysql_data_adapter" class="registered_link"></div>
 
-
 **Uninstalling an RPM Package**
 
 You can use the `yum remove` or `dnf remove` command to remove a package installed by `yum` or `dnf`. To remove a package, open a terminal window, assume superuser privileges, and enter the command:

--- a/product_docs/docs/mysql_data_adapter/2.5.5/13_troubleshooting.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/13_troubleshooting.mdx
@@ -2,13 +2,11 @@
 title: "Troubleshooting"
 ---
 
+In case you are experiencing issues with using MySQL 8 and MySQL_FDW, below is a list of solutions to some frequently seen issues:
 
+**Authentication plugin ‘caching_sha2_password’ Error**
 
-In case you are experiencing issues with using MySQL 8 and MySQL\_FDW, below is a list of solutions to some frequently seen issues:
-
-**Authentication plugin ‘caching\_sha2\_password’ Error**
-
-``` text
+```text
 ERROR:  failed to connect to MySQL: Authentication plugin ‘caching_sha2_password’ cannot be loaded: /usr/lib64/mysql/plugin/caching_sha2_password.so: cannot open shared  object file: No such file or directory
 ```
 
@@ -16,14 +14,5 @@ Specify the authentication plugin as `mysql_native_password` and set a cleartext
 
 > `ALTER USER 'username'@'host' IDENTIFIED WITH mysql_native_password BY '<password>';`
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-Refer to [MySQL 8 documentation](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html) for more details on the above error.
-
-</div>
+!!! Note
+    Refer to [MySQL 8 documentation](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html) for more details on the above error.

--- a/product_docs/docs/mysql_data_adapter/2.5.5/index.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/index.mdx
@@ -2,8 +2,6 @@
 title: "MySQL Foreign Data Wrapper Guide"
 ---
 
-
-
 The MySQL Foreign Data Wrapper (`mysql_fdw`) is a Postgres extension that allows you to access data that resides on a MySQL database from EDB Postgres Advanced Server. It is a writable foreign data wrapper that you can use with Postgres functions and utilities, or in conjunction with other data that resides on a Postgres host.
 
 The MySQL Foreign Data Wrapper can be installed with an RPM package. You can download an installer from the [EDB website](https://www.enterprisedb.com/software-downloads-postgres/).
@@ -12,6 +10,6 @@ This guide uses the term `Postgres` to refer to an instance of EDB Postgres Adva
 
 <div class="toctree" maxdepth="4">
 
-whats\_new requirements\_overview architecture\_overview installing\_the\_mysql\_data\_adapter updating\_the\_mysql\_data\_adapter features\_of\_mysql\_fdw configuring\_the\_mysql\_data\_adapter example\_using\_the\_mysql\_data\_adapter example\_import\_foreign\_schema example\_join\_push\_down identifying\_data\_adapter\_version uninstalling\_the\_mysql\_data\_adapter troubleshooting conclusion
+whats_new requirements_overview architecture_overview installing_the_mysql_data_adapter updating_the_mysql_data_adapter features_of_mysql_fdw configuring_the_mysql_data_adapter example_using_the_mysql_data_adapter example_import_foreign_schema example_join_push_down identifying_data_adapter_version uninstalling_the_mysql_data_adapter troubleshooting conclusion
 
 </div>


### PR DESCRIPTION
## What Changed?

Standard normalization script stuff:

- HTML -> Admonitions
- Whitespace & formatting standardization
- Rewrite & correct relative links

...The results of running:

```shell
node scripts/normalize/markdown.js "product_docs/docs/*_data_adapter/**/*.mdx"
```

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
