### PR TITLE
Formatting of the note for edb loader fixed in v12 and v13

### DIFF
--- a/product_docs/docs/epas/12/epas_compat_tools_guide/02_edb_loader.mdx
+++ b/product_docs/docs/epas/12/epas_compat_tools_guide/02_edb_loader.mdx
@@ -22,9 +22,7 @@ EDB\*Loader features include:
 These features are explained in detail in the following sections.
 
 !!! Note
-    The following are important version compatibility restrictions between the EDB\*Loader client and the database server.
-
-When you invoke the EDB\*Loader program (called `edbldr`), you pass in parameters and directive information to the database server. **We strongly recommend that the version 12 EDB\*Loader client (the edbldr program supplied with Advanced Server 12) be used to load data only into version 12 of the database server. In general, the EDB\*Loader client and database server should be the same version.**
+    When you invoke the EDB\*Loader program (called `edbldr`), you pass in parameters and directive information to the database server. **We strongly recommend that the version 12 EDB\*Loader client (the edbldr program supplied with Advanced Server 12) be used to load data only into version 12 of the database server. In general, the EDB\*Loader client and database server should be the same version.**
 
 <div id="data_loading_methods" class="registered_link"></div>
 

--- a/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/02_edb_loader.mdx
@@ -23,16 +23,15 @@ These features are explained in detail in the following sections.
 
 !!! Note
     The following are important version compatibility restrictions between the EDB\*Loader client and the database server.
+  
+    -   When you invoke the EDB\*Loader program (called `edbldr`), you pass in parameters and directive information to the database server. **We strongly recommend that the version 13 EDB\*Loader client (the edbldr program supplied with Advanced Server 13) be used to load data only into version 13 of the database server. In general, the EDB\*Loader client and database server should be the same version.**
+    -   Using EDB\*Loader in conjunction with connection poolers such as PgPool-II and PgBouncer is not supported. EDB\*Loader must connect directly to Advanced Server version 13. Alternatively, the following commands are some of the options that can be used for loading data through connection poolers:
 
--   When you invoke the EDB\*Loader program (called `edbldr`), you pass in parameters and directive information to the database server. **We strongly recommend that the version 13 EDB\*Loader client (the edbldr program supplied with Advanced Server 13) be used to load data only into version 13 of the database server. In general, the EDB\*Loader client and database server should be the same version.**
-
--   Using EDB\*Loader in conjunction with connection poolers such as PgPool-II and PgBouncer is not supported. EDB\*Loader must connect directly to Advanced Server version 13. Alternatively, the following commands are some of the options that can be used for loading data through connection poolers:
-
-    ```
-    psql \copy
-    jdbc copyIn
-    psycopg2 copy_from
-    ```
+        ```
+        psql \copy
+        jdbc copyIn
+        psycopg2 copy_from
+       ```
 
 <div id="data_loading_methods" class="registered_link"></div>
 


### PR DESCRIPTION
## What Changed?

The edb*loader version compatibility content moved under the NOTE section, as discussed with Dee Dee.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
