### PR TITLE
[WIP] Cross architecture Dockerfile for PDF builder

### DIFF
--- a/docker/images/Dockerfile.pdf-builder
+++ b/docker/images/Dockerfile.pdf-builder
@@ -1,9 +1,10 @@
 FROM ubuntu:focal
 
-ARG PANDOC_VERSION=2.12
-ARG PANDOC_DEB=pandoc-2.12-1-amd64.deb
+ARG TARGETARCH
+ARG PANDOC_VERSION=2.13
+ARG PANDOC_DEB=pandoc-${PANDOC_VERSION}-1-${TARGETARCH}.deb
 ARG WKHTML_TO_PDF_VERSION=0.12.6-1
-ARG WKHTML_TO_PDF_DEB=wkhtmltox_${WKHTML_TO_PDF_VERSION}.focal_amd64.deb
+ARG WKHTML_TO_PDF_DEB=wkhtmltox_${WKHTML_TO_PDF_VERSION}.focal_${TARGETARCH}.deb
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
   python3 \


### PR DESCRIPTION
Change PDF builder image definition to allow for multi-architecture builds. This only takes care of the case of amd64 and arm64 cases.

We need to do this because we have users that are on the new Apple M1 chip.