### PR TITLE
re-enable rel:canonical header

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -102,11 +102,9 @@ const Layout = ({
         )}
         <meta property="og:image" content={imageUrl} />
         <meta property="og:url" content={url} />
-        {/* Disabling this for now
         {meta.canonicalPath && (
           <link rel="canonical" href={baseUrl + meta.canonicalPath} />
         )}
-        */}
         <meta name="twitter:card" content="summary_large_image" />
         <body className={`bg-${background} fixed-container`} />
       </Helmet>


### PR DESCRIPTION
## What Changed?

We'd originally planned this for the inaugural release, but wanted to wait so as to gauge the effect in isolation (refs: #163, #166). 

...5 months is probably long enough.

Tl;dr: this tries to ensure that search engines see only ONE version of each topic, with each distinct version considered just a trivial variation. Vs. the status quo, which has them trying to index and distinguish between myriad versions, generally ranking out-of-date versions above current and penalizing us for duplicating content along the way.

Full details on this can be found in https://github.com/EnterpriseDB/docs-products/issues/139 - copying the relevant portions here:

> The purpose is to tell the search indexer that a given page corresponds to a given URL *even if it isn't being accessed via that URL*.
> 
> So for instance, right now both `/epas/11/01_epas_inst_linux` and `/epas/12/01_epas_inst_linux` should have the same "canonical URL" - and per the rationale above, it should be the one where the path is `/epas/latest/01_epas_inst_linux`. When version 13 is released, `/epas/latest/01_epas_inst_linux` will *still* have the same canonical URL - but now `/epas/12/01_epas_inst_linux` will have a canonical URL where the path is `/epas/12/01_epas_inst_linux`, while the new page `/epas/13/01_epas_inst_linux` will redirect to `/epas/latest/01_epas_inst_linux` and thus have the canonical URL `/epas/latest/01_epas_inst_linux`.
> 
> Sound confusing? Think of it this way: we're optimizing for the case where someone installing EPAS on Linux wants the latest version of EPAS. Not the version that was latest the last time Google indexed our site, the *latest version* - regardless of what version that might be. We provide a method of switching to a different version on-site, but for the purpose of searching there's just one page - the latest, the *canonical*, installation page.
> 
> \[We should at least consider using] rel=canonical to direct search engines to consider *all* versioned pages views onto the same, canonical, information. For example, instead of `/epas/11/01_epas_inst_linux` having a canonical URL containing the path `/epas/11/01_epas_inst_linux`, it could *also* use `/epas/latest/01_epas_inst_linux` as the canonical path. This would, over time, discourage search engines from presenting results from pages other than those in the version-agnostic, "latest" version of the documentation. It does require us to be able to map at least most of the pages within each version to the same, version-agnostic URL however.
> 
> An example of this in action can be found in the nodejs documentation. These four pages all have the same canonical URL:
> 
> -   <https://nodejs.org/docs/latest-v7.x/api/http.html>
> -   <https://nodejs.org/docs/latest-v14.x/api/http.html>
> -   <https://nodejs.org/docs/latest/api/http.html>
> -   <https://nodejs.org/api/http.html> (this is the canonical URL - it is referenced via `<link rel="canonical" href="https://nodejs.org/api/http.html">` by all three pages above).
> 
> (There are *eleven other versions* of that page as well...)
> 
> The end result of this is that [searching for nodejs Class: http.ClientRequest](https://www.google.com/search?q=nodejs+Class%3A+http.ClientRequest) returns only *one* result from nodejs.org, instead of the *13 to 15 functionally-identical* results that would otherwise be possible.
