### PR TITLE
Fix conversion error on md file with leading whitespace

### DIFF
--- a/advocacy_docs/kubernetes/cloud_native_postgresql/monitoring.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/monitoring.mdx
@@ -1,4 +1,3 @@
-
 ---
 title: 'Monitoring Instances'
 originalFilePath: 'src/monitoring.md'

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/monitoring.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/monitoring.mdx
@@ -119,8 +119,7 @@ data:
             description: "Replication lag behind primary in seconds"
 ```
 
-A list of basic monitoring queries can be found in the [`cnp-basic-monitoring.yaml` file](
-./samples/cnp-basic-monitoring.yaml).
+A list of basic monitoring queries can be found in the [`cnp-basic-monitoring.yaml` file](../samples/cnp-basic-monitoring.yaml).
 
 ### Structure of a user defined metric
 

--- a/scripts/source/source_cloud_native_operator.py
+++ b/scripts/source/source_cloud_native_operator.py
@@ -79,6 +79,10 @@ def process_md(file_path):
                         if new_file_path.name == "index.mdx"
                         else "",
                     )
+                elif not line.strip():
+                    line = ""
+                else:
+                    print("File does not begin with title - frontmatter will not be valid: " + file_path)
 
                 new_file.write(line)
 


### PR DESCRIPTION
## What Changed?

Conversion script was not handling markdown files where whitespace preceded the first heading. This is not a problem for Markdown, but MDX needs to lead with the frontmatter - no whitespace!

This case is handled now. However, there remains a possibility for a file that has *non-whitespace* preceding the first header; this can be handled with additional effort, but for now I've just added a warning to the script to call this out if it is detected.

A more robust approach would be needed anyway for #1224, so unless this potential problem shows up in the wild a fix can wait until that issue is processed.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
