### PR TITLE
Allow advo-style card nav for products

### DIFF
--- a/.github/workflows/deploy-draft.yml
+++ b/.github/workflows/deploy-draft.yml
@@ -1,0 +1,86 @@
+name: Deploy branch draft on Netlify
+on:
+  pull_request:
+    types: [labeled, opened, synchronize]
+    
+jobs:
+  build-deploy:
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy'))
+    runs-on: ubuntu-latest
+    steps:
+    - name: inject slug/short variables
+      uses: rlespinasse/github-slug-action@v3.x
+
+    - name: set STAGE variable in environment for next steps
+      run: echo "STAGE=pr-${{ github.event.number }}-${{ env.GITHUB_HEAD_REF_SLUG }}" >> $GITHUB_ENV
+
+    - name: create a github deployment
+      uses: bobheadxi/deployments@v0.5.2
+      id: deployment
+      with:
+        step: start
+        token: ${{ secrets.GITHUB_TOKEN }}
+        env: ${{ env.STAGE }}
+        ref: ${{ github.head_ref }}
+        
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # fetch whole repo so git-restore-mtime can work
+
+    - name: Adjust file watchers limit
+      run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - name: Install yarn
+      run: sudo npm -g install yarn
+    - name: Yarn install
+      run: yarn install --immutable
+      env:
+        NODE_ENV: ${{ secrets.NODE_ENV }}
+
+    - name: Checking Gatsby cache
+      id: gatsby-cache-build
+      uses: actions/cache@v2
+      with:
+        path: |
+          public
+          .cache
+        key: ${{ runner.os }}-gatsby-build-develop-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-gatsby-build-develop-
+
+    - name: Fix mtimes
+      run: yarn fix-mtimes --force
+    - name: Gatsby build
+      run: yarn build
+      env:
+        APP_ENV: staging
+        NODE_ENV: ${{ secrets.NODE_ENV }}
+        NODE_OPTIONS: --max-old-space-size=4096
+        ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+        ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+        ALGOLIA_INDEX_NAME: edb-docs-staging
+        INDEX_ON_BUILD: false
+
+    - name: Netlify deploy
+      run: |
+        sudo yarn global add netlify-cli
+        netlify deploy --dir=public --json | tee deploy_results.json
+        echo "NETLIFY_DRAFT_URL=`jq -r '.deploy_url' deploy_results.json`" >> $GITHUB_ENV
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_DEVELOP_SITE_ID }}
+
+    - name: update the github deployment status
+      uses: bobheadxi/deployments@v0.5.2
+      if: always()
+      with:
+        step: finish
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: ${{ job.status }}
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+        env_url: ${{ env.NETLIFY_DRAFT_URL }}

--- a/product_docs/docs/edbcloud/beta/index.mdx
+++ b/product_docs/docs/edbcloud/beta/index.mdx
@@ -1,7 +1,8 @@
 ---
 title: EDB Cloud
-directoryDefaults:
 description: "EDB Cloud: DBaaS for PostgresSQL "
+indexCards: simple
+directoryDefaults:
 navigation:
   - overview
   - getting_started


### PR DESCRIPTION
## What Changed?

The current EDBCloud branch is taking a hybrid format: something between current product docs (e.g. EPAS) and open source docs (e.g. pgBackRest). That means we're probably going to have to adjust navigation to allow for this sort of format. Specifically:

- Hierarchical side-nav
- "Card"-style index pages
- ...possibly different directory structure that eschews versioning (see: https://docs.google.com/document/d/1-jKMMldDDKHAksdttrC-UK6Bo3ctiXUUVtkAla098Ak/edit)

This PR aims to do the simplest thing that could work for now: enable card decks on index pages for product docs, if indicated in frontmatter via `indexCards: simple`

I've also added a workflow that'll produce draft builds for a PR if the `deploy` label is added. This addresses [UPM-1034](https://enterprisedb.atlassian.net/browse/UPM-1034).

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
