### PR TITLE
wip: prettier and hand-fix mdx

### DIFF
--- a/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/02_object_type_components/01_object_type_specification_syntax.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/15_object_types_and_objects/02_object_type_components/01_object_type_specification_syntax.mdx
@@ -69,9 +69,11 @@ RETURN self AS RESULT
 ```
 
 !!! Note
-    -   The `OR REPLACE` option cannot be currently used to add, delete, or modify the attributes of an existing object type. Use the `DROP TYPE` command to first delete the existing object type. The `OR REPLACE` option can be used to add, delete, or modify the methods in an existing object type.
 
-    -   The PostgreSQL form of the `ALTER TYPE ALTER ATTRIBUTE` command can be used to change the data type of an attribute in an existing object type. However, the `ALTER TYPE` command cannot add or delete attributes in the object type.
+- The `OR REPLACE` option cannot be currently used to add, delete, or modify the attributes of an existing object type. Use the `DROP TYPE` command to first delete the existing object type. The `OR REPLACE` option can be used to add, delete, or modify the methods in an existing object type.
+- The PostgreSQL form of the `ALTER TYPE ALTER ATTRIBUTE` command can be used to change the data type of an attribute in an existing object type. However, the `ALTER TYPE` command cannot add or delete attributes in the object type.
+
+!!!
 
 `name` is an identifier (optionally schema-qualified) assigned to the object type.
 
@@ -88,11 +90,13 @@ If the `AUTHID` clause is omitted or `DEFINER` is specified, the rights of the o
 Following the closing parenthesis of the `CREATE TYPE` definition, `[ NOT ] FINAL` specifies whether or not a subtype can be derived from this object type. `FINAL`, which is the default, means that no subtypes can be derived from this object type. Specify `NOT FINAL` if you want to allow subtypes to be defined under this object type.
 
 !!! Note
+
     Even though the specification of `NOT FINAL` is accepted in the `CREATE TYPE` command, SPL does not currently support the creation of subtypes.
 
 Following the closing parenthesis of the `CREATE TYPE` definition, `[ NOT ] INSTANTIABLE` specifies whether or not an object instance can be created of this object type. `INSTANTIABLE`, which is the default, means that an instance of this object type can be created. Specify `NOT INSTANTIABLE` if this object type is to be used only as a parent “template” from which other specialized subtypes are to be defined. If `NOT INSTANTIABLE` is specified, then `NOT FINAL` must be specified as well. If any method in the object type contains the `NOT INSTANTIABLE` qualifier, then the object type, itself, must be defined with `NOT INSTANTIABLE` and `NOT FINAL`.
 
 !!! Note
+
     Even though the specification of `NOT INSTANTIABLE` is accepted in the `CREATE TYPE` command, SPL does not currently support the creation of subtypes.
 
 `method_spec` denotes the specification of a member method or static method.
@@ -113,16 +117,16 @@ Include the `CONSTRUCTOR` keyword and function definition to define a constructo
 
 The following points should be noted about an object type specification:
 
--   There must be at least one attribute defined in the object type.
+- There must be at least one attribute defined in the object type.
 
--   There may be none, one, or more methods defined in the object type.
+- There may be none, one, or more methods defined in the object type.
 
--   For each member method there is an implicit, built-in parameter named `SELF`, whose data type is that of the object type being defined.
+- For each member method there is an implicit, built-in parameter named `SELF`, whose data type is that of the object type being defined.
 
-    `SELF` refers to the object instance that is currently invoking the method. `SELF` can be explicitly declared as an `IN` or `IN OUT` parameter in the parameter list (for example as `MEMBER FUNCTION (SELF IN OUT object_type ...)).`
+  `SELF` refers to the object instance that is currently invoking the method. `SELF` can be explicitly declared as an `IN` or `IN OUT` parameter in the parameter list (for example as `MEMBER FUNCTION (SELF IN OUT object_type ...)).`
 
-    If `SELF` is explicitly declared, `SELF` must be the first parameter in the parameter list. If `SELF` is not explicitly declared, its parameter mode defaults to `IN OUT` for member procedures and `IN` for member functions.
+  If `SELF` is explicitly declared, `SELF` must be the first parameter in the parameter list. If `SELF` is not explicitly declared, its parameter mode defaults to `IN OUT` for member procedures and `IN` for member functions.
 
--   A static method cannot be overridden (`OVERRIDING` and `STATIC` cannot be specified together in `method_spec`).
+- A static method cannot be overridden (`OVERRIDING` and `STATIC` cannot be specified together in `method_spec`).
 
--   A static method must be instantiable (`NOT INSTANTIABLE` and `STATIC` cannot be specified together in `method_spec`).
+- A static method must be instantiable (`NOT INSTANTIABLE` and `STATIC` cannot be specified together in `method_spec`).

--- a/product_docs/docs/mysql_data_adapter/2.5.5/06_features_of_mysql_fdw.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/06_features_of_mysql_fdw.mdx
@@ -11,6 +11,7 @@ The key features of the MySQL Foreign Data Wrapper are listed below:
 MySQL Foreign Data Wrapper provides the write capability. Users can insert, update and delete data in the remote MySQL tables by inserting, updating and deleting the data locally in the foreign tables. MySQL foreign data wrapper uses the Postgres type casting mechanism to provide opposite type casting between MySQL and Postgres data types.
 
 !!! Note
+
     The first column of MySQL table must have unique/primary key for DML to work.
 
 See also:
@@ -56,8 +57,11 @@ For more information, see [DROP EXTENSION](https://www.postgresql.org/docs/curre
 MySQL Foreign Data Wrapper supports join push-down. It pushes the joins between two foreign tables from the same remote MySQL server to a remote server, thereby enhancing the performance.
 
 !!! Note
-    -   Currently, joins involving only relational and arithmetic operators in join-clauses are pushed down to avoid any potential join failure.
-    -   Only the INNER and LEFT/RIGHT OUTER joins are supported.
+
+- Currently, joins involving only relational and arithmetic operators in join-clauses are pushed down to avoid any potential join failure.
+- Only the INNER and LEFT/RIGHT OUTER joins are supported.
+
+!!!
 
 See also:
 

--- a/product_docs/docs/mysql_data_adapter/2.5.5/07_configuring_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/07_configuring_the_mysql_data_adapter.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuring the MySQL Foreign Data Wrapper"
-redirects: 
-  - '/mysql_data_adapter/2.5.5/06_configuring_the_mysql_data_adapter/'
+redirects:
+  - "/mysql_data_adapter/2.5.5/06_configuring_the_mysql_data_adapter/"
 ---
 
 <div id="configuring_the_mysql_data_adapter" class="registered_link"></div>
@@ -268,6 +268,7 @@ For more information about using the `CREATE FOREIGN TABLE` command, see:
 > <https://www.postgresql.org/docs/current/static/sql-createforeigntable.html>
 
 !!! Note
+
     MySQL foreign data wrapper supports the write capability feature.
 
 <div id="data_type_mappings" class="registered_link"></div>
@@ -292,11 +293,14 @@ When using the foreign data wrapper, you must create a table on the Postgres ser
 | VARCHAR()   | VARCHAR()/CHARCTER VARYING() |
 
 !!! Note
-    For `ENUM` data type:
 
-    MySQL accepts `enum` value in string form. You must create exactly same `enum` listing on Advanced Server as that is present on MySQL server. Any sort of inconsistency will result in an error while fetching rows with values not known on the local server.
+For `ENUM` data type:
 
-    Also, when the given `enum` value is not present at MySQL side but present at Postgres/Advanced Server side, an empty string (`''`) is inserted as a value at MySQL side for the `enum` column. To select from such a table having enum value as `''`, create an `enum` type at Postgres side with all valid values and `''`.
+MySQL accepts `enum` value in string form. You must create exactly same `enum` listing on Advanced Server as that is present on MySQL server. Any sort of inconsistency will result in an error while fetching rows with values not known on the local server.
+
+Also, when the given `enum` value is not present at MySQL side but present at Postgres/Advanced Server side, an empty string (`''`) is inserted as a value at MySQL side for the `enum` column. To select from such a table having enum value as `''`, create an `enum` type at Postgres side with all valid values and `''`.
+
+!!!
 
 <div id="import_foreign_schema" class="registered_link"></div>
 

--- a/product_docs/docs/mysql_data_adapter/2.5.5/12_troubleshooting.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.5.5/12_troubleshooting.mdx
@@ -15,4 +15,5 @@ Specify the authentication plugin as `mysql_native_password` and set a cleartext
 > `ALTER USER 'username'@'host' IDENTIFIED WITH mysql_native_password BY '<password>';`
 
 !!! Note
+
     Refer to [MySQL 8 documentation](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html) for more details on the above error.

--- a/product_docs/docs/mysql_data_adapter/2.6.0/04_installing_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.6.0/04_installing_the_mysql_data_adapter.mdx
@@ -6,17 +6,20 @@ title: "Installing the MySQL Foreign Data Wrapper"
 
 The MySQL Foreign Data Wrapper can be installed with an RPM package. During the installation process, the installer will satisfy software prerequisites.
 
-<div id="using_an_rpm_package_to_install_the_data_adapter" class="registered_link"></div>
+<div
+  id="using_an_rpm_package_to_install_the_data_adapter"
+  class="registered_link"
+></div>
 
 ## Installing the MySQL Foreign Data Wrapper using an RPM Package
 
 You can install the MySQL Foreign Data Wrapper using an RPM package on the following platforms:
 
--   [RHEL 7](#rhel7)
--   [RHEL 7 PPCLE](#centos7_PPCLE)
--   [RHEL 8](#rhel8)
--   [CentOS 7](#centos7)
--   [CentOS 8](#centos8)
+- [RHEL 7](#rhel7)
+- [RHEL 7 PPCLE](#centos7_PPCLE)
+- [RHEL 8](#rhel8)
+- [CentOS 7](#centos7)
+- [CentOS 8](#centos8)
 
 <div id="rhel7" class="registered_link"></div>
 
@@ -26,13 +29,13 @@ Before installing the MySQL Foreign Data Wrapper, you must install the following
 
 Install the `epel-release` package:
 
-```text
+```sh
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ```
 
 Enable the optional, extras, and HA repositories:
 
-```text
+```sh
 subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"  --enable "rhel-ha-for-rhel-*-server-rpms"
 ```
 
@@ -42,25 +45,25 @@ You must also have credentials that allow access to the EDB repository. For info
 
 After receiving your repository credentials you can:
 
-1.  Create the repository configuration file.
-2.  Modify the file, providing your user name and password.
-3.  Install the MySQL Foreign Data Wrapper.
+1. Create the repository configuration file.
+1. Modify the file, providing your user name and password.
+1. Install the MySQL Foreign Data Wrapper.
 
-**Creating a Repository Configuration File**
+#### Creating a Repository Configuration File
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-```text
+```sh
 yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 ```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
-**Modifying the file, providing your user name and password**
+#### Modifying the file, providing your user name and password
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-```text
+```sh
 [edb]
 name=EnterpriseDB RPMs $releasever - $basearch
 baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -70,24 +73,25 @@ repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
 ```
 
-**Installing MySQL Foreign Data Wrapper**
+#### Installing MySQL Foreign Data Wrapper
 
 1. Before installing MySQL FDW, download and install the MySQL repo using the following commands:
- 
-   ```text
+
+   ```sh
    yum -y install https://dev.mysql.com/get/mysql80-community-release-el7-3.noarch.rpm
    ```
 
