### PR TITLE
Remove path-based defaults for card deck nav style

### DIFF
--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -127,14 +127,8 @@ const TileModes = {
 };
 const Tiles = ({ mode, node }) => {
   if (!node || !node.items) return null;
-  if (mode === TileModes.None) return null;
 
-  if (!mode) {
-    if (node.depth === 2) mode = TileModes.Full;
-    else if (node.depth >= 3) mode = TileModes.Simple;
-  }
-
-  if (Object.values(TileModes).includes(mode)) {
+  if (Object.values(TileModes).includes(mode) && mode !== TileModes.None) {
     const tiles = node.items.map((n) => getCards(n, mode === "simple" ? 0 : 1));
 
     return <CardDecks cards={tiles} cardType={mode} />;


### PR DESCRIPTION
## What Changed?

Added card deck functionality for EDBCloud in 8f45da165b8a31c5032f19c5bdbfcc06cc4b5c98 - but left the path-based behavior. That's undesirable for the product template, as it has its own style of index nav (for MOST products). Remove that default - getting this style requires explicit request via `indexCards` frontmatter key.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
