### PR TITLE
Handle URLs to .md or .mdx with fragment or query

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -21,7 +21,7 @@ const stripPathPrefix = (path, pathPrefix) => {
 };
 
 const stripMarkdownExtension = (path) => {
-  return path.replace(/\.mdx?$/, "");
+  return path.replace(/\.mdx?(?=$|\?|#)/, "");
 };
 
 const isAbsoluteOrProtocolRelativeUrl = (url) => {
@@ -29,7 +29,7 @@ const isAbsoluteOrProtocolRelativeUrl = (url) => {
 };
 
 const hasNonMarkdownExtension = (url) => {
-  return url.match(/\.[a-zA-Z]+$/) && !url.match(/\.mdx?$/);
+  return url.match(/\.[a-zA-Z]+$/) && !url.match(/\.mdx?(?=$|\?|#)/);
 };
 
 const rewriteUrl = (url, pageUrl, pageIsIndex, pathPrefix) => {


### PR DESCRIPTION
## What Changed?

Address an issue that cropped up in the CNP import: URLs that point to .md files along with a fragment (e.g., that point to a header).

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