-2. Use the following command to enable the appropriate subrepository and install the MySQL Foreign data Wrapper:
- - For MySQL 8:
-   ```text
-   yum -y install --enablerepo=mysql80-community --disablerepo=mysql57-community edb-as<xx>-mysql8_fdw
-   ```
- - For MySQL 5: 
-   ```text
-   yum -y install --enablerepo=mysql57-community --disablerepo=mysql80-community edb-as<xx>-mysql5_fdw
-   ```
-Where `xx` is the server version number i.e. 13.
+1. Use the following command to enable the appropriate subrepository and install the MySQL Foreign data Wrapper:
+
+   - For MySQL 8:
+     ```sh
+     yum -y install --enablerepo=mysql80-community --disablerepo=mysql57-community edb-as<xx>-mysql8_fdw
+     ```
+   - For MySQL 5:
+     ```sh
+     yum -y install --enablerepo=mysql57-community --disablerepo=mysql80-community edb-as<xx>-mysql5_fdw
+     ```
+     Where `xx` is the server version number i.e. 13.
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
 
@@ -98,57 +102,60 @@ During the installation, yum may encounter a dependency that it cannot resolve. 
 ### On RHEL 7 PPCLE
 
 Before installing the MySQL Foreign Data Wrapper, you must install the following prerequisite packages, and request credentials from EDB:
+
 1. Use the following commands to install Advance Toolchain:
-```text
-rpm --import https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
 
-cat > /etc/yum.repos.d/advance-toolchain.repo <<EOF
-# Begin of configuration file
-[advance-toolchain]
-name=Advance Toolchain IBM FTP
-baseurl=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7
-failovermethod=priority
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHELX/gpg-pubkey-6976a827-5164221b
-# End of
-```
+   ```sh
+   rpm --import https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
 
-2. Install the `epel-release` package:
+   cat > /etc/yum.repos.d/advance-toolchain.repo <<EOF
+   # Begin of configuration file
+   [advance-toolchain]
+   name=Advance Toolchain IBM FTP
+   baseurl=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7
+   failovermethod=priority
+   enabled=1
+   gpgcheck=1
+   repo_gpgcheck=1
+   gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHELX/gpg-pubkey-6976a827-5164221b
+   # End of
+   ```
 
-```text
-yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-```
+1. Install the `epel-release` package:
+
+   ```sh
+   yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+   ```
 
 !!! Note
+
     You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
- <https://info.enterprisedb.com/rs/069-ALB-339/images/Repository%20Access%2004-09-2019.pdf>
+<https://info.enterprisedb.com/rs/069-ALB-339/images/Repository%20Access%2004-09-2019.pdf>
 
 After receiving your repository credentials you can:
 
-1.  Create the repository configuration file.
-2.  Modify the file, providing your user name and password.
-3.  Install the MySQL Foreign Data Wrapper.
+1. Create the repository configuration file.
+1. Modify the file, providing your user name and password.
+1. Install the MySQL Foreign Data Wrapper.
 
-**Creating a Repository Configuration File**
+#### Creating a Repository Configuration File
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-```text
+```sh
 yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 ```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
-**Modifying the file, providing your user name and password**
+#### Modifying the file, providing your user name and password
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-```text
+```sh
 [edb]
 name=EnterpriseDB RPMs $releasever - $basearch
 baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -158,15 +165,18 @@ repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
 ```
 
-**Installing MySQL Foreign Data Wrapper**
+#### Installing MySQL Foreign Data Wrapper
 
 Use the following command to install the MySQL Foreign Data Wrapper:
-  ```text
-   yum install edb-as<xx>-mysql5_fdw
-   ```
-where `xx` is the server version number i.e. 13. 
 
- !!! Note
+```sh
+ yum install edb-as<xx>-mysql5_fdw
+```
+
+where `xx` is the server version number i.e. 13.
+
+!!! Note
+
     MySQL 8.0 RPMs are not available for CentOS 7 PPCLE platform.
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
@@ -181,13 +191,13 @@ Before installing the MySQL Foreign Data Wrapper, you must install the following
 
 Install the `epel-release` package:
 
-```text
+```sh
 dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 ```
 
 Enable the `codeready-builder-for-rhel-8-\*-rpms` repository:
 
-```text
+```sh
 ARCH=$( /bin/arch )
 subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
 ```
@@ -198,25 +208,25 @@ You must also have credentials that allow access to the EDB repository. For info
 
 After receiving your repository credentials you can:
 
-1.  Create the repository configuration file.
-2.  Modify the file, providing your user name and password.
-3.  Install the MySQL Foreign Data Wrapper.
+1. Create the repository configuration file.
+1. Modify the file, providing your user name and password.
+1. Install the MySQL Foreign Data Wrapper.
 
-**Creating a Repository Configuration File**
+#### Creating a Repository Configuration File
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-```text
+```sh
 dnf -y https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 ```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
-**Modifying the file, providing your user name and password**
+#### Modifying the file, providing your user name and password
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-```text
+```sh
 [edb]
 name=EnterpriseDB RPMs $releasever - $basearch
 baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -225,19 +235,20 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
 ```
-**Installing MySQL Foreign Data Wrapper**
+
+#### Installing MySQL Foreign Data Wrapper
 
 After saving your changes to the configuration file, use the below command to install the MySQL Foreign Data Wrapper:
 
-```text
+```sh
 dnf install edb-as<xx>-mysql8_fdw
 ```
+
 Where `xx` is the server version number i.e. 13.
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
 
 During the installation, yum may encounter a dependency that it cannot resolve. If it does, it will provide a list of the required dependencies that you must manually resolve.
-
 
 <div id="centos7" class="registered_link"></div>
 
@@ -247,11 +258,12 @@ Before installing the MySQL Foreign Data Wrapper, you must install the following
 
 Install the `epel-release` package:
 
-```text
+```sh
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ```
 
 !!! Note
+
     You may need to enable the `[extras]` repository definition in the `CentOS-Base.repo` file (located in `/etc/yum.repos.d`).
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
@@ -260,25 +272,25 @@ You must also have credentials that allow access to the EDB repository. For info
 
 After receiving your repository credentials you can:
 
-1.  Create the repository configuration file.
-2.  Modify the file, providing your user name and password.
-3.  Install the MySQL Foreign Data Wrapper.
+1. Create the repository configuration file.
+1. Modify the file, providing your user name and password.
+1. Install the MySQL Foreign Data Wrapper.
 
-**Creating a Repository Configuration File**
+#### Creating a Repository Configuration File
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-```text
+```sh
 yum -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 ```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
-**Modifying the file, providing your user name and password**
+#### Modifying the file, providing your user name and password
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-```text
+```sh
 [edb]
 name=EnterpriseDB RPMs $releasever - $basearch
 baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -288,22 +300,22 @@ repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
 ```
 
-**Installing MySQL Foreign Data Wrapper**
+#### Installing MySQL Foreign Data Wrapper
 
 1. Before installing MySQL FDW, download and install the MySQL repo using the following commands:
-   ```text
+   ```sh
    yum -y install https://dev.mysql.com/get/mysql80-community-release-el7-3.noarch.rpm
    ```
-2. Use the following command to enable the appropriate subrepository and install the MySQL Foreign data Wrapper:
- - For MySQL 8:
-   ```text
-   yum -y install --enablerepo=mysql80-community --disablerepo=mysql57-community edb-as<xx>-mysql8_fdw
-   ```
- - For MySQL 5: 
-   ```text
-   yum -y install --enablerepo=mysql57-community --disablerepo=mysql80-community edb-as<xx>-mysql5_fdw
-   ```
-Where `xx` is the server version number i.e. 13.
+1. Use the following command to enable the appropriate subrepository and install the MySQL Foreign data Wrapper:
+   - For MySQL 8:
+     ```sh
+     yum -y install --enablerepo=mysql80-community --disablerepo=mysql57-community edb-as<xx>-mysql8_fdw
+     ```
+   - For MySQL 5:
+     ```sh
+     yum -y install --enablerepo=mysql57-community --disablerepo=mysql80-community edb-as<xx>-mysql5_fdw
+     ```
+     Where `xx` is the server version number i.e. 13.
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
 
@@ -317,13 +329,13 @@ Before installing the MySQL Foreign Data Wrapper, you must install the following
 
 Install the `epel-release` package:
 
-```text
+```sh
 dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 ```
 
 Enable the `PowerTools` repository:
 
-```text
+```sh
 dnf config-manager --set-enabled PowerTools
 ```
 
@@ -333,25 +345,25 @@ You must also have credentials that allow access to the EDB repository. For info
 
 After receiving your repository credentials you can:
 
-1.  Create the repository configuration file.
-2.  Modify the file, providing your user name and password.
-3.  Install the MySQL Foreign Data Wrapper.
+1. Create the repository configuration file.
+1. Modify the file, providing your user name and password.
+1. Install the MySQL Foreign Data Wrapper.
 
-**Creating a Repository Configuration File**
+#### Creating a Repository Configuration File
 
 To create the repository configuration file, assume superuser privileges, and invoke the following command:
 
-```text
+```sh
 dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
 ```
 
 The repository configuration file is named `edb.repo`. The file resides in `/etc/yum.repos.d`.
 
-**Modifying the file, providing your user name and password**
+#### Modifying the file, providing your user name and password
 
 After creating the `edb.repo` file, use your choice of editor to ensure that the value of the `enabled` parameter is `1`, and replace the `username` and `password` placeholders in the `baseurl` specification with the name and password of a registered EDB user.
 
-```text
+```sh
 [edb]
 name=EnterpriseDB RPMs $releasever - $basearch
 baseurl=https://<username>:<password>@yum.enterprisedb.com/edb/redhat/rhel-$releasever-$basearch
@@ -361,13 +373,14 @@ repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/ENTERPRISEDB-GPG-KEY
 ```
 
-**Installing MySQL Foreign Data Wrapper**
+#### Installing MySQL Foreign Data Wrapper
 
 After saving your changes to the configuration file, use the following command to install the MySQL Foreign Data Wrapper:
 
-```text
+```sh
 dnf install edb-as<xx>-mysql8_fdw
 ```
+
 Where `xx` is the server version number i.e. 13.
 
 When you install an RPM package that is signed by a source that is not recognized by your system, yum may ask for your permission to import the key to your local server. If prompted, and you are satisfied that the packages come from a trustworthy source, enter `y`, and press `Return` to continue.
@@ -381,100 +394,102 @@ To install the MySQL Foreign Data Wrapper on a Debian or Ubuntu host, you must h
 The following steps will walk you through on using the EDB apt repository to install a DEB package. When using the commands, replace the `username` and `password` with the credentials provided by EDB.
 
 1.  Assume superuser privileges:
-   ```text
-   sudo su –
-   ```
+    ```sh
+    sudo su –
+    ```
+1.  Configure the EnterpriseDB repository:
 
-2.  Configure the EnterpriseDB repository:
+    - On Debian 9:
 
-    On Debian 9:
+      ```sh
+      sh -c 'echo "deb https://username:password@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
+      ```
 
-    ```text
-    sh -c 'echo "deb https://username:password@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
+    - On Debian 10, Ubuntu 18, and Ubuntu 20:
+
+      1.  Set up the EDB repository:
+
+          ```sh
+          sh -c 'echo "deb [arch=amd64] https://apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
+          ```
+
+      1.  Substitute your EDB credentials for the `username` and `password` in the following command:
+
+          ```sh
+          sh -c 'echo "machine apt.enterprisedb.com login <username> password <password>" > /etc/apt/auth.conf.d/edb.conf'
+          ```
+
+1.  Add support to your system for secure APT repositories:
+
+    ```sh
+    apt-get install apt-transport-https
     ```
 
-    On Debian 10, Ubuntu 18, and Ubuntu 20:
+1.  Add the EBD signing key:
 
-    1.  Set up the EDB repository:
-
-    ```text
-    sh -c 'echo "deb [arch=amd64] https://apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
+    ```sh
+    wget -q -O - https://username:password@apt.enterprisedb.com/edb-deb.gpg.key | apt-key add -
     ```
 
-    2.  Substitute your EDB credentials for the `username` and `password` in the following command:
+1.  If there is `libmysqlclient-dev` already installed on your system, remove it by using the following command:
 
