### PR TITLE
Allow paragraph margins within admonitions; only omit the ending margin

### DIFF
--- a/src/styles/_admonitions.scss
+++ b/src/styles/_admonitions.scss
@@ -31,7 +31,7 @@
   }
 }
 
-.admonition-content p {
+.admonition-content > :last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
## What Changed?

A particular rule in the styling for admonitions removed the bottom margin of any child. This change alters that to only remove the bottom margin of the *last* child, thus allowing paragraphs within the admonition to render normally.

Before:
![image](https://user-images.githubusercontent.com/63653723/118585636-8f0d0e00-b756-11eb-8745-670bda723586.png)

After:
![image](https://user-images.githubusercontent.com/63653723/118585671-a21fde00-b756-11eb-928a-eb474b83c1ba.png)
