### PR TITLE
Minor tweaks to EPAS guides

### DIFF
--- a/product_docs/docs/epas/12/ecpgplus_guide/02_overview.mdx
+++ b/product_docs/docs/epas/12/ecpgplus_guide/02_overview.mdx
@@ -205,7 +205,7 @@ The first option tells `make` how to transform a file that ends in `.pgc` (presu
     ecpg -C PROC -c $(INCLUDES) $?
 ```
 
-The second option tells make how to transform a file that ends in `.pg` (an ECPG source file) into a file that ends in `.c` (a C program), using the ECPGPlus extensions. It invokes the ECPG pre-compiler with the `-c` flag (instructing the compiler to convert SQL code into C), as well as the `-C PROC` flag (instructing the compiler to use ECPGPlus in Pro\*C-compatibility mode), using the value of the `INCLUDES` variable and the name of the `.pgc` file.
+The second option tells `make` how to transform a file that ends in `.pg` (an ECPG source file) into a file that ends in `.c` (a C program), using the ECPGPlus extensions. It invokes the ECPG pre-compiler with the `-c` flag (instructing the compiler to convert SQL code into C), as well as the `-C PROC` flag (instructing the compiler to use ECPGPlus in Pro\*C-compatibility mode), using the value of the `INCLUDES` variable and the name of the `.pgc` file.
 
 When you run `make`, pass the name of the ECPG source code file you wish to compile. For example, to compile an ECPG source code file named `customer_list.pgc`, use the command:
 

--- a/product_docs/docs/epas/12/ecpgplus_guide/07_reference.mdx
+++ b/product_docs/docs/epas/12/ecpgplus_guide/07_reference.mdx
@@ -239,7 +239,7 @@ struct SQLDA
 
 `N - maximum number of entries`
 
- The N structure member contains the maximum number of entries that the SQLDA may describe. This member is populated by the `sqlald()` function when you allocate the SQLDA structure. Before using a descriptor in an `OPEN` or `FETCH` statement, you must set `N` to the *actual* number of values described.
+ The `N` structure member contains the maximum number of entries that the SQLDA may describe. This member is populated by the `sqlald()` function when you allocate the SQLDA structure. Before using a descriptor in an `OPEN` or `FETCH` statement, you must set `N` to the *actual* number of values described.
 
 `V - data values`
 
@@ -401,7 +401,7 @@ EXEC SQL CALL get_job_desc(:ename)
 
 ### CLOSE
 
-Use the `CLOSE` statement to close a cursor, and free any resources scurrently in use by the cursor. A client application cannot fetch rows from a closed cursor. The syntax of the `CLOSE` statement is:
+Use the `CLOSE` statement to close a cursor, and free any resources currently in use by the cursor. A client application cannot fetch rows from a closed cursor. The syntax of the `CLOSE` statement is:
 
 ```text
 EXEC SQL CLOSE [<cursor_name>];
@@ -975,9 +975,9 @@ If you include an `INTO` clause, the `FETCH` statement will populate the host va
 The following code fragment declares a cursor named `employees` that retrieves the `employee number`, `name` and `salary` from the `emp` table:
 
 ```text
-EXEC SQL DECLARE employees CURSOR
-    SELECT empno, ename, esal FROM emp
-EXEC SQL OPEN emp_cursor
+EXEC SQL DECLARE employees CURSOR FOR
+    SELECT empno, ename, esal FROM emp;
+EXEC SQL OPEN emp_cursor;
 EXEC SQL FETCH emp_cursor INTO :emp_no, :emp_name, :emp_sal;
 ```
 
@@ -1295,7 +1295,7 @@ SELECT
   [ GROUP BY expression [, ...]]
   [ HAVING condition ]
   [ { UNION [ ALL ] | INTERSECT | MINUS } (subquery) ]
-  [ ORDER BY expression> [order_by_options]]
+  [ ORDER BY expression [order_by_options]]
   [ LIMIT { count | ALL }]
   [ OFFSET start [ ROW | ROWS ] ]
   [ FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } ONLY ]

--- a/product_docs/docs/epas/12/edb_plus/03_installing_edb_plus.mdx/02_rpm_installation.mdx
+++ b/product_docs/docs/epas/12/edb_plus/03_installing_edb_plus.mdx/02_rpm_installation.mdx
@@ -108,8 +108,8 @@ Open the `pg_ident.conf` file and create a user mapping:
 
 Where:
 