-    ```text
-    sh -c 'echo "machine apt.enterprisedb.com login <username> password <password>" > /etc/apt/auth.conf.d/edb.conf'
+    ```sh
+    sudo apt-get remove  libmysqlclient-dev
     ```
 
-3.  Add support to your system for secure APT repositories:
+1.  Enable the MySQL repo by using the apporpriate command:
 
-   ```text
-   apt-get install apt-transport-https
-   ```
+    - For Debian 9:
 
-4.  Add the EBD signing key:
+      - For MySQL 8:
+        ```sh
+        sudo echo "deb http://repo.mysql.com/apt/debian/stretch mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+        ```
+      - For MySQL 5:
+        ```sh
+        sudo echo "deb http://repo.mysql.com/apt/debian/stretch mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+        ```
 
-   ```text
-   wget -q -O - https://username:password@apt.enterprisedb.com/edb-deb.gpg.key | apt-key add -
-   ```
-5. If there is `libmysqlclient-dev` already installed on your system, remove it by using the following command:
-   ```text
-   sudo apt-get remove  libmysqlclient-dev
-   ```
+    - For Debian 10:
 
-6. Enable the MySQL repo by using the apporpriate command:
-- For Debian 9:
-    - For MySQL 8: 
-    ```text
-    sudo echo "deb http://repo.mysql.com/apt/debian/stretch mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+      - For MySQL 8:
+        ```sh
+        sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+        ```
+      - For MySQL 5:
+        ```sh
+        sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+        ```
+
+    - For Ubuntu 18:
+
+      - For MySQL 8:
+        ```sh
+        sudo echo "deb http://repo.mysql.com/apt/ubuntu/bionic mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+        ```
+      - For MySQL 5:
+        ```sh
+        sudo echo "deb http://repo.mysql.com/apt/ubuntu/bionic mysql-5.7" | sudo tee /etc/apt/sources.list.d/mysql.list
+        ```
+
+    Note that you do not need to enable the MySQL repo on Ubuntu 20.
+
+1.  Add the mysql repo key using the following commands:
+
+    ```sh
+    sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
     ```
-    - For MySQL 5: 
-    ```text
-    sudo echo "deb http://repo.mysql.com/apt/debian/stretch mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+
+1.  Update the repository metadata:
+
+    ```sh
+    apt-get update
     ```
 
-- For Debian 10:
-    - For MySQL 8: 
-    ```text
-    sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
-    ```
-    - For MySQL 5: 
-    ```text
-    sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+1.  Install DEB package:
+
+    ```sh
+    apt-get install edb-as<xx>-mysql<y>-fdw
     ```
 
-- For Ubuntu 18:
-    - For MySQL 8: 
-    ```text
-    sudo echo "deb http://repo.mysql.com/apt/ubuntu/bionic mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
-    ```
-    - For MySQL 5: 
-    ```text
-    sudo echo "deb http://repo.mysql.com/apt/ubuntu/bionic mysql-5.7" | sudo tee /etc/apt/sources.list.d/mysql.list
-    ```
-  Note that you do not need to enable the MySQL repo on Ubuntu 20.
-
-7.  Add the mysql repo key using the following commands:
-
-   ```text
-   sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
-   ```
-8. Update the repository metadata:
-
-   ```text
-   apt-get update
-   ```
-
-9.  Install DEB package:
-
-   ```text
-   apt-get install edb-as<xx>-mysql<y>-fdw
-   ```
-  Where `xx` is the server version number i.e. 13 and `y` is the MySQL version i.e. 5 or 8.
-
-
-
-
-
-
+    Where `xx` is the server version number i.e. 13 and `y` is the MySQL version i.e. 5 or 8.

--- a/product_docs/docs/mysql_data_adapter/2.6.0/06_features_of_mysql_fdw.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.6.0/06_features_of_mysql_fdw.mdx
@@ -11,6 +11,7 @@ The key features of the MySQL Foreign Data Wrapper are listed below:
 MySQL Foreign Data Wrapper provides the write capability. Users can insert, update and delete data in the remote MySQL tables by inserting, updating and deleting the data locally in the foreign tables. MySQL foreign data wrapper uses the Postgres type casting mechanism to provide opposite type casting between MySQL and Postgres data types.
 
 !!! Note
+
     The first column of MySQL table must have unique/primary key for DML to work.
 
 See also:
