### PR TITLE
DB-980 Add details for incorrect usage of SQL expressions in date mas…

### DIFF
--- a/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
@@ -118,9 +118,9 @@ LOAD DATA
   [ WHEN <field_condition> [ AND <field_condition> ] ...]
   [ FIELDS TERMINATED BY '<termstring>'
     [ OPTIONALLY ENCLOSED BY '<enclstring>' ] ]
-[ RECORDS DELIMITED BY '<delimstring>' ]
-[ TRAILING NULLCOLS ]
-  (<field_def> [, <field_def> ] ...)
+  [ RECORDS DELIMITED BY '<delimstring>' ]
+  [ TRAILING NULLCOLS ]
+   (<field_def> [, <field_def> ] ...)
 } ...
 ```
 
@@ -140,9 +140,9 @@ where `field_def` defines a field in the specified `data_file` that describes th
 where `fieldtype` is one of:
 
 ```text
-CHAR [(<length>)] | DATE [(<length>)] [ "<datemask>" ] |
+CHAR [(<length>)] | DATE [(<length>)] | TIMESTAMP [(<length>)] [ "<datemask>" ] |
 INTEGER EXTERNAL [(<length>)] |
-FLOAT EXTERNAL [(<length>)] | DECIMAL EXTERNAL [(length)] |
+FLOAT EXTERNAL [(<length>)] | DECIMAL EXTERNAL [(<length>)] |
 ZONED EXTERNAL [(<length>)] | ZONED [(<precision> [,<scale>])]
 ```
 
@@ -334,7 +334,7 @@ If the `FIELDS TERMINATED BY` clause is specified, then the `POSITION (start:end
  Conditional clause taking the following form:
 
 ```
-[ ( ] { (start:end) | column_name } { = | != | <> }` `'val' [ ) ]
+[ ( ] { (start:end) | column_name } { = | != | <> } 'val' [ ) ]
 ```
 
  This conditional clause is used for the `WHEN` clause, which is part of the `INTO TABLE target_table` clause, and the `NULLIF` clause, which is part of the field definition denoted as `field_def` in the syntax diagram.
@@ -375,7 +375,7 @@ If the `FIELDS TERMINATED BY` clause is specified, then the `POSITION (start:end
 
 `column_name`
 
- Name of a column in `target_table` into which a field value defined by `field_def` is to be inserted. If the field definition includes the `FILLER` or `BOUNDFILLER` clause, then `column_name` is not required t be the name of a column in the table. It can be any identifier name since the `FILLER` and `BOUNDFILLER` clauses prevent the loading of the field data into a table column.
+ Name of a column in `target_table` into which a field value defined by `field_def` is to be inserted. If the field definition includes the `FILLER` or `BOUNDFILLER` clause, then `column_name` is not required to be the name of a column in the table. It can be any identifier name since the `FILLER` and `BOUNDFILLER` clauses prevent the loading of the field data into a table column.
 
 `CONSTANT val`
 
@@ -402,7 +402,7 @@ If the `FIELDS TERMINATED BY` clause is specified, then the `POSITION (start:end
  Defines the location of the field in a record in a fixed-width field data file. `start` and `end` are positive integers. The first character in the record has a start value of `1`.
 
 ```
-CHAR [(<length>)] | DATE [(<length>)] [ "<datemask>" ] |
+CHAR [(<length>)] | DATE [(<length>)] | TIMESTAMP [(<length>)] [ "<datemask>" ] |
 
 INTEGER EXTERNAL [(<length>)] |
 
@@ -441,7 +441,19 @@ ZONED EXTERNAL [(<length>)] | ZONED [(<precision>[,<scale>])]
 
  Specifies the ordering and abbreviation of the day, month, and year components of a date field.
 
- **Note**: If the `DATE` field type is specified along with a SQL expression for the column, then `datemask` must be specified after `DATE` and before the SQL expression. See the following discussion of the `expr` parameter.
+ **Note**: If the `DATE` or `TIMESTAMP` field type is specified along with a SQL expression for the column, then `datemask` must be specified after `DATE` or `TIMESTAMP` and before the SQL expression. See the following discussion of the `expr` parameter.
+
+ When using the `TIMESTAMP` field datatype, if you specify `time_stamp timestamp "yyyymmddhh24miss"` the `datemask` is converted to the SQL expression. However, in case of `time_stamp timestamp "select to_timestamp(:time_stamp, 'yyyymmddhh24miss')"`, the EDB*Loader cannot differentiate between datemask and the SQL expression. It treats the third field (SQL expression in the example) as datemask and prepares the SQL expression, which will not be valid. Where:
+
+-  `first field` specifies the column name
+-  `second field` specifies the datatype
+-  `third field` specifies the datemask
+
+If you want to provide an SQL expression, then the simple workaround is to specify the datemask and SQL expression using the `TO_CHAR` function as:
+
+```text
+time_stamp timestamp "yyyymmddhh24miss" "to_char(to_timestamp(:time_stamp, 'yyyymmddhh24miss'), 'yyyymmddhh24miss')"
+```
 
 `NULLIF field_condition [ AND field_condition ] ...`
 
@@ -466,7 +478,7 @@ ZONED EXTERNAL [(<length>)] | ZONED [(<precision>[,<scale>])]
     The following is the syntax for use of the `SELECT` statement:
 
     ```
-    "(SELECT expr [ FROM table_list [ WHERE condition ] ])"
+    "(SELECT <expr> [ FROM <table_list> [ WHERE <condition> ] ])"
     ```
 
     !!! Note
@@ -591,9 +603,9 @@ LOAD DATA
 The following is the corresponding data file. The content is a single, physical record in the data file. The record delimiter character is included following the last record (that is, at the end of the file).
 
 ```text
-9101,ROGERS,CLERK,7902,17-DEC-10,1980.00,20,;9102,PETERSON,SALESMAN,7698,20-
-DEC-10,2600.00,30,2300.00;9103,WARREN,SALESMAN,7698,22-DEC-
-10,5250.00,30,2500.00;9104,"JONES, JR.",MANAGER,7839,02-APR-09,7975.00,20,;
+9101,ROGERS,CLERK,7902,17-DEC-10,1980.00,20,;9102,PETERSON,SALESMAN,7698,20-DEC-10,
+2600.00,30,2300.00;9103,WARREN,SALESMAN,7698,22-DEC-10,5250.00,30,2500.00;9104,"JONES, 
+JR.",MANAGER,7839,02-APR-09,7975.00,20,;
 ```
 
 **FILLER Clause**
@@ -818,8 +830,7 @@ LOAD DATA
   (
     empno       POSITION (1:4),
     ename       POSITION (5:14),
-    job         POSITION (15:23) "(SELECT dname FROM dept WHERE deptno =
-    :deptno)",
+    job         POSITION (15:23) "(SELECT dname FROM dept WHERE deptno = :deptno)",
     mgr         POSITION (24:27),
     hiredate    POSITION (28:38),
     sal         POSITION (39:46),
@@ -941,27 +952,18 @@ The following are the rows loaded into the `emp_research` and `emp_sales` tables
 ```text
 SELECT * FROM emp_research;
 
-empno  |   ename    |   job   |  mgr |      hiredate      |   sal   | comm |
-deptno
--------+------------+---------+------+--------------------+---------+------+-
-------
- 9101  | ROGERS     | CLERK   | 7902 | 17-DEC-10 00:00:00 | 1980.00 |      |
- 20.00
- 9104  | JONES, JR. | MANAGER | 7839 | 02-APR-09 00:00:00 | 7975.00 |      |
- 20.00
+empno  |   ename    |   job   |  mgr |      hiredate      |   sal   | comm | deptno
+-------+------------+---------+------+--------------------+---------+------+-------
+ 9101  | ROGERS     | CLERK   | 7902 | 17-DEC-10 00:00:00 | 1980.00 |      | 20.00
+ 9104  | JONES, JR. | MANAGER | 7839 | 02-APR-09 00:00:00 | 7975.00 |      | 20.00
 (2 rows)
-
 
 SELECT * FROM emp_sales;
 
-empno  |   ename  |    job   |  mgr |       hiredate     |    sal  |   comm
-| deptno
--------+----------+----------+------+--------------------+---------+---------
-+--------
- 9102  | PETERSON | SALESMAN | 7698 | 20-DEC-10 00:00:00 | 2600.00 | 2950.00
- | 30.00
- 9103  | WARREN   | SALESMAN | 7698 | 22-DEC-10 00:00:00 | 5250.00 | 3813.00
- | 30.00
+empno  |   ename  |    job   |  mgr |       hiredate     |    sal  |   comm  | deptno
+-------+----------+----------+------+--------------------+---------+---------+--------
+ 9102  | PETERSON | SALESMAN | 7698 | 20-DEC-10 00:00:00 | 2600.00 | 2950.00 | 30.00
+ 9103  | WARREN   | SALESMAN | 7698 | 22-DEC-10 00:00:00 | 5250.00 | 3813.00 | 30.00
 (2 rows)
 ```
 
@@ -1150,7 +1152,7 @@ In the following example EDB\*Loader is invoked using a control file named `emp.
 ```text
 $ /usr/edb/as13/bin/edbldr -d edb USERID=enterprisedb/password
 CONTROL=emp.ctl
-EDB*Loader: Copyright (c) 2007-2020, EnterpriseDB Corporation.
+EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 
 Successfully loaded (4) records
 ```
@@ -1162,7 +1164,7 @@ $ /usr/edb/as13/bin/edbldr -d edb CONTROL=emp.ctl BAD=/tmp/emp.bad
 LOG=/tmp/emp.log
 Enter the user name : enterprisedb
 Enter the password :
-EDB*Loader: Copyright (c) 2007-2020, EnterpriseDB Corporation.
+EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 
 Successfully loaded (4) records
 ```
@@ -1183,7 +1185,7 @@ EDB\*Loader is invoked with the parameter file as shown by the following:
 $ /usr/edb/as13/bin/edbldr -d edb PARFILE=emp.par
 Enter the user name : enterprisedb
 Enter the password :
-EDB*Loader: Copyright (c) 2007-2020, EnterpriseDB Corporation.
+EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 
 Successfully loaded (3) records
 ```
@@ -1193,7 +1195,7 @@ In the following example EDB\*Loader is invoked using a `connstr=` option using 
 ```text
 $ /usr/edb/as13/bin/edbldr connstr=\"sslmode=verify-ca sslcompression=0
 host=127.0.0.1 dbname=edb port=5444 user=enterprisedb\" CONTROL=emp.ctl
-EDB*Loader: Copyright (c) 2007-2020, EnterpriseDB Corporation.
+EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 
 Successfully loaded (4) records
 ```
@@ -1244,7 +1246,7 @@ To run a direct path load, add the `DIRECT=TRUE` option as shown by the followin
 ```text
 $ /usr/edb/as13/bin/edbldr -d edb USERID=enterprisedb/password
 CONTROL=emp.ctl DIRECT=TRUE
-EDB*Loader: Copyright (c) 2007-2020, EnterpriseDB Corporation.
+EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 
 Successfully loaded (4) records
 ```
@@ -1323,7 +1325,7 @@ The following shows the invocation of EDB\*Loader in the first session. The `DIR
 $ /usr/edb/as13/bin/edbldr -d edb USERID=enterprisedb/password
 CONTROL=emp_parallel_1.ctl DIRECT=TRUE PARALLEL=TRUE
 WARNING: index maintenance will be skipped with PARALLEL load
-EDB*Loader: Copyright (c) 2007-2020, EnterpriseDB Corporation.
+EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 ```
 
 The control file used for the second session appears as follows. Note that it is the same as the one used in the first session, but uses a different data file.
@@ -1353,7 +1355,7 @@ The preceding control file is used in a second session as shown by the following
 $ /usr/edb/as13/bin/edbldr -d edb USERID=enterprisedb/password
 CONTROL=emp_parallel_2.ctl DIRECT=TRUE PARALLEL=TRUE
 WARNING: index maintenance will be skipped with PARALLEL load
-EDB*Loader: Copyright (c) 2007-2020, EnterpriseDB Corporation.
+EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 ```
 
 EDB\*Loader displays the following message in each session when its respective load operation completes:

--- a/product_docs/docs/epas/13/epas_compat_tools_guide/03_edb_wrap.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/03_edb_wrap.mdx
@@ -27,7 +27,7 @@ The entire source file is wrapped into one unit. Any `psql` meta-commands includ
 EDB\*Wrap is a command line utility; it accepts a single input source file, obfuscates the contents and returns a single output file. When you invoke the `edbwrap` utility, you must provide the name of the file that contains the source code to obfuscate. You may also specify the name of the file where `edbwrap` will write the obfuscated form of the code. `edbwrap` offers three different command-line styles. The first style is compatible with Oracle's `wrap` utility:
 
 ```text
-edbwrap iname=<input_file> [oname= <output_file>]
+edbwrap iname=<input_file> [oname=<output_file>]
 ```
 
 The `iname=input_file` argument specifies the name of the input file; if `input_file` does not contain an extension, `edbwrap` will search for a file named `input_file.sql`
@@ -72,7 +72,7 @@ BEGIN                                               
      LOOP                                            
          FETCH emp_cur INTO v_empno, v_ename;        
          EXIT WHEN emp_cur%NOTFOUND;                 
-         DBMS_OUTPUT.PUT_LINE(v_empno \|\| '     ' \|\| v_ename);
+         DBMS_OUTPUT.PUT_LINE(v_empno || '     ' || v_ename);
      END LOOP;                                               
      CLOSE emp_cur;                                          
 END;                                                        
@@ -85,10 +85,10 @@ You can import the `list_emp` procedure with a client application such as `edb-p
 [bash] edb-psql edb
 Welcome to edb-psql 8.4.3.2, the EnterpriseDB interactive terminal.
 Type:  \copyright for distribution terms
-        \h for help with SQL commands    
-        \? for help with edb-psql commands
-        \g or terminate with semicolon to execute query
-        \q to quit                                     
+       \h for help with SQL commands    
+       \? for help with edb-psql commands
+       \g or terminate with semicolon to execute query
+       \q to quit                                     
 edb=# \i listemp.sql
 CREATE PROCEDURE
 ```
@@ -111,7 +111,7 @@ edb=# SELECT prosrc FROM pg_proc WHERE proname = 'list_emp';
       LOOP                                                     
           FETCH emp_cur INTO v_empno, v_ename;                 
           EXIT WHEN emp_cur%NOTFOUND;                          
-          DBMS_OUTPUT.PUT_LINE(v_empno \|\| '     ' \|\| v_ename); 
+          DBMS_OUTPUT.PUT_LINE(v_empno || '     ' || v_ename); 
       END LOOP;                                                
       CLOSE emp_cur;                                           
   END                                                          
@@ -126,7 +126,7 @@ Next, obfuscate the plaintext file with EDB\*Wrap:
 [bash] edbwrap -i listemp.sql                                        
 EDB*Wrap Utility: Release 8.4.3.2
 
-Copyright (c) 2004-2020 EnterpriseDB Corporation.  All Rights Reserved.
+Copyright (c) 2004-2021 EnterpriseDB Corporation.  All Rights Reserved.
 
 Using encoding UTF8 for input
 Processing listemp.sql to listemp.plb
@@ -154,10 +154,10 @@ You can import the obfuscated code into the PostgreSQL server using the same too
 [bash] edb-psql edb
 Welcome to edb-psql 8.4.3.2, the EnterpriseDB interactive terminal.
 Type:  \copyright for distribution terms
-        \h for help with SQL commands
-        \? for help with edb-psql commands
-        \g or terminate with semicolon to execute query
-        \q to quit
+       \h for help with SQL commands
+       \? for help with edb-psql commands
+       \g or terminate with semicolon to execute query
+       \q to quit
 
 edb=# \i listemp.plb
 CREATE PROCEDURE

--- a/product_docs/docs/epas/13/epas_compat_tools_guide/04_dynamic_runtime_instrumentation_tools_architecture_DRITA.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/04_dynamic_runtime_instrumentation_tools_architecture_DRITA.mdx
@@ -124,7 +124,7 @@ SELECT * FROM sys_rpt(9, 10, 10);
                                   sys_rpt
 -----------------------------------------------------------------------------
 WAIT NAME                    COUNT     WAIT TIME                     % WAIT
----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 wal flush                    8359      1.357593                      30.62
 wal write                    8358      1.349153                      30.43
 wal file sync                8358      1.286437                      29.02
@@ -176,28 +176,17 @@ The following example demonstrates a call to the `sess_rpt()` function:
 SELECT * FROM sess_rpt(8, 9, 10);
 
                                      sess_rpt
------------------------------------------------------------------------------
---------
-ID    USER       WAIT NAME                 COUNT TIME           % WAIT SES %
-WAIT ALL
------------------------------------------------------------------------------
---------
-3501 enterprise  wal flush                 8354  1.354958      30.61
-30.61
-3501 enterprise  wal write                 8354  1.348192      30.46
-30.46
-3501 enterprise  wal file sync             8354  1.285607      29.04
-29.04
-3501 enterprise  query plan                33413 0.436901      9.87
-9.87
-3501 enterprise  db file extend            54    0.000578      0.01
-0.01
-3501 enterprise  db file read              56    0.000541      0.01
-0.01
-3501 enterprise  ProcArrayLock             0     0.000000      0.00
-0.00
-3501 enterprise  CLogControlLock           0     0.000000      0.00
-0.00
+-------------------------------------------------------------------------------------
+ID    USER       WAIT NAME                 COUNT TIME           % WAIT SES % WAIT ALL
+-------------------------------------------------------------------------------------
+3501 enterprise  wal flush                 8354  1.354958      30.61      30.61
+3501 enterprise  wal write                 8354  1.348192      30.46      30.46
+3501 enterprise  wal file sync             8354  1.285607      29.04      29.04
+3501 enterprise  query plan                33413 0.436901      9.87       9.87
+3501 enterprise  db file extend            54    0.000578      0.01       0.01
+3501 enterprise  db file read              56    0.000541      0.01       0.01
+3501 enterprise  ProcArrayLock             0     0.000000      0.00       0.00
+3501 enterprise  CLogControlLock           0     0.000000      0.00       0.00
 (10 rows)
 ```
 
@@ -243,28 +232,17 @@ The following code sample demonstrates a call to `sessid_rpt()`:
 SELECT * FROM sessid_rpt(8, 9, 3501);
 
                                      sessid_rpt
------------------------------------------------------------------------------
---------
-ID    USER       WAIT NAME                 COUNT  TIME          % WAIT SES %
-WAIT ALL
------------------------------------------------------------------------------
---------
-3501 enterprise CLogControlLock           0      0.000000      0.00
-0.00
-3501 enterprise ProcArrayLock             0      0.000000      0.00
-0.00
-3501 enterprise db file read              56     0.000541      0.01
-0.01
-3501 enterprise db file extend            54     0.000578      0.01
-0.01
-3501 enterprise query plan                33413  0.436901      9.87
-9.87
-3501 enterprise wal file sync             8354   1.285607      29.04
-29.04
-3501 enterprise wal write                 8354   1.348192      30.46
-30.46
-3501 enterprise wal flush                 8354   1.354958      30.61
-30.61
+-------------------------------------------------------------------------------------
+ID    USER       WAIT NAME                 COUNT  TIME          % WAIT SES % WAIT ALL
+-------------------------------------------------------------------------------------
+3501 enterprise CLogControlLock           0      0.000000      0.00       0.00
+3501 enterprise ProcArrayLock             0      0.000000      0.00       0.00
+3501 enterprise db file read              56     0.000541      0.01       0.01
+3501 enterprise db file extend            54     0.000578      0.01       0.01
+3501 enterprise query plan                33413  0.436901      9.87       9.87
+3501 enterprise wal file sync             8354   1.285607      29.04      29.04
+3501 enterprise wal write                 8354   1.348192      30.46      30.46
+3501 enterprise wal flush                 8354   1.354958      30.61      30.61
 (10 rows)
 ```
 
@@ -581,11 +559,9 @@ The call to the `edbreport()` function returns a composite report that contains 
 ```text
 SELECT * FROM edbreport(9, 10);
                                    edbreport
------------------------------------------------------------------------------
----------
+--------------------------------------------------------------------------------------
     EnterpriseDB Report for database acctg             25-JUL-18
- Version: PostgreSQL 13.0 (EnterpriseDB Advanced Server 13.0.0)on x86_64-pc-
- linux-gnu,
+ Version: PostgreSQL 13.0 (EnterpriseDB Advanced Server 13.0.0)on x86_64-pc-linux-gnu,
 compiled by gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18), 64-bit
 
     Begin snapshot: 9 at 25-JUL-18 09:49:44.788392
@@ -596,14 +572,14 @@ Size of database acctg is 173 MB
      Tablespace: pg_default Size: 231 MB Owner: enterprisedb
      Tablespace: pg_global Size: 719 kB Owner: enterprisedb
 
-Schema: pg_toast_temp_1 Size: 0 bytes Owner: enterprisedb
-Schema: public Size: 158 MB Owner: enterprisedb
+Schema: pg_toast_temp_1     Size: 0 bytes       Owner: enterprisedb
+Schema: public              Size: 158 MB        Owner: enterprisedb
 ```
 
 The information displayed in the report introduction includes the database name and version, the current date, the beginning and ending snapshot date and times, database and tablespace details and schema information.
 
 ```text
-Top 10 Relations by pages
+                Top 10 Relations by pages
 
 TABLE                                        RELPAGES
 -----------------------------------------------------
@@ -627,7 +603,7 @@ The information displayed in the `Top 10 Relations by pages` section includes:
 | `RELPAGES`  | The number of pages in the table. |
 
 ```text
-Top 10 Indexes by pages
+              Top 10 Indexes by pages
 
 INDEX                                        RELPAGES
 -----------------------------------------------------
@@ -640,8 +616,7 @@ pg_description_o_c_o_index                   24
 pg_attribute_relid_attnum_index              17
 pg_proc_oid_index                            14
 pg_collation_name_enc_nsp_index              12
-edb$stat_idx_pk
-10
+edb$stat_idx_pk                              10
 ```
 
 The information displayed in the `Top 10 Indexes by pages` section includes:
@@ -652,7 +627,7 @@ The information displayed in the `Top 10 Indexes by pages` section includes:
 | `RELPAGES`  | The number of pages in the index. |
 
 ```text
-Top 10 Relations by DML
+                      Top 10 Relations by DML
 
 SCHEMA        RELATION                        UPDATES     DELETES    INSERTS
 ----------------------------------------------------------------------------
@@ -673,14 +648,11 @@ The information displayed in the `Top 10 Relations by DML` section includes:
 | `INSERTS`   | The number of INSERTS performed on the table.      |
 
 ```text
-DATA from pg_stat_database
+       DATA from pg_stat_database
 
-DATABASE    NUMBACKENDS  XACT COMMIT   XACT ROLLBACK   BLKS READ  BLKS HIT
-HIT RATIO
------------------------------------------------------------------------------
---------
-acctg       0            8261          0               117        127985
-99.91
+DATABASE    NUMBACKENDS  XACT COMMIT   XACT ROLLBACK   BLKS READ  BLKS HIT  HIT RATIO
+-------------------------------------------------------------------------------------
+acctg       0            8261          0               117        127985    99.91
 ```
 
 The information displayed in the DATA from `pg_stat_database` section of the report includes:
@@ -696,7 +668,7 @@ The information displayed in the DATA from `pg_stat_database` section of the rep
 | `HIT RATIO`     | The percentage of times that a block was found in the shared buffer cache.                                                                                                                                         |
 
 ```text
-DATA from pg_buffercache
+      DATA from pg_buffercache
 
 RELATION                            BUFFERS
 -------------------------------------------
@@ -727,43 +699,31 @@ For more information on the `CREATE EXTENSION` command, see the PostgreSQL Core 
 <https://www.postgresql.org/docs/current/static/sql-createextension.html>
 
 ```text
-DATA from pg_stat_all_tables ordered by seq scan
+       DATA from pg_stat_all_tables ordered by seq scan
 
-SCHEMA                RELATION                     SEQ SCAN    REL TUP READ
-IDX SCAN
+ SCHEMA                RELATION                      SEQ SCAN    REL TUP READ  IDX SCAN
 IDX TUP READ INS   UPD     DEL
------------------------------------------------------------------------------
---------
+-----------------------------------------------------------------------------------------------
 ----------------------------------
-public                pgbench_branches              8258        82580
-0
+ public                pgbench_branches              8258        82580        0
 0             0     8258    0
-public                pgbench_tellers               8258        825800
-0
+ public                pgbench_tellers               8258        825800       0
 0             0     8258    0
-pg_catalog            pg_class                      7           3969
-92
+ pg_catalog            pg_class                      7           3969         92
 80            0     0       0
-pg_catalog            pg_index                      5           950
-31
+ pg_catalog            pg_index                      5           950          31
 38            0     0       0
-pg_catalog            pg_namespace                  4           144
-5
+ pg_catalog            pg_namespace                  4           144          5
 4             0     0       0
-pg_catalog            pg_database                   2           12
-7
+ pg_catalog            pg_database                   2           12           7
 7             0     0       0
-pg_catalog            pg_am                         1           1
-0
+ pg_catalog            pg_am                         1           1            0
 0             0     0       0
-pg_catalog            pg_authid                     1           10
-2
+ pg_catalog            pg_authid                     1           10           2
 2             0     0       0
-sys                   callback_queue_table          0           0
-0
+ sys                   callback_queue_table          0           0            0
 0             0     0       0
-sys                   edb$session_wait_history      0           0
-0
+ sys                   edb$session_wait_history      0           0            0
 0             125   0       0
 ```
 
@@ -782,31 +742,31 @@ The information displayed in the `DATA from pg_stat_all_tables ordered by seq sc
 | `DEL`          | The number of rows deleted.                             |
 
 ```text
-DATA from pg_stat_all_tables ordered by rel tup read
+      DATA from pg_stat_all_tables ordered by rel tup read
 
-SCHEMA             RELATION                 SEQ SCAN  REL TUP READ IDX SCAN
+ SCHEMA             RELATION                 SEQ SCAN  REL TUP READ IDX SCAN
 IDX TUP READ INS  UPD    DEL
 ---------------------------------------------------------------------------
 --------------------------------------------
-public             pgbench_tellers          8258      825800       0
+ public             pgbench_tellers          8258      825800       0
 0            0    8258   0
-public             pgbench_branches         8258      82580        0
+ public             pgbench_branches         8258      82580        0
 0            0    8258   0
-pg_catalog         pg_class                 7         3969         92
+ pg_catalog         pg_class                 7         3969         92
 80           0    0      0
-pg_catalog         pg_index                 5         950          31
+ pg_catalog         pg_index                 5         950          31
 38           0    0      0
-pg_catalog         pg_namespace             4         144          5
+ pg_catalog         pg_namespace             4         144          5
 4            0    0      0
-pg_catalog         pg_database              2         12           7
+ pg_catalog         pg_database              2         12           7
 7            0    0      0
-pg_catalog         pg_authid                1         10           2
+ pg_catalog         pg_authid                1         10           2
 2            0    0      0
-pg_catalog         pg_am                    1         1            0
+ pg_catalog         pg_am                    1         1            0
 0            0    0      0
-sys                callback_queue_table     0         0            0
+ sys                callback_queue_table     0         0            0
 0            0    0      0
-sys                edb$session_wait_history 0         0            0
+ sys                edb$session_wait_history 0         0            0
 0            125  0      0
 ```
 
@@ -825,33 +785,33 @@ The information displayed in the `DATA from pg_stat_all_tables ordered by rel tu
 | `DEL`          | The number of rows deleted.                            |
 
 ```text
-DATA from pg_statio_all_tables
+    DATA from pg_statio_all_tables
 
-SCHEMA               RELATION             HEAP     HEAP     IDX      IDX
+ SCHEMA               RELATION             HEAP     HEAP     IDX      IDX
 TOAST     TOAST     TIDX    TIDX
                                           READ     HIT      READ     HIT
 READ      HIT       READ    HIT
 --------------------------------------------------------------------------
 ---------------------------------------
-public               pgbench_accounts     32       25016     0       49913
+ public               pgbench_accounts     32       25016     0       49913
 0         0         0       0
-public               pgbench_tellers      0        24774     0       0
+ public               pgbench_tellers      0        24774     0       0
 0         0         0       0
-public               pgbench_branches     0        16516     0       0
+ public               pgbench_branches     0        16516     0       0
 0         0         0       0
-public               pgbench_history      53       8364      0       0
+ public               pgbench_history      53       8364      0       0
 0         0         0       0
-pg_catalog           pg_class             0        199       0       187
+ pg_catalog           pg_class             0        199       0       187
 0         0         0       0
-pg_catalog           pg_attribute         0        198       0       395
+ pg_catalog           pg_attribute         0        198       0       395
 0         0         0       0
-pg_catalog           pg_proc              0        75        0       153
+ pg_catalog           pg_proc              0        75        0       153
 0         0         0       0
-pg_catalog           pg_index             0        56        0       33
+ pg_catalog           pg_index             0        56        0       33
 0         0         0       0
-pg_catalog           pg_amop              0        48        0       56
+ pg_catalog           pg_amop              0        48        0       56
 0         0         0       0
-pg_catalog           pg_namespace         0        28        0       7
+ pg_catalog           pg_namespace         0        28        0       7
 0         0         0       0
 ```
 
@@ -871,34 +831,31 @@ The information displayed in the `DATA from pg_statio_all_tables` section includ
 | `TIDX HIT`   | The number of toast index blocks hit.              |
 
 ```Text
-DATA from pg_stat_all_indexes
+    DATA from pg_stat_all_indexes
 
-SCHEMA                  RELATION                    INDEX
+ SCHEMA                  RELATION                    INDEX
 IDX SCAN     IDX TUP READ IDX TUP FETCH
------------------------------------------------------------------------------
--
+------------------------------------------------------------------------------
 -------------------------------------------
-public                  pgbench_accounts            pgbench_accounts_pkey
+ public                  pgbench_accounts            pgbench_accounts_pkey
 16516        16679         16516
-pg_catalog              pg_attribute
+ pg_catalog              pg_attribute
 pg_attribute_relid_attnum_index   196               402          402
-pg_catalog              pg_proc                     pg_proc_oid_index
+ pg_catalog              pg_proc                     pg_proc_oid_index
 70           70            70
-pg_catalog              pg_class                    pg_class_oid_index
+ pg_catalog              pg_class                    pg_class_oid_index
 61           61            61
-pg_catalog              pg_class
-pg_class_relname_nsp_index
+ pg_catalog              pg_class                    pg_class_relname_nsp_index
 31 19 19
-pg_catalog              pg_type                     pg_type_oid_index
+ pg_catalog              pg_type                     pg_type_oid_index
 22           22            22
-pg_catalog             edb_policy
-edb_policy_object_name_index
+ pg_catalog             edb_policy                   edb_policy_object_name_index
 21           0             0
-pg_catalog             pg_amop                      pg_amop_fam_strat_index
+ pg_catalog             pg_amop                      pg_amop_fam_strat_index
 16           16            16
-pg_catalog             pg_index                     pg_index_indexrelid_index
+ pg_catalog             pg_index                     pg_index_indexrelid_index
 16           16            16
-pg_catalog             pg_index                     pg_index_indrelid_index
+ pg_catalog             pg_index                     pg_index_indrelid_index
 15           22            22
 ```
 
@@ -914,31 +871,31 @@ The information displayed in the `DATA from pg_stat_all_indexes` section include
 | `IDX TUP FETCH` | Number of live table rows fetched by simple index scans using this index. |
 
 ```Text
-DATA from pg_statio_all_indexes
+     DATA from pg_statio_all_indexes
 
-SCHEMA            RELATION                  INDEX
+ SCHEMA            RELATION                  INDEX
 IDX BLKS READ IDX BLKS HIT
 ------------------------------------------------------------------------
 ------------------------------------------
-public            pgbench_accounts          pgbench_accounts_pkey
+ public            pgbench_accounts          pgbench_accounts_pkey
 0             49913
-pg_catalog        pg_attribute
+ pg_catalog        pg_attribute
 pg_attribute_relid_attnum_index    0         395
-sys               edb$stat_all_indexes      edb$stat_idx_pk
+ sys               edb$stat_all_indexes      edb$stat_idx_pk
 1            382
-sys               edb$statio_all_indexes    edb$statio_idx_pk
+ sys               edb$statio_all_indexes    edb$statio_idx_pk
 1            382
-sys               edb$statio_all_tables     edb$statio_tab_pk
+ sys               edb$statio_all_tables     edb$statio_tab_pk
 2            262
-sys               edb$stat_all_tables       edb$stat_tab_pk
+ sys               edb$stat_all_tables       edb$stat_tab_pk
 0            259
-sys               edb$session_wait_history  session_waits_hist_pk
+ sys               edb$session_wait_history  session_waits_hist_pk
 0            251
-pg_catalog        pg_proc                   pg_proc_oid_index
+ pg_catalog        pg_proc                   pg_proc_oid_index
 0            142
-pg_catalog        pg_class                  pg_class_oid_index
+ pg_catalog        pg_class                  pg_class_oid_index
 0            123
-pg_catalog        pg_class                  pg_class_relname_nsp_index
+ pg_catalog        pg_class                  pg_class_relname_nsp_index
 0            63
 ```
 
@@ -953,7 +910,7 @@ The information displayed in the `DATA from pg_statio_all_indexes` section inclu
 | `IDX BLKS HIT`  | The number of index blocks hit.                      |
 
 ```text
-System Wait Information
+      System Wait Information
 
 WAIT NAME                              COUNT        WAIT TIME        % WAIT
 ---------------------------------------------------------------------------
@@ -978,41 +935,41 @@ The information displayed in the `System Wait Information` section includes:
 | `% WAIT`    | The percentage of the total wait time used by this wait for this session. |
 
 ```text
-Database Parameters from postgresql.conf
+     Database Parameters from postgresql.conf
 
-PARAMETER                             SETTING
+ PARAMETER                             SETTING
 CONTEXT       MINVAL         MAXVAL
 ----------------------------------------------------------------------
 ---------------------------------------------------
-allow_system_table_mods               off
+ allow_system_table_mods               off
 postmaster
-application_name                      psql.bin
+ application_name                      psql.bin
 user
-archive_command                       (disabled)
+ archive_command                       (disabled)
 sighup
-archive_mode                          off
+ archive_mode                          off
 postmaster
-archive_timeout                       0
+ archive_timeout                       0
 sighup      0               1073741823
-array_nulls                           on
+ array_nulls                           on
 user
-authentication_timeout                60
+ authentication_timeout                60
 sighup       1              600
-autovacuum                            on
+ autovacuum                            on
 sighup
-autovacuum_analyze_scale_factor       0.1
+ autovacuum_analyze_scale_factor       0.1
 sighup       0              100
-autovacuum_analyze_threshold          50
+ autovacuum_analyze_threshold          50
 sighup       0              2147483647
-autovacuum_freeze_max_age             200000000
+ autovacuum_freeze_max_age             200000000
 postmaster   100000         2000000000
-autovacuum_max_workers                3
+ autovacuum_max_workers                3
 postmaster   1              262143
-autovacuum_multixact_freeze_max_age   400000000
+ autovacuum_multixact_freeze_max_age   400000000
 postmaster   10000          2000000000
-autovacuum_naptime         60
+ autovacuum_naptime         60
 sighup       1            2147483
-autovacuum_vacuum_cost_delay           20
+ autovacuum_vacuum_cost_delay           20
 sighup      -1              100
                         .
                         .
@@ -1055,16 +1012,12 @@ The following example demonstrates the `stat_db_rpt()` function:
 SELECT * FROM stat_db_rpt(9, 10);
 
                                     stat_db_rpt
------------------------------------------------------------------------------
---------
+-------------------------------------------------------------------------------------
    DATA from pg_stat_database
 
-DATABASE  NUMBACKENDS   XACT COMMIT  XACT ROLLBACK  BLKS READ  BLKS HIT
-HIT RATIO
------------------------------------------------------------------------------
---------
-acctg     0             8261         0              117        127985
-99.91
+DATABASE  NUMBACKENDS   XACT COMMIT  XACT ROLLBACK  BLKS READ  BLKS HIT  HIT RATIO
+-------------------------------------------------------------------------------------
+acctg     0             8261         0              117        127985    99.91
 (5 rows)
 ```
 
@@ -1119,43 +1072,31 @@ SELECT * FROM stat_tables_rpt(8, 9, 10, 'ALL');
 
                          stat_tables_rpt
 ----------------------------------------------------------------------------
-   DATA from pg_stat_all_tables ordered by seq scan
+    DATA from pg_stat_all_tables ordered by seq scan
 
-SCHEMA               RELATION                      SEQ SCAN   REL TUP READ
-IDX SCAN
+ SCHEMA               RELATION                      SEQ SCAN   REL TUP READ IDX SCAN
 IDX TUP READ INS   UPD    DEL
------------------------------------------------------------------------------
---------
+-------------------------------------------------------------------------------------
 ----------------------------------
-public               pgbench_branches               8249       82490
-0
+ public               pgbench_branches               8249       82490      0
 0            0    8249    0
-public               pgbench_tellers                8249       824900
-0
+ public               pgbench_tellers                8249       824900     0
 0            0    8249    0
-pg_catalog           pg_class                       7          3969
-92
+ pg_catalog           pg_class                       7          3969       92
 80           0    0       0
-pg_catalog           pg_index                       5          950
-31
+ pg_catalog           pg_index                       5          950        31
 38           0    0       0
-pg_catalog           pg_namespace                   4          144
-5
+ pg_catalog           pg_namespace                   4          144        5
 4            0    0       0
-pg_catalog           pg_am                          1          1
-0
+ pg_catalog           pg_am                          1          1          0
 0            0    0       0
-pg_catalog           pg_authid                      1          10
-2
+ pg_catalog           pg_authid                      1          10         2
 2            0    0       0
-pg_catalog           pg_database                    1          6
-3
+ pg_catalog           pg_database                    1          6          3
 3            0    0       0
-sys                  callback_queue_table           0          0
-0
+ sys                  callback_queue_table           0          0          0
 0            0    0       0
-sys                 edb$session_wait_history        0          0
-0
+ sys                 edb$session_wait_history        0          0          0
 0            125 0        0
 ```
 
@@ -1176,32 +1117,31 @@ The information displayed in the `DATA from pg_stat_all_tables ordered by seq sc
 The second portion of the report contains:
 
 ```text
-DATA from pg_stat_all_tables ordered by rel tup read
+      DATA from pg_stat_all_tables ordered by rel tup read
 
-SCHEMA               RELATION                 SEQ SCAN REL   TUP READ   IDX
-SCAN
+ SCHEMA               RELATION                 SEQ SCAN REL   TUP READ   IDX SCAN
 IDX TUP READ INS    UPD     DEL
------------------------------------------------------------------------------
---------------------------------------
-public               pgbench_tellers          8249          824900      0
+------------------------------------------------------------------------------------
+------------------------------------
+ public               pgbench_tellers          8249          824900      0
 0            0     8249     0
-public               pgbench_branches         8249          82490       0
+ public               pgbench_branches         8249          82490       0
 0            0     8249     0
-pg_catalog           pg_class                 7             3969        92
+ pg_catalog           pg_class                 7             3969        92
 80           0     0        0
-pg_catalog           pg_index                 5             950         31
+ pg_catalog           pg_index                 5             950         31
 38           0     0        0
-pg_catalog           pg_namespace             4             144         5
+ pg_catalog           pg_namespace             4             144         5
 4            0     0        0
-pg_catalog           pg_authid                1             10          2
+ pg_catalog           pg_authid                1             10          2
 2            0     0        0
-pg_catalog           pg_database              1             6           3
+ pg_catalog           pg_database              1             6           3
 3            0     0        0
-pg_catalog           pg_am                    1             1           0
+ pg_catalog           pg_am                    1             1           0
 0            0     0        0
-sys                  callback_queue_table     0             0           0
+ sys                  callback_queue_table     0             0           0
 0            0     0        0
-sys                  edb$session_wait_history 0             0           0
+ sys                  edb$session_wait_history 0             0           0
 0            125   0        0
 (29 rows)
 ```
@@ -1258,49 +1198,36 @@ The `statio_tables_rpt()` function returns a report that contains:
 SELECT * FROM statio_tables_rpt(9, 10, 10, 'SYS');
 
                                                statio_tables_rpt
------------------------------------------------------------------------------
--------
+------------------------------------------------------------------------------------
 -------------------------------
     DATA from pg_statio_all_tables
 
-SCHEMA                  RELATION             HEAP     HEAP    IDX     IDX
-TOAST
+ SCHEMA                  RELATION             HEAP     HEAP    IDX     IDX    TOAST
 TOAST      TIDX      TIDX
-                                             READ     HIT     READ    HIT
-                                                READ
+                                             READ     HIT     READ    HIT    READ
+                                                
 HIT        READ      HIT
------------------------------------------------------------------------------
---------
+-------------------------------------------------------------------------------------
 ----------------------------
-sys                     edb$stat_all_indexes 8        18      1       382
-0
+ sys                     edb$stat_all_indexes 8        18      1       382    0
 0          0         0
-sys                     edb$statio_all_index 8        18      1       382
-0
+ sys                     edb$statio_all_index 8        18      1       382    0
 0          0         0
-sys                     edb$statio_all_table 5        12      2       262
-0
+ sys                     edb$statio_all_table 5        12      2       262    0
 0          0         0
-sys                     edb$stat_all_tables  4        10      0       259
-0
+ sys                     edb$stat_all_tables  4        10      0       259    0
 0          0         0
-sys                     edb$session_wait_his 2        6       0       251
-0
+ sys                     edb$session_wait_his 2        6       0       251    0
 0          0         0
-sys                     edb$session_waits    1        4       0       12
-0
+ sys                     edb$session_waits    1        4       0       12     0
 0          0         0
-sys                     callback_queue_table 0        0       0       0
-0
+ sys                     callback_queue_table 0        0       0       0      0
 0          0         0
-sys                     dual                 0        0       0       0
-0
+ sys                     dual                 0        0       0       0      0
 0          0         0
-sys                    edb$snap              0        1       0       2
-0
+ sys                    edb$snap              0        1       0       2      0
 0          0         0
-sys                    edb$stat_database     0        2       0       7
-0
+ sys                    edb$stat_database     0        2       0       7      0
 0          0         0
 (15 rows)
 ```
@@ -1358,36 +1285,33 @@ The `stat_indexes_rpt()` function returns a report that contains:
 edb=# SELECT * FROM stat_indexes_rpt(9, 10, 10, 'ALL');
 
                                stat_indexes_rpt
------------------------------------------------------------------------------
---
+-------------------------------------------------------------------------------
 ---------------------------------------------
      DATA from pg_stat_all_indexes
 
-SCHEMA                   RELATION                  INDEX
+ SCHEMA                   RELATION                  INDEX
 IDX SCAN       IDX TUP READ IDX TUP FETCH
------------------------------------------------------------------------------
---
+-------------------------------------------------------------------------------
 ------------------------------------------
-public                   pgbench_accounts          pgbench_accounts_pkey
+ public                   pgbench_accounts          pgbench_accounts_pkey
 16516          16679        16516
-pg_catalog               pg_attribute
-pg_attribute_relid_attnum_index      196      402      402
-pg_catalog               pg_proc                   pg_proc_oid_index
+ pg_catalog               pg_attribute
+pg_attribute_relid_attnum_index      196           402      402
+ pg_catalog               pg_proc                   pg_proc_oid_index
 70             70           70
-pg_catalog               pg_class                  pg_class_oid_index
+ pg_catalog               pg_class                  pg_class_oid_index
 61             61           61
-pg_catalog               pg_class                  pg_class_relname_nsp_index
+ pg_catalog               pg_class                  pg_class_relname_nsp_index
 31             19           19
-pg_catalog               pg_type                   pg_type_oid_index
+ pg_catalog               pg_type                   pg_type_oid_index
 22             22           22
-pg_catalog               edb_policy
-edb_policy_object_name_index
+ pg_catalog               edb_policy                edb_policy_object_name_index
 21             0            0
-pg_catalog               pg_amop                   pg_amop_fam_strat_index
+ pg_catalog               pg_amop                   pg_amop_fam_strat_index
 16             16           16
-pg_catalog               pg_index                  pg_index_indexrelid_index
+ pg_catalog               pg_index                  pg_index_indexrelid_index
 16             16           16
-pg_catalog               pg_index                  pg_index_indrelid_index
+ pg_catalog               pg_index                  pg_index_indrelid_index
 15             22           22
 (14 rows)
 ```
@@ -1443,33 +1367,31 @@ edb=# SELECT * FROM statio_indexes_rpt(9, 10, 10, 'SYS');
                            statio_indexes_rpt
 ----------------------------------------------------------------------------
 ------------------------------------
-  DATA from pg_statio_all_indexes
+   DATA from pg_statio_all_indexes
 
-SCHEMA                      RELATION                       INDEX
+ SCHEMA                      RELATION                       INDEX
 IDX BLKS READ         IDX BLKS HIT
 ----------------------------------------------------------------------------
 ---------------------------------
-pg_catalog                 pg_attribute
+ pg_catalog                 pg_attribute
 pg_attribute_relid_attnum_index          0                      395
-sys                        edb$stat_all_indexes           edb$stat_idx_pk
+ sys                        edb$stat_all_indexes           edb$stat_idx_pk
 1                    382
-sys                        edb$statio_all_indexes         edb$statio_idx_pk
+ sys                        edb$statio_all_indexes         edb$statio_idx_pk
 1                    382
-sys                        edb$statio_all_tables          edb$statio_tab_pk
+ sys                        edb$statio_all_tables          edb$statio_tab_pk
 2                    262
-sys                        edb$stat_all_tables            edb$stat_tab_pk
+ sys                        edb$stat_all_tables            edb$stat_tab_pk
 0                    259
-sys                        edb$session_wait_history
-session_waits_hist_pk
+ sys                        edb$session_wait_history       session_waits_hist_pk
 0                    251
-pg_catalog                 pg_proc                        pg_proc_oid_index
+ pg_catalog                 pg_proc                        pg_proc_oid_index
 0                    142
-pg_catalog                 pg_class                       pg_class_oid_index
+ pg_catalog                 pg_class                       pg_class_oid_index
 0                    123
-pg_catalog                 pg_class
-pg_class_relname_nsp_index
+ pg_catalog                 pg_class                       pg_class_relname_nsp_index
 0                    63
-pg_catalog                 pg_type                        pg_type_oid_index
+ pg_catalog                 pg_type                        pg_type_oid_index
 0                    45
 (14 rows)
 ```


### PR DESCRIPTION
## What Changed?

DB-980 add details for incorrect usage of SQL expressions in date mask column of control file. This is a customer escalation fix that needs to be published on docs 2.0 site.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
