### PR TITLE
updated link label

### DIFF
--- a/product_docs/docs/edbcloud/beta/overview/index.mdx
+++ b/product_docs/docs/edbcloud/beta/overview/index.mdx
@@ -4,7 +4,7 @@ description: "Learn about EDB Cloud "
 ---
 <div id="requirements_overview" class="registered_link"></div>
 
-EDB Cloud is a fully managed database as a service with built-in Oracle compatibility, running in your cloud account, and operated by the Postgres experts. EDB Cloud makes it easy to set up, manage, and scale your databases. Provision [PostgreSQL](https://www.enterprisedb.com/docs/supported-open-source/postgresql/) or [EDB Postgres Advanced Server with Oracle compatibility](https://www.enterprisedb.com/docs/epas/latest/). 
+EDB Cloud is a fully managed database as a service with built-in Oracle compatibility, running in your cloud account, and operated by the Postgres experts. EDB Cloud makes it easy to set up, manage, and scale your databases. Provision [PostgreSQL](https://www.enterprisedb.com/docs/supported-open-source/postgresql/) or [EDB Postgres Advanced Server](https://www.enterprisedb.com/docs/epas/latest/) with Oracle compatibility. 
 
 
 


### PR DESCRIPTION
moved  "with Oracle compatibility" to normal text outside of the link label in the Overview of Service index page


- [ ] This PR adds new content
- [x ] This PR changes existing content
- [ ] This PR removes existing content