@@ -56,8 +57,11 @@ For more information, see [DROP EXTENSION](https://www.postgresql.org/docs/curre
 MySQL Foreign Data Wrapper supports join push-down. It pushes the joins between the foreign tables of the same remote MySQL server to that remote MySQL server, thereby enhancing the performance.
 
 !!! Note
-    -   Currently, joins involving only relational and arithmetic operators in join-clauses are pushed down to avoid any potential join failure.
-    -   Only the INNER and LEFT/RIGHT OUTER joins are supported.
+
+- Currently, joins involving only relational and arithmetic operators in join-clauses are pushed down to avoid any potential join failure.
+- Only the INNER and LEFT/RIGHT OUTER joins are supported.
+
+!!!
 
 See also:
 

--- a/product_docs/docs/mysql_data_adapter/2.6.0/07_configuring_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.6.0/07_configuring_the_mysql_data_adapter.mdx
@@ -6,10 +6,10 @@ title: "Configuring the MySQL Foreign Data Wrapper"
 
 Before using the MySQL Foreign Data Wrapper, you must:
 
- 1.  Use the [CREATE EXTENSION](#create-extension) command to create the MySQL Foreign Data Wrapper extension on the Postgres host.
- 2.  Use the [CREATE SERVER](#create-server) command to define a connection to the MySQL server.
- 3.  Use the [CREATE USER MAPPING](#create-user-mapping) command to define a mapping that associates a Postgres role with the server.
- 4.  Use the [CREATE FOREIGN TABLE](#create-foreign-table) command to define a single table in the Postgres database that corresponds to a table that resides on the MySQL server or use the [IMPORT FOREIGN SCHEMA](#import-foreign-schema) command to import multiple remote tables in the local schema.
+1.  Use the [CREATE EXTENSION](#create-extension) command to create the MySQL Foreign Data Wrapper extension on the Postgres host.
+1.  Use the [CREATE SERVER](#create-server) command to define a connection to the MySQL server.
+1.  Use the [CREATE USER MAPPING](#create-user-mapping) command to define a mapping that associates a Postgres role with the server.
+1.  Use the [CREATE FOREIGN TABLE](#create-foreign-table) command to define a single table in the Postgres database that corresponds to a table that resides on the MySQL server or use the [IMPORT FOREIGN SCHEMA](#import-foreign-schema) command to import multiple remote tables in the local schema.
 
 <div id="create_extension" class="registered_link"></div>
 
@@ -25,21 +25,21 @@ CREATE EXTENSION [IF NOT EXISTS] mysql_fdw [WITH] [SCHEMA schema_name];
 
 `IF NOT EXISTS`
 
- Include the `IF NOT EXISTS` clause to instruct the server to issue a notice instead of throwing an error if an extension with the same name already exists.
+Include the `IF NOT EXISTS` clause to instruct the server to issue a notice instead of throwing an error if an extension with the same name already exists.
 
 `schema_name`
 
- Optionally specify the name of the schema in which to install the extension's objects.
+Optionally specify the name of the schema in which to install the extension's objects.
 
 **Example**
 
 The following command installs the MySQL foreign data wrapper:
 
- `CREATE EXTENSION mysql_fdw;`
+`CREATE EXTENSION mysql_fdw;`
 
 For more information about using the foreign data wrapper `CREATE EXTENSION` command, see:
 
- <https://www.postgresql.org/docs/current/static/sql-createextension.html>.
+<https://www.postgresql.org/docs/current/static/sql-createextension.html>.
 
 <div id="create_server" class="registered_link"></div>
 
@@ -58,15 +58,15 @@ The role that defines the server is the owner of the server; use the `ALTER SERV
 
 `server_name`
 
- Use `server_name` to specify a name for the foreign server. The server name must be unique within the database.
+Use `server_name` to specify a name for the foreign server. The server name must be unique within the database.
 
 `FOREIGN_DATA_WRAPPER`
 
- Include the `FOREIGN_DATA_WRAPPER` clause to specify that the server should use the `mysql_fdw` foreign data wrapper when connecting to the cluster.
+Include the `FOREIGN_DATA_WRAPPER` clause to specify that the server should use the `mysql_fdw` foreign data wrapper when connecting to the cluster.
 
 `OPTIONS`
 
- Use the `OPTIONS` clause of the `CREATE SERVER` command to specify connection information for the foreign server. You can include:
+Use the `OPTIONS` clause of the `CREATE SERVER` command to specify connection information for the foreign server. You can include:
 
 | Option              | Description                                                                                                                                                                     |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -93,7 +93,7 @@ The foreign server uses the default port (`3306`) for the connection to the clie
 
 For more information about using the `CREATE SERVER` command, see:
 
- <https://www.postgresql.org/docs/current/static/sql-createserver.html>
+<https://www.postgresql.org/docs/current/static/sql-createserver.html>
 
 <div id="create_user_mapping" class="registered_link"></div>
 
@@ -112,25 +112,25 @@ You must be the owner of the foreign server to create a user mapping for that se
 
 `role_name`
 
- Use `role_name` to specify the role that will be associated with the foreign server.
+Use `role_name` to specify the role that will be associated with the foreign server.
 
 `server_name`
 
- Use `server_name` to specify the name of the server that defines a connection to the MySQL cluster.
+Use `server_name` to specify the name of the server that defines a connection to the MySQL cluster.
 
 `OPTIONS`
 
- Use the `OPTIONS` clause to specify connection information for the foreign server.
+Use the `OPTIONS` clause to specify connection information for the foreign server.
 
- `username`: the name of the user on the MySQL server.
+`username`: the name of the user on the MySQL server.
 
- `password`: the password associated with the username.
+`password`: the password associated with the username.
 
 **Example**
 
 The following command creates a user mapping for a role named `enterprisedb`; the mapping is associated with a server named `mysql_server`:
 
- `CREATE USER MAPPING FOR enterprisedb SERVER mysql_server;`
+`CREATE USER MAPPING FOR enterprisedb SERVER mysql_server;`
 
 If the database host uses secure authentication, provide connection credentials when creating the user mapping:
 
@@ -142,7 +142,7 @@ The command creates a user mapping for a role named `public` that is associated 
 
 For detailed information about the `CREATE USER MAPPING` command, see:
 
- <https://www.postgresql.org/docs/current/static/sql-createusermapping.html>
+<https://www.postgresql.org/docs/current/static/sql-createusermapping.html>
 
 <div id="create_foreign_table" class="registered_link"></div>
 
@@ -177,57 +177,57 @@ and `table_constraint` is:
 
 `table_name`
 
- Specifies the name of the foreign table; include a schema name to specify the schema in which the foreign table should reside.
+Specifies the name of the foreign table; include a schema name to specify the schema in which the foreign table should reside.
 
 `IF NOT EXISTS`
 
- Include the `IF NOT EXISTS` clause to instruct the server to not throw an error if a table with the same name already exists; if a table with the same name exists, the server will issue a notice.
+Include the `IF NOT EXISTS` clause to instruct the server to not throw an error if a table with the same name already exists; if a table with the same name exists, the server will issue a notice.
 
 `column_name`
 
- Specifies the name of a column in the new table; each column should correspond to a column described on the MySQL server.
+Specifies the name of a column in the new table; each column should correspond to a column described on the MySQL server.
 
 `data_type`
 
- Specifies the data type of the column; when possible, specify the same data type for each column on the Postgres server and the MySQL server. If a data type with the same name is not available, the Postgres server will attempt to cast the data type to a type compatible with the MySQL server. If the server cannot identify a compatible data type, it will return an error.
+Specifies the data type of the column; when possible, specify the same data type for each column on the Postgres server and the MySQL server. If a data type with the same name is not available, the Postgres server will attempt to cast the data type to a type compatible with the MySQL server. If the server cannot identify a compatible data type, it will return an error.
 
 `COLLATE collation`
 
- Include the `COLLATE` clause to assign a collation to the column; if not specified, the column data type's default collation is used.
+Include the `COLLATE` clause to assign a collation to the column; if not specified, the column data type's default collation is used.
 
 `INHERITS (parent_table [, ... ])`
 
- Include the `INHERITS` clause to specify a list of tables from which the new foreign table automatically inherits all columns. Parent tables can be plain tables or foreign tables.
+Include the `INHERITS` clause to specify a list of tables from which the new foreign table automatically inherits all columns. Parent tables can be plain tables or foreign tables.
 
 `CONSTRAINT constraint_name`
 
- Specify an optional name for a column or table constraint; if not specified, the server will generate a constraint name.
+Specify an optional name for a column or table constraint; if not specified, the server will generate a constraint name.
 
 `NOT NULL`
 
- Include the `NOT NULL` keywords to indicate that the column is not allowed to contain null values.
+Include the `NOT NULL` keywords to indicate that the column is not allowed to contain null values.
 
 `NULL`
 
- Include the `NULL` keywords to indicate that the column is allowed to contain null values. This is the default.
+Include the `NULL` keywords to indicate that the column is allowed to contain null values. This is the default.
 
 `CHECK (expr) [NO INHERIT]`
 
- Use the `CHECK` clause to specify an expression that produces a Boolean result that each row in the table must satisfy. A check constraint specified as a column constraint should reference that column's value only, while an expression appearing in a table constraint can reference multiple columns.
+Use the `CHECK` clause to specify an expression that produces a Boolean result that each row in the table must satisfy. A check constraint specified as a column constraint should reference that column's value only, while an expression appearing in a table constraint can reference multiple columns.
 
- A `CHECK` expression cannot contain subqueries or refer to variables other than columns of the current row.
+A `CHECK` expression cannot contain subqueries or refer to variables other than columns of the current row.
 
- Include the `NO INHERIT` keywords to specify that a constraint should not propagate to child tables.
+Include the `NO INHERIT` keywords to specify that a constraint should not propagate to child tables.
 
 `DEFAULT default_expr`
 
- Include the `DEFAULT` clause to specify a default data value for the column whose column definition it appears within. The data type of the default expression must match the data type of the column.
+Include the `DEFAULT` clause to specify a default data value for the column whose column definition it appears within. The data type of the default expression must match the data type of the column.
 
 `SERVER server_name [OPTIONS (option 'value' [, ... ] ) ]`
 
- To create a foreign table that will allow you to query a table that resides on a MySQL file system, include the `SERVER` clause and specify the `server_name` of the foreign server that uses the MySQL data adapter.
+To create a foreign table that will allow you to query a table that resides on a MySQL file system, include the `SERVER` clause and specify the `server_name` of the foreign server that uses the MySQL data adapter.
 
- Use the `OPTIONS` clause to specify the following `options` and their corresponding values:
+Use the `OPTIONS` clause to specify the following `options` and their corresponding values:
 
 | option        | value                                                                                    |
 | ------------- | ---------------------------------------------------------------------------------------- |
@@ -266,6 +266,7 @@ For more information about using the `CREATE FOREIGN TABLE` command, see:
 > <https://www.postgresql.org/docs/current/static/sql-createforeigntable.html>
 
 !!! Note
+
     MySQL foreign data wrapper supports the write capability feature.
 
 <div id="data_type_mappings" class="registered_link"></div>
@@ -290,11 +291,14 @@ When using the foreign data wrapper, you must create a table on the Postgres ser
 | VARCHAR()   | VARCHAR()/CHARCTER VARYING() |
 
 !!! Note
-    For `ENUM` data type:
 
-    MySQL accepts `enum` value in string form. You must create exactly same `enum` listing on Advanced Server as that is present on MySQL server. Any sort of inconsistency will result in an error while fetching rows with values not known on the local server.
+For `ENUM` data type:
 
-    Also, when the given `enum` value is not present at MySQL side but present at Postgres/Advanced Server side, an empty string (`''`) is inserted as a value at MySQL side for the `enum` column. To select from such a table having enum value as `''`, create an `enum` type at Postgres side with all valid values and `''`.
+MySQL accepts `enum` value in string form. You must create exactly same `enum` listing on Advanced Server as that is present on MySQL server. Any sort of inconsistency will result in an error while fetching rows with values not known on the local server.
+
+Also, when the given `enum` value is not present at MySQL side but present at Postgres/Advanced Server side, an empty string (`''`) is inserted as a value at MySQL side for the `enum` column. To select from such a table having enum value as `''`, create an `enum` type at Postgres side with all valid values and `''`.
+
+!!!
 
 <div id="import_foreign_schema" class="registered_link"></div>
 
@@ -314,32 +318,32 @@ IMPORT FOREIGN SCHEMA remote_schema
 
 `remote_schema`
 
- Specifies the remote schema (MySQL database) to import from.
+Specifies the remote schema (MySQL database) to import from.
 
 `LIMIT TO ( table_name [, ...] )`
 
- By default, all views and tables existing in a particular database on the MySQL host are imported. Using this option, you can limit the list of tables to a specified subset.
+By default, all views and tables existing in a particular database on the MySQL host are imported. Using this option, you can limit the list of tables to a specified subset.
 
 `EXCEPT ( table_name [, ...] )`
 
- By default, all views and tables existing in a particular database on the MySQL host are imported. Using this option, you can exclude specified foreign tables from the import.
+By default, all views and tables existing in a particular database on the MySQL host are imported. Using this option, you can exclude specified foreign tables from the import.
 
 `SERVER server_name`
 
- Specify the name of server to import foreign tables from.
+Specify the name of server to import foreign tables from.
 
 `local_schema`
 
- Specify the name of local schema where the imported foreign tables must be created.
+Specify the name of local schema where the imported foreign tables must be created.
 
 `OPTIONS`
 
- Use the `OPTIONS` clause to specify the following `options` and their corresponding values:
+Use the `OPTIONS` clause to specify the following `options` and their corresponding values:
 
- | **Option**      | **Description**                                                                                                                                         |
- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
- | import_default  | Controls whether column `DEFAULT` expressions are included in the definitions of foreign tables imported from a foreign server. The default is `false`. |
- | import_not_null | Controls whether column `NOT NULL` constraints are included in the definitions of foreign tables imported from a foreign server. The default is `true`. |
+| **Option**      | **Description**                                                                                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| import_default  | Controls whether column `DEFAULT` expressions are included in the definitions of foreign tables imported from a foreign server. The default is `false`. |
+| import_not_null | Controls whether column `NOT NULL` constraints are included in the definitions of foreign tables imported from a foreign server. The default is `true`. |
 
 **Example**
 
@@ -383,7 +387,7 @@ The command imports table definitions from a remote schema `edb` on server `mysq
 
 For more information about using the `IMPORT FOREIGN SCHEMA` command, see:
 
- <https://www.postgresql.org/docs/current/static/sql-importforeignschema.html>
+<https://www.postgresql.org/docs/current/static/sql-importforeignschema.html>
 
 ## DROP EXTENSION
 
@@ -397,29 +401,29 @@ DROP EXTENSION [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ];
 
 `IF EXISTS`
 
- Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if an extension with the specified name doesn't exists.
+Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if an extension with the specified name doesn't exists.
 
 `name`
 
- Specify the name of the installed extension. It is optional.
+Specify the name of the installed extension. It is optional.
 
- `CASCADE`
+`CASCADE`
 
- Automatically drop objects that depend on the extension. It drops all the other dependent objects too.
+Automatically drop objects that depend on the extension. It drops all the other dependent objects too.
 
- `RESTRICT`
+`RESTRICT`
 
- Do not allow to drop extension if any objects, other than its member objects and extensions listed in the same DROP command are dependent on it.
+Do not allow to drop extension if any objects, other than its member objects and extensions listed in the same DROP command are dependent on it.
 
 **Example**
 
 The following command removes the extension from the existing database:
 
- `DROP EXTENSION mysql_fdw;`
+`DROP EXTENSION mysql_fdw;`
 
 For more information about using the foreign data wrapper `DROP EXTENSION` command, see:
 
- <https://www.postgresql.org/docs/current/sql-dropextension.html>.
+<https://www.postgresql.org/docs/current/sql-dropextension.html>.
 
 ## DROP SERVER
 
@@ -435,29 +439,29 @@ The role that drops the server is the owner of the server; use the `ALTER SERVER
 
 `IF EXISTS`
 
- Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if a server with the specified name doesn't exists.
+Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if a server with the specified name doesn't exists.
 
 `name`
 
- Specify the name of the installed server. It is optional.
+Specify the name of the installed server. It is optional.
 
- `CASCADE`
+`CASCADE`
 
- Automatically drop objects that depend on the server. It should drop all the other dependent objects too.
+Automatically drop objects that depend on the server. It should drop all the other dependent objects too.
 
- `RESTRICT`
+`RESTRICT`
 
- Do not allow to drop the server if any objects are dependent on it.
+Do not allow to drop the server if any objects are dependent on it.
 
 **Example**
 
 The following command removes a foreign server named `mysql_server`:
 
- `DROP SERVER mysql_server;`
+`DROP SERVER mysql_server;`
 
 For more information about using the `DROP SERVER` command, see:
 
- <https://www.postgresql.org/docs/current/sql-dropserver.html>
+<https://www.postgresql.org/docs/current/sql-dropserver.html>
 
 ## DROP USER MAPPING
 
@@ -471,25 +475,25 @@ DROP USER MAPPING [ IF EXISTS ] FOR { user_name | USER | CURRENT_USER | PUBLIC }
 
 `IF EXISTS`
 
- Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if the user mapping doesn't exist.
+Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if the user mapping doesn't exist.
 
 `user_name`
 
- Specify the user name of the mapping.
+Specify the user name of the mapping.
 
 `server_name`
 
- Specify the name of the server that defines a connection to the MySQL cluster.
+Specify the name of the server that defines a connection to the MySQL cluster.
 
 **Example**
 
 The following command drops a user mapping for a role named `enterprisedb`; the mapping is associated with a server named `mysql_server`:
 
- `DROP USER MAPPING FOR enterprisedb SERVER mysql_server;`
+`DROP USER MAPPING FOR enterprisedb SERVER mysql_server;`
 
 For detailed information about the `DROP USER MAPPING` command, see:
 
- <https://www.postgresql.org/docs/current/static/sql-dropusermapping.html>
+<https://www.postgresql.org/docs/current/static/sql-dropusermapping.html>
 
 ## DROP FOREIGN TABLE
 
@@ -503,19 +507,19 @@ DROP FOREIGN TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
 
 `IF EXISTS`
 
- Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if the foreign table with the specified name doesn't exists.
+Include the `IF EXISTS` clause to instruct the server to issue a notice instead of throwing an error if the foreign table with the specified name doesn't exists.
 
 `name`
 
- Specify the name of the foreign table.
+Specify the name of the foreign table.
 
 `CASCADE`
 
- Automatically drop objects that depend on the foreign table. It should drop all the other dependent objects too.
+Automatically drop objects that depend on the foreign table. It should drop all the other dependent objects too.
 
 `RESTRICT`
 
- Do not allow to drop foreign table if any objects are dependent on it.
+Do not allow to drop foreign table if any objects are dependent on it.
 
 **Example**
 
@@ -525,4 +529,4 @@ DROP FOREIGN TABLE warehouse;
 
 For more information about using the `DROP FOREIGN TABLE` command, see:
 
- <https://www.postgresql.org/docs/current/sql-dropforeigntable.html>
+<https://www.postgresql.org/docs/current/sql-dropforeigntable.html>

--- a/product_docs/docs/mysql_data_adapter/2.6.0/13_troubleshooting.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.6.0/13_troubleshooting.mdx
@@ -15,4 +15,5 @@ Specify the authentication plugin as `mysql_native_password` and set a cleartext
 > `ALTER USER 'username'@'host' IDENTIFIED WITH mysql_native_password BY '<password>';`
 
 !!! Note
+
     Refer to [MySQL 8 documentation](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html) for more details on the above error.

--- a/product_docs/docs/pem/7.16/pem_online_help/02_toc_pem_agent/07_pem_agent_self_registration.mdx
+++ b/product_docs/docs/pem/7.16/pem_online_help/02_toc_pem_agent/07_pem_agent_self_registration.mdx
@@ -8,8 +8,8 @@ Each PEM agent must be `registered` with the PEM server. The registration proces
 
 The RPM installer places the PEM worker utility in the `/usr/edb/pem/agent/bin` directory. Use the following commands to register an agent:
 
--   **On Linux**: pemworker −−register-agent \[register-options]
--   **On Windows**: pemworker.exe REGISTER \[register-options]
+- **On Linux**: pemworker −−register-agent \[register-options]
+- **On Windows**: pemworker.exe REGISTER \[register-options]
 
 The following information is required when registering an agent with the PEM Server; you will be prompted for information if it is not provided on the command line:
 
@@ -28,6 +28,7 @@ The following information is required when registering an agent with the PEM Ser
 | **Agent User**               | −−pem-agent-user                   | Yes      | Use this user to connect the PEM database server. Specify, it when you would like to use a connection pooler between PEM Agent and PEM database server. It will generate the SSL Ceriticates, which will used by the pemworker to connect to the PEM database server instead, for this user instead of the default agent user.<br /><br />**NOTE:** Specified user must be a member of 'pem_agent' role.<br /> |                                                |
 
 !!! Note
+
     You can use the `PEM_SERVER_PASSWORD` environment variable to set the password of the `PEM Admin User`. If the `PEM_SERVER_PASSWORD` is not set, the server will use the `PGPASSWORD` or `pgpass file` when connecting to the **PEM Database Server**.
 
 Example:

--- a/product_docs/docs/pem/7.16/pem_online_help/08_toc_pem_developer_tools/02_query_tool.mdx
+++ b/product_docs/docs/pem/7.16/pem_online_help/08_toc_pem_developer_tools/02_query_tool.mdx
@@ -6,13 +6,13 @@ title: "Query Tool"
 
 The Query Tool is a powerful, feature-rich environment that allows you to execute arbitrary SQL commands and review the result set. You can access the Query Tool via the `Query Tool` menu option on the `Tools` menu, or through the context menu of select nodes of the Browser tree control. The Query Tool allows you to:
 
--   Issue ad-hoc SQL queries.
--   Execute arbitrary SQL commands.
--   Edit the result set of a SELECT query if it is [updatable](#updatable-result-set).
--   Displays current connection and transaction status as configured by the user.
--   Save the data displayed in the output panel to a CSV file.
--   Review the execution plan of a SQL statement in either a text, a graphical format or a table format (similar to <https://explain.depesz.com>).
--   View analytical information about a SQL statement.
+- Issue ad-hoc SQL queries.
+- Execute arbitrary SQL commands.
+- Edit the result set of a SELECT query if it is [updatable](#updatable-result-set).
+- Displays current connection and transaction status as configured by the user.
+- Save the data displayed in the output panel to a CSV file.
+- Review the execution plan of a SQL statement in either a text, a graphical format or a table format (similar to <https://explain.depesz.com>).
+- View analytical information about a SQL statement.
 
 ![Query Tool tab](../images/query_tool.png)
 
@@ -20,8 +20,8 @@ You can open multiple copies of the Query tool in individual tabs simultaneously
 
 The Query Tool features two panels:
 
--   The upper panel displays the `SQL Editor`. You can use the panel to enter, edit, or execute a query. It also shows the `History` tab which can be used to view the queries that have been executed in the session, and a `Scratch Pad` which can be used to hold text snippets during editing. If the Scratch Pad is closed, it can be re-opened (or additional ones opened) by right-clicking in the SQL Editor and other panels and adding a new panel.
--   The lower panel displays the `Data Output` panel. The tabbed panel displays the result set returned by a query, information about a query's execution plan, server messages related to the query's execution and any asynchronous notifications received from the server.
+- The upper panel displays the `SQL Editor`. You can use the panel to enter, edit, or execute a query. It also shows the `History` tab which can be used to view the queries that have been executed in the session, and a `Scratch Pad` which can be used to hold text snippets during editing. If the Scratch Pad is closed, it can be re-opened (or additional ones opened) by right-clicking in the SQL Editor and other panels and adding a new panel.
+- The lower panel displays the `Data Output` panel. The tabbed panel displays the result set returned by a query, information about a query's execution plan, server messages related to the query's execution and any asynchronous notifications received from the server.
 
 **The Query Tool Toolbar**
 
@@ -31,26 +31,26 @@ The `Query Tool` toolbar uses context-sensitive icons that provide shortcuts to 
 
 Hover over an icon to display a tooltip that describes the icon's functionality:
 
-| Icon              | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Shortcut                                                                                    |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `Open File`       | Click the `Open File` icon to display a previously saved query in the SQL Editor.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Accesskey + O                                                                               |
-| `Save`            | Click the `Save` icon to perform a quick-save of a previously saved query, or to access the `Save` menu:<br />-   Select      `Save`      to save the selected content of the SQL Editor panel in a file.     <br /> -   Select      `Save As`      to open a new browser dialog and specify a new location to which to save the selected content of the SQL Editor panel.     <br />                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Accesskey + S                                                                               |
-| `Find`            | Use the `Find` menu to search, replace, or navigate the code displayed in the SQL Editor:<br />-   Select      `Find`      to provide a search target, and search the SQL Editor contents.     <br /> -   Select      `Find next`      to locate the next occurrence of the search target.     <br /> -   Select      `Find previous`      to move to the last occurrence of the search target.     <br /> -   Select      `Pesistent find`      to identify all occurrences of the search target within the editor.     <br /> -   Select      `Replace`      to locate and replace (with prompting) individual occurrences of the target.     <br /> -   Select      `Replace all`      to locate and replace all occurrences of the target within the editor.     <br /> -   Select      `Jump`      to navigate to the next occurrence of the search target.     <br /> | Cmd+F<br /><br />Cmd+G<br /><br />Cmd+Shift+G<br /><br />Cmd+Shift+F<br /><br />Alt+G<br /> |
-| `Copy`            | Click the `Copy` icon to copy the content that is currently highlighted in the Data Output panel. when in View/Edit data mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Accesskey + C                                                                               |
-| `Paste`           | Click the `Paste` icon to paste a previously row into a new row when in View/Edit data mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Accesskey + P                                                                               |
-| `Delete`          | Click the `Delete` icon to mark the selected rows for delete when in View/Edit data mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Accesskey + D                                                                               |
-| `Edit`            | Use options on the `Edit` menu to access text editing tools; the options operate on the text displayed in the SQL Editor panel when in Query Tool mode:<br />-   Select      `Indent Selection`      to indent the currently selected text.     <br /> -   Select      `Unindent Selection`      to remove indentation from the currently selected text.     <br /> -   Select      `Inline Comment Selection`      to enclose any lines that contain the selection in SQL style comment notation.     <br /> -   Select      `Inline Uncomment Selection`      to remove SQL style comment notation from the selected line.     <br /> -   Select      `Block Comment`      to enclose all lines that contain the selection in C style comment notation. This option acts as a toggle.     <br />                                                                          | Tab<br /><br />Shift+Tab<br /><br />Cmd+/<br /><br />Cmd+.<br /><br />Shift+Cmd+/<br />     |
-| `Filter`          | Click the `Filter` icon to set filtering and sorting criteria for the data when in View/Edit data mode. Click the down arrow to access other filtering and sorting options:<br />-   Click      `Sort/Filter`      to open the sorting and filtering dialogue.     <br /> -   Click      `Filter by Selection`      to show only the rows containing the values in the selected cells.     <br /> -   Click      `Exclude by Selection`      to show only the rows that do not contain the values in the selected cells.     <br /> -   Click      `Remove Sort/Filter`      to remove any previously selected sort or filtering options.     <br />                                                                                                                                                                                                                        | Accesskey + F                                                                               |
-| Limit Selector    | Select a value in the `Limit Selector` to limit the size of the dataset to a number of rows.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Accesskey + R                                                                               |
-| `Stop`            | Click the `Stop` icon to cancel the execution of the currently running query.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Accesskey + Q                                                                               |
-| `Execute/Refresh` | Click the `Execute/Refresh` icon to either execute or refresh the query highlighted in the SQL editor panel. Click the down arrow to access other execution options:<br />-   Add a check next to      `Auto-Rollback`      to instruct the server to automatically roll back a transaction if an error occurs during the transaction.     <br /> -   Add a check next to      `Auto-Commit`      to instruct the server to automatically commit each transaction. Any changes made by the transaction will be visible to others, and durable in the event of a crash.     <br />                                                                                                                                                                                                                                                                                           | F5                                                                                          |
-| `Explain`         | -   Click the       `Explain`       icon to view an explanation plan for the current query. The result of the      <br />      <br />      EXPLAIN is displayed graphically on the       `Explain`       tab of the output panel, and in text form on the       `Data Output`       tab.      <br />                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | F7                                                                                          |
-| `Explain analyze` | Click the `Explain analyze` icon to invoke an EXPLAIN ANALYZE command on the current query.<br /><br />Navigate through the `Explain Options` menu to select options for the EXPLAIN command:<br />-   Select      `Verbose`      to display additional information regarding the query plan.     <br /> -   Select      `Costs`      to include information on the estimated startup and total cost of each plan node, as well as the estimated number of rows and the estimated width of each row.     <br /> -   Select      `Buffers`      to include information on buffer usage.     <br /> -   Select      `Timing`      to include information about the startup time and the amount of time spent in each node of the query.     <br />                                                                                                                            | Shift+F7                                                                                    |
-| `Commit`          | Click the `Commit` icon to commit the transaction.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Shift+CTRL+M                                                                                |
-| `Rollback`        | Click the `Rollback` icon to rollback the transaction.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Shift+CTRL+R                                                                                |
-| `Clear`           | Use options on the `Clear` drop-down menu to erase display contents:<br />-   Select      `Clear Query Window`      to erase the content of the SQL Editor panel.     <br /> -   Select      `Clear History`      to erase the content of the      `History`      tab.     <br />                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Accesskey + L                                                                               |
-| `Download as CSV` | Click the `Download as CSV` icon to download the result set of the current query to a comma-separated list. You can specify the CSV settings through `Preferences -> SQL Editor -> CSV output` dialogue.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | F8                                                                                          |
-| `Macros`          | Click the *Macros* icon to manage the macros. You can create, edit or clear the macros through *Manage Macros* option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |                                                                                             |
+| Icon              | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Shortcut                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Open File`       | Click the `Open File` icon to display a previously saved query in the SQL Editor.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Accesskey + O                                                                               |
+| `Save`            | Click the `Save` icon to perform a quick-save of a previously saved query, or to access the `Save` menu:<br />- Select `Save` to save the selected content of the SQL Editor panel in a file. <br /> - Select `Save As` to open a new browser dialog and specify a new location to which to save the selected content of the SQL Editor panel. <br />                                                                                                                                                                                                                                                                                                                                                                                                       | Accesskey + S                                                                               |
+| `Find`            | Use the `Find` menu to search, replace, or navigate the code displayed in the SQL Editor:<br />- Select `Find` to provide a search target, and search the SQL Editor contents. <br /> - Select `Find next` to locate the next occurrence of the search target. <br /> - Select `Find previous` to move to the last occurrence of the search target. <br /> - Select `Pesistent find` to identify all occurrences of the search target within the editor. <br /> - Select `Replace` to locate and replace (with prompting) individual occurrences of the target. <br /> - Select `Replace all` to locate and replace all occurrences of the target within the editor. <br /> - Select `Jump` to navigate to the next occurrence of the search target. <br /> | Cmd+F<br /><br />Cmd+G<br /><br />Cmd+Shift+G<br /><br />Cmd+Shift+F<br /><br />Alt+G<br /> |
+| `Copy`            | Click the `Copy` icon to copy the content that is currently highlighted in the Data Output panel. when in View/Edit data mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Accesskey + C                                                                               |
+| `Paste`           | Click the `Paste` icon to paste a previously row into a new row when in View/Edit data mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Accesskey + P                                                                               |
+| `Delete`          | Click the `Delete` icon to mark the selected rows for delete when in View/Edit data mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Accesskey + D                                                                               |
+| `Edit`            | Use options on the `Edit` menu to access text editing tools; the options operate on the text displayed in the SQL Editor panel when in Query Tool mode:<br />- Select `Indent Selection` to indent the currently selected text. <br /> - Select `Unindent Selection` to remove indentation from the currently selected text. <br /> - Select `Inline Comment Selection` to enclose any lines that contain the selection in SQL style comment notation. <br /> - Select `Inline Uncomment Selection` to remove SQL style comment notation from the selected line. <br /> - Select `Block Comment` to enclose all lines that contain the selection in C style comment notation. This option acts as a toggle. <br />                                          | Tab<br /><br />Shift+Tab<br /><br />Cmd+/<br /><br />Cmd+.<br /><br />Shift+Cmd+/<br />     |
+| `Filter`          | Click the `Filter` icon to set filtering and sorting criteria for the data when in View/Edit data mode. Click the down arrow to access other filtering and sorting options:<br />- Click `Sort/Filter` to open the sorting and filtering dialogue. <br /> - Click `Filter by Selection` to show only the rows containing the values in the selected cells. <br /> - Click `Exclude by Selection` to show only the rows that do not contain the values in the selected cells. <br /> - Click `Remove Sort/Filter` to remove any previously selected sort or filtering options. <br />                                                                                                                                                                        | Accesskey + F                                                                               |
+| Limit Selector    | Select a value in the `Limit Selector` to limit the size of the dataset to a number of rows.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Accesskey + R                                                                               |
+| `Stop`            | Click the `Stop` icon to cancel the execution of the currently running query.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Accesskey + Q                                                                               |
+| `Execute/Refresh` | Click the `Execute/Refresh` icon to either execute or refresh the query highlighted in the SQL editor panel. Click the down arrow to access other execution options:<br />- Add a check next to `Auto-Rollback` to instruct the server to automatically roll back a transaction if an error occurs during the transaction. <br /> - Add a check next to `Auto-Commit` to instruct the server to automatically commit each transaction. Any changes made by the transaction will be visible to others, and durable in the event of a crash. <br />                                                                                                                                                                                                           | F5                                                                                          |
+| `Explain`         | - Click the `Explain` icon to view an explanation plan for the current query. The result of the <br /> <br /> EXPLAIN is displayed graphically on the `Explain` tab of the output panel, and in text form on the `Data Output` tab. <br />                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | F7                                                                                          |
+| `Explain analyze` | Click the `Explain analyze` icon to invoke an EXPLAIN ANALYZE command on the current query.<br /><br />Navigate through the `Explain Options` menu to select options for the EXPLAIN command:<br />- Select `Verbose` to display additional information regarding the query plan. <br /> - Select `Costs` to include information on the estimated startup and total cost of each plan node, as well as the estimated number of rows and the estimated width of each row. <br /> - Select `Buffers` to include information on buffer usage. <br /> - Select `Timing` to include information about the startup time and the amount of time spent in each node of the query. <br />                                                                            | Shift+F7                                                                                    |
+| `Commit`          | Click the `Commit` icon to commit the transaction.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Shift+CTRL+M                                                                                |
+| `Rollback`        | Click the `Rollback` icon to rollback the transaction.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Shift+CTRL+R                                                                                |
+| `Clear`           | Use options on the `Clear` drop-down menu to erase display contents:<br />- Select `Clear Query Window` to erase the content of the SQL Editor panel. <br /> - Select `Clear History` to erase the content of the `History` tab. <br />                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Accesskey + L                                                                               |
+| `Download as CSV` | Click the `Download as CSV` icon to download the result set of the current query to a comma-separated list. You can specify the CSV settings through `Preferences -> SQL Editor -> CSV output` dialogue.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | F8                                                                                          |
+| `Macros`          | Click the _Macros_ icon to manage the macros. You can create, edit or clear the macros through _Manage Macros_ option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |                                                                                             |
 
 **The SQL Editor Panel**
 
@@ -58,7 +58,7 @@ The `SQL editor` panel is a workspace where you can manually provide a query, co
 
 ![Query Tool - Query Editor tab](../images/query_sql_editor.png)
 
-To use autocomplete, begin typing your query; when you would like the Query editor to suggest object names or commands that might be next in your query, press the Control+Space key combination. For example, type "*SELECT \* FROM*" (without quotes, but with a trailing space), and then press the Control+Space key combination to select from a popup menu of autocomplete options.
+To use autocomplete, begin typing your query; when you would like the Query editor to suggest object names or commands that might be next in your query, press the Control+Space key combination. For example, type "_SELECT \* FROM_" (without quotes, but with a trailing space), and then press the Control+Space key combination to select from a popup menu of autocomplete options.
 
 ![Query Tool - Query Editor tab - Autocomplete feature](../images/query_autocomplete.png)
 
@@ -72,9 +72,9 @@ The message returned by the server when a command executes is displayed on the `
 
 Options on the `Edit` menu offer functionality that helps with code formatting and commenting:
 
--   The auto-indent feature will automatically indent text to the same depth as the previous line when you press the Return key.
--   Block indent text by selecting two or more lines and pressing the Tab key.
--   Implement or remove SQL style or toggle C style comment notation within your code.
+- The auto-indent feature will automatically indent text to the same depth as the previous line when you press the Return key.
+- Block indent text by selecting two or more lines and pressing the Tab key.
+- Implement or remove SQL style or toggle C style comment notation within your code.
 
 You can also **drag and drop** certain objects from the treeview which can save time in typing long object names. Text containing the object name will be fully qualified with schema. Double quotes will be added if required. For functions and procedures, the function name along with parameter names will be pasted in the Query Tool.
 
@@ -86,17 +86,17 @@ The `Data Output` panel displays data and statistics generated by the most recen
 
 The `Data Output` tab displays the result set of the query in a table format. You can:
 
--   Select and copy from the displayed result set.
--   Use the `Execute/Refresh` options to retrieve query execution information and set query execution options.
--   Use the `Save results to file` icon to save the content of the `Data Output` tab as a comma-delimited file.
--   Edit the data in the result set of a SELECT query if it is updatable.
+- Select and copy from the displayed result set.
+- Use the `Execute/Refresh` options to retrieve query execution information and set query execution options.
+- Use the `Save results to file` icon to save the content of the `Data Output` tab as a comma-delimited file.
+- Edit the data in the result set of a SELECT query if it is updatable.
 
 <div id="updatable-result-set" class="registered_link"></div>
 
 A result set is updatable if:
 
--   All columns are either selected directly from a single table, or are not table columns at all (e.g. concatenation of 2 columns). Only columns that are selected directly from the table are editable, other columns are read-only.
--   All the primary key columns or OIDs of the table are selected in the result set.
+- All columns are either selected directly from a single table, or are not table columns at all (e.g. concatenation of 2 columns). Only columns that are selected directly from the table are editable, other columns are read-only.
+- All the primary key columns or OIDs of the table are selected in the result set.
 
 Any columns that are renamed or selected more than once are also read-only.
 
@@ -126,20 +126,21 @@ Please note that pgAdmin generates the `Explain [Analyze]` plan in JSON format.
 
 On successful generation of `Explain` plan, it will create three tabs/panels under the Explain panel.
 
--   Graphical
+- Graphical
 
 Please note that `EXPLAIN VERBOSE` cannot be displayed graphically. Click on a node icon on the `Graphical` tab to review information about that item; a popup window will display on the right side with the information about the selected object. For information on JIT statistics, triggers and a summary, Click on the button top-right corner; a similar popup window will be displayed when appropriate.
 
 Use the download button on top left corner of the `Explain` canvas to download the plan as an SVG file.
 
 !!! Note
+
     Download as SVG is not supported on Internet Explorer.
 
 ![Query Tool - Explain tab - Graphical plan tab](../images/query_output_explain_details.png)
 
 Note that the query plan that accompanies the `Explain analyze` is available on the `Data Output` tab.
 
--   Table
+- Table
 
 `Table` tab shows the plan details in table format, it generates table format similar to `explain.depsez.com`. Each row of the table represent the data for a `Explain Plan Node`. It may contain the node information, exclusive timing, inclusive timing, actual vs planned rows differences, actual rows, planned rows, loops.
 
@@ -151,7 +152,7 @@ If planner mis-estimated number of rows (actual vs planned) by 10 times - Yellow
 
 ![Query Tool - Explain tab - Analysis tab](../images/query_explain_analyze_table.png)
 
--   Statistics
+- Statistics
 
 `Statistics` tab shows two tables: 1. Statistics per Plan Node Type 2. Statistics per Table
 
@@ -167,7 +168,7 @@ If the server returns an error, the error message will be displayed on the `Mess
 
 ![Query Tool - Messages tabn](../images/query_output_messages.png)
 
-*Query tool output information*
+_Query tool output information_
 
 ## Query History Panel
 
@@ -177,12 +178,12 @@ Use the `Query History` tab to review activity for the current session:
 
 The Query History tab displays information about recent commands:
 
--   The date and time that a query was invoked.
--   The text of the query.
--   The number of rows returned by the query.
--   The amount of time it took the server to process the query and return a result set.
--   Messages returned by the server (not noted on the `Messages` tab).
--   The source of the query (indicated by icons corresponding to the toolbar).
+- The date and time that a query was invoked.
+- The text of the query.
+- The number of rows returned by the query.
+- The amount of time it took the server to process the query and return a result set.
+- Messages returned by the server (not noted on the `Messages` tab).
+- The source of the query (indicated by icons corresponding to the toolbar).
 
 You can show or hide the queries generated internally by pgAdmin (during 'View/Edit Data' or 'Save Data' operations).
 
@@ -200,40 +201,72 @@ Change connection +\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
 
 User can connect to another server or database from existing open session of query tool.
 
--   Click on the connection link next to connection status.
--   Now click on the *&lt;New Connection>* option from the dropdown.
+- Click on the connection link next to connection status.
+- Now click on the _&lt;New Connection>_ option from the dropdown.
 
-<img src="../images/new_connection_options.png" class="align-center" alt="Query tool connection options" />
+<img
+  src="../images/new_connection_options.png"
+  class="align-center"
+  alt="Query tool connection options"
+/>
 
--   Now select server, database, user, and role to connect and click OK.
+- Now select server, database, user, and role to connect and click OK.
 
-<img src="../images/new_connection_dialog.png" class="align-center" alt="Query tool connection dialog" />
+<img
+  src="../images/new_connection_dialog.png"
+  class="align-center"
+  alt="Query tool connection dialog"
+/>
 
--   A newly created connection will now get listed in the options.
--   To connect, select the newly created connection from the dropdown list.
+- A newly created connection will now get listed in the options.
+- To connect, select the newly created connection from the dropdown list.
 
 ## Macros
 
 Query Tool Macros enable you to execute pre-defined SQL queries with a single key press. Pre-defined queries can contain the placeholder $SELECTION$. Upon macro execution, the placeholder will be replaced with the currently selected text in the Query Editor pane of the Query Tool.
 
-<img src="../images/query_tool_manage_macros.png" class="align-center" alt="Query Tool Manage macros" />
+<img
+  src="../images/query_tool_manage_macros.png"
+  class="align-center"
+  alt="Query Tool Manage macros"
+/>
 
-To create a macro, select the *Manage Macros* option from the *Macros* menu on the *Query Tool*. Select the key you wish to use, enter the name of the macro, and the query, optionally including the selection placeholder, and then click the *Save* button to store the macro.
+To create a macro, select the _Manage Macros_ option from the _Macros_ menu on the _Query Tool_. Select the key you wish to use, enter the name of the macro, and the query, optionally including the selection placeholder, and then click the _Save_ button to store the macro.
 
-<img src="../images/query_tool_manage_macros_dialog.png" class="align-center" alt="Query Tool Manage Macros dialogue" />
+<img
+  src="../images/query_tool_manage_macros_dialog.png"
+  class="align-center"
+  alt="Query Tool Manage Macros dialogue"
+/>
 
-To clear a macro, select the macro on the *Manage Macros* dialogue, and then click the *Clear* button.
+To clear a macro, select the macro on the _Manage Macros_ dialogue, and then click the _Clear_ button.
 
-<img src="../images/query_tool_macros_clear_row.png" class="align-center" alt="Query Tool Manage Macros clear the row" />
+<img
+  src="../images/query_tool_macros_clear_row.png"
+  class="align-center"
+  alt="Query Tool Manage Macros clear the row"
+/>
 
 The server will prompt you for confirmation to clear the macro.
 
-<img src="../images/query_tool_macros_clear_confirmation.png" class="align-center" alt="Query Tool Manage Macros Clear row confirmation" />
+<img
+  src="../images/query_tool_macros_clear_confirmation.png"
+  class="align-center"
+  alt="Query Tool Manage Macros Clear row confirmation"
+/>
 
-To clear all macros, click on the *Clear* button on left side of the key. The server will prompt you for confirmation to clear all the rows.
+To clear all macros, click on the _Clear_ button on left side of the key. The server will prompt you for confirmation to clear all the rows.
 
-<img src="../images/query_tool_macros_clear_all.png" class="align-center" alt="Query Tool Macros Clear All" />
+<img
+  src="../images/query_tool_macros_clear_all.png"
+  class="align-center"
+  alt="Query Tool Macros Clear All"
+/>
 
-To execute a macro, simply select the appropriate shortcut keys, or select it from the *Macros* menu.
+To execute a macro, simply select the appropriate shortcut keys, or select it from the _Macros_ menu.
 
-<img src="../images/query_tool_macros_execution.png" class="align-center" alt="Query Tool Macros Execution" />
+<img
+  src="../images/query_tool_macros_execution.png"
+  class="align-center"
+  alt="Query Tool Macros Execution"
+/>

--- a/product_docs/docs/pem/7.16/pem_online_help/08_toc_pem_developer_tools/05_schema_diff.mdx
+++ b/product_docs/docs/pem/7.16/pem_online_help/08_toc_pem_developer_tools/05_schema_diff.mdx
@@ -8,26 +8,33 @@ title: "Schema Diff"
 
 The Schema Diff feature allows you to:
 
-> -   Compare and synchronize the database objects (from source to target).
-> -   Visualize the differences between database objects.
-> -   List the differences in SQL statement for target database objects.
-> -   Generate synchronization scripts.
+- Compare and synchronize the database objects (from source to target).
+- Visualize the differences between database objects.
+- List the differences in SQL statement for target database objects.
+- Generate synchronization scripts.
 
 !!! Note
-    > -   The source and target database servers must be of the same major version.
-    > -   If you compare two **schemas** then dependencies won't be resolved.
 
-Click on *Schema Diff* under the *Tools* menu to open a selection panel. To compare **databases** choose the source and target servers, and databases. To compare **schemas** choose the source and target servers, databases, and schemas. After selecting the objects, click on the *Compare* button.
+- The source and target database servers must be of the same major version.
+- If you compare two **schemas** then dependencies won't be resolved.
+
+!!!
+
+Click on _Schema Diff_ under the _Tools_ menu to open a selection panel. To compare **databases** choose the source and target servers, and databases. To compare **schemas** choose the source and target servers, databases, and schemas. After selecting the objects, click on the _Compare_ button.
 
 You can open multiple copies of `Schema Diff` in individual tabs simultaneously. To close a copy of Schema Diff, click the \*X\* in the upper-right hand corner of the tab bar. You can rename the panel title by right-clicking and select the "Rename Panel" option.
 
-<img src="../images/schema_diff_dialog.png" class="align-center" alt="schema diff dialog" />
+<img
+  src="../images/schema_diff_dialog.png"
+  class="align-center"
+  alt="schema diff dialog"
+/>
 
 Use the [Preferences](../03_toc_pem_client/04_preferences/#preferences) dialog to specify following:
 
-> -   *Schema Diff* should open in a new browser tab. Set *Open in new browser tab* option to true.
-> -   *Schema Diff* should ignore the whitespaces while comparing string objects. Set *Ignore whitespaces* option to true.
-> -   *Schema Diff* should ignore the owner while comparing objects. Set *Ignore owner* option to true.
+- _Schema Diff_ should open in a new browser tab. Set _Open in new browser tab_ option to true.
+- _Schema Diff_ should ignore the whitespaces while comparing string objects. Set _Ignore whitespaces_ option to true.
+- _Schema Diff_ should ignore the owner while comparing objects. Set _Ignore owner_ option to true.
 
 The `Schema Diff` panel is divided into two panels; an Object Comparison panel and a DDL Comparison panel.
 
@@ -37,22 +44,34 @@ In the object comparison panel, you can select the source and target servers of 
 
 Next, select the databases that will be compared. The databases can be the same or different (and within the same server or from different servers).
 
-<img src="../images/schema_diff_compare_button.png" class="align-center" alt="Schema diff compare button" />
+<img
+  src="../images/schema_diff_compare_button.png"
+  class="align-center"
+  alt="Schema diff compare button"
+/>
 
-After you select servers and databases, click on the *Compare* button to obtain the `Comparison Result`.
+After you select servers and databases, click on the _Compare_ button to obtain the `Comparison Result`.
 
-<img src="../images/schema_diff_comparison_results.png" class="align-center" alt="Schema diff comparison results" />
+<img
+  src="../images/schema_diff_comparison_results.png"
+  class="align-center"
+  alt="Schema diff comparison results"
+/>
 
 Use the drop-down lists of Database Objects to view the DDL statements.
 
-In the upper-right hand corner of the object comparison panel is a *Filter* option that you can use to filter the database objects based on the following comparison criteria:
+In the upper-right hand corner of the object comparison panel is a _Filter_ option that you can use to filter the database objects based on the following comparison criteria:
 
-> -   Identical – If the object is found in both databases with the same SQL statement, then the comparison result is identical.
-> -   Different – If the object is found in both databases but have different SQL statements, then the comparison result is different.
-> -   Source Only – If the object is found in source database only and not in target database, then the comparison result is source only.
-> -   Target Only – If the object is found in target database only and not in source database, then the comparison result is target only.
+- Identical – If the object is found in both databases with the same SQL statement, then the comparison result is identical.
+- Different – If the object is found in both databases but have different SQL statements, then the comparison result is different.
+- Source Only – If the object is found in source database only and not in target database, then the comparison result is source only.
+- Target Only – If the object is found in target database only and not in source database, then the comparison result is target only.
 
-<img src="../images/schema_diff_filter_option.png" class="align-center" alt="Schema diff filter option" />
+<img
+  src="../images/schema_diff_filter_option.png"
+  class="align-center"
+  alt="Schema diff filter option"
+/>
 
 Click on any of the database objects in the object comparison panel to display the DDL Statements of that object in the DDL Comparison panel.
 
@@ -60,24 +79,36 @@ Click on any of the database objects in the object comparison panel to display t
 
 The `DDL Comparison` panel displays three columns:
 
--   The first column displays the DDL statement of the object from the source database.
--   The second column displays the DDL statement of the object from the target database.
--   The third column displays the difference in the SQL statement of the target database object.
+- The first column displays the DDL statement of the object from the source database.
+- The second column displays the DDL statement of the object from the target database.
+- The third column displays the difference in the SQL statement of the target database object.
 
-<img src="../images/schema_diff_DDL_comparison.png" class="align-center" alt="Schema diff DDL comparison" />
+<img
+  src="../images/schema_diff_DDL_comparison.png"
+  class="align-center"
+  alt="Schema diff DDL comparison"
+/>
 
 You can review the DDL statements of all the database objects to check for the differences in the SQL statements.
 
-Also, you can generate the SQL script of the differences found in the target database object based on the SQL statement of the source database object. To generate the script, select the checkboxes of the database objects in the object comparison panel and then click on the *Generate Script* button in the upper-right hand corner of the object comparison panel.
+Also, you can generate the SQL script of the differences found in the target database object based on the SQL statement of the source database object. To generate the script, select the checkboxes of the database objects in the object comparison panel and then click on the _Generate Script_ button in the upper-right hand corner of the object comparison panel.
 
-<img src="../images/schema_diff_generate_script.png" class="align-center" alt="Schema diff generate script" />
+<img
+  src="../images/schema_diff_generate_script.png"
+  class="align-center"
+  alt="Schema diff generate script"
+/>
 
-Select the database objects and click on the *Generate Script* button to open the `Query Tool` in a new tab, with the difference in the SQL statement displayed in the `Query Editor`.
+Select the database objects and click on the _Generate Script_ button to open the `Query Tool` in a new tab, with the difference in the SQL statement displayed in the `Query Editor`.
 
 If you have clicked on the database object to check the difference generated in the `DDL Comparison` Panel, and you have not selected the checkbox of the database object, PEM will open the `Query Tool` in a new tab, with the differences in the SQL statements displayed in the `Query Editor`.
 
 You can also use the `Copy` button to copy the difference generated in the `DDL Comparison` panel.
 
-<img src="../images/schema_diff_generate_script_query_editor.png" class="align-center" alt="Schema diff generate script query editor" />
+<img
+  src="../images/schema_diff_generate_script_query_editor.png"
+  class="align-center"
+  alt="Schema diff generate script query editor"
+/>
 
 Apply the SQL Statement in the target database to synchronize the databases.

--- a/product_docs/docs/pem/7.16/pem_online_help/10_pgagent/03_pgagent_jobs.mdx
+++ b/product_docs/docs/pem/7.16/pem_online_help/10_pgagent/03_pgagent_jobs.mdx
@@ -14,24 +14,24 @@ When the pgAgent dialog opens, use the tabs on the `pgAgent Job` dialog to defin
 
 Use the fields on the `General` tab to provide general information about a job:
 
-> -   Provide a name for the job in the `Name` field.
->
-> -   Move the `Enabled` switch to the `Yes` position to enable a job, or `No` to disable a job.
->
-> -   Use the `Job Class` drop-down to select a class (for job categorization).
->
-> -   Use the `Host Agent` field to specify the name of a machine that is running pgAgent to indicate that only that machine may execute the job. Leave the field blank to specify that any machine may perform the job.
->
->     !!! Note
->         It is not always obvious what value to specify for the Host Agent in order to target a job step to a specific machine. With pgAgent running on the required machines and connected to the scheduler database, you can use the following query to view the hostnames as reported by each agent:
->
->     ```
->     SELECT jagstation FROM pgagent.pga_jobagent
->     ```
->
->     Use the hostname exactly as reported by the query in the Host Agent field.
->
-> -   Use the `Comment` field to store notes about the job.
+- Provide a name for the job in the `Name` field.
+- Move the `Enabled` switch to the `Yes` position to enable a job, or `No` to disable a job.
+- Use the `Job Class` drop-down to select a class (for job categorization).
+- Use the `Host Agent` field to specify the name of a machine that is running pgAgent to indicate that only that machine may execute the job. Leave the field blank to specify that any machine may perform the job.
+
+!!! Note
+
+It is not always obvious what value to specify for the Host Agent in order to target a job step to a specific machine. With pgAgent running on the required machines and connected to the scheduler database, you can use the following query to view the hostnames as reported by each agent:
+
+```
+SELECT jagstation FROM pgagent.pga_jobagent
+```
+
+Use the hostname exactly as reported by the query in the Host Agent field.
+
+!!!
+
+- Use the `Comment` field to store notes about the job.
 
 ![Create pgAgent Job dialog - Steps tab](../images/pgagent_steps.png)
 
@@ -41,12 +41,11 @@ Use the `Steps` tab to define and manage the steps that the job will perform. Cl
 
 Use fields on the step definition dialog to define the step:
 
-> -   Provide a name for the step in the `Name` field; please note that steps will be performed in alphanumeric order by name.
-> -   Use the `Enabled` switch to include the step when executing the job (`True`) or to disable the step (`False`).
-> -   Use the `Kind` switch to indicate if the job step invokes SQL code (`SQL`) or a batch script (`Batch`).
->
-> > -   If you select `SQL`, use the `Code` tab to provide SQL code for the step.
-> > -   If you select `Batch`, use the `Code` tab to provide the batch script that will be executed during the step.
+- Provide a name for the step in the `Name` field; please note that steps will be performed in alphanumeric order by name.
+- Use the `Enabled` switch to include the step when executing the job (`True`) or to disable the step (`False`).
+- Use the `Kind` switch to indicate if the job step invokes SQL code (`SQL`) or a batch script (`Batch`).
+  - If you select `SQL`, use the `Code` tab to provide SQL code for the step.
+  - If you select `Batch`, use the `Code` tab to provide the batch script that will be executed during the step.
 
 <div class="note">
 
@@ -60,22 +59,23 @@ The fields `Connection type`, `Database` and `Connection string` are only applic
 
 </div>
 
--   Use the `Connection type` switch to indicate if the step is performed on a local server (`Local`) or on a remote host (`Remote`). If you specify a remote connection should be used for the step, the `Connection string` field will be enabled, and you must provide a libpq-style connection string.
--   Use the `Database` drop-down to select the database on which the job step will be performed.
--   Use the `Connection string` field to specify a libpq-style connection string to the remote server on which the step will be performed. For more information about writing a connection string, please see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq.html#libpq-connect).
--   Use the `On error` drop-down to specify the behavior of pgAgent if it encounters an error while executing the step. Select from:
-    -   `Fail` - Stop the job if you encounter an error while processing this step.
-    -   `Success` - Mark the step as completing successfully, and continue.
-    -   `Ignore` - Ignore the error, and continue.
+- Use the `Connection type` switch to indicate if the step is performed on a local server (`Local`) or on a remote host (`Remote`). If you specify a remote connection should be used for the step, the `Connection string` field will be enabled, and you must provide a libpq-style connection string.
+- Use the `Database` drop-down to select the database on which the job step will be performed.
+- Use the `Connection string` field to specify a libpq-style connection string to the remote server on which the step will be performed. For more information about writing a connection string, please see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq.html#libpq-connect).
+- Use the `On error` drop-down to specify the behavior of pgAgent if it encounters an error while executing the step. Select from:
 
-> -   Use the `Comment` field to provide a comment about the step.
+  - `Fail` - Stop the job if you encounter an error while processing this step.
+  - `Success` - Mark the step as completing successfully, and continue.
+  - `Ignore` - Ignore the error, and continue.
+
+- Use the `Comment` field to provide a comment about the step.
 
 ![Create pgAgent Job dialog - Steps tab - Code tab](../images/pgagent_step_definition_code.png)
 
 Use the context-sensitive field on the step definition dialog's `Code` tab to provide the SQL code or batch script that will be executed during the step:
 
-> -   If the step invokes SQL code, provide one or more SQL statements in the `SQL query` field.
-> -   If the step performs a batch script, provide the script in the `Script` field. If you are running on a Windows server, standard batch file syntax must be used. When running on a Linux server, any shell script may be used, provided that a suitable interpreter is specified on the first line (e.g. `#!/bin/sh`).
+- If the step invokes SQL code, provide one or more SQL statements in the `SQL query` field.
+- If the step performs a batch script, provide the script in the `Script` field. If you are running on a Windows server, standard batch file syntax must be used. When running on a Linux server, any shell script may be used, provided that a suitable interpreter is specified on the first line (e.g. `#!/bin/sh`).
 
 When you've provided all of the information required by the step, click the compose icon to close the step definition dialog. Click the add icon (+) to add each additional step, or select the `Schedules` tab to define the job schedule.
 
@@ -87,11 +87,11 @@ Click the Add icon (+) to add a schedule for the job; then click the compose ico
 
 Use the fields on the schedule definition tab to specify the days and times at which the job will execute.
 
-> -   Provide a name for the schedule in the `Name` field.
-> -   Use the `Enabled` switch to indicate that pgAgent should use the schedule (`Yes`) or to disable the schedule (`No`).
-> -   Use the calendar selector in the `Start` field to specify the starting date and time for the schedule.
-> -   Use the calendar selector in the `End` field to specify the ending date and time for the schedule.
-> -   Use the `Comment` field to provide a comment about the schedule.
+- Provide a name for the schedule in the `Name` field.
+- Use the `Enabled` switch to indicate that pgAgent should use the schedule (`Yes`) or to disable the schedule (`No`).
+- Use the calendar selector in the `Start` field to specify the starting date and time for the schedule.
+- Use the calendar selector in the `End` field to specify the ending date and time for the schedule.
+- Use the `Comment` field to provide a comment about the schedule.
 
 Select the `Repeat` tab to define the days on which the schedule will execute.
 
@@ -103,14 +103,14 @@ Click within a field to open a list of valid values for that field; click on a s
 
 Use the fields within the `Days` box to specify the days on which the job will execute:
 
-> -   Use the `Week Days` field to select the days on which the job will execute.
-> -   Use the `Month Days` field to select the numeric days on which the job will execute. Specify the `Last Day` to indicate that the job should be performed on the last day of the month, irregardless of the date.
-> -   Use the `Months` field to select the months in which the job will execute.
+- Use the `Week Days` field to select the days on which the job will execute.
+- Use the `Month Days` field to select the numeric days on which the job will execute. Specify the `Last Day` to indicate that the job should be performed on the last day of the month, irregardless of the date.
+- Use the `Months` field to select the months in which the job will execute.
 
-Use the fields within the `Times` box to specify the times at which the job will execute:
+e the fields within the `Times` box to specify the times at which the job will execute:
 
-> -   Use the `Hours` field to select the hour at which the job will execute.
-> -   Use the `Minutes` field to select the minute at which the job will execute.
+- Use the `Hours` field to select the hour at which the job will execute.
+- Use the `Minutes` field to select the minute at which the job will execute.
 
 Select the `Exceptions` tab to specify any days on which the schedule will `not` execute.
 
@@ -120,8 +120,8 @@ Use the fields on the `Exceptions` tab to specify days on which you wish the job
 
 Click the Add icon (+) to add a row to the exception table, then:
 
-> -   Click within the `Date` column to open a calendar selector, and select a date on which the job will not execute. Specify `<Any>` in the `Date` column to indicate that the job should not execute on any day at the time selected.
-> -   Click within the `Time` column to open a time selector, and specify a time on which the job will not execute. Specify `<Any>` in the `Time` column to indicate that the job should not execute at any time on the day selected.
+- Click within the `Date` column to open a calendar selector, and select a date on which the job will not execute. Specify `<Any>` in the `Date` column to indicate that the job should not execute on any day at the time selected.
+- Click within the `Time` column to open a time selector, and specify a time on which the job will not execute. Specify `<Any>` in the `Time` column to indicate that the job should not execute at any time on the day selected.
 
 When you've finished defining the schedule, you can use the `SQL` tab to review the code that will create or modify your job.
 

--- a/product_docs/docs/pem/7.16/pem_sqlprofiler/01_installing_the_sql_profiler_plugin.mdx
+++ b/product_docs/docs/pem/7.16/pem_sqlprofiler/01_installing_the_sql_profiler_plugin.mdx
@@ -39,6 +39,7 @@ When the installation is complete, the SQL Profiler plugin is ready to be config
 ## Using an RPM Package to Install SQL Profiler
 
 !!! Note
+
     You may be required to add the `sslutils` package to your PostgreSQL database servers before installing SQL Profiler.
 
 If you have already configured the EDB repository on your system, you can use `yum` or `dnf` to install SQL Profiler:
@@ -58,6 +59,7 @@ For detailed information about configuring the EDB repository, please see the [P
 ## Installing SQL Profiler on Debian/Ubuntu
 
 !!! Note
+
     You may be required to add the `sslutils` package to your PostgreSQL database servers before installing SQL Profiler.
 
 You can use an `apt` command to install SQL Profiler using DEB on Debian 9.x or Ubuntu 18; assume root privileges and enter:
@@ -86,8 +88,8 @@ Use the following steps to enable the plugin:
 
 3.  Using the `Query Tool` or the `psql` command line interface, run the `sql-profiler.sql` script in the database specified as the `Maintenance Database` on the server you wish to profile. If you are using:
 
-    -   PostgreSQL, the default maintenance database is `postgres`.
-    -   Advanced Server, the default maintenance database is `edb`.
+    - PostgreSQL, the default maintenance database is `postgres`.
+    - Advanced Server, the default maintenance database is `edb`.
 
     To use the PEM Query Tool to run the script, highlight the name of the maintenance database in the `Browser` tree control, and navigate through the `Tools` menu to select `Query tool`. When the Query Tool opens, use the `Open` option on the `Files` menu to open a web browser and navigate to the `sql-profiler.sql` script. By default, the `sql-profiler.sql` script is located in the `contrib` folder, under your Postgres installation.
 
@@ -107,7 +109,7 @@ Use the following steps to enable the plugin:
 
     To access SQL Profiler functionality, highlight the name of the database in the PEM `Browser` tree control; navigate through `Server` option under `Tools` menu to the `SQL Profiler` pull-aside menu. Menu options allow you to manage your SQL traces:
 
-    -   Select `Create trace`… to define a new trace.
-    -   Select `Open trace`… to open an existing trace.
-    -   Select `Delete trace(s)`… to delete one or more traces.
-    -   Select `View scheduled trace(s)`… to review a list of scheduled traces.
+    - Select `Create trace`… to define a new trace.
+    - Select `Open trace`… to open an existing trace.
+    - Select `Delete trace(s)`… to delete one or more traces.
+    - Select `View scheduled trace(s)`… to review a list of scheduled traces.

--- a/product_docs/docs/repmgr/5.2.1/index.mdx
+++ b/product_docs/docs/repmgr/5.2.1/index.mdx
@@ -10,13 +10,14 @@ repmgr (Replication Manager) is among the most popular open-source tools for man
 repmgr is distributed under GNU GPL 3 and maintained by EDB. repmgr is developed, tested and certified with PostgreSQL and EDB Postgres Extended. repmgr is not certified with EDB Postgres Advanced.
 
 !!! Note
-   Looking for repmgr documentation? Head over to [repmgr.org](https://repmgr.org/)
-!!!
+
+    Looking for repmgr documentation? Head over to [repmgr.org](https://repmgr.org/)
 
 Key capabilities include:
-* Perform automatic failover by detecting failure of the primary and promoting the most suitable standby server
-* Monitoring and recording replication performance
-* User defined scripts can be triggered by cluster events to perform tasks such as sending email alerts
-* Witness servers can improve repmgr failure assessment and resolution, especially in deployments involving multiple data centers
-* A "location" configuration option can restrict potential promotion candidates to a single location, e.g., when nodes are spread over multiple data centers
-* Supports multiple methods to determine node availability: PostgreSQL ping, query execution, or new connection
+
+- Perform automatic failover by detecting failure of the primary and promoting the most suitable standby server
+- Monitoring and recording replication performance
+- User defined scripts can be triggered by cluster events to perform tasks such as sending email alerts
+- Witness servers can improve repmgr failure assessment and resolution, especially in deployments involving multiple data centers
+- A "location" configuration option can restrict potential promotion candidates to a single location, e.g., when nodes are spread over multiple data centers
+- Supports multiple methods to determine node availability: PostgreSQL ping, query execution, or new connection


### PR DESCRIPTION
Prettier and hand-fix MDX files.

* Add blank space between admonition tag and content.
* Reformat various markdown elements, e.g.
    * strong → header
    * remove unnecessary quote blocks
    * proper code fence syntax declarations
