### PR TITLE
style: better MD formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,31 +36,53 @@ We recommend using MacOS to work with the EDB Docs application.
 
 1. And finally, you can start up the site locally with `yarn develop`, which should make it live at `http://localhost:8000/`. Huzzah!
 
-
 ### Building Local PDFs (optional)
-To build PDFs locally, you'll need to use a Docker container. 
 
-1. Install Docker using Homebrew:  `brew install --cask docker`  
-If you get a message saying that you already have Docker installed, check which version is installed using these commands:  
-`brew ls --formula docker`  
-`brew ls --cask docker`  
-If the first command yields results, enter the following command to uninstall the formula version and to install the cask version:  
-`brew uninstall -f docker && brew install --cask docker`
+To build PDFs locally, you'll need to use a Docker container.
 
+1. Install Docker using Homebrew:
 
-1. Start the Docker app. You can tell whether Docker has started or not by looking at your menu bar icons, you should see a whale with containers on its back: https://icon-icons.com/icon/docker/138669.
+   ```sh
+   brew install --cask docker
+   ```
 
+   If you get a message saying that you already have Docker installed, check which version is installed using these commands:
 
-1. Create the Docker image:  
-`docker-compose -f docker/docker-compose.build-pdf.yaml build --pull`
+   ```sh
+   brew ls --formula docker
+   brew ls --cask docker
+   ```
 
+   If the first command yields results, enter the following command to uninstall the formula version and to install the cask version:
 
-1. Run the following command inside the docs project to create a PDF:  
-`yarn build-pdf product_docs/docs/<product_folder><version>`  
-For example, to build a PDF for the EPAS 13 documentation:  
-`yarn build-pdf product_docs/docs/epas/13`
+   ```sh
+   brew uninstall -f docker && brew install --cask docker
+   ```
+
+1. Start the Docker app. You can tell whether Docker has started or not by looking at your menu bar icons, you should see a whale with containers on its back:
+
+   ![Docker Whale](https://cdn.icon-icons.com/icons2/2248/PNG/32/docker_icon_138669.png)
+
+1. Create the Docker image (optional):
+
+   ```sh
+   docker-compose -f docker/docker-compose.build-pdf.yaml build --pull
+   ```
+
+1. Run the following command inside the docs project to create a PDF:
+
+   ```sh
+   yarn build-pdf product_docs/docs/<product_folder>/<version>
+   ```
+
+   For example, to build a PDF for the EPAS 13 documentation:
+
+   ```sh
+   yarn build-pdf product_docs/docs/epas/13
+   ```
 
 ### Converting RST to MDX (optional)
+
 If you need to run parts of the RST to MDX conversion pipeline, you'll need to install `pandoc`, a general purpose document conversion tool. This can also be installed with homebrew - `brew install pandoc`.
 
 ## Windows Installation


### PR DESCRIPTION
Suggested changes to #1542.

@drothery-edb I've made these markdown formatting changes:

1. In general, avoid using the trailing double space trick if possible. If you're in a bulleted block, just use blank line and indentation to keep everything as a block.
2. Prefer code fence blocks.