### PR TITLE
Typo fixed for Subpartition tempate

### DIFF
--- a/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/11_alter_table_set_subpartition_template/01_example_setting_a_subpartition_template.mdx
+++ b/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/11_alter_table_set_subpartition_template/01_example_setting_a_subpartition_template.mdx
@@ -83,7 +83,7 @@ ALL_TAB_SUBPARTITIONS WHERE table_name = 'SALES' and partition_name =
 
 ## Example - Resetting a SUBPARTITION TEMPLATE
 
-The following example creates a list-partitioned table `sales` that is list partitioned by `country` and has subpartitioned by `part_no`. Use the following command to create the `sales` table:
+The following example creates a list-partitioned table `sales` that is list partitioned by `country` and hash subpartitioned by `part_no`. Use the following command to create the `sales` table:
 
 ```text
 CREATE TABLE sales
@@ -102,7 +102,7 @@ PARTITION BY LIST (country) SUBPARTITION BY HASH (part_no) SUBPARTITIONS 3
 );
 ```
 
-The table contains three partitions (`AMERICAS`, `ASIA`, and `EUROPE`), each partition consists of three subpartitions with system-generated names.
+The table contains three partitions (`americas`, `asia`, and `europe`), each partition consists of three subpartitions with system-generated names.
 
 ```text
 edb=# SELECT table_name, partition_name, subpartition_name FROM


### PR DESCRIPTION
## What Changed?

- Fixed the typo for (hash) in the subpartition template section.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
