### PR TITLE
Toctree and formtting issues fixed for PEM Mangement Basics section

### DIFF
--- a/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/01_pem_custom_probes.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/01_pem_custom_probes.mdx
@@ -27,7 +27,7 @@ Use the fields on the `General` tab to modify the definition of an existing prob
 
     Before creating a batch probe on a Linux system, you must modify the `agent.cfg` file, setting the `allow_batch_probes` parameter equal to `true` and restart the PEM agent. The `agent.cfg` file is located in `/opt/PEM/agent/etc`.
 
-    On 64-bit Windows systems, agent settings are stored in the registry. Before creating a batch probe, modify the registry entry for the `AllowBatchProbes` registry entry and restart the PEM agent. PEM registry entries are located in `HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\EnterpriseDB\\PEM\\agent`.
+    On 64-bit Windows systems, agent settings are stored in the registry. Before creating a batch probe, modify the registry entry for the `AllowBatchProbes` registry entry and restart the PEM agent. PEM registry entries are located in `HKEY_LOCAL_MACHINE\Software\Wow6432Node\EnterpriseDB\PEM\agent`.
 
     Please note that batch probes are platform-specific. If you specify a collection method of `Batch`, you must specify a platform type in the `Platform` field.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/01_pem_custom_probes.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/01_pem_custom_probes.mdx
@@ -19,19 +19,19 @@ Use the fields on the `General` tab to modify the definition of an existing prob
 -   Use the `Probe name` field to provide a name for a new probe.
 -   Use the `Collection method` field to specify the probe type. Use the drop-down listbox to select from:
 
-> -   `SQL` (the probe will gather information via a SQL statement)
->
-> -   `WMI` (the probe will gather information via a Windows Management Instrumentation extension)
->
-> -   `Batch/Shell Script` (the probe will use a command-script or shell-script to gather information).
->
->     Before creating a batch probe on a Linux system, you must modify the `agent.cfg` file, setting the `allow_batch_probes` parameter equal to `true` and restart the PEM agent. The `agent.cfg` file is located in `/opt/PEM/agent/etc`.
->
->     On 64-bit Windows systems, agent settings are stored in the registry. Before creating a batch probe, modify the registry entry for the `AllowBatchProbes` registry entry and restart the PEM agent. PEM registry entries are located in `HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\EnterpriseDB\\PEM\\agent`.
->
->     Please note that batch probes are platform-specific. If you specify a collection method of `Batch`, you must specify a platform type in the `Platform` field.
->
->     To invoke a script on a Linux system, you must modify the entry for `batch_script_user` parameter of agent.cfg file and specify the user that should be used to run the script. You can either specify a non-root user or root for this parameter. If you do not specify a user, or the specified user does not exist, then the script will not be executed. Restart the agent after modifying the file. If pemagent is being run by a non-root user then the value of `batch_script_user` will be ignored and the script will be executed by the same non-root user that is being used for running the pemagent.
+-   `SQL` (the probe will gather information via a SQL statement)
+
+-   `WMI` (the probe will gather information via a Windows Management Instrumentation extension)
+
+-   `Batch/Shell Script` (the probe will use a command-script or shell-script to gather information).
+
+    Before creating a batch probe on a Linux system, you must modify the `agent.cfg` file, setting the `allow_batch_probes` parameter equal to `true` and restart the PEM agent. The `agent.cfg` file is located in `/opt/PEM/agent/etc`.
+
+    On 64-bit Windows systems, agent settings are stored in the registry. Before creating a batch probe, modify the registry entry for the `AllowBatchProbes` registry entry and restart the PEM agent. PEM registry entries are located in `HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\EnterpriseDB\\PEM\\agent`.
+
+    Please note that batch probes are platform-specific. If you specify a collection method of `Batch`, you must specify a platform type in the `Platform` field.
+
+    To invoke a script on a Linux system, you must modify the entry for `batch_script_user` parameter of agent.cfg file and specify the user that should be used to run the script. You can either specify a non-root user or root for this parameter. If you do not specify a user, or the specified user does not exist, then the script will not be executed. Restart the agent after modifying the file. If pemagent is being run by a non-root user then the value of `batch_script_user` will be ignored and the script will be executed by the same non-root user that is being used for running the pemagent.
 
 -   Use the `Target type` drop-down listbox to select the object type that the probe will monitor. `Target type` is disabled if `Collection method` is `WMI`.
 -   Use the `Minutes` and `Seconds` selectors to specify how often the probe will collect data.
@@ -71,10 +71,10 @@ Use the `Code` tab to specify the default code that will be executed by the prob
 -   If the probe is a SQL probe, you must specify the SQL SELECT statement invoked by the probe on the `Code` tab. The column names returned by the query must match the `Internal Name` specified on the `Column` tab. The number of columns returned by the query, as well as the column name, datatype, etc. must match the information specified on the `Columns` tab.
 -   If the probe is a Batch probe, you must specify the shell or .bat script that will be invoked when the probe runs. The output of the script should be as follows:
 
-> -   The first line must contain the names of the columns provided on the `Columns` tab. Each column name should be separated by a tab (t) character.
-> -   From the second line onwards, each line should contain the data for each column, separated by a tab character.
-> -   If a specified column is defined as key column, make sure the script does not produce duplicate data for that column across lines of output.
-> -   The number of columns specified in the `Columns` tab and their names, data type, etc. should match with the output of the script output.
+-   The first line must contain the names of the columns provided on the `Columns` tab. Each column name should be separated by a tab (t) character.
+-   From the second line onwards, each line should contain the data for each column, separated by a tab character.
+-   If a specified column is defined as key column, make sure the script does not produce duplicate data for that column across lines of output.
+-   The number of columns specified in the `Columns` tab and their names, data type, etc. should match with the output of the script output.
 
 -   If the probe is a WMI probe, you must specify the WMI query as a SELECT WMI query. The column name referenced in the SELECT statement should be same as the name of the corresponding column specified on the `Column` tab. The column names returned by the query must match the `Internal Name` specified on the `Column` tab. The number of columns returned by the query, as well as the column name, datatype, etc. must match the information specified on the `Columns` tab.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/03_pem_probe_config/index.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/03_pem_probe_config/index.mdx
