### PR TITLE
Security Guide Formatting fixes

### DIFF
--- a/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/01_sql_protect_overview.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/01_sql_protect_overview.mdx
@@ -12,15 +12,15 @@ This section contains an introduction to the different types of SQL injection at
 
 ## Types of SQL Injection Attacks
 
-There are a number of different techniques used to perpetrate SQL injection attacks. Each technique is characterized by a certain `signature`. SQL/Protect examines queries for the following signatures:
+There are a number of different techniques used to perpetrate SQL injection attacks. Each technique is characterized by a certain *signature*. SQL/Protect examines queries for the following signatures:
 
 **Unauthorized Relations**
 
-While Advanced Server allows administrators to restrict access to relations (tables, views, etc.), many administrators do not perform this tedious task. SQL/Protect provides a `learn` mode that tracks the relations a user accesses.
+While Advanced Server allows administrators to restrict access to relations (tables, views, etc.), many administrators do not perform this tedious task. SQL/Protect provides a *learn* mode that tracks the relations a user accesses.
 
 This allows administrators to examine the workload of an application, and for SQL/Protect to learn which relations an application should be allowed to access for a given user or group of users in a role.
 
-When SQL/Protect is switched to either `passive` or `active` mode, the incoming queries are checked against the list of learned relations.
+When SQL/Protect is switched to either *passive* or *active* mode, the incoming queries are checked against the list of learned relations.
 
 **Utility Commands**
 
@@ -44,32 +44,32 @@ A dangerous action taken during SQL injection attacks is the running of unbounde
 
 ## Monitoring SQL Injection Attacks
 
-This section describes how `SQL/Protect` monitors and reports on SQL injection attacks.
+This section describes how SQL/Protect monitors and reports on SQL injection attacks.
 
 ### Protected Roles
 
-Monitoring for SQL injection attacks involves analyzing SQL statements originating in database sessions where the current user of the session is a protected role. A `protected role` is an Advanced Server user or group that the database administrator has chosen to monitor using SQL/Protect. (In Advanced Server, users and groups are collectively referred to as `roles`.)
+Monitoring for SQL injection attacks involves analyzing SQL statements originating in database sessions where the current user of the session is a protected role. A *protected role* is an Advanced Server user or group that the database administrator has chosen to monitor using SQL/Protect. (In Advanced Server, users and groups are collectively referred to as *roles*.)
 
 Each protected role can be customized for the types of SQL injection attacks for which it is to be monitored, thus providing different levels of protection by role and significantly reducing the user maintenance load for DBAs.
 
 A role with the superuser privilege cannot be made a protected role. If a protected non-superuser role is subsequently altered to become a superuser, certain behaviors are exhibited whenever an attempt is made by that superuser to issue any command:
 
 -   A warning message is issued by SQL/Protect on every command issued by the protected superuser.
--   The statistic in column superusers of `edb_sql_protect_stats` is incremented with every command issued by the protected superuser. See `Attack Attempt Statistics` for information on the `edb_sql_protect_stats` view.
+-   The statistic in column superusers of `edb_sql_protect_stats` is incremented with every command issued by the protected superuser. See *Attack Attempt Statistics* for information on the `edb_sql_protect_stats` view.
 -   When SQL/Protect is in active mode, all commands issued by the protected superuser are prevented from running.
 
 A protected role that has the superuser privilege should either be altered so that it is no longer a superuser, or it should be reverted back to an unprotected role.
 
 ### Attack Attempt Statistics
 
-Each usage of a command by a protected role that is considered an attack by SQL/Protect is recorded. Statistics are collected by type of SQL injection attack as discussed in `Types of SQL Injection Attacks`.
+Each usage of a command by a protected role that is considered an attack by SQL/Protect is recorded. Statistics are collected by type of SQL injection attack as discussed in *Types of SQL Injection Attacks*.
 
 These statistics are accessible from view `edb_sql_protect_stats` that can be easily monitored to identify the start of a potential attack.
 
 The columns in `edb_sql_protect_stats` monitor the following:
 
 -   **username.** Name of the protected role.
