### PR TITLE
Updated the restrictions on data types

### DIFF
--- a/product_docs/docs/eprs/6.2/02_overview/04_design_replication_system/03_restrictions_on_replicated_database_objects.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/04_design_replication_system/03_restrictions_on_replicated_database_objects.mdx
@@ -77,6 +77,9 @@ For replicating Postgres partitioned tables see [Replicating Postgres Partitione
 -   `BLOB`
 -   `BYTEA`
 -   `RAW`
+
+PostgreSQL or EDB Postgres Advanced Server database tables that include the following data types cannot be replicated to the Oracle database:
+
 -   `JSON`
 -   `JSONB`
 

--- a/product_docs/docs/eprs/6.2/02_overview/04_design_replication_system/03_restrictions_on_replicated_database_objects.mdx
+++ b/product_docs/docs/eprs/6.2/02_overview/04_design_replication_system/03_restrictions_on_replicated_database_objects.mdx
@@ -77,6 +77,9 @@ For replicating Postgres partitioned tables see [Replicating Postgres Partitione
 -   `BLOB`
 -   `BYTEA`
 -   `RAW`
+-   `JSON`
+-   `JSONB`
+
 
 Postgres tables that include `OID` based large objects cannot be replicated. For information on `OID` based large objects see `pg_largeobject` in the PostgreSQL Core Documentation located at:
 


### PR DESCRIPTION
## What Changed?

Updated the Replication Serve User's guide v6.2 to include the restrictions on the PG database objects.



Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [X ] This PR changes existing content
- [ ] This PR removes existing content