@@ -10,8 +10,8 @@ A [probe](01_pem_probes/#pem_probes) is a scheduled task that returns a set of p
 
 The `Manage Probes` tab provides a set of `Quick Links` that you can use to create and manage probes:
 
--   Click the `` `Manage Custom Probes `` &lt;pem_custom_probes><span class="title-ref"> icon to open the </span><span class="title-ref">Custom Probes</span>\` tab and create or modify a custom probe.
--   Click the `` `Copy Probes `` &lt;copy_probe_config><span class="title-ref"> icon to open the </span><span class="title-ref">Copy Probe</span>\` dialog, and copy the probe configurations from the currently selected object to one or more monitored objects.
+-   Click the [Manage Custom Probes](01_pem_custom_probes/#pem_custom_probes) icon to open the tab and create or modify a custom probe.
+-   Click the [Copy Probes](02_copy_probe_config/#copy_probe_config) icon to open the dialog, and copy the probe configurations from the currently selected object to one or more monitored objects.
 
 A probe monitors a unique set of metrics for each specific object type (server, database, database object, or agent); select the name of an object in the tree control to review the probes for that object.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/index.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/04_toc_pem_features/12_pem_manage_probes/index.mdx
@@ -10,8 +10,8 @@ A [probe](03_pem_probe_config/01_pem_probes/#pem_probes) is a scheduled task tha
 
 The `Manage Probes` tab provides a set of `Quick Links` that you can use to create and manage probes:
 
--   Click the `` `Manage Custom Probes `` &lt;pem_custom_probes><span class="title-ref"> icon to open the </span><span class="title-ref">Custom Probes</span>\` tab and create or modify a custom probe.
--   Click the `` `Copy Probes `` &lt;copy_probe_config><span class="title-ref"> icon to open the </span><span class="title-ref">Copy Probe</span>\` dialog, and copy the probe configurations from the currently selected object to one or more monitored objects.
+-   Click the [Manage Custom Probes](01_pem_custom_probes/#pem_custom_probes) icon to open the and create or modify a custom probe.
+-   Click the [Copy Probes](02_copy_probe_config/#copy_probe_config) icon to open the dialog, and copy the probe configurations from the currently selected object to one or more monitored objects.
 
 A probe monitors a unique set of metrics for each specific object type (server, database, database object, or agent); select the name of an object in the tree control to review the probes for that object.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/01_grant_wizard.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/01_grant_wizard.mdx
@@ -16,9 +16,9 @@ Use the fields in the `Object Selection (step 1 of 3)` window to select the obje
 
 -   Each row in the table lists object identifiers; check the checkbox in the left column to include an object as a target of the Grant Wizard. The table displays:
 
-    > -   The object type in the `Object Type` field
-    > -   The schema in which the object resides in the `Schema` field
-    > -   The object name in the `Name` field.
+    -   The object type in the `Object Type` field
+    -   The schema in which the object resides in the `Schema` field
+    -   The object name in the `Name` field.
 
 Click the `Next` button to continue, or the `Cancel` button to close the wizard without modifying privileges.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/03_import_export_data.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/03_import_export_data.mdx
@@ -16,22 +16,22 @@ Use the fields in the `Options` tab to specify import and export preferences:
 
 -   Use the fields in the `File Info` field box to specify information about the source or target file:
 
-    > -   Enter the name of the source or target file in the `Filename` field. Optionally, select the `Browser` icon (ellipsis) to the right to navigate into a directory and select a file.
-    > -   Use the drop-down listbox in the `Format` field to specify the file type. Select:
-    >     -   `binary` for a .bin file.
-    >     -   `csv` for a .csv file.
-    >     -   `text` for a .txt file.
-    > -   Use the drop-down listbox in the `Encoding` field to specify the type of character encoding.
+    -   Enter the name of the source or target file in the `Filename` field. Optionally, select the `Browser` icon (ellipsis) to the right to navigate into a directory and select a file.
+    -   Use the drop-down listbox in the `Format` field to specify the file type. Select:
+        -   `binary` for a .bin file.
+        -   `csv` for a .csv file.
+        -   `text` for a .txt file.
+    -   Use the drop-down listbox in the `Encoding` field to specify the type of character encoding.
 
 ![Import/Export data dialog - Miscellaneous tab](../images/import_export_miscellaneous.png)
 
 -   Use the fields in the `Miscellaneous` field box to specify additional information:
 
-    > -   Move the `OID` switch to the `Yes` position to include the `OID` column. The `OID` is a system-assigned value that may not be modified. The default is `No`.
-    > -   Move the `Header` switch to the `Yes` position to include the table header with the data rows. If you include the table header, the first row of the file will contain the column names.
-    > -   If you are exporting data, specify the delimiter that will separate the columns within the target file in the `Delimiter` field. The separating character can be a colon, semicolon, a vertical bar, or a tab.
-    > -   Specify a quoting character used in the `Quote` field. Quoting can be applied to string columns only (i.e. numeric columns will not be quoted) or all columns regardless of data type. The character used for quoting can be a single quote or a double quote.
-    > -   Specify a character that should appear before a data character that matches the `QUOTE` value in the `Escape` field.
+    -   Move the `OID` switch to the `Yes` position to include the `OID` column. The `OID` is a system-assigned value that may not be modified. The default is `No`.
+    -   Move the `Header` switch to the `Yes` position to include the table header with the data rows. If you include the table header, the first row of the file will contain the column names.
+    -   If you are exporting data, specify the delimiter that will separate the columns within the target file in the `Delimiter` field. The separating character can be a colon, semicolon, a vertical bar, or a tab.
+    -   Specify a quoting character used in the `Quote` field. Quoting can be applied to string columns only (i.e. numeric columns will not be quoted) or all columns regardless of data type. The character used for quoting can be a single quote or a double quote.
+    -   Specify a character that should appear before a data character that matches the `QUOTE` value in the `Escape` field.
 
 Click the `Columns` tab to continue.
 
@@ -53,14 +53,5 @@ Use the `Click here for details` link on the notification to open the `Process W
 
 ![Import/Export data dialog - Process Watcher](../images/import_export_pw.png)
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .
-
-</div>
+!!! Note
+    You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/04_maintenance/01_maintenance_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/04_maintenance/01_maintenance_dialog.mdx
@@ -14,9 +14,9 @@ Select a button next to `Maintenance operation` to specify the type of maintenan
 
 -   Click `VACUUM` to scan the selected database or table to reclaim storage used by dead tuples.
 
-    > -   Move the `FULL` switch to the `Yes` position to compact tables by writing a completely new version of the table file without dead space. The default is `No`.
-    > -   Move the `FREEZE` switch to the `Yes` position to freeze data in a table when it will have no further updates. The default is `No`.
-    > -   Move the `ANALYZE` switch to the `Yes` position to issue ANALYZE commands whenever the content of a table has changed sufficiently. The default is `No`.
+    -   Move the `FULL` switch to the `Yes` position to compact tables by writing a completely new version of the table file without dead space. The default is `No`.
+    -   Move the `FREEZE` switch to the `Yes` position to freeze data in a table when it will have no further updates. The default is `No`.
+    -   Move the `ANALYZE` switch to the `Yes` position to issue ANALYZE commands whenever the content of a table has changed sufficiently. The default is `No`.
 
 -   Click `ANALYZE` to update the stored statistics used by the query planner. This enables the query optimizer to select the fastest query plan for optimal performance.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/04_maintenance/index.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/04_maintenance/index.mdx
@@ -30,8 +30,4 @@ REINDEX rebuilds the indexes in case these have degenerated caused by unusual da
 
 The RECREATE option doesn't call the REINDEX SQL command internally, instead it drops the existing table and recreates it according to the current index definition.This doesn't lock the table exclusively, as REINDEX does, but will lock write access only.
 
-<div class="toctree">
-
-maintenance_dialog
-
-</div>
+-   [Maintenance Dialog](01_maitenance_dialog/#maintenance_dialog)

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/05_storage_manager.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/05_storage_manager.mdx
@@ -16,25 +16,18 @@ You can access `Storage Manager` from the `Tools` Menu.
 
 Use icons on the top of the `Storage Manager` window to manage storage:
 
-Use the `Home` icon ![home](../images/home.png) to return to the home directory.
-
-Use the `Up Arrow` icon ![uparrow](../images/uparrow.png) to return to the previous directory.
-
-Use the `Refresh` icon ![refresh](../images/refresh.png) to display the most-recent files available.
-
-Select the `Download` icon ![download](../images/download.png) to download the selected file.
-
-Select the `Delete` icon ![delete](../images/delete.png) to delete the selected file or folder.
-
-Select the `Edit` icon ![edit](../images/edit.png) to rename a file or folder.
-
-Use the `Upload` icon ![upload](../images/upload.png) to upload a file.
-
-Use the `New Folder` icon ![folder](../images/folder.png) to add a new folder.
-
-Use the `Grid View` icon ![gridview](../images/gridview.png) to display all the files and folders in a grid view.
-
-Use the `Table View` icon ![tableview](../images/tableview.png) to display all the files and folders in a list view.
+| **Icons**                             | **Description**                                                                     |
+|---------------------------------------|-------------------------------------------------------------------------------------|
+| ![home](../images/home.png)           | Use the `Home` icon  to return to the home directory.                               |
+| ![uparrow](../images/uparrow.png)     | Use the `Up Arrow` icon  to return to the previous directory.                       |
+| ![refresh](../images/refresh.png)     | Use the `Refresh` icon  to display the most-recent files available.                 |
+| ![download](../images/download.png)   | Select the `Download` icon  to download the selected file.                          |
+| ![delete](../images/delete.png)       | Select the `Delete` icon  to delete the selected file or folder.                    |
+| ![edit](../images/edit.png)           | Select the `Edit` icon  to rename a file or folder.                                 |
+| ![upload](../images/upload.png)       | Use the `Upload` icon  to upload a file.                                            |
+| ![folder](../images/folder.png)       | Use the `New Folder` icon  to add a new folder.                                     |
+| ![gridview](../images/gridview.png)   | Use the `Grid View` icon  to display all the files and folders in a grid view.      |
+| ![tableview](../images/tableview.png) | Use the `Table View` icon  to display all the files and folders in a list view.     |
 
 Click on the check box next to `Show hidden files and folders` at the bottom of the window to view hidden files and folders.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/05_storage_manager.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/05_storage_manager.mdx
@@ -4,17 +4,17 @@ title: "Storage Manager"
 
 <div id="storage_manager" class="registered_link"></div>
 
-*Storage Manager* is a feature that helps you manage your systems storage device. You can use *Storage Manager* to:
+`Storage Manager` is a feature that helps you manage your systems storage device. You can use `Storage Manager` to:
 
 -   Download, upload, or manage operating system files.
--   Download *backup* or *export* files (custom, tar and plain text format) on a client machine.
--   Download *export* dump files of tables.
+-   Download `backup` or `export` files (custom, tar and plain text format) on a client machine.
+-   Download `export` dump files of tables.
 
-You can access *Storage Manager* from the *Tools* Menu.
+You can access `Storage Manager` from the `Tools` Menu.
 
-<img src="../images/storage_manager.png" class="align-center" alt="Storage Manager" />
+![Storage Manager](../images/storage_manager.png)
 
-Use icons on the top of the *Storage Manager* window to manage storage:
+Use icons on the top of the `Storage Manager` window to manage storage:
 
 Use the `Home` icon ![home](../images/home.png) to return to the home directory.
 
@@ -36,12 +36,12 @@ Use the `Grid View` icon ![gridview](../images/gridview.png) to display all the 
 
 Use the `Table View` icon ![tableview](../images/tableview.png) to display all the files and folders in a list view.
 
-Click on the check box next to *Show hidden files and folders* at the bottom of the window to view hidden files and folders.
+Click on the check box next to `Show hidden files and folders` at the bottom of the window to view hidden files and folders.
 
-Use the *Format* drop down list to select the format of the files to be displayed; choose from *sql*, *csv*, or *All Files*.
+Use the `Format` drop down list to select the format of the files to be displayed; choose from `sql`, `csv`, or `All Files`.
 
-You can also download backup files through *Storage Manager* at the successful completion of the backups taken through [Backup Dialog](06_backup_dialog/#backup_dialog), [Backup Global Dialog](07_backup_globals_dialog/#backup_globals_dialog), or [Backup Server Dialog](08_backup_server_dialog/#backup_server_dialog).
+You can also download backup files through `Storage Manager` at the successful completion of the backups taken through [Backup Dialog](06_backup_dialog/#backup_dialog), [Backup Global Dialog](07_backup_globals_dialog/#backup_globals_dialog), or [Backup Server Dialog](08_backup_server_dialog/#backup_server_dialog).
 
-At the successful completion of a backup, click on the icon to open the current backup file in *Storage Manager* on the *process watcher* window.
+At the successful completion of a backup, click on the icon to open the current backup file in `Storage Manager` on the `process watcher` window.
 
-<img src="../images/process_watcher_storage_manager.png" class="align-center" alt="Process watcher with storage manager icon" />
+![Process Watcher with Storage Manager](../images/process_watcher_storage_manager.png)

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/06_backup_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/06_backup_dialog.mdx
@@ -16,10 +16,10 @@ Use the fields in the `General` tab to specify parameters for the backup:
 
 -   Use the drop-down listbox in the `Format` field to select the format that is best suited for your application. Each format has advantages and disadvantages:
 
-    > -   Select `Custom` to create a custom archive file that you can use with `pg_restore` to create a copy of a database. Custom archive file formats must be restored with `pg_restore`. This format offers the opportunity to select which database objects to restore from the backup file. `Custom` archive format is recommended for medium to large databases as it is compressed by default.
-    > -   Select `Tar` to generate a tar archive file that you can restore with `pg_restore`. The tar format does not support compression.
-    > -   Select `Plain` to create a plain-text script file. A plain-text script file contains SQL statements and commands that you can execute at the `psql` command line to recreate the database objects and load the table data. A plain-text backup file can be edited in a text editor, if desired, before using the `psql` program to restore database objects. `Plain` format is normally recommended for smaller databases; script dumps are not recommended for blobs. The SQL commands within the script will reconstruct the database to the last saved state of the database. A plain-text script can be used to reconstruct the database on another machine, or (with modifications) on other architectures.
-    > -   Select `Directory` to generate a directory-format archive suitable for use with `pg_restore`. This file format creates a directory with one file for each table and blob being dumped, plus a `Table of Contents` file describing the dumped objects in a machine-readable format that `pg_restore` can read. This format is compressed by default.
+    -   Select `Custom` to create a custom archive file that you can use with `pg_restore` to create a copy of a database. Custom archive file formats must be restored with `pg_restore`. This format offers the opportunity to select which database objects to restore from the backup file. `Custom` archive format is recommended for medium to large databases as it is compressed by default.
+    -   Select `Tar` to generate a tar archive file that you can restore with `pg_restore`. The tar format does not support compression.
+    -   Select `Plain` to create a plain-text script file. A plain-text script file contains SQL statements and commands that you can execute at the `psql` command line to recreate the database objects and load the table data. A plain-text backup file can be edited in a text editor, if desired, before using the `psql` program to restore database objects. `Plain` format is normally recommended for smaller databases; script dumps are not recommended for blobs. The SQL commands within the script will reconstruct the database to the last saved state of the database. A plain-text script can be used to reconstruct the database on another machine, or (with modifications) on other architectures.
+    -   Select `Directory` to generate a directory-format archive suitable for use with `pg_restore`. This file format creates a directory with one file for each table and blob being dumped, plus a `Table of Contents` file describing the dumped objects in a machine-readable format that `pg_restore` can read. This format is compressed by default.
 
 -   Use the `Compression Ratio` field to select a compression level for the backup. Specify a value of zero to mean use no compression; specify a maximum compression value of 9. Please note that tar archives do not support compression.
 
@@ -35,53 +35,53 @@ Click the `Dump options` tab to continue. Use the box fields in the `Dump option
 
 -   Move switches in the **Sections** field box to select a portion of the object that will be backed up.
 
-    > -   Move the switch next to `Pre-data` to the `Yes` position to include all data definition items not included in the data or post-data item lists.
-    > -   Move the switch next to `Data` to the `Yes` position to backup actual table data, large-object contents, and sequence values.
-    > -   Move the switch next to `Post-data` to the `Yes` position to include definitions of indexes, triggers, rules, and constraints other than validated check constraints.
+    -   Move the switch next to `Pre-data` to the `Yes` position to include all data definition items not included in the data or post-data item lists.
+    -   Move the switch next to `Data` to the `Yes` position to backup actual table data, large-object contents, and sequence values.
+    -   Move the switch next to `Post-data` to the `Yes` position to include definitions of indexes, triggers, rules, and constraints other than validated check constraints.
 
 ![Backup dialog - Dump Options tab - Type of Objects](../images/backup_objects.png)
 
 -   Move switches in the **Type of objects** field box to specify details about the type of objects that will be backed up.
 
-    > -   Move the switch next to `Only data` to the `Yes` position to limit the back up to data.
-    > -   Move the switch next to `Only schema` to limit the back up to schema-level database objects.
-    > -   Move the switch next to `Blobs` to the `No` position to exclude large objects in the backup.
+    -   Move the switch next to `Only data` to the `Yes` position to limit the back up to data.
+    -   Move the switch next to `Only schema` to limit the back up to schema-level database objects.
+    -   Move the switch next to `Blobs` to the `No` position to exclude large objects in the backup.
 
 ![Backup dialog - Dump Options tab - Do not save options](../images/backup_do_not_save.png)
 
 -   Move switches in the **Do not save** field box to select the objects that will not be included in the backup.
 
-    > -   Move the switch next to `Owner` to the `Yes` position to exclude commands that set object ownership.
-    > -   Move the switch next to `Privilege` to the `Yes` position to exclude commands that create access privileges.
-    > -   Move the switch next to `Tablespace` to the `Yes` position to exclude tablespaces.
-    > -   Move the switch next to `Unlogged table data` to the `Yes` position to exclude the contents of unlogged tables.
-    > -   Move the switch next to `Comments` to the `Yes` position to exclude commands that set the comments. **Note:** This option is visible only for database server greater than or equal to 11.
+    -   Move the switch next to `Owner` to the `Yes` position to exclude commands that set object ownership.
+    -   Move the switch next to `Privilege` to the `Yes` position to exclude commands that create access privileges.
+    -   Move the switch next to `Tablespace` to the `Yes` position to exclude tablespaces.
+    -   Move the switch next to `Unlogged table data` to the `Yes` position to exclude the contents of unlogged tables.
+    -   Move the switch next to `Comments` to the `Yes` position to exclude commands that set the comments. **Note:** This option is visible only for database server greater than or equal to 11.
 
 ![Backup dialog - Dump Options tab - Queries options](../images/backup_queries.png)
 
 -   Move switches in the **Queries** field box to specify the type of statements that should be included in the backup.
 
-    > -   Move the switch next to `Use Column Inserts` to the `Yes` position to dump the data in the form of INSERT statements and include explicit column names. Please note: this may make restoration from backup slow.
-    > -   Move the switch next to `Use Insert commands` to the `Yes` position to dump the data in the form of INSERT statements rather than using a COPY command. Please note: this may make restoration from backup slow.
-    > -   Move the switch next to `Include CREATE DATABASE statement` to the `Yes` position to include a command in the backup that creates a new database when restoring the backup.
-    > -   Move the switch next to `Include DROP DATABASE statement` to the `Yes` position to include a command in the backup that will drop any existing database object with the same name before recreating the object during a backup.
-    > -   Move the switch next to `Load Via Partition Root` to the `Yes` position, so when dumping a COPY or INSERT statement for a partitioned table, target the root of the partitioning hierarchy which contains it rather than the partition itself. **Note:** This option is visible only for database server greater than or equal to 11.
+    -   Move the switch next to `Use Column Inserts` to the `Yes` position to dump the data in the form of INSERT statements and include explicit column names. Please note: this may make restoration from backup slow.
+    -   Move the switch next to `Use Insert commands` to the `Yes` position to dump the data in the form of INSERT statements rather than using a COPY command. Please note: this may make restoration from backup slow.
+    -   Move the switch next to `Include CREATE DATABASE statement` to the `Yes` position to include a command in the backup that creates a new database when restoring the backup.
+    -   Move the switch next to `Include DROP DATABASE statement` to the `Yes` position to include a command in the backup that will drop any existing database object with the same name before recreating the object during a backup.
+    -   Move the switch next to `Load Via Partition Root` to the `Yes` position, so when dumping a COPY or INSERT statement for a partitioned table, target the root of the partitioning hierarchy which contains it rather than the partition itself. **Note:** This option is visible only for database server greater than or equal to 11.
 
 ![Backup dialog - Dump Options tab - Disable options](../images/backup_disable.png)
 
 -   Move switches in the **Disable** field box to specify the type of statements that should be excluded from the backup.
 
-    > -   Move the switch next to `Trigger` (active when creating a data-only backup) to the `Yes` position to include commands that will disable triggers on the target table while the data is being loaded.
-    > -   Move the switch next to `$ quoting` to the `Yes` position to enable dollar quoting within function bodies; if disabled, the function body will be quoted using SQL standard string syntax.
+    -   Move the switch next to `Trigger` (active when creating a data-only backup) to the `Yes` position to include commands that will disable triggers on the target table while the data is being loaded.
+    -   Move the switch next to `$ quoting` to the `Yes` position to enable dollar quoting within function bodies; if disabled, the function body will be quoted using SQL standard string syntax.
 
 ![Backup dialog - Dump Options tab - Miscellaneous options](../images/backup_miscellaneous.png)
 
 -   Move switches in the **Miscellaneous** field box to specify miscellaneous backup options.
 
-    > -   Move the switch next to `With OIDs` to the `Yes` position to include object identifiers as part of the table data for each table.
-    > -   Move the switch next to `Verbose messages` to the `No` position to instruct `pg_dump` to exclude verbose messages.
-    > -   Move the switch next to `Force double quotes on identifiers` to the `Yes` position to force the quoting of all identifiers.
-    > -   Move the switch next to `Use SET SESSION AUTHORIZATION` to the `Yes` position to include a statement that will use a SET SESSION AUTHORIZATION command to determine object ownership (instead of an ALTER OWNER command).
+    -   Move the switch next to `With OIDs` to the `Yes` position to include object identifiers as part of the table data for each table.
+    -   Move the switch next to `Verbose messages` to the `No` position to instruct `pg_dump` to exclude verbose messages.
+    -   Move the switch next to `Force double quotes on identifiers` to the `Yes` position to force the quoting of all identifiers.
+    -   Move the switch next to `Use SET SESSION AUTHORIZATION` to the `Yes` position to include a statement that will use a SET SESSION AUTHORIZATION command to determine object ownership (instead of an ALTER OWNER command).
 
 When you’ve specified the details that will be incorporated into the pg_dump command:
 
@@ -98,14 +98,5 @@ If the backup is successful, a popup window will confirm success. Click *More de
 
 If the backup is unsuccessful, you can review the error messages returned by the backup command on the `Process Watcher`.
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .
-
-</div>
+!!! Note
+    You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/07_backup_globals_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/07_backup_globals_dialog.mdx
@@ -30,14 +30,5 @@ If the backup is successful, a popup window will confirm success. Click `Click h
 
 If the backup is unsuccessful, review the error message returned by the `Process Watcher` to resolve any issue.
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .
-
-</div>
+!!! Note
+    You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/08_backup_server_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/08_backup_server_dialog.mdx
@@ -18,42 +18,42 @@ Use the fields in the `General` tab to specify the following:
 
 -   Move switches in the **Type of objects** field box to specify details about the type of objects that will be backed up.
 
-    > -   Move the switch next to `Only data` to the `Yes` position to limit the back up to data.
-    > -   Move the switch next to `Only schema` to limit the back up to schema-level database objects.
+    -   Move the switch next to `Only data` to the `Yes` position to limit the back up to data.
+    -   Move the switch next to `Only schema` to limit the back up to schema-level database objects.
 
 ![Backup Server dialog - Dump Options tab - Do not save options](../images/backup_server_do_not_save.png)
 
 -   Move switches in the **Do not save** field box to select the objects that will not be included in the backup.
 
-    > -   Move the switch next to `Owner` to the `Yes` position to exclude commands that set object ownership.
-    > -   Move the switch next to `Privilege` to the `Yes` position to exclude commands that create access privileges.
-    > -   Move the switch next to `Tablespace` to the `Yes` position to exclude tablespaces.
-    > -   Move the switch next to `Unlogged table data` to the `Yes` position to exclude the contents of unlogged tables.
-    > -   Move the switch next to `Comments` to the `Yes` position to exclude commands that set the comments. **Note:** This option is visible only for database server greater than or equal to 11.
+    -   Move the switch next to `Owner` to the `Yes` position to exclude commands that set object ownership.
+    -   Move the switch next to `Privilege` to the `Yes` position to exclude commands that create access privileges.
+    -   Move the switch next to `Tablespace` to the `Yes` position to exclude tablespaces.
+    -   Move the switch next to `Unlogged table data` to the `Yes` position to exclude the contents of unlogged tables.
+    -   Move the switch next to `Comments` to the `Yes` position to exclude commands that set the comments. **Note:** This option is visible only for database server greater than or equal to 11.
 
 ![Backup Server dialog - Dump Options - Queries options](../images/backup_server_queries.png)
 
 -   Move switches in the **Queries** field box to specify the type of statements that should be included in the backup.
 
-    > -   Move the switch next to `Use Column Inserts` to the `Yes` position to dump the data in the form of INSERT statements and include explicit column names. Please note: this may make restoration from backup slow.
-    > -   Move the switch next to `Use Insert commands` to the `Yes` position to dump the data in the form of INSERT statements rather than using a COPY command. Please note: this may make restoration from backup slow.
-    > -   Move the switch next to `Include DROP DATABASE statement` to the `Yes` position to include a command in the backup that will drop any existing database object with the same name before recreating the object during a backup.
+    -   Move the switch next to `Use Column Inserts` to the `Yes` position to dump the data in the form of INSERT statements and include explicit column names. Please note: this may make restoration from backup slow.
+    -   Move the switch next to `Use Insert commands` to the `Yes` position to dump the data in the form of INSERT statements rather than using a COPY command. Please note: this may make restoration from backup slow.
+    -   Move the switch next to `Include DROP DATABASE statement` to the `Yes` position to include a command in the backup that will drop any existing database object with the same name before recreating the object during a backup.
 
 ![Backup Server dialog - Dump Options tab - Disable options](../images/backup_server_disable.png)
 
 -   Move switches in the **Disable** field box to specify the type of statements that should be excluded from the backup.
 
-    > -   Move the switch next to `Trigger` (active when creating a data-only backup) to the `Yes` position to include commands that will disable triggers on the target table while the data is being loaded.
-    > -   Move the switch next to `$ quoting` to the `Yes` position to enable dollar quoting within function bodies; if disabled, the function body will be quoted using SQL standard string syntax.
+    -   Move the switch next to `Trigger` (active when creating a data-only backup) to the `Yes` position to include commands that will disable triggers on the target table while the data is being loaded.
+    -   Move the switch next to `$ quoting` to the `Yes` position to enable dollar quoting within function bodies; if disabled, the function body will be quoted using SQL standard string syntax.
 
 ![Backup Server dialog - Dump Options tab - Miscellaneous options](../images/backup_server_miscellaneous.png)
 
 -   Move switches in the **Miscellaneous** field box to specify miscellaneous backup options.
 
-    > -   Move the switch next to `With OIDs` to the `Yes` position to include object identifiers as part of the table data for each table.
-    > -   Move the switch next to `Verbose messages` to the `No` position to instruct `pg_dump` to exclude verbose messages.
-    > -   Move the switch next to `Force double quotes on identifiers` to the `Yes` position to force the quoting of all identifiers.
-    > -   Move the switch next to `Use SET SESSION AUTHORIZATION` to the `Yes` position to include a statement that will use a SET SESSION AUTHORIZATION command to determine object ownership (instead of an ALTER OWNER command).
+    -   Move the switch next to `With OIDs` to the `Yes` position to include object identifiers as part of the table data for each table.
+    -   Move the switch next to `Verbose messages` to the `No` position to instruct `pg_dump` to exclude verbose messages.
+    -   Move the switch next to `Force double quotes on identifiers` to the `Yes` position to force the quoting of all identifiers.
+    -   Move the switch next to `Use SET SESSION AUTHORIZATION` to the `Yes` position to include a statement that will use a SET SESSION AUTHORIZATION command to determine object ownership (instead of an ALTER OWNER command).
 
 Click the `Backup` button to build and execute a command based on your selections; click the `Cancel` button to exit without saving work.
 
@@ -67,14 +67,5 @@ If the backup is successful, a popup window will confirm success. Click `Click h
 
 If the backup is unsuccessful, review the error message returned by the `Process Watcher` to resolve any issue.
 
-<div class="note">
-
-<div class="title">
-
-Note
-
-</div>
-
-You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .
-
-</div>
+!!! Note
+    You can click on the ![sm_icon](../images/sm_icon.png) icon in the process watcher window to open the file location in the Storage Manager. You can use the [Storage Manager](05_storage_manager/#storage_manager) to download the backup file on the client machine .

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/09_restore_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/09_restore_dialog.mdx
@@ -14,8 +14,8 @@ Use the fields on the `General` tab to specify general information about the res
 
 -   Use the drop-down listbox in the `Format` field to select the format of your backup file.
 
-    > -   Select `Custom or tar` to restore from a custom archive file to create a copy of the backed-up object.
-    > -   Select `Directory` to restore from a compressed directory-format archive.
+    -   Select `Custom or tar` to restore from a custom archive file to create a copy of the backed-up object.
+    -   Select `Directory` to restore from a compressed directory-format archive.
 
 -   Enter the complete path to the backup file in the `Filename` field. Optionally, select the `Browser` icon (ellipsis) to the right to navigate into a directory and select the file that contains the archive.
 
@@ -29,48 +29,48 @@ Click the `Restore options` tab to continue. Use the fields on the `Restore opti
 
 -   Use the switches in the **Sections** box to specify the content that will be restored:
 
-    > -   Move the switch next to `Pre-data` to the `Yes` position to restore all data definition items not included in the data or post-data item lists.
-    > -   Move the switch next to `Data` to the `Yes` position to restore actual table data, large-object contents, and sequence values.
-    > -   Move the switch next to `Post-data` to the `Yes` position to restore definitions of indexes, triggers, rules, and constraints (other than validated check constraints).
+    -   Move the switch next to `Pre-data` to the `Yes` position to restore all data definition items not included in the data or post-data item lists.
+    -   Move the switch next to `Data` to the `Yes` position to restore actual table data, large-object contents, and sequence values.
+    -   Move the switch next to `Post-data` to the `Yes` position to restore definitions of indexes, triggers, rules, and constraints (other than validated check constraints).
 
 ![Restore dialog - Restore Options tab - Type of objects section](../images/restore_objects.png)
 
 -   Use the switches in the **Type of objects** box to specify the objects that will be restored:
 
-    > -   Move the switch next to `Only data` to the `Yes` position to limit the restoration to data.
-    > -   Move the switch next to `Only schema` to limit the restoration to schema-level database objects.
+    -   Move the switch next to `Only data` to the `Yes` position to limit the restoration to data.
+    -   Move the switch next to `Only schema` to limit the restoration to schema-level database objects.
 
 ![Restore dialog - Restore Options tab - Do not save section](../images/restore_do_not_save.png)
 
 -   Use the switches in the **Do not save** box to specify which objects will not be restored:
 
-    > -   Move the switch next to `Owner` to the `Yes` position to exclude commands that set object ownership.
-    > -   Move the switch next to `Privilege` to the `Yes` position to exclude commands that create access privileges.
-    > -   Move the switch next to `Tablespace` to the `Yes` position to exclude tablespaces.
-    > -   Move the switch next to `Comments` to the `Yes` position to exclude commands that set the comments. **Note:** This option is visible only for database server greater than or equal to 11.
+    -   Move the switch next to `Owner` to the `Yes` position to exclude commands that set object ownership.
+    -   Move the switch next to `Privilege` to the `Yes` position to exclude commands that create access privileges.
+    -   Move the switch next to `Tablespace` to the `Yes` position to exclude tablespaces.
+    -   Move the switch next to `Comments` to the `Yes` position to exclude commands that set the comments. **Note:** This option is visible only for database server greater than or equal to 11.
 
 ![Restore dialog - Restore Options tab - Queries section](../images/restore_queries.png)
 
 -   Use the switches in the **Queries** box to specify the type of statements that should be included in the restore:
 
-    > -   Move the switch next to `Include CREATE DATABASE statement` to the `Yes` position to include a command that creates a new database before performing the restore.
-    > -   Move the switch next to `Clean before restore` to the `Yes` position to drop each existing database object (and data) before restoring.
-    > -   Move the switch next to `Single transaction` to the `Yes` position to execute the restore as a single transaction (that is, wrap the emitted commands in `BEGIN/COMMIT`). This ensures that either all the commands complete successfully, or no changes are applied. This option implies `--exit-on-error`.
+    -   Move the switch next to `Include CREATE DATABASE statement` to the `Yes` position to include a command that creates a new database before performing the restore.
+    -   Move the switch next to `Clean before restore` to the `Yes` position to drop each existing database object (and data) before restoring.
+    -   Move the switch next to `Single transaction` to the `Yes` position to execute the restore as a single transaction (that is, wrap the emitted commands in `BEGIN/COMMIT`). This ensures that either all the commands complete successfully, or no changes are applied. This option implies `--exit-on-error`.
 
 ![Restore dialog - Restore Options tab - Disable section](../images/restore_disable.png)
 
 -   Use the switches in the **Disable** box to specify the type of statements that should be excluded from the restore:
 
-    > -   Move the switch next to `Trigger` (active when creating a data-only restore) to the `Yes` position to include commands that will disable triggers on the target table while the data is being loaded.
-    > -   Move the switch next to `No data for Failed Tables` to the `Yes` position to ignore data that fails a trigger.
+    -   Move the switch next to `Trigger` (active when creating a data-only restore) to the `Yes` position to include commands that will disable triggers on the target table while the data is being loaded.
+    -   Move the switch next to `No data for Failed Tables` to the `Yes` position to ignore data that fails a trigger.
 
 ![Restore dialog - Restore Options tab - Miscellaneous section](../images/restore_miscellaneous.png)
 
 -   Use the switches in the **Miscellaneous/Behavior** box to specify miscellaneous restore options:
 
-    > -   Move the switch next to `Verbose messages` to the `No` position to instruct `pg_restore` to exclude verbose messages.
-    > -   Move the switch next to `Use SET SESSION AUTHORIZATION` to the `Yes` position to include a statement that will use a SET SESSION AUTHORIZATION command to determine object ownership (instead of an ALTER OWNER command).
-    > -   Move the switch next to `Exit on error` to the `Yes` position to instruct `pg_restore` to exit restore if there is an error in sending SQL commands. The default is to continue and to display a count of errors at the end of the restore.
+    -   Move the switch next to `Verbose messages` to the `No` position to instruct `pg_restore` to exclude verbose messages.
+    -   Move the switch next to `Use SET SESSION AUTHORIZATION` to the `Yes` position to include a statement that will use a SET SESSION AUTHORIZATION command to determine object ownership (instead of an ALTER OWNER command).
+    -   Move the switch next to `Exit on error` to the `Yes` position to instruct `pg_restore` to exit restore if there is an error in sending SQL commands. The default is to continue and to display a count of errors at the end of the restore.
 
 When you’ve specified the details that will be incorporated into the pg_restore command, click the `Restore` button to start the process, or click the `Cancel` button to exit without saving your work. A popup will confirm if the restore is successful.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/10_managing_cluster_objects/index.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/10_managing_cluster_objects/index.mdx
@@ -8,8 +8,8 @@ Some object definitions reside at the cluster level; PEM provides dialogs that a
 
 Contents:
 
-<div class="toctree">
-
-database_dialog move_objects resource_group_dialog role_dialog tablespace_dialog
-
-</div>
+-   [Database Dialog](01_database_dialog/#database_dialog)
+-   [Move Objects Dialog](02_move_objects/#move_objects)
+-   [Resource Group Dialog](03_resource_group_dialog/#resource_group_dialog)
+-   [Login/Group Role Dialog](04_role_dialog/#role_dialog)
+-   [Tablespace Dialog](05_tablespace_dialog/#tablespace_dialog)

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/02_collation_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/02_collation_dialog.mdx
@@ -42,7 +42,7 @@ The example shown demonstrates creating a collation named `french` that uses the
 
 -   Click the `Info` button (i) to access online help. For more information about setting a locale, see Chapter 22.1 Locale Support of the PostgreSQL core documentation:
 
-    > <http://www.postgresql.org/docs/current/static/locale.html>
+    <http://www.postgresql.org/docs/current/static/locale.html>
 
 -   Click the `Save` button to save work.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/14_function_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/14_function_dialog.mdx
@@ -47,9 +47,9 @@ Use the fields in the `Options` tab to describe or modify the action of the func
 
 -   Use the drop-down listbox next to `Volatility` to select one of the following. `VOLATILE` is the default value.
 
-    > -   `VOLATILE` indicates that the function value can change even within a single table scan, so no optimizations can be made.
-    > -   `STABLE` indicates that the function cannot modify the database, and that within a single table scan it will consistently return the same result for the same argument values.
-    > -   `IMMUTABLE` indicates that the function cannot modify the database and always returns the same result when given the same argument values.
+    -   `VOLATILE` indicates that the function value can change even within a single table scan, so no optimizations can be made.
+    -   `STABLE` indicates that the function cannot modify the database, and that within a single table scan it will consistently return the same result for the same argument values.
+    -   `IMMUTABLE` indicates that the function cannot modify the database and always returns the same result when given the same argument values.
 
 -   Move the `Returns a Set?` switch to indicate if the function returns a set that includes multiple rows. The default is `No`.
 
@@ -59,7 +59,7 @@ Use the fields in the `Options` tab to describe or modify the action of the func
 
 -   Move the `Window?` switch to indicate that the function is a window function rather than a plain function. The default is `No`. This is currently only useful for functions written in C. The WINDOW attribute cannot be changed when replacing an existing function definition. For more information about the CREATE FUNCTION command, see the PostgreSQL core documentation available at:
 
-    > <http://www.postgresql.org/docs/current/static/functions-window.html>
+    <http://www.postgresql.org/docs/current/static/functions-window.html>
 
 -   Use the `Estimated cost` field to specify a positive number representing the estimated execution cost for the function, in units of cpu_operator_cost. If the function returns a set, this is the cost per returned row.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/18_procedure_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/18_procedure_dialog.mdx
@@ -46,9 +46,9 @@ Use the fields in the `Options` tab to describe or modify the behavior of the pr
 
 -   Use the drop-down listbox under `Volatility` to select one of the following. `VOLATILE` is the default value.
 
-    > -   `VOLATILE` indicates that the value can change even within a single table scan, so no optimizations can be made.
-    > -   `STABLE` indicates that the procedure cannot modify the database, and that within a single table scan it will consistently return the same result for the same argument values, but that its result could change across SQL statements.
-    > -   `IMMUTABLE` indicates that the procedure cannot modify the database and always returns the same result when given the same argument values.
+    -   `VOLATILE` indicates that the value can change even within a single table scan, so no optimizations can be made.
+    -   `STABLE` indicates that the procedure cannot modify the database, and that within a single table scan it will consistently return the same result for the same argument values, but that its result could change across SQL statements.
+    -   `IMMUTABLE` indicates that the procedure cannot modify the database and always returns the same result when given the same argument values.
 
 -   Move the `Strict?` switch to indicate if the procedure always returns NULL whenever any of its arguments are NULL. If `Yes`, the procedure is not executed when there are NULL arguments; instead a NULL result is assumed automatically. The default is `No`.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/22_trigger_function_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/22_trigger_function_dialog.mdx
@@ -25,8 +25,8 @@ Use the fields in the `Definition` tab to define the trigger function:
 
 -   Use the drop-down listbox next to `Return type` to specify the pseudotype that is associated with the trigger function:
 
-    > -   Select `trigger` if you are creating a DML trigger.
-    > -   Select `event_trigger` if you are creating a DDL trigger.
+    -   Select `trigger` if you are creating a DML trigger.
+    -   Select `event_trigger` if you are creating a DDL trigger.
 
 -   Use the drop-down listbox next to `Language` to select the implementation language. The default is `plpgsql`.
 
@@ -44,9 +44,9 @@ Use the fields in the `Options` tab to describe or modify the action of the trig
 
 -   Use the drop-down listbox next to `Volatility` to select one of the following:
 
-    > -   `VOLATILE` indicates that the trigger function value can change even within a single table scan.
-    > -   `STABLE` indicates that the trigger function cannot modify the database, and that within a single table scan it will consistently return the same result for the same argument values.
-    > -   `IMMUTABLE` indicates that the trigger function cannot modify the database and always returns the same result when given the same argument values.
+    -   `VOLATILE` indicates that the trigger function value can change even within a single table scan.
+    -   `STABLE` indicates that the trigger function cannot modify the database, and that within a single table scan it will consistently return the same result for the same argument values.
+    -   `IMMUTABLE` indicates that the trigger function cannot modify the database and always returns the same result when given the same argument values.
 
 -   Move the `Returns a Set?` switch to indicate if the trigger function returns a set that includes multiple rows. The default is `No`.
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/23_type_dialog.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/23_type_dialog.mdx
@@ -23,11 +23,11 @@ Select a data type from the drop-down listbox next to `Type` on the `Definition`
 
 There are five data types:
 
-> -   *Composite Type*
-> -   *Enumeration Type*
-> -   *Range Type*
-> -   `External Type` (or `Base Type`)
-> -   *Shell Type*
+-   `Composite Type`
+-   `Enumeration Type`
+-   `Range Type`
+-   `External Type` (or `Base Type`)
+-   `Shell Type`
 
 If you select `Composite` in the `Type` field, the `Definition` tab displays the `Composite Type` panel:
 

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/index.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/11_managing_database_objects/index.mdx
@@ -10,8 +10,28 @@ To access a dialog that allows you to create a database object, right-click on t
 
 Contents:
 
-<div class="toctree">
-
-cast_dialog collation_dialog domain_dialog domain_constraint_dialog event_trigger_dialog extension_dialog foreign_data_wrapper_dialog foreign_server_dialog foreign_table_dialog fts_configuration_dialog fts_dictionary_dialog fts_parser_dialog fts_template_dialog function_dialog language_dialog materialized_view_dialog package_dialog procedure_dialog schema_dialog sequence_dialog synonym_dialog trigger_function_dialog type_dialog user_mapping_dialog view_dialog
-
-</div>
+-   [Cast Dialog](01_cast_dialog/#cast_dialog)
+-   [Collation Dialog](02_collation_dialog/#collation_dialog)
+-   [Domain Dialog](03_domain_dialog/#domain_dialog)
+-   [Domain Constraints Dialog](04_domain_constraint_dialog/#domain_constraint_dialog)
+-   [Event Trigger Dialog](05_event_trigger_dialog/#event_trigger_dialog)
+-   [Extension Dialog](06_extension_dialog/#extension_dialog)
+-   [Foreign Data Wrapper Dialog](07_foreign_data_wrapper_dialog/#foreign_data_wrapper_dialog)
+-   [Foreign Server Dialog](08_foreign_sever_dialog/#foreign_server_dialog)
+-   [Foreign Table Dialog](09_foreign_table_dialog/#foreign_table_dialog)
+-   [FTS Configuration Dialog](10_fts_configuration_dialog/#fts_configuration_dialog)
+-   [FTS Dictionary Dialog](11_fts_dictionary_dialog/#fts_dictionary_dialog)
+-   [FTS Parser Dialog](12_fts_parser_dialog/#fts_parser_dialog)
+-   [FTS Template Dialog](13_fts_template_dialog/#fts_template_dialog)
+-   [Function Dialog](14_function_dialog/#function_dialog)
+-   [Language Dialog](15_language_dialog/#language_dialog)
+-   [Materialized View Dialog](16_materialized_view/#materialized_view_dialog)
+-   [Package Dialog](17_package_dialog/#package_dialog)
+-   [Procedure Dialog](18_procedure_dialog/#procedure_dialog)
+-   [Schema Dialog](19_schema_dialog/#schema_dialog)
+-   [Sequence Dialog](20_sequence_dialog/#sequence_dialog)
+-   [Subscription Dialog](21_synonym_dialog/#synonym_dialog)
+-   [Trigger Function Dialog](22_trigger_function_dialog/#trigger_function_dialog)
+-   [Type Dialog](23_type_dialog/#type_dialog)
+-   [User Mapping Dialog](24_user_mapping_dialog/#user_mapping_dialog)
+-   [View Dialog](25_view_dialog/#view_dialog)

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/12_modifying_tables/index.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/12_modifying_tables/index.mdx
@@ -10,8 +10,15 @@ To access a dialog that allows you to create a database object, right-click on t
 
 Contents:
 
-<div class="toctree">
-
-check_dialog column_dialog compound_trigger_dialog exclusion_constraint_dialog foreign_key_dialog index_dialog primary_key_dialog rls_policy_dialog rule_dialog table_dialog trigger_dialog unique_constraint_dialog
-
-</div>
+-   [Check Dialog](01_check_dialog/#check_dialog)
+-   [Column Dialog](02_column_dialog/#column_dialog)
+-   [Compound Trigger Dialog](03_compound_trigger_dialog/#compound_trigger_dialog)
+-   [Exclusion Constraint Dialog](04_exclusion_constraint_dialog/#exclusion_constraint_dialog)
+-   [Foreign Key Dialog](05_foreign_key_dialog/#foreign_key_dialog)
+-   [Index Dialog/06_index_dialog/#index_dialog]
+-   [Primary Key Dialog](07_primary_key_dialog/#primary_key_dialog)
+-   [RLS Policy Dialog](08_rls_policy_dialog/#rls_policy_dialog)
+-   [Rule Dialog](09_rule_dialog/#rule_dialog)
+-   [Table Dialog](10_table_dialog/#table_dialog)
+-   [Trigger Dialog](11_trigger_dialog/#trigger_dialog)
+-   [Unique Constraint Dialog](12_unique_constraint_dialog/#unique_constraint_dialog)

--- a/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/index.mdx
+++ b/product_docs/docs/pem/8.0/pem_online_help/05_toc_pem_management_basics/index.mdx
@@ -10,38 +10,30 @@ The Grant Wizard simplifies the task of privilege management; to open the Grant 
 
 Contents:
 
-<div class="toctree">
-
-grant_wizard
-
-</div>
+-   [Grant Wizard](01_grant_wizard/#grant_wizard)
 
 PEM provides an easy to use environment in which to manage restore points, import/export tasks, and organize vacuum/analyze management.
 
 Contents:
 
-<div class="toctree">
-
-add_restore_point_dialog import_export_data maintenance storage_manager
-
-</div>
+-   [Add named restore point Dialog](02_add_restore_point_dialog/#add_restore_point_dialog)
+-   [Import/Export data Dialog](03_import_export_data/#import_export_data)
+-   [Maintain a Database Object](04_maintenance/#maintenance)
+-   [Storage Manager](05_storage_manager/#storage_manager)
 
 A powerful, but user-friendly interface provides an easy way to use take backups and create copies of databases or database objects.
 
 Contents:
 
-<div class="toctree">
-
-backup_dialog backup_globals_dialog backup_server_dialog restore_dialog
-
-</div>
+-   [Backup Dialog](06_backup_dialog/#backup_dialog)
+-   [Backup Globals Dialog](07_backup_globals_dailog/#backup_globals_dialog)
+-   [Backup Server Dialog](08_backup_server_dialog/#backup_server_dialog)
+-   [Restore Dialog](09_restore_dialog/#restore_dialog)
 
 You can also use the client to manage objects that reside on managed and unmanaged database servers:
 
 Contents:
 
-<div class="toctree">
-
-managing_cluster_objects managing_database_objects modifying_tables
-
-</div>
+-   [Managing Cluster Level Objects](10_managing_cluster_objects/#managing_cluster_objects)
+-   [Managing Database Objects](11_managing_database_objects/#managing_database_objects)
+-   [Creating or Modifying Tables](12_modifying_tables/#modifying_tables)


### PR DESCRIPTION
## What Changed?

Toctree and formatting issues fixed for the PEM Management Basics section of PEM 8.0 Online Help. Also, the review comments of the previous PR are fixed.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