--   **superusers.** Number of SQL statements issued when the protected role is a superuser. In effect, any SQL statement issued by a protected superuser increases this statistic. See `Protected Roles` for information on protected superusers.
+-   **superusers.** Number of SQL statements issued when the protected role is a superuser. In effect, any SQL statement issued by a protected superuser increases this statistic. See *Protected Roles* for information on protected superusers.
 -   **relations.** Number of SQL statements issued referencing relations that were not learned by a protected role. (That is, relations that are not in a role’s protected relations list.)
 -   **commands.** Number of DDL statements issued by a protected role.
 -   **tautology.** Number of SQL statements issued by a protected role that contained a tautological condition.

--- a/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/02_configuring_sql_protect.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/02_configuring_sql_protect.mdx
@@ -192,7 +192,7 @@ If you are using `SQL/Protect` for the first time, set `edb_sql_protect.level` t
 
 Once you have configured SQL/Protect in a database, added roles to the protected roles list, and set the desired protection level, you can then activate SQL/Protect in either `learn` mode, `passive` mode, or `active` mode. You can then start running your applications.
 
-With a new SQL/Protect installation, the first step is to determine the relations that protected roles should be permitted to access during normal operation. Learn mode allows a role to run applications during which time SQL/Protect is recording the relations that are accessed. These are added to the role’s `protected relations list` stored in table `edb_sql_protect_rel`.
+With a new SQL/Protect installation, the first step is to determine the relations that protected roles should be permitted to access during normal operation. Learn mode allows a role to run applications during which time SQL/Protect is recording the relations that are accessed. These are added to the role’s *protected relations list* stored in table `edb_sql_protect_rel`.
 
 Monitoring for protection against attack begins when SQL/Protect is run in passive or active mode. In passive and active modes, the role is permitted to access the relations in its protected relations list as these were determined to be the relations the role should be able to access during typical usage.
 
@@ -308,7 +308,7 @@ edb_sql_protect.enabled = on
 edb_sql_protect.level = passive
 ```
 
-**Step 2:** Reload the configuration file as shown in `Step 2` of the [Learn Mode](#learn-mode) section.
+**Step 2:** Reload the configuration file as shown in Step 2 of the [Learn Mode](#learn-mode) section.
 
 Now SQL/Protect is in passive mode. For relations that have been learned such as the `dept` and `emp` tables of the prior examples, SQL statements are permitted with no special notification to the client by `SQL/Protect` as shown by the following queries run by user `appuser`:
 
@@ -355,7 +355,7 @@ f1
 
 **Step 3:** Monitor the statistics for suspicious activity.
 
-By querying the view `edb_sql_protect_stats`, you can see the number of times SQL statements were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See `Attack Attempt Statistics` for more information on view `edb_sql_protect_stats`.
+By querying the view `edb_sql_protect_stats`, you can see the number of times SQL statements were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See *Attack Attempt Statistics* for more information on view `edb_sql_protect_stats`.
 
 The following is a query on `edb_sql_protect_stats`:
 
@@ -371,7 +371,7 @@ edb=# SELECT * FROM edb_sql_protect_stats;
 
 **Step 4:** View information on specific attacks.
 
-By querying the `edb_sql_protect_queries` view, you can see the SQL statements that were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See `Attack Attempt Queries` for more information on view `edb_sql_protect_queries`.
+By querying the `edb_sql_protect_queries` view, you can see the SQL statements that were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See *Attack Attempt Queries* for more information on view `edb_sql_protect_queries`.
 
 The following code sample shows a query on `edb_sql_protect_queries`:
 
@@ -421,9 +421,9 @@ edb_sql_protect.enabled = on
 edb_sql_protect.level = active
 ```
 
