### PR TITLE
Hide product version and show banner for EDB Cloud pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -126,6 +126,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
               codelanguages
             }
             hideVersion
+            displayBanner
             directoryDefaults {
               description
               prevNext

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -125,6 +125,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
               initializeCommand
               codelanguages
             }
+            hideVersion
             directoryDefaults {
               description
               prevNext

--- a/product_docs/docs/edbcloud/beta/index.mdx
+++ b/product_docs/docs/edbcloud/beta/index.mdx
@@ -3,6 +3,7 @@ title: EDB Cloud Preview
 description: "EDB Cloud: DBaaS for PostgresSQL "
 indexCards: simple
 hideVersion: true
+displayBanner: 'edbcloud'
 directoryDefaults:
   iconName: clouddb
 navigation:

--- a/product_docs/docs/edbcloud/beta/index.mdx
+++ b/product_docs/docs/edbcloud/beta/index.mdx
@@ -1,7 +1,8 @@
 ---
-title: EDB Cloud
+title: EDB Cloud Preview
 description: "EDB Cloud: DBaaS for PostgresSQL "
 indexCards: simple
+hideVersion: true
 directoryDefaults:
   iconName: clouddb
 navigation:

--- a/src/components/left-nav.js
+++ b/src/components/left-nav.js
@@ -33,6 +33,7 @@ const SectionHeadingWithVersions = ({
   path,
   versionArray,
   iconName,
+  hideVersion,
 }) => {
   return (
     <li className="ml-0 mb-4 d-flex align-items-center">
@@ -49,13 +50,13 @@ const SectionHeadingWithVersions = ({
         >
           {navTree.title}
         </Link>
-        {versionArray.length > 1 ? (
+        {!hideVersion && versionArray.length > 1 ? (
           <div>
             <VersionDropdown versionArray={versionArray} path={path} />
           </div>
-        ) : (
+        ) : !hideVersion ? (
           <div className="text-muted">Version {versionArray[0].version}</div>
-        )}
+        ) : null}
       </div>
     </li>
   );
@@ -68,6 +69,7 @@ const LeftNav = ({
   versionArray,
   iconName,
   hideEmptySections = false,
+  hideVersion = false,
 }) => {
   return (
     <ul className="list-unstyled mt-0">
@@ -78,6 +80,7 @@ const LeftNav = ({
           path={path}
           versionArray={versionArray}
           iconName={iconName}
+          hideVersion={hideVersion}
         />
       ) : (
         <SectionHeading navTree={navTree} path={path} iconName={iconName} />

--- a/src/components/left-nav.js
+++ b/src/components/left-nav.js
@@ -50,11 +50,11 @@ const SectionHeadingWithVersions = ({
         >
           {navTree.title}
         </Link>
-        {!hideVersion && versionArray.length > 1 ? (
+        {!navTree.hideVersion && versionArray.length > 1 ? (
           <div>
             <VersionDropdown versionArray={versionArray} path={path} />
           </div>
-        ) : !hideVersion ? (
+        ) : !navTree.hideVersion ? (
           <div className="text-muted">Version {versionArray[0].version}</div>
         ) : null}
       </div>

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -149,6 +149,8 @@ const treeNodeToNavNode = (treeNode, withItems = false) => {
     path: treeNode.path,
     navTitle: frontmatter?.navTitle,
     title: frontmatter?.title,
+    hideVersion: frontmatter?.hideVersion,
+    displayBanner: frontmatter?.displayBanner,
     depth: treeNode.mdxNode?.fields?.depth,
     iconName: frontmatter?.iconName,
     description: frontmatter?.description,

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -292,7 +292,7 @@ const DocTemplate = ({ data, pageContext }) => {
             </div>
           </div>
 
-          {frontmatter.displayBanner === "edbcloud" ? (
+          {navTree.displayBanner === "edbcloud" ? (
             <div class="alert alert-warning mt-3" role="alert">
               EDB Cloud is currently in Preview mode. If you would like to sign
               up, see{" "}

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -17,6 +17,7 @@ import {
 } from "../components";
 import { products } from "../constants/products";
 import Icon from "../components/icon";
+import { createImportSpecifier } from "typescript";
 
 export const query = graphql`
   query($nodeId: String!, $potentialLatestNodePath: String) {
@@ -290,6 +291,19 @@ const DocTemplate = ({ data, pageContext }) => {
               <FeedbackDropdown githubIssuesLink={githubIssuesLink} />
             </div>
           </div>
+
+          {frontmatter.displayBanner === "edbcloud" ? (
+            <div class="alert alert-warning mt-3" role="alert">
+              EDB Cloud is currently in Preview mode. If you would like to sign
+              up, see{" "}
+              <a
+                className="pl-1 font-weight-bold"
+                href="https://resources.enterprisedb.com/postgres-database-as-a-service-dbaas-cloud-postgresql"
+              >
+                EDB Cloud Preview Signup.
+              </a>
+            </div>
+          ) : null}
 
           <ContentRow>
             <Col xs={showToc ? 9 : 12}>

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -236,10 +236,10 @@ const DocTemplate = ({ data, pageContext }) => {
   const sections = depth === 2 ? buildSections(navTree) : null;
 
   let title = frontmatter.title;
-  if (depth === 2) {
+  if (depth === 2 && !navTree.hideVersion) {
     // product version root
     title += ` v${version}`;
-  } else if (depth > 2) {
+  } else if (depth > 2 && !navTree.hideVersion) {
     const prettyProductName = (
       products[product] || { name: product.toUpperCase() }
     ).name;
@@ -277,9 +277,11 @@ const DocTemplate = ({ data, pageContext }) => {
           <div className="d-flex justify-content-between align-items-center">
             <h1 className="balance-text">
               {frontmatter.title}{" "}
-              <span className="font-weight-light ml-2 text-muted badge-light px-2 rounded text-smaller position-relative lh-1 top-minus-3">
-                v{version}
-              </span>
+              {!navTree.hideVersion && (
+                <span className="font-weight-light ml-2 text-muted badge-light px-2 rounded text-smaller position-relative lh-1 top-minus-3">
+                  v{version}
+                </span>
+              )}
             </h1>
             <div className="d-flex">
               <a

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -269,6 +269,7 @@ const DocTemplate = ({ data, pageContext }) => {
             pagePath={pagePath}
             versionArray={versionArray}
             iconName={iconName}
+            hideVersion={frontmatter.hideVersion}
           />
         </SideNavigation>
         <MainContent>


### PR DESCRIPTION
* Added 2 new keys to the frontmatter of the MDX pages: `hideVersion` and `showBanner`.
* `hideVersion` is expected to be `true` or `false`.
* `showBanner` accepts a `string` ('edbcloud' for this case). The idea is that in the future, we can show banners with different content if needed.
* The 2 new keys are available in the `navTree` so that we only need to define their value on the top-level page.