### PR TITLE
Give new frontmatter options a type so that they can be completely optional

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -426,6 +426,8 @@ exports.createSchemaCustomization = ({ actions }) => {
       legacyRedirects: [String]
       legacyRedirectsGenerated: [String]
       showInteractiveBadge: Boolean
+      hideVersion: Boolean
+      displayBanner: String
     }
 
     enum TileModes {


### PR DESCRIPTION
## What Changed?

This builds on #1721 by making the new frontmatter options optional: with types defined, Gatsby won't try to infer types and will therefore be content if the options are not used anywhere in the codebase. 

My immediate need for this involves being weary of Heroku builds failing, but I do foresee a time when the banner won't be needed anywhere and thus removing it entirely might be useful.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
