### PR TITLE
Fix HTML in titles (hopefully for the last time)

### DIFF
--- a/advocacy_docs/kubernetes/cloud_native_postgresql/api_reference.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/api_reference.mdx
@@ -51,7 +51,9 @@ Below you will find a description of the defined resources:
 - [WalBackupConfiguration](#WalBackupConfiguration)
 
 
-## <a name='AffinityConfiguration'></a> `AffinityConfiguration`
+<a id='AffinityConfiguration'></a>
+
+## AffinityConfiguration
 
 AffinityConfiguration contains the info we need to create the affinity rules for Pods
 
@@ -61,7 +63,9 @@ Name                  | Description                                             
 `topologyKey          ` | TopologyKey to use for anti-affinity configuration. See k8s documentation for more info on that                                                                          - *mandatory*  | string           
 `nodeSelector         ` | NodeSelector is map of key-value pairs used to define the nodes on which the pods can run. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | map[string]string
 
-## <a name='Backup'></a> `Backup`
+<a id='Backup'></a>
+
+## Backup
 
 Backup is the Schema for the backups API
 
@@ -71,7 +75,9 @@ Name     | Description                                                          
 `spec    ` | Specification of the desired behavior of the backup. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status                                                              | [BackupSpec](#BackupSpec)                                                                                   
 `status  ` | Most recently observed status of the backup. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status | [BackupStatus](#BackupStatus)                                                                               
 
-## <a name='BackupConfiguration'></a> `BackupConfiguration`
+<a id='BackupConfiguration'></a>
+
+## BackupConfiguration
 
 BackupConfiguration defines how the backup of the cluster are taken. Currently the only supported backup method is barmanObjectStore. For details and examples refer to the Backup and Recovery section of the documentation
 
@@ -79,7 +85,9 @@ Name              | Description                                       | Type
 ----------------- | ------------------------------------------------- | ------------------------------------------------------------------
 `barmanObjectStore` | The configuration for the barman-cloud tool suite | [*BarmanObjectStoreConfiguration](#BarmanObjectStoreConfiguration)
 
-## <a name='BackupList'></a> `BackupList`
+<a id='BackupList'></a>
+
+## BackupList
 
 BackupList contains a list of Backup
 
@@ -88,7 +96,9 @@ Name     | Description                                                          
 `metadata` | Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta)
 `items   ` | List of backups                                                                                                                    - *mandatory*  | [[]Backup](#Backup)                                                                                     
 
-## <a name='BackupSpec'></a> `BackupSpec`
+<a id='BackupSpec'></a>
+
+## BackupSpec
 
 BackupSpec defines the desired state of Backup
 
@@ -96,7 +106,9 @@ Name    | Description           | Type
 ------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------
 `cluster` | The cluster to backup | [v1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core)
 
-## <a name='BackupStatus'></a> `BackupStatus`
+<a id='BackupStatus'></a>
+
+## BackupStatus
 
 BackupStatus defines the observed state of Backup
 
@@ -115,7 +127,9 @@ Name            | Description                                                   
 `commandOutput  ` | The backup command output                                                                                                                              | string                                                                                           
 `commandError   ` | The backup command output                                                                                                                              | string                                                                                           
 
-## <a name='BarmanObjectStoreConfiguration'></a> `BarmanObjectStoreConfiguration`
+<a id='BarmanObjectStoreConfiguration'></a>
+
+## BarmanObjectStoreConfiguration
 
 BarmanObjectStoreConfiguration contains the backup configuration using Barman against an S3-compatible object storage
 
@@ -128,7 +142,9 @@ Name            | Description                                                   
 `wal            ` | The configuration for the backup of the WAL stream. When not defined, WAL files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.            | [*WalBackupConfiguration](#WalBackupConfiguration)  
 `data           ` | The configuration to be used to backup the data files When not defined, base backups files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy. | [*DataBackupConfiguration](#DataBackupConfiguration)
 
-## <a name='BootstrapConfiguration'></a> `BootstrapConfiguration`
+<a id='BootstrapConfiguration'></a>
+
+## BootstrapConfiguration
 
 BootstrapConfiguration contains information about how to create the PostgreSQL cluster. Only a single bootstrap method can be defined among the supported ones. `initdb` will be used as the bootstrap method if left unspecified. Refer to the Bootstrap page of the documentation for more information.
 
@@ -137,7 +153,9 @@ Name     | Description                         | Type
 `initdb  ` | Bootstrap the cluster via initdb    | [*BootstrapInitDB](#BootstrapInitDB)    
 `recovery` | Bootstrap the cluster from a backup | [*BootstrapRecovery](#BootstrapRecovery)
 
-## <a name='BootstrapInitDB'></a> `BootstrapInitDB`
+<a id='BootstrapInitDB'></a>
+
+## BootstrapInitDB
 
 BootstrapInitDB is the configuration of the bootstrap process when initdb is used Refer to the Bootstrap page of the documentation for more information.
 
@@ -149,7 +167,9 @@ Name     | Description                                                          
 `redwood ` | If we need to enable/disable Redwood compatibility. Requires EPAS and for EPAS defaults to true                                              | *bool                                                                                                                            
 `options ` | The list of options that must be passed to initdb when creating the cluster                                                                  | []string                                                                                                                         
 
-## <a name='BootstrapRecovery'></a> `BootstrapRecovery`
+<a id='BootstrapRecovery'></a>
+
+## BootstrapRecovery
 
 BootstrapRecovery contains the configuration required to restore the backup with the specified name and, after having changed the password with the one chosen for the superuser, will use it to bootstrap a full cluster cloning all the instances from the restored primary. Refer to the Bootstrap page of the documentation for more information.
 
@@ -158,7 +178,9 @@ Name           | Description                                                    
 `backup        ` | The backup we need to restore                                                                                                                                                   - *mandatory*  | [corev1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core)
 `recoveryTarget` | By default the recovery will end as soon as a consistent state is reached: in this case that means at the end of a backup. This option allows to fine tune the recovery process | [*RecoveryTarget](#RecoveryTarget)                                                                                              
 
-## <a name='Cluster'></a> `Cluster`
+<a id='Cluster'></a>
+
+## Cluster
 
 Cluster is the Schema for the PostgreSQL API
 
@@ -168,7 +190,9 @@ Name     | Description                                                          
 `spec    ` | Specification of the desired behavior of the cluster. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status                                                              | [ClusterSpec](#ClusterSpec)                                                                                 
 `status  ` | Most recently observed status of the cluster. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status | [ClusterStatus](#ClusterStatus)                                                                             
 
-## <a name='ClusterList'></a> `ClusterList`
+<a id='ClusterList'></a>
+
+## ClusterList
 
 ClusterList contains a list of Cluster
 
@@ -177,7 +201,9 @@ Name     | Description                                                          
 `metadata` | Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta)
 `items   ` | List of clusters                                                                                                                   - *mandatory*  | [[]Cluster](#Cluster)                                                                                   
 
-## <a name='ClusterSpec'></a> `ClusterSpec`
+<a id='ClusterSpec'></a>
+
+## ClusterSpec
 
 ClusterSpec defines the desired state of Cluster
 
@@ -205,7 +231,9 @@ Name                  | Description                                             
 `licenseKey           ` | The license key of the cluster. When empty, the cluster operates in trial mode and after the expiry date (default 30 days) the operator will cease any reconciliation attempt. For details, please refer to the license agreement that comes with the operator. | string                                                                                                                            
 `monitoring           ` | The configuration of the monitoring infrastructure of this cluster                                                                                                                                                                                              | [*MonitoringConfiguration](#MonitoringConfiguration)                                                                              
 
-## <a name='ClusterStatus'></a> `ClusterStatus`
+<a id='ClusterStatus'></a>
+
+## ClusterStatus
 
 ClusterStatus defines the observed state of Cluster
 
@@ -228,7 +256,9 @@ Name                   | Description                                            
 `phaseReason           ` | Reason for the current phase                                                                                                                                                | string                                           
 `secretsResourceVersion` | The list of resource versions of the secrets managed by the operator. Every change here is done in the interest of the instance manager, which will refresh the secret data | [SecretsResourceVersion](#SecretsResourceVersion)
 
-## <a name='DataBackupConfiguration'></a> `DataBackupConfiguration`
+<a id='DataBackupConfiguration'></a>
+
+## DataBackupConfiguration
 
 DataBackupConfiguration is the configuration of the backup of the data directory
 
@@ -239,7 +269,9 @@ Name                | Description                                               
 `immediateCheckpoint` | Control whether the I/O workload for the backup initial checkpoint will be limited, according to the `checkpoint_completion_target` setting on the PostgreSQL server. If set to true, an immediate checkpoint will be used, meaning PostgreSQL will complete the checkpoint as soon as possible. `false` by default. | bool           
 `jobs               ` | The number of parallel jobs to be used to upload the backup, defaults to 2                                                                                                                                                                                                                                           | *int32         
 
-## <a name='MonitoringConfiguration'></a> `MonitoringConfiguration`
+<a id='MonitoringConfiguration'></a>
+
+## MonitoringConfiguration
 
 MonitoringConfiguration is the type containing all the monitoring configuration for a certain cluster
 
@@ -248,7 +280,9 @@ Name                   | Description                                           |
 `customQueriesConfigMap` | The list of config maps containing the custom queries | [[]corev1.ConfigMapKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#configmapkeyselector-v1-core)
 `customQueriesSecret   ` | The list of secrets containing the custom queries     | [[]corev1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core)      
 
-## <a name='NodeMaintenanceWindow'></a> `NodeMaintenanceWindow`
+<a id='NodeMaintenanceWindow'></a>
+
+## NodeMaintenanceWindow
 
 NodeMaintenanceWindow contains information that the operator will use while upgrading the underlying node.
 
@@ -259,7 +293,9 @@ Name       | Description                                                        
 `inProgress` | Is there a node maintenance activity in progress?                                          - *mandatory*  | bool 
 `reusePVC  ` | Reuse the existing PVC (wait for the node to come up again) or not (recreate it elsewhere) - *mandatory*  | *bool
 
-## <a name='PostgresConfiguration'></a> `PostgresConfiguration`
+<a id='PostgresConfiguration'></a>
+
+## PostgresConfiguration
 
 PostgresConfiguration defines the PostgreSQL configuration
 
@@ -268,7 +304,9 @@ Name       | Description                                                        
 `parameters` | PostgreSQL configuration options (postgresql.conf)                                        | map[string]string
 `pg_hba    ` | PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file) | []string         
 
-## <a name='RecoveryTarget'></a> `RecoveryTarget`
+<a id='RecoveryTarget'></a>
+
+## RecoveryTarget
 
 RecoveryTarget allows to configure the moment where the recovery process will stop. All the target options except TargetTLI are mutually exclusive.
 
@@ -282,7 +320,9 @@ Name            | Description                                                   
 `targetImmediate` | End recovery as soon as a consistent state is reached                     | *bool 
 `exclusive      ` | Set the target to be exclusive (defaults to true)                         | *bool 
 
-## <a name='RollingUpdateStatus'></a> `RollingUpdateStatus`
+<a id='RollingUpdateStatus'></a>
+
+## RollingUpdateStatus
 
 RollingUpdateStatus contains the information about an instance which is being updated
 
@@ -291,7 +331,9 @@ Name      | Description                         | Type
 `imageName` | The image which we put into the Pod - *mandatory*  | string                                                                                          
 `startedAt` | When the update has been started    | [metav1.Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta)
 
-## <a name='S3Credentials'></a> `S3Credentials`
+<a id='S3Credentials'></a>
+
+## S3Credentials
 
 S3Credentials is the type for the credentials to be used to upload files to S3
 
@@ -300,7 +342,9 @@ Name            | Description                            | Type
 `accessKeyId    ` | The reference to the access key id     - *mandatory*  | [corev1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core)
 `secretAccessKey` | The reference to the secret access key - *mandatory*  | [corev1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core)
 
-## <a name='ScheduledBackup'></a> `ScheduledBackup`
+<a id='ScheduledBackup'></a>
+
+## ScheduledBackup
 
 ScheduledBackup is the Schema for the scheduledbackups API
 
@@ -310,7 +354,9 @@ Name     | Description                                                          
 `spec    ` | Specification of the desired behavior of the ScheduledBackup. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status                                                              | [ScheduledBackupSpec](#ScheduledBackupSpec)                                                                 
 `status  ` | Most recently observed status of the ScheduledBackup. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status | [ScheduledBackupStatus](#ScheduledBackupStatus)                                                             
 
-## <a name='ScheduledBackupList'></a> `ScheduledBackupList`
+<a id='ScheduledBackupList'></a>
+
+## ScheduledBackupList
 
 ScheduledBackupList contains a list of ScheduledBackup
 
@@ -319,7 +365,9 @@ Name     | Description                                                          
 `metadata` | Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta)
 `items   ` | List of clusters                                                                                                                   - *mandatory*  | [[]ScheduledBackup](#ScheduledBackup)                                                                   
 
-## <a name='ScheduledBackupSpec'></a> `ScheduledBackupSpec`
+<a id='ScheduledBackupSpec'></a>
+
+## ScheduledBackupSpec
 
 ScheduledBackupSpec defines the desired state of ScheduledBackup
 
@@ -329,7 +377,9 @@ Name     | Description                                                          
 `schedule` | The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron. - *mandatory*  | string                                                                                                                      
 `cluster ` | The cluster to backup                                                | [v1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#localobjectreference-v1-core)
 
-## <a name='ScheduledBackupStatus'></a> `ScheduledBackupStatus`
+<a id='ScheduledBackupStatus'></a>
+
+## ScheduledBackupStatus
 
 ScheduledBackupStatus defines the observed state of ScheduledBackup
 
@@ -339,7 +389,9 @@ Name             | Description                                                  
 `lastScheduleTime` | Information when was the last time that backup was successfully scheduled. | [*metav1.Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta)
 `nextScheduleTime` | Next time we will run a backup                                             | [*metav1.Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta)
 
-## <a name='SecretsResourceVersion'></a> `SecretsResourceVersion`
+<a id='SecretsResourceVersion'></a>
+
+## SecretsResourceVersion
 
 SecretsResourceVersion is the resource versions of the secrets managed by the operator
 
@@ -351,7 +403,9 @@ Name                     | Description                                          
 `caSecretVersion         ` | The resource version of the "ca" secret version                   - *mandatory*  | string
 `serverSecretVersion     ` | The resource version of the PostgreSQL server-side secret version - *mandatory*  | string
 
-## <a name='StorageConfiguration'></a> `StorageConfiguration`
+<a id='StorageConfiguration'></a>
+
+## StorageConfiguration
 
 StorageConfiguration is the configuration of the storage of the PostgreSQL instances
 
@@ -362,7 +416,9 @@ Name               | Description                                                
 `resizeInUseVolumes` | Resize existent PVCs, defaults to true                                                                                                                                                     | *bool                                                                                                                                  
 `pvcTemplate       ` | Template to be used to generate the Persistent Volume Claim                                                                                                                                | [*corev1.PersistentVolumeClaimSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#persistentvolumeclaim-v1-core)
 
-## <a name='WalBackupConfiguration'></a> `WalBackupConfiguration`
+<a id='WalBackupConfiguration'></a>
+
+## WalBackupConfiguration
 
 WalBackupConfiguration is the configuration of the backup of the WAL stream
 


### PR DESCRIPTION
## What Changed?

Move anchor links *above* titles; the ToC plugin does not care for HTML *in* titles. Arguably a bug in that plugin, since it really should know better - but... HTML *in* Markdown titles is a bit unusual, and parsing that properly is not a small thing.

Strictly-speaking, we don't need these anchor links at all *for this repo* - the ToC plugin generates its own (via remark-autolink-headers). But they're presumably useful for other targets, they might be useful for cross-linking, and it's nice to be consistent.

There's a fix for this in https://github.com/EnterpriseDB/cloud-native-postgresql/pull/298 - I should've verified the status of that first, since got bit by this for the 1.3.0 release as well.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