-- The name specified in the map_name column is a user-defined name that will identify the mapping in the `pg_hba.conf` file.
-- The name specified in the system_username column is `enterprisedb`.
+- The name specified in the `map_name` column is a user-defined name that will identify the mapping in the `pg_hba.conf` file.
+- The name specified in the `system_username` column is `enterprisedb`.
 - The name specified in the `postgres_username` column is `enterprisedb`.
 
 Then, open the `pg_hba.conf` file and modify the `IDENT` entries:
@@ -124,7 +124,7 @@ Then, open the `pg_hba.conf` file and modify the `IDENT` entries:
 
 You must restart the Advanced Server service before invoking EDB\*Plus. For detailed information about controlling the Advanced Server service, see the *EDB Postgres Advanced Server Installation Guide*, available at:
 
-<https://www.enterprisedb.com/docs/>
+[https://www.enterprisedb.com/docs](/epas/12/)
 
 
 

--- a/product_docs/docs/epas/12/edb_plus/06_command_summary.mdx
+++ b/product_docs/docs/epas/12/edb_plus/06_command_summary.mdx
@@ -49,10 +49,10 @@ SQL> LIST
 `CHANGE` is a line editor command performs a search-and-replace on the current line in the SQL buffer.
 
 ```text
-C[HANGE ] /from/[to/ ]
+C[HANGE ] FROM [ TO ]
 ```
 
-If `to/` is specified, the first occurrence of text `from` in the current line is changed to text `to`. If `to/` is omitted, the first occurrence of text `from` in the current line is deleted.
+If `TO/` is specified, the first occurrence of text `FROM` in the current line is changed to text `TO`. If `TO/` is omitted, the first occurrence of text `FROM` in the current line is deleted.
 
 The following sequence of commands makes line 3 the current line, then changes the department number in the `WHERE` clause from 20 to 30.
 

--- a/product_docs/docs/epas/12/epas_compat_bip_guide/03_built-in_packages/03_dbms_aqadm/07_purge_queue_table.mdx
+++ b/product_docs/docs/epas/12/epas_compat_bip_guide/03_built-in_packages/03_dbms_aqadm/07_purge_queue_table.mdx
@@ -31,7 +31,7 @@ PURGE_QUEUE_TABLE(
 
 | Attribute       | Type    | Description                                                                                                         |
 | --------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| `Block`         | Boolean | Specify `TRUE` if an exclusive lock should be held on all queues within the table; the default is `FALSE`.          |
+| `block`         | Boolean | Specify `TRUE` if an exclusive lock should be held on all queues within the table; the default is `FALSE`.          |
 | `delivery_mode` | INTEGER | `delivery_mode` specifies the type of message that will be purged. The only accepted value is `DBMS_AQ.PERSISTENT`. |
 
 **Example**

--- a/product_docs/docs/epas/13/ecpgplus_guide/02_overview.mdx
+++ b/product_docs/docs/epas/13/ecpgplus_guide/02_overview.mdx
@@ -205,7 +205,7 @@ The first option tells `make` how to transform a file that ends in `.pgc` (presu
     ecpg -C PROC -c $(INCLUDES) $?
 ```
 
-The second option tells make how to transform a file that ends in `.pg` (an ECPG source file) into a file that ends in `.c` (a C program), using the ECPGPlus extensions. It invokes the ECPG pre-compiler with the `-c` flag (instructing the compiler to convert SQL code into C), as well as the `-C PROC` flag (instructing the compiler to use ECPGPlus in Pro\*C-compatibility mode), using the value of the `INCLUDES` variable and the name of the `.pgc` file.
+The second option tells `make` how to transform a file that ends in `.pg` (an ECPG source file) into a file that ends in `.c` (a C program), using the ECPGPlus extensions. It invokes the ECPG pre-compiler with the `-c` flag (instructing the compiler to convert SQL code into C), as well as the `-C PROC` flag (instructing the compiler to use ECPGPlus in Pro\*C-compatibility mode), using the value of the `INCLUDES` variable and the name of the `.pgc` file.
 
 When you run `make`, pass the name of the ECPG source code file you wish to compile. For example, to compile an ECPG source code file named `customer_list.pgc`, use the command:
 

--- a/product_docs/docs/epas/13/ecpgplus_guide/07_reference.mdx
+++ b/product_docs/docs/epas/13/ecpgplus_guide/07_reference.mdx
@@ -239,7 +239,7 @@ struct SQLDA
 
 `N - maximum number of entries`
 
- The N structure member contains the maximum number of entries that the SQLDA may describe. This member is populated by the `sqlald()` function when you allocate the SQLDA structure. Before using a descriptor in an `OPEN` or `FETCH` statement, you must set `N` to the *actual* number of values described.
+ The `N` structure member contains the maximum number of entries that the SQLDA may describe. This member is populated by the `sqlald()` function when you allocate the SQLDA structure. Before using a descriptor in an `OPEN` or `FETCH` statement, you must set `N` to the *actual* number of values described.
 
 `V - data values`
 
@@ -401,7 +401,7 @@ EXEC SQL CALL get_job_desc(:ename)
 
 ### CLOSE
 
-Use the `CLOSE` statement to close a cursor, and free any resources scurrently in use by the cursor. A client application cannot fetch rows from a closed cursor. The syntax of the `CLOSE` statement is:
+Use the `CLOSE` statement to close a cursor, and free any resources currently in use by the cursor. A client application cannot fetch rows from a closed cursor. The syntax of the `CLOSE` statement is:
 
 ```text
 EXEC SQL CLOSE [<cursor_name>];
@@ -975,9 +975,9 @@ If you include an `INTO` clause, the `FETCH` statement will populate the host va
 The following code fragment declares a cursor named `employees` that retrieves the `employee number`, `name` and `salary` from the `emp` table:
 
 ```text
-EXEC SQL DECLARE employees CURSOR
-    SELECT empno, ename, esal FROM emp
-EXEC SQL OPEN emp_cursor
+EXEC SQL DECLARE employees CURSOR FOR
+    SELECT empno, ename, esal FROM emp;
+EXEC SQL OPEN emp_cursor;
 EXEC SQL FETCH emp_cursor INTO :emp_no, :emp_name, :emp_sal;
 ```
 
@@ -1295,7 +1295,7 @@ SELECT
   [ GROUP BY expression [, ...]]
   [ HAVING condition ]
   [ { UNION [ ALL ] | INTERSECT | MINUS } (subquery) ]
-  [ ORDER BY expression> [order_by_options]]
+  [ ORDER BY expression [order_by_options]]
   [ LIMIT { count | ALL }]
   [ OFFSET start [ ROW | ROWS ] ]
   [ FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } ONLY ]

--- a/product_docs/docs/epas/13/edb_plus/06_command_summary.mdx
+++ b/product_docs/docs/epas/13/edb_plus/06_command_summary.mdx
@@ -49,10 +49,10 @@ SQL> LIST
 `CHANGE` is a line editor command performs a search-and-replace on the current line in the SQL buffer.
 
 ```text
-C[HANGE ] /from/[to/ ]
+C[HANGE ] FROM [ TO ]
 ```
 
-If `to/` is specified, the first occurrence of text `from` in the current line is changed to text `to`. If `to/` is omitted, the first occurrence of text `from` in the current line is deleted.
+If `TO/` is specified, the first occurrence of text `FROM` in the current line is changed to text `TO`. If `TO/` is omitted, the first occurrence of text `FROM` in the current line is deleted.
 
 The following sequence of commands makes line 3 the current line, then changes the department number in the `WHERE` clause from 20 to 30.
 

--- a/product_docs/docs/epas/13/epas_compat_bip_guide/03_built-in_packages/03_dbms_aqadm/07_purge_queue_table.mdx
+++ b/product_docs/docs/epas/13/epas_compat_bip_guide/03_built-in_packages/03_dbms_aqadm/07_purge_queue_table.mdx
@@ -31,7 +31,7 @@ PURGE_QUEUE_TABLE(
 
 | Attribute       | Type    | Description                                                                                                         |
 | --------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| `Block`         | Boolean | Specify `TRUE` if an exclusive lock should be held on all queues within the table; the default is `FALSE`.          |
+| `block`         | Boolean | Specify `TRUE` if an exclusive lock should be held on all queues within the table; the default is `FALSE`.          |
 | `delivery_mode` | INTEGER | `delivery_mode` specifies the type of message that will be purged. The only accepted value is `DBMS_AQ.PERSISTENT`. |
 
 **Example**


### PR DESCRIPTION
## What Changed?

Found bugs while reviewing the v11 migration guides (ecpgplus and edb*plus guides), fixed:
- Missing tags & Syntax

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
