### PR TITLE
SPL Guide syntax fixes

### DIFF
--- a/product_docs/docs/epas/12/epas_compat_ora_dev_guide/06_dblink_ora/02_calling_dblink_ora_functions.mdx
+++ b/product_docs/docs/epas/12/epas_compat_ora_dev_guide/06_dblink_ora/02_calling_dblink_ora_functions.mdx
@@ -14,7 +14,7 @@ The following command establishes a connection using the `dblink_ora_connect()` 
 SELECT dblink_ora_connect('acctg', 'localhost', 'xe', 'hr', 'pwd', 1521);
 ```
 
-The example connects to a service named xe running on port `1521` (on the `localhost`) with a user name of `hr` and a password of `pwd`. You can use the connection name `acctg` to refer to this connection when calling other dblink_ora functions.
+The example connects to a service named `xe` running on port `1521` (on the `localhost`) with a user name of `hr` and a password of `pwd`. You can use the connection name `acctg` to refer to this connection when calling other dblink_ora functions.
 
 The following command uses the `dblink_ora_copy()` function over a connection named `edb_conn` to copy the `empid` and `deptno` columns from a table (on an Oracle server) named `ora_acctg` to a table located in the `public` schema on an instance of Advanced Server named `as_acctg`. The `TRUNCATE` option is enforced, and a feedback count of `3` is specified:
 

--- a/product_docs/docs/epas/12/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/04_invoking_subprograms.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/04_invoking_subprograms.mdx
@@ -15,7 +15,7 @@ The subprogram may be invoked with none, one, or more qualifiers, which are the 
 The invocation is specified as a dot-separated list of qualifiers ending with the subprogram name and any of its arguments as shown by the following:
 
 ```text
-[[<qualifier_1.>][...]<qualifier_n.>]<subprog> [(<arguments>)]
+[[<qualifier_1>.][...]<qualifier_n>.]<subprog> [(<arguments>)]
 ```
 
 If specified, `qualifier_n` is the subprogram in which `subprog` has been declared in its declaration section. The preceding list of qualifiers must reside in a continuous path up the hierarchy from `qualifier_n` to `qualifier_1. qualifier_1` may be any ancestor subprogram in the path as well as any of the following:

--- a/product_docs/docs/epas/12/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/07_accessing_subprogram_variables.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/07_accessing_subprogram_variables.mdx
@@ -22,7 +22,7 @@ The variable may be accessed by at most one qualifier, which is the name of the 
 The syntax to reference a variable is shown by the following:
 
 ```text
-[<qualifier.>]<variable>
+[<qualifier>.]<variable>
 ```
 
 If specified, `qualifier` is the subprogram or labeled anonymous block in which `variable` has been declared in its declaration section (that is, it is a local variable).

--- a/product_docs/docs/epas/12/epas_compat_spl/03_variable_declarations/02_using__type_in_variable_declarations.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/03_variable_declarations/02_using__type_in_variable_declarations.mdx
@@ -14,10 +14,10 @@ Instead of coding the specific column data type into the variable declaration th
     The `%TYPE` attribute can be used with formal parameter declarations as well.
 
 ```text
-<name> { { <table> | <view> }<.column> | <variable> }%TYPE;
+<name> { { <table> | <view> }.<column> | <variable> }%TYPE;
 ```
 
-`name` is the identifier assigned to the variable or formal parameter that is being declared. `column` is the name of a column in `table` or `view.variable` is the name of a variable that was declared prior to the variable identified by `name`.
+`name` is the identifier assigned to the variable or formal parameter that is being declared. `column` is the name of a column in `table` or `view`. `variable` is the name of a variable that was declared prior to the variable identified by `name`.
 
 !!! Note
     The variable does not inherit any of the column’s other attributes such as might be specified on the column with the `NOT NULL` clause or the `DEFAULT` clause.

--- a/product_docs/docs/epas/12/epas_compat_spl/03_variable_declarations/03_using__row_type_in_record_declarations.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/03_variable_declarations/03_using__row_type_in_record_declarations.mdx
@@ -11,7 +11,7 @@ A *record* is a named, ordered collection of fields. A *field* is similar to a v
 You can use the `%ROWTYPE` attribute to declare a record. The `%ROWTYPE` attribute is prefixed by a table name. Each column in the named table defines an identically named field in the record with the same data type as the column.
 
 ```text
