### PR TITLE
Fix for #1602

### DIFF
--- a/product_docs/docs/epas/12/epas_guide/10_edb_resource_manager.mdx
+++ b/product_docs/docs/epas/12/epas_guide/10_edb_resource_manager.mdx
@@ -340,7 +340,7 @@ edb=# SELECT rgrpname, rgrpcpuratelimit FROM edb_resource_group;
 
 Changing the `cpu_rate_limit` of a resource group not only affects new processes that are assigned to the group, but any currently running processes that are members of the group are immediately affected by the change. That is, if the `cpu_rate_limit` is changed from .5 to .3, currently running processes in the group would be throttled downward so that the aggregate group CPU usage would be near 30% instead of 50%.
 
-To illustrate the effect of setting the CPU rate limit for resource groups, the following examples use a CPU-intensive calculation of 20000 factorial (multiplication of 20000 \* 19999 \* 19998, etc.) performed by the query `SELECT 20000!`; run in the `psql` command line utility.
+To illustrate the effect of setting the CPU rate limit for resource groups, the following examples use a CPU-intensive calculation of 20000 factorial (multiplication of 20000 \* 19999 \* 19998, etc.) performed by the query `SELECT factorial(20000)`; run in the `psql` command line utility.
 
 The resource groups with the CPU rate limit settings shown in the previous query are used in these examples.
 
@@ -356,7 +356,7 @@ edb=# SHOW edb_resource_group;
 --------------------
  resgrp_b
 (1 row)
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 In a second session, the Linux `top` command is used to display the CPU usage as shown under the `%CPU` column. The following is a snapshot at an arbitrary point in time as the `top` command output periodically changes.
@@ -391,7 +391,7 @@ edb=# SHOW edb_resource_group;
 
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 Under the `%CPU` column for `edb-postgres`, the CPU usage is now 93.6, which is significantly higher than the 39.9 when the process was part of the resource group.
@@ -430,7 +430,7 @@ edb=# SHOW edb_resource_group;
  resgrp_b
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 **Session 2:**
@@ -444,7 +444,7 @@ edb=# SHOW edb_resource_group;
  resgrp_b
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 A third session monitors the CPU usage.
@@ -507,7 +507,7 @@ edb=# SHOW edb_resource_group;
  resgrp_c
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 **Session 4:**
@@ -520,7 +520,7 @@ edb=# SHOW edb_resource_group;
 --------------------
  resgrp_c
 (1 row)
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 The `top` command displays the following output.

--- a/product_docs/docs/epas/13/epas_guide/10_edb_resource_manager.mdx
+++ b/product_docs/docs/epas/13/epas_guide/10_edb_resource_manager.mdx
@@ -340,7 +340,7 @@ edb=# SELECT rgrpname, rgrpcpuratelimit FROM edb_resource_group;
 
 Changing the `cpu_rate_limit` of a resource group not only affects new processes that are assigned to the group, but any currently running processes that are members of the group are immediately affected by the change. That is, if the `cpu_rate_limit` is changed from .5 to .3, currently running processes in the group would be throttled downward so that the aggregate group CPU usage would be near 30% instead of 50%.
 
-To illustrate the effect of setting the CPU rate limit for resource groups, the following examples use a CPU-intensive calculation of 20000 factorial (multiplication of 20000 \* 19999 \* 19998, etc.) performed by the query `SELECT 20000!`; run in the `psql` command line utility.
+To illustrate the effect of setting the CPU rate limit for resource groups, the following examples use a CPU-intensive calculation of 20000 factorial (multiplication of 20000 \* 19999 \* 19998, etc.) performed by the query `SELECT factorial(20000)`; run in the `psql` command line utility.
 
 The resource groups with the CPU rate limit settings shown in the previous query are used in these examples.
 
@@ -356,7 +356,7 @@ edb=# SHOW edb_resource_group;
 --------------------
  resgrp_b
 (1 row)
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 In a second session, the Linux `top` command is used to display the CPU usage as shown under the `%CPU` column. The following is a snapshot at an arbitrary point in time as the `top` command output periodically changes.
@@ -391,7 +391,7 @@ edb=# SHOW edb_resource_group;
 
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 Under the `%CPU` column for `edb-postgres`, the CPU usage is now 93.6, which is significantly higher than the 39.9 when the process was part of the resource group.
@@ -430,7 +430,7 @@ edb=# SHOW edb_resource_group;
  resgrp_b
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 **Session 2:**
@@ -444,7 +444,7 @@ edb=# SHOW edb_resource_group;
  resgrp_b
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 A third session monitors the CPU usage.
@@ -507,7 +507,7 @@ edb=# SHOW edb_resource_group;
  resgrp_c
 (1 row)
 
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 **Session 4:**
@@ -520,7 +520,7 @@ edb=# SHOW edb_resource_group;
 --------------------
  resgrp_c
 (1 row)
-edb=# SELECT 20000!;
+edb=# SELECT factorial(20000);
 ```
 
 The `top` command displays the following output.


### PR DESCRIPTION
## What Changed?

Fixed some examples of using `!` instead of `factorial()`. I used:

```
find product_docs/ -name \*.mdx | xargs grep '[0-9]!'
```

to find them. Note that two more files (`product_docs/docs/epas/1[23]/epas_compat_spl/02_spl_programs/07_subprogra
ms_subprocedures_and_subfunctions/02_creating_a_subfunction.mdx`) have that pattern, but they are merely printing out the results of `factorial()` in a human-readable way. So those are safe.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
