### PR TITLE
reconcile differences between merge_sources and CNP import

### DIFF
--- a/advocacy_docs/kubernetes/cloud_native_postgresql/interactive_demo.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/interactive_demo.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Installation, Configuration and Demployment Demo"
+title: "Installation, Configuration and Deployment Demo"
 description: "Walk through the process of installing, configuring and deploying the Cloud Native PostgreSQL Operator via a browser-hosted Minikube console"
 navTitle: Install, Configure, Deploy
 product: 'Cloud Native PostgreSQL Operator'

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/quickstart.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/quickstart.mdx
@@ -9,11 +9,14 @@ using Cloud Native PostgreSQL on a local Kubernetes cluster in
 [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) or
 [Kind](https://kind.sigs.k8s.io/).
 
+<!-- section below inserted by source_cloud_native_opreator.py - changes made here will be lost -->
+
 !!! Tip "Live demonstration"
     Don't want to install anything locally just yet? Try a demonstration directly in your browser:
 
     [Cloud Native PostgreSQL Operator Interactive Quickstart](interactive_demo)
 
+<!-- end inserted section -->
 RedHat OpenShift Container Platform users can test the certified operator for
 Cloud Native PostgreSQL on the [Red Hat CodeReady Containers (CRC)](https://developers.redhat.com/products/codeready-containers/overview)
 for OpenShift.

--- a/merge_sources/kubernetes/cloud_native_postgresql/interactive/index.mdx
+++ b/merge_sources/kubernetes/cloud_native_postgresql/interactive/index.mdx
@@ -1,8 +1,0 @@
----
-title: 'Cloud Native PostgreSQL Interactive Demonstrations'
-navTitle: 'Interactive Demos'
-product: 'Cloud Native Operator'
-indexCards: full
-showInteractiveBadge: true
----
-

--- a/merge_sources/kubernetes/cloud_native_postgresql/interactive_demo.mdx
+++ b/merge_sources/kubernetes/cloud_native_postgresql/interactive_demo.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Installation, Configuration and Demployment Demo"
+title: "Installation, Configuration and Deployment Demo"
 description: "Walk through the process of installing, configuring and deploying the Cloud Native PostgreSQL Operator via a browser-hosted Minikube console"
 navTitle: Install, Configure, Deploy
 product: 'Cloud Native PostgreSQL Operator'
@@ -24,7 +24,7 @@ Want to see what it takes to get the Cloud Native PostgreSQL Operator up and run
 
 It will take roughly 5-10 minutes to work through.
 
-!!! Note This demo is interactive.
+!!!interactive This demo is interactive
     You can follow along right in your browser by clicking the button below. Once the environment initializes, you'll see a terminal open at the bottom of the screen.
 
 <KatacodaPanel />
@@ -40,7 +40,7 @@ __OUTPUT__
 * OS release is Ubuntu 18.04.4 LTS
 * Preparing Kubernetes v1.17.3 on Docker 19.03.6 ...
   - kubelet.resolv-conf=/run/systemd/resolve/resolv.conf
-* Launching Kubernetes ... 
+* Launching Kubernetes ...
 * Enabling addons: default-storageclass, storage-provisioner
 * Configuring local host environment ...
 * Waiting for cluster to come online ...
@@ -61,7 +61,7 @@ You will see one node called `minikube`. If the status isn't yet "Ready", wait f
 
 ## Install Cloud Native PostgreSQL
 
-Now that the Minikube cluster is running, you can proceed with Cloud Native PostgreSQL installation as described in the ["Installation"](installation.md) section: 
+Now that the Minikube cluster is running, you can proceed with Cloud Native PostgreSQL installation as described in the ["Installation"](installation.md) section:
 
 ```shell
 kubectl apply -f https://get.enterprisedb.io/cnp/postgresql-operator-1.2.0.yaml
@@ -132,7 +132,7 @@ __OUTPUT__
 cluster.postgresql.k8s.enterprisedb.io/cluster-example created
 ```
 
-You can check that the pods are being created with the `get pods` command. It'll take a bit to initialize, so if you run that 
+You can check that the pods are being created with the `get pods` command. It'll take a bit to initialize, so if you run that
 immediately after applying the cluster configuration you'll see the status as `Init:` or `PodInitializing`:
 
 ```shell
@@ -219,7 +219,7 @@ status:
     By default, the operator will install the latest available minor version
     of the latest major version of PostgreSQL when the operator was released.
     You can override this by setting [the `imageName` key in the `spec` section of
-    the `Cluster` definition](../api_reference/#clusterspec).
+    the `Cluster` definition](api_reference/#clusterspec).
 
 !!! Important
     The immutable infrastructure paradigm requires that you always
@@ -247,7 +247,7 @@ The `cnp` command is now available in kubectl:
 ```shell
 kubectl cnp status cluster-example
 __OUTPUT__
-Cluster in healthy state   
+Cluster in healthy state
 Name:              cluster-example
 Namespace:         default
 PostgreSQL Image:  quay.io/enterprisedb/postgresql:13.2
@@ -264,15 +264,15 @@ cluster-example-3               0/6000060     0/6000060   6941211174657425425  â
 ```
 
 !!! Note "There's more"
-    See [the Cloud Native PostgreSQL Plugin page](../cnp-plugin/) for more commands and options.
+    See [the Cloud Native PostgreSQL Plugin page](cnp-plugin/) for more commands and options.
 
 
 ### Further reading
 
-This is all it takes to get a PostgreSQL cluster up and running, but of course there's a lot more possible - and certainly much more that is prudent before you should ever deploy in a production environment! 
+This is all it takes to get a PostgreSQL cluster up and running, but of course there's a lot more possible - and certainly much more that is prudent before you should ever deploy in a production environment!
 
-- For information on using the Cloud Native PostgreSQL Operator to deploy on public cloud platforms, see the [Cloud Setup](.../cloud_setup/) section.
+- For information on using the Cloud Native PostgreSQL Operator to deploy on public cloud platforms, see the [Cloud Setup](cloud_setup/) section.
 
-- For the design goals and possibilities offered by the Cloud Native PostgreSQL Operator, check out the [Architecture](../architecture/) and [Use cases](../use_cases/) sections.
+- For the design goals and possibilities offered by the Cloud Native PostgreSQL Operator, check out the [Architecture](architecture/) and [Use cases](use_cases/) sections.
 
-- And for details on what it takes to configure a secure and reliable system, read through the [Security](../security/), [Failure Modes](../failure_modes/) and [Backup and Recovery](../backup_recovery/) sections.
+- And for details on what it takes to configure a secure and reliable system, read through the [Security](security/), [Failure Modes](failure_modes/) and [Backup and Recovery](backup_recovery/) sections.

--- a/scripts/source/source_cloud_native_operator.py
+++ b/scripts/source/source_cloud_native_operator.py
@@ -38,7 +38,7 @@ def index_frontmatter():
             elif readingNav:
                 nav.append(line.replace(".md", ""))
                 if "quickstart.md" in line:
-                    nav.append("  - interactive\n")
+                    nav.append("  - interactive_demo\n")
 
     return INDEX_FRONTMATTER.format("".join(nav))
 
@@ -59,11 +59,14 @@ def process_md(file_path):
 
                     if paragraph == 2:
                         line = """
+<!-- section below inserted by source_cloud_native_opreator.py - changes made here will be lost -->
+
 !!! Tip "Live demonstration"
     Don't want to install anything locally just yet? Try a demonstration directly in your browser:
 
-    [Cloud Native PostgreSQL Operator Interactive Quickstart](interactive/installation_and_deployment/)
+    [Cloud Native PostgreSQL Operator Interactive Quickstart](interactive_demo)
 
+<!-- end inserted section -->
 """
                 elif copying:
                     line = rewrite_yaml_links(line)


### PR DESCRIPTION
## What Changed?

Docs-specific content for CNP lives in `merge_sources` and is merged in during import of CNP sources by `source_cloud_native_operator.py` - these became out of date over the course of last week's deployment. This PR puts them back in sync in preparation for the merging of CNP 1.3.0 docs.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
