### PR TITLE
Update index.mdx

### DIFF
--- a/product_docs/docs/pem/7/pem_rel_notes/index.mdx
+++ b/product_docs/docs/pem/7/pem_rel_notes/index.mdx
@@ -9,6 +9,5 @@ The Postgres Enterprise Manager (PEM) documentation describes the latest version
 | [7.15](02_715_rel_notes) | 23 Jul 2020 | pgAdmin [4.22](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_22.html#bug-fixes), [4.23](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_23.html#bug-fixes), [4.24](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_24.html#bug-fixes) |
 | [7.14](03_714_rel_notes) | 14 May 2020 | pgAdmin [4.20](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_20.html#bug-fixes), [4.21](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_21.html#bug-fixes) |
 | [7.13](04_713_rel_notes) | 26 Feb 2020 | pgAdmin [4.17](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_17.html#bug-fixes), [4.18](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_18.html#bug-fixes), [4.19](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_19.html#bug-fixes) |
-| [7.12](05_712_rel_notes) | 18 Dec 2019 | pgAdmin [4.15](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_15.html#bug-fixes), [4.16](https://www.pgadmin.org/docs/pgadmin4/5.3/release_notes_4_16.html#bug-fixes) |
 
 Often only select issues are included in the upstream merges. The specific issues included in the merges are listed in the release note topics.


### PR DESCRIPTION
Delete the 7.12 version from here and also in the pulldown menu on the left column for "Version 7". EOL for PEM 7.12 was August 26, 2021.

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [X ] This PR removes existing content
