### PR TITLE
Fix "undefined" in archive paths

### DIFF
--- a/src/components/archive.js
+++ b/src/components/archive.js
@@ -3,7 +3,8 @@ import React from "react";
 import Icon from "./icon";
 import Link from "./link";
 
-const environment = process.env.GATSBY_ENVIRONMENT_BRANCH;
+const isProduction = process.env.APP_ENV === "production";
+const environment = isProduction ? "main" : "develop";
 
 export default function Archive({
   variant = "default",


### PR DESCRIPTION
## What Changed?

Apparently `GATSBY_ENVIRONMENT_BRANCH` is undefined (at least in local and staging builds). Re-use the APP_ENV approach already used elsewhere to determine which archive branch to link to.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
