### PR TITLE
DB-1115 Improve Oracle Memory usage with dblink_oci

### DIFF
--- a/product_docs/docs/epas/12/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/12/epas_compat_sql/21_create_public_database_link.mdx
@@ -40,10 +40,9 @@ For information about high availability, load balancing, and replication for Pos
 <https://www.postgresql.org/docs/12/static/high-availability.html>
 
 !!! Note
-    For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
-
-!!! Note
-    The `edb_dblink_oci.rescans` GUC can be set to `SCROLL` or `SERIALIZABLE` at the server level in `postgresql.conf` file. It can also be set at session level using the `SET` command, but the setting will not be applied to existing dblink connections due to dblink connection caching.
+    -  For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
+    -  The `edb_dblink_oci.rescans` GUC can be set to `SCROLL` or `SERIALIZABLE` at the server level in `postgresql.conf` file. It can also be set at session level using the `SET` command, but the setting will not be applied to existing dblink connections due to dblink connection caching.
+    -  When executing `SELECT` on LOB data of more than 4000 characters, it is advisable to use `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding the `PGA_AGGREGATE_LIMIT`.
 
 The `edb_dblink_oci` supports both types of rescans: `SCROLL` and `SERIALIZABLE`. By default it is set to `SERIALIZABLE`. When set to `SERIALIZABLE`, `edb_dblink_oci` uses the `SERIALIZABLE` transaction isolation level on the Oracle side, which corresponds to PostgreSQL’s `REPEATABLE READ`.
 

--- a/product_docs/docs/epas/13/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/13/epas_compat_sql/21_create_public_database_link.mdx
@@ -40,10 +40,9 @@ For information about high availability, load balancing, and replication for Pos
 <https://www.postgresql.org/docs/current/static/high-availability.html>
 
 !!! Note
-    For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
-
-!!! Note
-    The `edb_dblink_oci.rescans` GUC can be set to `SCROLL` or `SERIALIZABLE` at the server level in `postgresql.conf` file. It can also be set at session level using the `SET` command, but the setting will not be applied to existing dblink connections due to dblink connection caching.
+    -  For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
+    -  The `edb_dblink_oci.rescans` GUC can be set to `SCROLL` or `SERIALIZABLE` at the server level in `postgresql.conf` file. It can also be set at session level using the `SET` command, but the setting will not be applied to existing dblink connections due to dblink connection caching.
+    -  When executing `SELECT` on LOB data of more than 4000 characters, it is advisable to use `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding the `PGA_AGGREGATE_LIMIT`.
 
 The `edb_dblink_oci` supports both types of rescans: `SCROLL` and `SERIALIZABLE`. By default it is set to `SERIALIZABLE`. When set to `SERIALIZABLE`, `edb_dblink_oci` uses the `SERIALIZABLE` transaction isolation level on the Oracle side, which corresponds to PostgreSQL’s `REPEATABLE READ`.
 


### PR DESCRIPTION
## What Changed?

DB-1115: Updated the doc and included the Oracle memory usage info with dblink_oci in SQL guide. 

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