-**Step 2:** Reload the configuration file as shown in `Step 2` of the [Learn Mode](#learn-mode) section.
+**Step 2:** Reload the configuration file as shown in Step 2 of the [Learn Mode](#learn-mode) section.
 
-The following example illustrates SQL statements similar to those given in the examples of `Step 2` in `Passive Mode`, but executed by user `appuser` when `edb_sql_protect.level` is set to `active`:
+The following example illustrates SQL statements similar to those given in the examples of Step 2 in `Passive Mode`, but executed by user `appuser` when `edb_sql_protect.level` is set to `active`:
 
 ```text
 edb=> CREATE TABLE appuser_tab_3 (f1 INTEGER);

--- a/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/03_common_maintenance_operations.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/03_common_maintenance_operations.mdx
@@ -182,7 +182,7 @@ edb=# SELECT * FROM edb_sql_protect_stats;
 
 ## Deleting Offending Queries
 
-You can delete offending queries from `view edb_sql_protect_queries` using either of the two following functions:
+You can delete offending queries from view `edb_sql_protect_queries` using either of the two following functions:
 
 ```text
 drop_queries('rolename')

--- a/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/04_backing_up_restoring_sql_protect.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/02_protecting_against_sql_injection_attacks/04_backing_up_restoring_sql_protect.mdx
@@ -145,7 +145,7 @@ edb=# SELECT sqlprotect.drop_queries('appuser');
 
 If the original and new databases reside in the same database server, then nothing needs to be done assuming you have not deleted any of these roles from the database server.
 
-**Step 7:** Run the function `import_sqlprotect('sqlprotect_file')` where `sqlprotect_file` is the fully qualified path to the file you created in `Step 2` of `Backing Up the Database`.
+**Step 7:** Run the function `import_sqlprotect('sqlprotect_file')` where `sqlprotect_file` is the fully qualified path to the file you created in Step 2 of *Backing Up the Database*.
 
 ```text
 newdb=# SELECT sqlprotect.import_sqlprotect('/tmp/sqlprotect.dmp');

--- a/product_docs/docs/epas/12/epas_security_guide/03_virtual_private_database.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/03_virtual_private_database.mdx
@@ -8,7 +8,7 @@ legacyRedirectsGenerated:
 
 <div id="virtual_private_database" class="registered_link"></div>
 
-`Virtual Private Database` is a type of fine-grained access control using security policies. `Fine-grained access control` means that access to data can be controlled down to specific rows as defined by the security policy.
+*Virtual Private Database* is a type of fine-grained access control using security policies. *Fine-grained access control* means that access to data can be controlled down to specific rows as defined by the security policy.
 
 The rules that encode a security policy are defined in a *policy function*, which is an SPL function with certain input parameters and return value. The *security policy* is the named association of the policy function to a particular database object, typically a table.
 

--- a/product_docs/docs/epas/12/epas_security_guide/04_sslutils.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/04_sslutils.mdx
@@ -8,11 +8,11 @@ legacyRedirectsGenerated:
 
 <div id="sslutils" class="registered_link"></div>
 
-`sslutils` is a Postgres extension that provides SSL certificate generation functions to Advanced Server for use by the EDB Postgres Enterprise Manager server. sslutils is installed by using the `edb-asxx-server-sslutils` RPM package where `xx` is the Advanced Server version number.
+`sslutils` is a Postgres extension that provides SSL certificate generation functions to Advanced Server for use by the EDB Postgres Enterprise Manager server. `sslutils` is installed by using the `edb-asxx-server-sslutils` RPM package where `xx` is the Advanced Server version number.
 
 The `sslutils` package provides the functions shown in the following sections.
 
-In these sections, each parameter in the function’s parameter list is described by `parameter n` under the `Parameters` subsection where `n` refers to the `nth` ordinal position (for example, first, second, third, etc.) within the function’s parameter list.
+In these sections, each parameter in the function’s parameter list is described by `parameter n` under the **Parameters** subsection where `n` refers to the `nth` ordinal position (for example, first, second, third, etc.) within the function’s parameter list.
 
 ## openssl_rsa_generate_key
 
@@ -30,7 +30,7 @@ The `openssl_rsa_key_to_csr` function generates a certificate signing request (C
 
 ```text
 openssl_rsa_key_to_csr(<text>, <text>, <text>, <text>, <text>, <text>,
-<text>) RETURNS text
+<text>) RETURNS <text>
 ```
 
 The function generates and returns the certificate signing request.

--- a/product_docs/docs/epas/12/epas_security_guide/05_data_redaction.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/05_data_redaction.mdx
@@ -214,7 +214,7 @@ edb=> SELECT * FROM employees WHERE substring(ssn from 0 for 4) = '123';
 
 **Caveats**
 
-1.  The data redaction policy created on inheritance hierarchies will not be cascaded. For example, if the data redaction policy is created for a parent, it will not be applied to the child table, which inherits it and vice versa. Someone who has access to these child tables can see the non-redacted data. For information about inheritance hierarchies, see `Inheritance` in the PostgreSQL Core Documentation available at:
+1.  The data redaction policy created on inheritance hierarchies will not be cascaded. For example, if the data redaction policy is created for a parent, it will not be applied to the child table, which inherits it and vice versa. Someone who has access to these child tables can see the non-redacted data. For information about inheritance hierarchies, see *Inheritance* in the PostgreSQL Core Documentation available at:
 
      <https://www.postgresql.org/docs/12/static/ddl-inherit.html>
 
@@ -403,7 +403,7 @@ To drop the data redaction policy called `redact_policy_personal_info` on the ta
 DROP REDACTION POLICY redact_policy_personal_info ON employees;
 ```
 
-**Compatibilities**
+**Compatibility**
 
 `DROP REDACTION POLICY` is an EnterpriseDB extension.
 

--- a/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/01_sql_protect_overview.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/01_sql_protect_overview.mdx
@@ -12,15 +12,15 @@ This section contains an introduction to the different types of SQL injection at
 
 ## Types of SQL Injection Attacks
 
-There are a number of different techniques used to perpetrate SQL injection attacks. Each technique is characterized by a certain `signature`. SQL/Protect examines queries for the following signatures:
+There are a number of different techniques used to perpetrate SQL injection attacks. Each technique is characterized by a certain *signature*. SQL/Protect examines queries for the following signatures:
 
 **Unauthorized Relations**
 
-While Advanced Server allows administrators to restrict access to relations (tables, views, etc.), many administrators do not perform this tedious task. SQL/Protect provides a `learn` mode that tracks the relations a user accesses.
+While Advanced Server allows administrators to restrict access to relations (tables, views, etc.), many administrators do not perform this tedious task. SQL/Protect provides a *learn* mode that tracks the relations a user accesses.
 
 This allows administrators to examine the workload of an application, and for SQL/Protect to learn which relations an application should be allowed to access for a given user or group of users in a role.
 
-When SQL/Protect is switched to either `passive` or `active` mode, the incoming queries are checked against the list of learned relations.
+When SQL/Protect is switched to either *passive* or *active* mode, the incoming queries are checked against the list of learned relations.
 
 **Utility Commands**
 
@@ -44,32 +44,32 @@ A dangerous action taken during SQL injection attacks is the running of unbounde
 
 ## Monitoring SQL Injection Attacks
 
-This section describes how `SQL/Protect` monitors and reports on SQL injection attacks.
+This section describes how SQL/Protect monitors and reports on SQL injection attacks.
 
 ### Protected Roles
 
-Monitoring for SQL injection attacks involves analyzing SQL statements originating in database sessions where the current user of the session is a protected role. A `protected role` is an Advanced Server user or group that the database administrator has chosen to monitor using SQL/Protect. (In Advanced Server, users and groups are collectively referred to as `roles`.)
+Monitoring for SQL injection attacks involves analyzing SQL statements originating in database sessions where the current user of the session is a protected role. A *protected role* is an Advanced Server user or group that the database administrator has chosen to monitor using SQL/Protect. (In Advanced Server, users and groups are collectively referred to as *roles*.)
 
 Each protected role can be customized for the types of SQL injection attacks for which it is to be monitored, thus providing different levels of protection by role and significantly reducing the user maintenance load for DBAs.
 
 A role with the superuser privilege cannot be made a protected role. If a protected non-superuser role is subsequently altered to become a superuser, certain behaviors are exhibited whenever an attempt is made by that superuser to issue any command:
 
 -   A warning message is issued by SQL/Protect on every command issued by the protected superuser.
--   The statistic in column superusers of `edb_sql_protect_stats` is incremented with every command issued by the protected superuser. See `Attack Attempt Statistics` for information on the `edb_sql_protect_stats` view.
+-   The statistic in column superusers of `edb_sql_protect_stats` is incremented with every command issued by the protected superuser. See *Attack Attempt Statistics* for information on the `edb_sql_protect_stats` view.
 -   When SQL/Protect is in active mode, all commands issued by the protected superuser are prevented from running.
 
 A protected role that has the superuser privilege should either be altered so that it is no longer a superuser, or it should be reverted back to an unprotected role.
 
 ### Attack Attempt Statistics
 
-Each usage of a command by a protected role that is considered an attack by SQL/Protect is recorded. Statistics are collected by type of SQL injection attack as discussed in `Types of SQL Injection Attacks`.
+Each usage of a command by a protected role that is considered an attack by SQL/Protect is recorded. Statistics are collected by type of SQL injection attack as discussed in *Types of SQL Injection Attacks*.
 
 These statistics are accessible from view `edb_sql_protect_stats` that can be easily monitored to identify the start of a potential attack.
 
 The columns in `edb_sql_protect_stats` monitor the following:
 
 -   **username.** Name of the protected role.
--   **superusers.** Number of SQL statements issued when the protected role is a superuser. In effect, any SQL statement issued by a protected superuser increases this statistic. See `Protected Roles` for information on protected superusers.
+-   **superusers.** Number of SQL statements issued when the protected role is a superuser. In effect, any SQL statement issued by a protected superuser increases this statistic. See *Protected Roles* for information on protected superusers.
 -   **relations.** Number of SQL statements issued referencing relations that were not learned by a protected role. (That is, relations that are not in a role’s protected relations list.)
 -   **commands.** Number of DDL statements issued by a protected role.
 -   **tautology.** Number of SQL statements issued by a protected role that contained a tautological condition.

--- a/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/02_configuring_sql_protect.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/02_configuring_sql_protect.mdx
@@ -192,7 +192,7 @@ If you are using `SQL/Protect` for the first time, set `edb_sql_protect.level` t
 
 Once you have configured SQL/Protect in a database, added roles to the protected roles list, and set the desired protection level, you can then activate SQL/Protect in either `learn` mode, `passive` mode, or `active` mode. You can then start running your applications.
 
-With a new SQL/Protect installation, the first step is to determine the relations that protected roles should be permitted to access during normal operation. Learn mode allows a role to run applications during which time SQL/Protect is recording the relations that are accessed. These are added to the role’s `protected relations list` stored in table `edb_sql_protect_rel`.
+With a new SQL/Protect installation, the first step is to determine the relations that protected roles should be permitted to access during normal operation. Learn mode allows a role to run applications during which time SQL/Protect is recording the relations that are accessed. These are added to the role’s *protected relations list* stored in table `edb_sql_protect_rel`.
 
 Monitoring for protection against attack begins when SQL/Protect is run in passive or active mode. In passive and active modes, the role is permitted to access the relations in its protected relations list as these were determined to be the relations the role should be able to access during typical usage.
 
@@ -308,7 +308,7 @@ edb_sql_protect.enabled = on
 edb_sql_protect.level = passive
 ```
 
-**Step 2:** Reload the configuration file as shown in `Step 2` of the [Learn Mode](#learn-mode) section.
+**Step 2:** Reload the configuration file as shown in Step 2 of the [Learn Mode](#learn-mode) section.
 
 Now SQL/Protect is in passive mode. For relations that have been learned such as the `dept` and `emp` tables of the prior examples, SQL statements are permitted with no special notification to the client by `SQL/Protect` as shown by the following queries run by user `appuser`:
 
@@ -355,7 +355,7 @@ f1
 
 **Step 3:** Monitor the statistics for suspicious activity.
 
-By querying the view `edb_sql_protect_stats`, you can see the number of times SQL statements were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See `Attack Attempt Statistics` for more information on view `edb_sql_protect_stats`.
+By querying the view `edb_sql_protect_stats`, you can see the number of times SQL statements were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See *Attack Attempt Statistics* for more information on view `edb_sql_protect_stats`.
 
 The following is a query on `edb_sql_protect_stats`:
 
@@ -371,7 +371,7 @@ edb=# SELECT * FROM edb_sql_protect_stats;
 
 **Step 4:** View information on specific attacks.
 
-By querying the `edb_sql_protect_queries` view, you can see the SQL statements that were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See `Attack Attempt Queries` for more information on view `edb_sql_protect_queries`.
+By querying the `edb_sql_protect_queries` view, you can see the SQL statements that were executed that referenced relations that were not in a role’s protected relations list, or contained SQL injection attack signatures. See *Attack Attempt Queries* for more information on view `edb_sql_protect_queries`.
 
 The following code sample shows a query on `edb_sql_protect_queries`:
 
@@ -421,9 +421,9 @@ edb_sql_protect.enabled = on
 edb_sql_protect.level = active
 ```
 
-**Step 2:** Reload the configuration file as shown in `Step 2` of the [Learn Mode](#learn-mode) section.
+**Step 2:** Reload the configuration file as shown in Step 2 of the [Learn Mode](#learn-mode) section.
 
-The following example illustrates SQL statements similar to those given in the examples of `Step 2` in `Passive Mode`, but executed by user `appuser` when `edb_sql_protect.level` is set to `active`:
+The following example illustrates SQL statements similar to those given in the examples of Step 2 in `Passive Mode`, but executed by user `appuser` when `edb_sql_protect.level` is set to `active`:
 
 ```text
 edb=> CREATE TABLE appuser_tab_3 (f1 INTEGER);

--- a/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/03_common_maintenance_operations.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/03_common_maintenance_operations.mdx
@@ -182,7 +182,7 @@ edb=# SELECT * FROM edb_sql_protect_stats;
 
 ## Deleting Offending Queries
 
-You can delete offending queries from `view edb_sql_protect_queries` using either of the two following functions:
+You can delete offending queries from view `edb_sql_protect_queries` using either of the two following functions:
 
 ```text
 drop_queries('rolename')

--- a/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/04_backing_up_restoring_sql_protect.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/02_protecting_against_sql_injection_attacks/04_backing_up_restoring_sql_protect.mdx
@@ -145,7 +145,7 @@ edb=# SELECT sqlprotect.drop_queries('appuser');
 
 If the original and new databases reside in the same database server, then nothing needs to be done assuming you have not deleted any of these roles from the database server.
 
-**Step 7:** Run the function `import_sqlprotect('sqlprotect_file')` where `sqlprotect_file` is the fully qualified path to the file you created in `Step 2` of `Backing Up the Database`.
+**Step 7:** Run the function `import_sqlprotect('sqlprotect_file')` where `sqlprotect_file` is the fully qualified path to the file you created in Step 2 of *Backing Up the Database*.
 
 ```text
 newdb=# SELECT sqlprotect.import_sqlprotect('/tmp/sqlprotect.dmp');

--- a/product_docs/docs/epas/13/epas_security_guide/03_virtual_private_database.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/03_virtual_private_database.mdx
@@ -8,7 +8,7 @@ legacyRedirectsGenerated:
 
 <div id="virtual_private_database" class="registered_link"></div>
 
-`Virtual Private Database` is a type of fine-grained access control using security policies. `Fine-grained access control` means that access to data can be controlled down to specific rows as defined by the security policy.
+*Virtual Private Database* is a type of fine-grained access control using security policies. *Fine-grained access control* means that access to data can be controlled down to specific rows as defined by the security policy.
 
 The rules that encode a security policy are defined in a *policy function*, which is an SPL function with certain input parameters and return value. The *security policy* is the named association of the policy function to a particular database object, typically a table.
 

--- a/product_docs/docs/epas/13/epas_security_guide/04_sslutils.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/04_sslutils.mdx
@@ -8,11 +8,11 @@ legacyRedirectsGenerated:
 
 <div id="sslutils" class="registered_link"></div>
 
-`sslutils` is a Postgres extension that provides SSL certificate generation functions to Advanced Server for use by the EDB Postgres Enterprise Manager server. sslutils is installed by using the `edb-asxx-server-sslutils` RPM package where `xx` is the Advanced Server version number.
+`sslutils` is a Postgres extension that provides SSL certificate generation functions to Advanced Server for use by the EDB Postgres Enterprise Manager server. `sslutils` is installed by using the `edb-asxx-server-sslutils` RPM package where `xx` is the Advanced Server version number.
 
 The `sslutils` package provides the functions shown in the following sections.
 
-In these sections, each parameter in the function’s parameter list is described by `parameter n` under the `Parameters` subsection where `n` refers to the `nth` ordinal position (for example, first, second, third, etc.) within the function’s parameter list.
+In these sections, each parameter in the function’s parameter list is described by `parameter n` under the **Parameters** subsection where `n` refers to the `nth` ordinal position (for example, first, second, third, etc.) within the function’s parameter list.
 
 ## openssl_rsa_generate_key
 
@@ -30,7 +30,7 @@ The `openssl_rsa_key_to_csr` function generates a certificate signing request (C
 
 ```text
 openssl_rsa_key_to_csr(<text>, <text>, <text>, <text>, <text>, <text>,
-<text>) RETURNS text
+<text>) RETURNS <text>
 ```
 
 The function generates and returns the certificate signing request.

--- a/product_docs/docs/epas/13/epas_security_guide/05_data_redaction.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/05_data_redaction.mdx
@@ -214,7 +214,7 @@ edb=> SELECT * FROM employees WHERE substring(ssn from 0 for 4) = '123';
 
 **Caveats**
 
-1.  The data redaction policy created on inheritance hierarchies will not be cascaded. For example, if the data redaction policy is created for a parent, it will not be applied to the child table, which inherits it and vice versa. Someone who has access to these child tables can see the non-redacted data. For information about inheritance hierarchies, see `Inheritance` in the PostgreSQL Core Documentation available at:
+1.  The data redaction policy created on inheritance hierarchies will not be cascaded. For example, if the data redaction policy is created for a parent, it will not be applied to the child table, which inherits it and vice versa. Someone who has access to these child tables can see the non-redacted data. For information about inheritance hierarchies, see *Inheritance* in the PostgreSQL Core Documentation available at:
 
      <https://www.postgresql.org/docs/current/static/ddl-inherit.html>
 
@@ -403,7 +403,7 @@ To drop the data redaction policy called `redact_policy_personal_info` on the ta
 DROP REDACTION POLICY redact_policy_personal_info ON employees;
 ```
 
-**Compatibilities**
+**Compatibility**
 
 `DROP REDACTION POLICY` is an EDB extension.
 


### PR DESCRIPTION
## What Changed?

While working on v11 migration for Security Features Guide came across formatting issues, fixed.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**
- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
