### PR TITLE
Incorporated feedback from PR#1733

### DIFF
--- a/product_docs/docs/epas/11/epas_guide/10_edb_resource_manager.mdx
+++ b/product_docs/docs/epas/11/epas_guide/10_edb_resource_manager.mdx
@@ -305,6 +305,8 @@ CPU usage of a resource group is controlled by setting the `cpu_rate_limit` reso
 
 Set the `cpu_rate_limit` parameter to the fraction of CPU time over wall-clock time to which the combined, simultaneous CPU usage of all processes in the group should not exceed. Thus, the value assigned to `cpu_rate_limit` should typically be less than or equal to 1.
 
+On multicore systems, you can apply the `cpu_rate_limit` to more than one CPU core by setting it to greater than 1. For example, if `cpu_rate_limit` is set to 2.0, you use 100% of two CPUs.
+
 The valid range of the `cpu_rate_limit` parameter is `0` to `1.67772e+07`. A setting of 0 means no CPU rate limit has been set for the resource group.
 
 When multiplied by `100`, the `cpu_rate_limit` can also be interpreted as the CPU usage percentage for a resource group.

--- a/product_docs/docs/epas/12/epas_guide/10_edb_resource_manager.mdx
+++ b/product_docs/docs/epas/12/epas_guide/10_edb_resource_manager.mdx
@@ -305,6 +305,8 @@ CPU usage of a resource group is controlled by setting the `cpu_rate_limit` reso
 
 Set the `cpu_rate_limit` parameter to the fraction of CPU time over wall-clock time to which the combined, simultaneous CPU usage of all processes in the group should not exceed. Thus, the value assigned to `cpu_rate_limit` should typically be less than or equal to 1.
 
+On multicore systems, you can apply the `cpu_rate_limit` to more than one CPU core by setting it to greater than 1. For example, if `cpu_rate_limit` is set to 2.0, you use 100% of two CPUs.
+
 The valid range of the `cpu_rate_limit` parameter is `0` to `1.67772e+07`. A setting of 0 means no CPU rate limit has been set for the resource group.
 
 When multiplied by `100`, the `cpu_rate_limit` can also be interpreted as the CPU usage percentage for a resource group.

--- a/product_docs/docs/epas/13/epas_guide/10_edb_resource_manager.mdx
+++ b/product_docs/docs/epas/13/epas_guide/10_edb_resource_manager.mdx
@@ -305,6 +305,8 @@ CPU usage of a resource group is controlled by setting the `cpu_rate_limit` reso
 
 Set the `cpu_rate_limit` parameter to the fraction of CPU time over wall-clock time to which the combined, simultaneous CPU usage of all processes in the group should not exceed. Thus, the value assigned to `cpu_rate_limit` should typically be less than or equal to 1.
 
+On multicore systems, you can apply the `cpu_rate_limit` to more than one CPU core by setting it to greater than 1. For example, if `cpu_rate_limit` is set to 2.0, you use 100% of two CPUs.
+
 The valid range of the `cpu_rate_limit` parameter is `0` to `1.67772e+07`. A setting of 0 means no CPU rate limit has been set for the resource group.
 
 When multiplied by `100`, the `cpu_rate_limit` can also be interpreted as the CPU usage percentage for a resource group.


### PR DESCRIPTION
Added this sentence to EDB Resource Manager topic in epas guide v11, 12, 13

On multicore systems, you can apply the `cpu_rate_limit` to more than one CPU core by setting it to greater than 1. For example, if `cpu_rate_limit` is set to 2.0, you use 100% of two CPUs.

- [ ] This PR adds new content
- [ x] This PR changes existing content
- [ ] This PR removes existing content