-<record table>%ROWTYPE;
+<record> <table>%ROWTYPE;
 ```
 
 `record` is an identifier assigned to the record. `table` is the name of a table (or view) whose columns are to define the fields in the record. The following example shows how the `emp_sal_query` procedure from the prior section can be modified to use `emp%ROWTYPE` to create a record named `r_emp` instead of declaring individual variables for the columns in `emp`.

--- a/product_docs/docs/epas/12/epas_compat_spl/08_static_cursors/07_cursor_for_loop.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/08_static_cursors/07_cursor_for_loop.mdx
@@ -21,7 +21,7 @@ LOOP
 END LOOP;
 ```
 
-`record` is an identifier assigned to an implicitly declared record with definition, `cursor%ROWTYPE. cursor` is the name of a previously declared cursor. `statements` are one or more SPL statements. There must be at least one statement.
+`record` is an identifier assigned to an implicitly declared record with definition, `cursor%ROWTYPE`. `cursor` is the name of a previously declared cursor. `statements` are one or more SPL statements. There must be at least one statement.
 
 The following example shows the example from [%NOTFOUND](06_cursor_attributes/03_notfound/#%25notfound), modified to use a cursor `FOR` loop.
 

--- a/product_docs/docs/epas/12/epas_compat_spl/10_collections/01_associative_arrays.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/10_collections/01_associative_arrays.mdx
@@ -32,7 +32,7 @@ TYPE <assoctype> IS TABLE OF { <datatype> | <rectype> | <objtype> }
 In order to make use of the array, a *variable* must be declared with that array type. The following is the syntax for declaring an array variable.
 
 ```text
-<array assoctype>
+<array> <assoctype>
 ```
 
 `array` is an identifier assigned to the associative array. `assoctype` is the identifier of a previously defined array type.

--- a/product_docs/docs/epas/12/epas_compat_spl/10_collections/02_nested_tables.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/10_collections/02_nested_tables.mdx
@@ -26,12 +26,12 @@ TYPE <tbltype> IS TABLE OF { <datatype> | <rectype> | <objtype> };
 `tbltype` is an identifier assigned to the nested table type. `datatype` is a scalar data type such as `VARCHAR2` or `NUMBER`. `rectype` is a previously defined record type. `objtype` is a previously defined object type.
 
 !!! Note
-    You can use the `CREATE TYPE` command to define a nested table type that is available to all SPL programs in the database. See the *Database Compatibility for Oracle Developers Reference Guide* for more information about the `CREATE TYPE` command.
+    You can use the `CREATE TYPE` command to define a nested table type that is available to all SPL programs in the database. See the *Database Compatibility for Oracle Developers SQL Guide* for more information about the `CREATE TYPE` command.
 
 In order to make use of the table, a *variable* must be declared of that nested table type. The following is the syntax for declaring a table variable.
 
 ```text
-<table tbltype>
+<table> <tbltype>
 ```
 
 `table` is an identifier assigned to the nested table. `tbltype` is the identifier of a previously defined nested table type.

--- a/product_docs/docs/epas/12/epas_compat_spl/10_collections/03_varrays.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/10_collections/03_varrays.mdx
@@ -32,7 +32,7 @@ TYPE <varraytype> IS { VARRAY | VARYING ARRAY }(<maxsize>)
 The `CREATE TYPE` command can be used to define a varray type that is available to all SPL programs in the database. In order to make use of the varray, a *variable* must be declared of that varray type. The following is the syntax for declaring a varray variable:
 
 ```text
-<varray varraytype>
+<varray> <varraytype>
 ```
 
 `varray` is an identifier assigned to the varray. `varraytype` is the identifier of a previously defined varray type.

--- a/product_docs/docs/epas/12/epas_compat_spl/13_triggers/03_creating_triggers.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/13_triggers/03_creating_triggers.mdx
@@ -48,7 +48,7 @@ CREATE [ OR REPLACE ] TRIGGER <name>
   FOR { INSERT | UPDATE | DELETE | TRUNCATE }
         [ OR { INSERT | UPDATE | DELETE | TRUNCATE } ] [, ...]
            ON <table>
-       [ REFERENCING { OLD AS <old> | NEW AS <new. } ...]
+       [ REFERENCING { OLD AS <old> | NEW AS <new>. } ...]
        [ WHEN <condition> ]
        COMPOUND TRIGGER
        [ <private_declaration>; ] ...
@@ -84,11 +84,11 @@ PROCEDURE proc_name[ argument_list ]
 Where `procedure_body :=`
 
 ```text
-[ declaration; ] [, ...]
+[ <declaration>; ] [, ...]
 BEGIN
-  statement; [...]
+  <statement>; [...]
 [ EXCEPTION
-   { WHEN exception [OR exception] [...]] THEN statement; }
+   { WHEN <exception> [OR <exception>] [...]] THEN <statement>; }
    [...]
 ]
 ```
@@ -107,11 +107,11 @@ FUNCTION func_name [ argument_list ]
 Where `function_body :=`
 
 ```text
-[ declaration; ] [, ...]
+[ <declaration>; ] [, ...]
 BEGIN
-  statement; [...]
+  <statement>; [...]
 [ EXCEPTION
-  { WHEN exception [ OR exception ] [...] THEN statement; }
+  { WHEN <exception> [ OR <exception> ] [...] THEN <statement>; }
   [...]
 ]
 ```
@@ -133,11 +133,11 @@ Where `compound_trigger_event:=`
 Where `compound_trigger_body:=`
 
 ```text
-[ declaration; ] [, ...]
+[ <declaration>; ] [, ...]
 BEGIN
-  statement; [...]
+  <statement>; [...]
 [ EXCEPTION
-   { WHEN exception [OR exception] [...] THEN statement; }
+   { WHEN <exception> [OR <exception>] [...] THEN <statement>; }
    [...]
 ]
 ```
@@ -186,7 +186,7 @@ When you use syntax compatible with Oracle databases to create a trigger, the tr
 
  `REFERENCING` clause to reference old rows and new rows, but restricted in that `old` may only be replaced by an identifier named `old` or any equivalent that is saved in all lowercase (for example, `REFERENCING OLD AS old, REFERENCING OLD AS OLD`, or `REFERENCING OLD AS "old")`. Also, `new` may only be replaced by an identifier named `new` or any equivalent that is saved in all lowercase (for example, `REFERENCING NEW AS new, REFERENCING NEW AS NEW`, or `REFERENCING NEW AS "new")`.
 
- Either one, or both phrases `OLD AS old` and `NEW AS new` may be specified in the `REFERENCING` clause (for example, `REFERENCING NEW AS New OLD AS Old)`. This clause is not compatible with Oracle databases in that identifiers other than old or new may not be used.
+ Either one, or both phrases `OLD AS old` and `NEW AS new` may be specified in the `REFERENCING` clause (for example, `REFERENCING NEW AS New OLD AS Old)`. This clause is not compatible with Oracle databases in that identifiers other than `old` or `new` may not be used.
 
 `FOR EACH ROW`
 

--- a/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/02_object_type_components/02_object_type_body_syntax.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/02_object_type_components/02_object_type_body_syntax.mdx
@@ -28,10 +28,10 @@ and `subprogram_spec` is the following:
 { MEMBER | STATIC }
 { PROCEDURE <proc_name>
     [ ( [  SELF [ IN | IN OUT ] <name> ]
-        [, parm1 [ IN | IN OUT | OUT ] datatype1
-                 [ DEFAULT value1 ] ]
-        [, parm2 [ IN | IN OUT | OUT ] datatype2
-                 [ DEFAULT value2 ]
+        [, <parm1> [ IN | IN OUT | OUT ] <datatype1>
+                 [ DEFAULT <value1> ] ]
+        [, <parm2> [ IN | IN OUT | OUT ] <datatype2>
+                 [ DEFAULT <value2> ]
         ] ...)
     ]
 { IS | AS }
@@ -46,10 +46,10 @@ and `subprogram_spec` is the following:
 |
   FUNCTION <func_name>
     [ ( [  SELF [ IN | IN OUT ] <name> ]
-        [, parm1 [ IN | IN OUT | OUT ] datatype1
-                 [ DEFAULT value1 ] ]
-        [, parm2 [ IN | IN OUT | OUT ] datatype2
-                 [ DEFAULT value2 ]
+        [, <parm1> [ IN | IN OUT | OUT ] <datatype1>
+                 [ DEFAULT <value1> ] ]
+        [, <parm2> [ IN | IN OUT | OUT ] <datatype2>
+                 [ DEFAULT <value2> ]
         ] ...)
     ]
   RETURN <return_type>
@@ -69,10 +69,10 @@ where `constructor` is:
 ```text
 CONSTRUCTOR <func_name>
   [ ( [  SELF [ IN | IN OUT ] <name> ]
-      [, parm1 [ IN | IN OUT | OUT ] datatype1
-               [ DEFAULT value1 ] ]
-      [, parm2 [ IN | IN OUT | OUT ] datatype2
-               [ DEFAULT value2 ]
+      [, <parm1> [ IN | IN OUT | OUT ] <datatype1>
+               [ DEFAULT <value1> ] ]
+      [, <parm2> [ IN | IN OUT | OUT ] <datatype2>
+               [ DEFAULT <value2> ]
       ] ...)
   ]
 RETURN self AS RESULT

--- a/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/04_creating_object_instances.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/04_creating_object_instances.mdx
@@ -11,7 +11,7 @@ legacyRedirectsGenerated:
 To create an instance of an object type, you must first declare a variable of the object type, and then initialize the declared object variable. The syntax for declaring an object variable is:
 
 ```text
-<object obj_type>
+<object> <obj_type>
 ```
 
 `object` is an identifier assigned to the object variable.
@@ -21,7 +21,7 @@ To create an instance of an object type, you must first declare a variable of th
 After declaring the object variable, you must invoke a *constructor* *method* to initialize the object with values. Use the following syntax to invoke the constructor method:
 
 ```text
-[NEW] <obj_type> ({expr1 | NULL} [, {expr2 | NULL} ] [, ...])
+[NEW] <obj_type> ({<expr1> | NULL} [, {<expr2> | NULL} ] [, ...])
 ```
 
 `obj_type` is the identifier of the object type’s constructor method; the constructor method has the same name as the previously declared object type.
@@ -58,7 +58,7 @@ END;
     In Advanced Server, the following alternate syntax can be used in place of the constructor method.
 
 ```text
-[ ROW ] ({ expr1 | NULL } [, { expr2 | NULL } ] [, ...])
+[ ROW ] ({ <expr1> | NULL } [, { <expr2> | NULL } ] [, ...])
 ```
 
 `ROW` is an optional keyword if two or more terms are specified within the parenthesis-enclosed, comma-delimited list. If only one term is specified, then specification of the `ROW` keyword is mandatory.

--- a/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/05_referencing_an_object.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/05_referencing_an_object.mdx
@@ -11,7 +11,7 @@ legacyRedirectsGenerated:
 Once an object variable is created and initialized, individual attributes can be referenced using dot notation of the form:
 
 ```text
-<object.attribute>
+<object>.<attribute>
 ```
 
 `object` is the identifier assigned to the object variable. `attribute` is the identifier of an object type attribute.
@@ -19,7 +19,7 @@ Once an object variable is created and initialized, individual attributes can be
 If `attribute`, itself, is of an object type, then the reference must take the form:
 
 ```text
-<object.attribute.attribute_inner>
+<object>.<attribute>.<attribute_inner>
 ```
 
 `attribute_inner` is an identifier belonging to the object type to which `attribute` references in its definition of `object`.
@@ -54,7 +54,7 @@ Methods are called in a similar manner as attributes.
 Once an object variable is created and initialized, member procedures or functions are called using dot notation of the form:
 
 ```text
-<object.prog_name>
+<object>.<prog_name>
 ```
 
 `object` is the identifier assigned to the object variable. `prog_name` is the identifier of the procedure or function.
@@ -62,7 +62,7 @@ Once an object variable is created and initialized, member procedures or functio
 Static procedures or functions are not called utilizing an object variable. Instead the procedure or function is called utilizing the object type name:
 
 ```text
-<object_type.prog_name>
+<object_type>.<prog_name>
 ```
 
 `object_type` is the identifier assigned to the object type. `prog_name` is the identifier of the procedure or function.

--- a/product_docs/docs/epas/13/epas_compat_ora_dev_guide/06_dblink_ora/02_calling_dblink_ora_functions.mdx
+++ b/product_docs/docs/epas/13/epas_compat_ora_dev_guide/06_dblink_ora/02_calling_dblink_ora_functions.mdx
@@ -14,7 +14,7 @@ The following command establishes a connection using the `dblink_ora_connect()` 
 SELECT dblink_ora_connect('acctg', 'localhost', 'xe', 'hr', 'pwd', 1521);
 ```
 
-The example connects to a service named xe running on port `1521` (on the `localhost`) with a user name of `hr` and a password of `pwd`. You can use the connection name `acctg` to refer to this connection when calling other dblink_ora functions.
+The example connects to a service named `xe` running on port `1521` (on the `localhost`) with a user name of `hr` and a password of `pwd`. You can use the connection name `acctg` to refer to this connection when calling other dblink_ora functions.
 
 The following command uses the `dblink_ora_copy()` function over a connection named `edb_conn` to copy the `empid` and `deptno` columns from a table (on an Oracle server) named `ora_acctg` to a table located in the `public` schema on an instance of Advanced Server named `as_acctg`. The `TRUNCATE` option is enforced, and a feedback count of `3` is specified:
 

--- a/product_docs/docs/epas/13/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/04_invoking_subprograms.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/04_invoking_subprograms.mdx
@@ -15,7 +15,7 @@ The subprogram may be invoked with none, one, or more qualifiers, which are the 
 The invocation is specified as a dot-separated list of qualifiers ending with the subprogram name and any of its arguments as shown by the following:
 
 ```text
-[[<qualifier_1.>][...]<qualifier_n.>]<subprog> [(<arguments>)]
+[[<qualifier_1>.][...]<qualifier_n>.]<subprog> [(<arguments>)]
 ```
 
 If specified, `qualifier_n` is the subprogram in which `subprog` has been declared in its declaration section. The preceding list of qualifiers must reside in a continuous path up the hierarchy from `qualifier_n` to `qualifier_1. qualifier_1` may be any ancestor subprogram in the path as well as any of the following:

--- a/product_docs/docs/epas/13/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/07_accessing_subprogram_variables.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/02_spl_programs/07_subprograms_subprocedures_and_subfunctions/07_accessing_subprogram_variables.mdx
@@ -22,7 +22,7 @@ The variable may be accessed by at most one qualifier, which is the name of the 
 The syntax to reference a variable is shown by the following:
 
 ```text
-[<qualifier.>]<variable>
+[<qualifier>.]<variable>
 ```
 
 If specified, `qualifier` is the subprogram or labeled anonymous block in which `variable` has been declared in its declaration section (that is, it is a local variable).

--- a/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/02_using__type_in_variable_declarations.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/02_using__type_in_variable_declarations.mdx
@@ -14,10 +14,10 @@ Instead of coding the specific column data type into the variable declaration th
     The `%TYPE` attribute can be used with formal parameter declarations as well.
 
 ```text
-<name> { { <table> | <view> }<.column> | <variable> }%TYPE;
+<name> { { <table> | <view> }.<column> | <variable> }%TYPE;
 ```
 
-`name` is the identifier assigned to the variable or formal parameter that is being declared. `column` is the name of a column in `table` or `view.variable` is the name of a variable that was declared prior to the variable identified by `name`.
+`name` is the identifier assigned to the variable or formal parameter that is being declared. `column` is the name of a column in `table` or `view`. `variable` is the name of a variable that was declared prior to the variable identified by `name`.
 
 !!! Note
     The variable does not inherit any of the column’s other attributes such as might be specified on the column with the `NOT NULL` clause or the `DEFAULT` clause.

--- a/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/03_using__row_type_in_record_declarations.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/03_variable_declarations/03_using__row_type_in_record_declarations.mdx
@@ -11,7 +11,7 @@ A *record* is a named, ordered collection of fields. A *field* is similar to a v
 You can use the `%ROWTYPE` attribute to declare a record. The `%ROWTYPE` attribute is prefixed by a table name. Each column in the named table defines an identically named field in the record with the same data type as the column.
 
 ```text
-<record table>%ROWTYPE;
+<record> <table>%ROWTYPE;
 ```
 
 `record` is an identifier assigned to the record. `table` is the name of a table (or view) whose columns are to define the fields in the record. The following example shows how the `emp_sal_query` procedure from the prior section can be modified to use `emp%ROWTYPE` to create a record named `r_emp` instead of declaring individual variables for the columns in `emp`.

--- a/product_docs/docs/epas/13/epas_compat_spl/08_static_cursors/07_cursor_for_loop.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/08_static_cursors/07_cursor_for_loop.mdx
@@ -21,7 +21,7 @@ LOOP
 END LOOP;
 ```
 
-`record` is an identifier assigned to an implicitly declared record with definition, `cursor%ROWTYPE. cursor` is the name of a previously declared cursor. `statements` are one or more SPL statements. There must be at least one statement.
+`record` is an identifier assigned to an implicitly declared record with definition, `cursor%ROWTYPE`. `cursor` is the name of a previously declared cursor. `statements` are one or more SPL statements. There must be at least one statement.
 
 The following example shows the example from [%NOTFOUND](06_cursor_attributes/03_notfound/#%25notfound), modified to use a cursor `FOR` loop.
 

--- a/product_docs/docs/epas/13/epas_compat_spl/10_collections/01_associative_arrays.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/10_collections/01_associative_arrays.mdx
@@ -32,7 +32,7 @@ TYPE <assoctype> IS TABLE OF { <datatype> | <rectype> | <objtype> }
 In order to make use of the array, a *variable* must be declared with that array type. The following is the syntax for declaring an array variable.
 
 ```text
-<array assoctype>
+<array> <assoctype>
 ```
 
 `array` is an identifier assigned to the associative array. `assoctype` is the identifier of a previously defined array type.

--- a/product_docs/docs/epas/13/epas_compat_spl/10_collections/02_nested_tables.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/10_collections/02_nested_tables.mdx
@@ -26,12 +26,12 @@ TYPE <tbltype> IS TABLE OF { <datatype> | <rectype> | <objtype> };
 `tbltype` is an identifier assigned to the nested table type. `datatype` is a scalar data type such as `VARCHAR2` or `NUMBER`. `rectype` is a previously defined record type. `objtype` is a previously defined object type.
 
 !!! Note
-    You can use the `CREATE TYPE` command to define a nested table type that is available to all SPL programs in the database. See the *Database Compatibility for Oracle Developers Reference Guide* for more information about the `CREATE TYPE` command.
+    You can use the `CREATE TYPE` command to define a nested table type that is available to all SPL programs in the database. See the *Database Compatibility for Oracle Developers SQL Guide* for more information about the `CREATE TYPE` command.
 
 In order to make use of the table, a *variable* must be declared of that nested table type. The following is the syntax for declaring a table variable.
 
 ```text
-<table tbltype>
+<table> <tbltype>
 ```
 
 `table` is an identifier assigned to the nested table. `tbltype` is the identifier of a previously defined nested table type.

--- a/product_docs/docs/epas/13/epas_compat_spl/10_collections/03_varrays.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/10_collections/03_varrays.mdx
@@ -32,7 +32,7 @@ TYPE <varraytype> IS { VARRAY | VARYING ARRAY }(<maxsize>)
 The `CREATE TYPE` command can be used to define a varray type that is available to all SPL programs in the database. In order to make use of the varray, a *variable* must be declared of that varray type. The following is the syntax for declaring a varray variable:
 
 ```text
-<varray varraytype>
+<varray> <varraytype>
 ```
 
 `varray` is an identifier assigned to the varray. `varraytype` is the identifier of a previously defined varray type.

--- a/product_docs/docs/epas/13/epas_compat_spl/13_triggers/03_creating_triggers.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/13_triggers/03_creating_triggers.mdx
@@ -48,7 +48,7 @@ CREATE [ OR REPLACE ] TRIGGER <name>
   FOR { INSERT | UPDATE | DELETE | TRUNCATE }
         [ OR { INSERT | UPDATE | DELETE | TRUNCATE } ] [, ...]
            ON <table>
-       [ REFERENCING { OLD AS <old> | NEW AS <new. } ...]
+       [ REFERENCING { OLD AS <old> | NEW AS <new>. } ...]
        [ WHEN <condition> ]
        COMPOUND TRIGGER
        [ <private_declaration>; ] ...
@@ -84,11 +84,11 @@ PROCEDURE proc_name[ argument_list ]
 Where `procedure_body :=`
 
 ```text
-[ declaration; ] [, ...]
+[ <declaration>; ] [, ...]
 BEGIN
-  statement; [...]
+  <statement>; [...]
 [ EXCEPTION
-   { WHEN exception [OR exception] [...]] THEN statement; }
+   { WHEN <exception> [OR <exception>] [...]] THEN <statement>; }
    [...]
 ]
 ```
@@ -107,11 +107,11 @@ FUNCTION func_name [ argument_list ]
 Where `function_body :=`
 
 ```text
-[ declaration; ] [, ...]
+[ <declaration>; ] [, ...]
 BEGIN
-  statement; [...]
+  <statement>; [...]
 [ EXCEPTION
-  { WHEN exception [ OR exception ] [...] THEN statement; }
+  { WHEN <exception> [ OR <exception> ] [...] THEN <statement>; }
   [...]
 ]
 ```
@@ -133,11 +133,11 @@ Where `compound_trigger_event:=`
 Where `compound_trigger_body:=`
 
 ```text
-[ declaration; ] [, ...]
+[ <declaration>; ] [, ...]
 BEGIN
-  statement; [...]
+  <statement>; [...]
 [ EXCEPTION
-   { WHEN exception [OR exception] [...] THEN statement; }
+   { WHEN <exception> [OR <exception>] [...] THEN <statement>; }
    [...]
 ]
 ```
@@ -188,7 +188,7 @@ When you use syntax compatible with Oracle databases to create a trigger, the tr
 
  `REFERENCING` clause to reference old rows and new rows, but restricted in that `old` may only be replaced by an identifier named `old` or any equivalent that is saved in all lowercase (for example, `REFERENCING OLD AS old, REFERENCING OLD AS OLD`, or `REFERENCING OLD AS "old")`. Also, `new` may only be replaced by an identifier named `new` or any equivalent that is saved in all lowercase (for example, `REFERENCING NEW AS new, REFERENCING NEW AS NEW`, or `REFERENCING NEW AS "new")`.
 
- Either one, or both phrases `OLD AS old` and `NEW AS new` may be specified in the `REFERENCING` clause (for example, `REFERENCING NEW AS New OLD AS Old)`. This clause is not compatible with Oracle databases in that identifiers other than old or new may not be used.
+ Either one, or both phrases `OLD AS old` and `NEW AS new` may be specified in the `REFERENCING` clause (for example, `REFERENCING NEW AS New OLD AS Old)`. This clause is not compatible with Oracle databases in that identifiers other than `old` or `new` may not be used.
 
 `FOR EACH ROW`
 

--- a/product_docs/docs/epas/13/epas_compat_spl/15_object_types_and_objects/02_object_type_components/02_object_type_body_syntax.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/15_object_types_and_objects/02_object_type_components/02_object_type_body_syntax.mdx
@@ -28,10 +28,10 @@ and `subprogram_spec` is the following:
 { MEMBER | STATIC }
 { PROCEDURE <proc_name>
     [ ( [  SELF [ IN | IN OUT ] <name> ]
-        [, parm1 [ IN | IN OUT | OUT ] datatype1
-                 [ DEFAULT value1 ] ]
-        [, parm2 [ IN | IN OUT | OUT ] datatype2
-                 [ DEFAULT value2 ]
+        [, <parm1> [ IN | IN OUT | OUT ] <datatype1>
+                 [ DEFAULT <value1> ] ]
+        [, <parm2> [ IN | IN OUT | OUT ] <datatype2>
+                 [ DEFAULT <value2> ]
         ] ...)
     ]
 { IS | AS }
@@ -46,10 +46,10 @@ and `subprogram_spec` is the following:
 |
   FUNCTION <func_name>
     [ ( [  SELF [ IN | IN OUT ] <name> ]
-        [, parm1 [ IN | IN OUT | OUT ] datatype1
-                 [ DEFAULT value1 ] ]
-        [, parm2 [ IN | IN OUT | OUT ] datatype2
-                 [ DEFAULT value2 ]
+        [, <parm1> [ IN | IN OUT | OUT ] <datatype1>
+                 [ DEFAULT <value1> ] ]
+        [, <parm2> [ IN | IN OUT | OUT ] <datatype2>
+                 [ DEFAULT <value2> ]
         ] ...)
     ]
   RETURN <return_type>
@@ -69,10 +69,10 @@ where `constructor` is:
 ```text
 CONSTRUCTOR <func_name>
   [ ( [  SELF [ IN | IN OUT ] <name> ]
-      [, parm1 [ IN | IN OUT | OUT ] datatype1
-               [ DEFAULT value1 ] ]
-      [, parm2 [ IN | IN OUT | OUT ] datatype2
-               [ DEFAULT value2 ]
+      [, <parm1> [ IN | IN OUT | OUT ] <datatype1>
+               [ DEFAULT <value1> ] ]
+      [, <parm2> [ IN | IN OUT | OUT ] <datatype2>
+               [ DEFAULT <value2> ]
       ] ...)
   ]
 RETURN self AS RESULT

--- a/product_docs/docs/epas/13/epas_compat_spl/15_object_types_and_objects/04_creating_object_instances.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/15_object_types_and_objects/04_creating_object_instances.mdx
@@ -11,7 +11,7 @@ legacyRedirectsGenerated:
 To create an instance of an object type, you must first declare a variable of the object type, and then initialize the declared object variable. The syntax for declaring an object variable is:
 
 ```text
-<object obj_type>
+<object> <obj_type>
 ```
 
 `object` is an identifier assigned to the object variable.
@@ -21,7 +21,7 @@ To create an instance of an object type, you must first declare a variable of th
 After declaring the object variable, you must invoke a *constructor* *method* to initialize the object with values. Use the following syntax to invoke the constructor method:
 
 ```text
-[NEW] <obj_type> ({expr1 | NULL} [, {expr2 | NULL} ] [, ...])
+[NEW] <obj_type> ({<expr1> | NULL} [, {<expr2> | NULL} ] [, ...])
 ```
 
 `obj_type` is the identifier of the object type’s constructor method; the constructor method has the same name as the previously declared object type.
@@ -58,7 +58,7 @@ END;
     In Advanced Server, the following alternate syntax can be used in place of the constructor method.
 
 ```text
-[ ROW ] ({ expr1 | NULL } [, { expr2 | NULL } ] [, ...])
+[ ROW ] ({ <expr1> | NULL } [, { <expr2> | NULL } ] [, ...])
 ```
 
 `ROW` is an optional keyword if two or more terms are specified within the parenthesis-enclosed, comma-delimited list. If only one term is specified, then specification of the `ROW` keyword is mandatory.

--- a/product_docs/docs/epas/13/epas_compat_spl/15_object_types_and_objects/05_referencing_an_object.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/15_object_types_and_objects/05_referencing_an_object.mdx
@@ -11,7 +11,7 @@ legacyRedirectsGenerated:
 Once an object variable is created and initialized, individual attributes can be referenced using dot notation of the form:
 
 ```text
-<object.attribute>
+<object>.<attribute>
 ```
 
 `object` is the identifier assigned to the object variable. `attribute` is the identifier of an object type attribute.
@@ -19,7 +19,7 @@ Once an object variable is created and initialized, individual attributes can be
 If `attribute`, itself, is of an object type, then the reference must take the form:
 
 ```text
-<object.attribute.attribute_inner>
+<object>.<attribute>.<attribute_inner>
 ```
 
 `attribute_inner` is an identifier belonging to the object type to which `attribute` references in its definition of `object`.
@@ -54,7 +54,7 @@ Methods are called in a similar manner as attributes.
 Once an object variable is created and initialized, member procedures or functions are called using dot notation of the form:
 
 ```text
-<object.prog_name>
+<object>.<prog_name>
 ```
 
 `object` is the identifier assigned to the object variable. `prog_name` is the identifier of the procedure or function.
@@ -62,7 +62,7 @@ Once an object variable is created and initialized, member procedures or functio
 Static procedures or functions are not called utilizing an object variable. Instead the procedure or function is called utilizing the object type name:
 
 ```text
-<object_type.prog_name>
+<object_type>.<prog_name>
 ```
 
 `object_type` is the identifier assigned to the object type. `prog_name` is the identifier of the procedure or function.


### PR DESCRIPTION
## What Changed?

During reviewing the SPL guide for v11 migration, came across syntax-related bugs. Fixed the same.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
