### PR TITLE
fix image paths (and names in some cases)

### DIFF
--- a/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/03_efm_vip.mdx
+++ b/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/03_efm_vip.mdx
@@ -5,7 +5,7 @@ title: "Failover Manager with virtual IP"
 
 Failover Manager provides support for clusters that use a virtual IP (VIP). 
 
-![Failover Manager with VIP](/images/efm_with_vip.png)
+![Failover Manager with VIP](images/efm_with_vip.png)
 
 *Figure 1: Failover Manager's traffic routing using virtual IP*
 

--- a/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/04_efm_client_connect_failover.mdx
+++ b/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/04_efm_client_connect_failover.mdx
@@ -11,7 +11,7 @@ read-write connection. Do note that the speed on reconnecting to the new
 master is highly dependent on the connection timeouts as configured in
 the driver and tcp layer.
 
-![Failover Manager with VIP](/images/efm_with_vip.png)
+![Failover Manager traffic routing diagram for client connect failover](images/architecture diagram.png)
 
 <div style="text-align: center">Figure 2: Failover Manager's traffic routing using client connect failover</div>
 

--- a/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/05_efm_pgbouncer.mdx
+++ b/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/05_efm_pgbouncer.mdx
@@ -17,7 +17,7 @@ Failover Manager with PgBouncer On-premises
 For an on-premises setup, use the connection libraries to provide high
 availability by using a connection string with multiple hosts.
 
-![Failover Manager with VIP](/images/efm_with_vip.png)
+![Failover Manager using pgBouncer on-premises architecture diagram](images/efm_with_pgbouncer_on_premises.png)
 
 <div style="text-align: center">Figure 3: Failover Manager's traffic routing using PgBouncer on-premises</div>
 
@@ -27,7 +27,7 @@ Failover Manager with PgBouncer in Cloud
 For a cloud setup, you can use NLB (Network Load Balancer) in place of
 VIP to provide high availability.
 
-![Failover Manager with VIP](/images/efm_with_vip.png)
+![Failover Manager with PgBouncer cloud architecture diagram](images/efm_with_pgbouncer_on_cloud.png)
 
 <div style="text-align: center">Figure 4: Failover Manager's traffic routing using PgBouncer in cloud</div>
 

--- a/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/06_efm_pgpool.mdx
+++ b/product_docs/docs/efm/4.2/efm_pgpool_ha_guide/06_efm_pgpool.mdx
@@ -15,7 +15,7 @@ the automatic failover of Pgpool and configure settings for Failover
 Manager and Pgpool.
 
 
-![Failover Manager with Pgpool on-premises](/images/efm_with_pgpool_on_premises.png)
+![Failover Manager with Pgpool on-premises](images/efm_with_pgpool_on_premises.png)
 
 <div style="text-align: center">Figure 5: Failover Manager's traffic routing using Pgpool on-premises</div>
 
@@ -25,7 +25,7 @@ Failover Manager with Pgpool in Cloud
 For a cloud setup, you can use NLB (Network Load Balancer) in place of
 VIP to provide high availability.
 
-![Failover Manager with Pgpool in cloud](/images/efm_with_pgpool_on_cloud.png)
+![Failover Manager with Pgpool in cloud](images/efm_with_pgpool_on_cloud.png)
 
 <div style="text-align: center">Figure 6: Failover Manager's traffic routing using Pgpool in cloud</div>
 


### PR DESCRIPTION
## What Changed?

PDF builds were failing due to bad image paths in the latest EFM content. In some cases, these also appeared to be pointing to the wrong images. I've corrected both.

Related: #1578

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
