### PR TITLE
Table Partitioning Guides Fixes

### DIFF
--- a/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/01_create_table_partition_by/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/01_create_table_partition_by/index.mdx
@@ -62,7 +62,7 @@ CREATE TABLE [ schema. ]<table_name>
 
 Where hash_partition_definition is:
 
-      [PARTITION <partition_name>]
+      PARTITION [<partition_name>]
         [TABLESPACE <tablespace_name>]
         [(<subpartition>, ...)]
 ```
@@ -88,7 +88,7 @@ where range_subpartition is:
 
 where hash_subpartition is:
 
-      SUBPARTITION <subpartition_name>
+      SUBPARTITION [<subpartition_name>]
         [TABLESPACE <tablespace_name>]       
 ```
 

--- a/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/02_alter_table_add_partition/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/02_alter_table_add_partition/index.mdx
@@ -15,7 +15,7 @@ ALTER TABLE <table_name> ADD PARTITION <partition_definition>;
 
 Where partition_definition is:
 
-        {<list_partition> | <range_partition> }
+        {<list_partition> | <range_partition>}
 
 and list_partition is:
 
@@ -43,7 +43,7 @@ and list_subpartition is:
 
 and range_subpartition is:
 
-        SUBPARTITION [<subpartition_name> ]
+        SUBPARTITION [<subpartition_name>]
           VALUES LESS THAN (<value>[, <value>]...)
           [TABLESPACE <tablespace_name>]
 ```

--- a/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/05_alter_table_split_subpartition/02_example_splitting_a_range_subpartition.mdx
+++ b/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/05_alter_table_split_subpartition/02_example_splitting_a_range_subpartition.mdx
@@ -158,7 +158,7 @@ edb=# SELECT tableoid::regclass, * FROM sales;
  sales_europe_2012     |  10   | 9519a | FRANCE  | 18-AUG-12 00:00:00|650000
  sales_europe_2012     |  10   | 9519b | FRANCE  | 18-AUG-12 00:00:00|650000
  sales_asia_2012       |  20   | 3788a | INDIA   | 01-MAR-12 00:00:00|75000
- sales_asia_2012       |  20   | 3788a | PAKISTAN|04-JUN-12 00:00:00 |37500
+ sales_asia_2012       |  20   | 3788a | PAKISTAN| 04-JUN-12 00:00:00|37500
  sales_asia_2012       |  20   | 3788b | INDIA   | 21-SEP-12 00:00:00|5090
  sales_asia_2012       |  20   | 4519a | INDIA   | 18-OCT-12 00:00:00|650000
  sales_asia_2012       |  20   | 4519b | INDIA   | 02-DEC-12 00:00:00| 5090

--- a/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/06_alter_table_exchange_partition/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/06_alter_table_exchange_partition/index.mdx
@@ -50,7 +50,7 @@ The same behavior as previously described applies for the `target_subpartition` 
 
 You must own a table to invoke `ALTER TABLE… EXCHANGE PARTITION` or `ALTER TABLE… EXCHANGE SUBPARTITION` against that table.
 
-**Parameters:**
+**Parameters**
 
 `target_table`
 

--- a/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/01_create_table_partition_by/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/01_create_table_partition_by/index.mdx
@@ -64,7 +64,7 @@ CREATE TABLE [ schema. ]<table_name>
 
 Where hash_partition_definition is:
 
-      [PARTITION <partition_name>]
+      PARTITION [<partition_name>]
         [TABLESPACE <tablespace_name>]
         [(<subpartition>, ...)]
 ```
@@ -90,7 +90,7 @@ where range_subpartition is:
 
 where hash_subpartition is:
 
-      SUBPARTITION <subpartition_name>
+      SUBPARTITION [<subpartition_name>]
         [TABLESPACE <tablespace_name>] |
       SUBPARTITIONS <num> [STORE IN ( <tablespace_name> [, <tablespace_name>]... ) ]
 ```

--- a/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/02_alter_table_add_partition/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/02_alter_table_add_partition/index.mdx
@@ -15,7 +15,7 @@ ALTER TABLE <table_name> ADD PARTITION <partition_definition>;
 
 Where partition_definition is:
 
-        {<list_partition> | <range_partition> }
+        {<list_partition> | <range_partition>}
 
 and list_partition is:
 
@@ -43,13 +43,13 @@ and list_subpartition is:
 
 and range_subpartition is:
 
-        SUBPARTITION [<subpartition_name> ]
+        SUBPARTITION [<subpartition_name>]
           VALUES LESS THAN (<value>[, <value>]...)
           [TABLESPACE <tablespace_name>]
 
 and hash_subpartition is:
 
-        SUBPARTITION <subpartition_name>
+        SUBPARTITION [<subpartition_name>]
           [TABLESPACE <tablespace_name>] |
         SUBPARTITIONS <num> [STORE IN ( <tablespace_name> [, <tablespace_name>]... ) ]
 ```

--- a/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/05_alter_table_split_subpartition/02_example_splitting_a_range_subpartition.mdx
+++ b/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/05_alter_table_split_subpartition/02_example_splitting_a_range_subpartition.mdx
@@ -158,7 +158,7 @@ edb=# SELECT tableoid::regclass, * FROM sales;
  sales_europe_2012     |  10   | 9519a | FRANCE  | 18-AUG-12 00:00:00|650000
  sales_europe_2012     |  10   | 9519b | FRANCE  | 18-AUG-12 00:00:00|650000
  sales_asia_2012       |  20   | 3788a | INDIA   | 01-MAR-12 00:00:00|75000
- sales_asia_2012       |  20   | 3788a | PAKISTAN|04-JUN-12 00:00:00 |37500
+ sales_asia_2012       |  20   | 3788a | PAKISTAN| 04-JUN-12 00:00:00|37500
  sales_asia_2012       |  20   | 3788b | INDIA   | 21-SEP-12 00:00:00|5090
  sales_asia_2012       |  20   | 4519a | INDIA   | 18-OCT-12 00:00:00|650000
  sales_asia_2012       |  20   | 4519b | INDIA   | 02-DEC-12 00:00:00| 5090

--- a/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/06_alter_table_exchange_partition/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_table_partitioning/04_partitioning_commands_compatible_with_oracle_databases/06_alter_table_exchange_partition/index.mdx
@@ -50,7 +50,7 @@ The same behavior as previously described applies for the `target_subpartition` 
 
 You must own a table to invoke `ALTER TABLE… EXCHANGE PARTITION` or `ALTER TABLE… EXCHANGE SUBPARTITION` against that table.
 
-**Parameters:**
+**Parameters**
 
 `target_table`
 


### PR DESCRIPTION
## What Changed?

While reviewing the Table Partitioning Guide for v11 migration, found syntax related bugs. Fixed the same.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
