### PR TITLE
Clean up Netlify redirects, write guidance for usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ The app is concerned with two different types of redirects that can be defined i
 
 ### Internal Redirects (within Docs 2.0)
 
+*For specific examples of when to use redirects, see: [How to avoid breaking links when reorganizing, consolidating or deprecating content](docs/how-tos/avoid-breaking-links.md).*
+
 #### `redirects`
 
 The `redirects` frontmatter is to be used for redirects internal to Docs. For example, if you had a file `great_file.mdx` with this following frontmatter...
@@ -180,7 +182,17 @@ redirects:
   - "/another_old_path"
 ```
 
-both `/old_path` and `/another_old_path` would redirect to `great_file.mdx`'s current path. This is perfect for setting up redirects when moving a file around within Docs. Redirects created with `redirects` are permanent (301).
+both `/old_path` and `/another_old_path` would redirect to `great_file.mdx`'s current path. This is perfect for setting up redirects when moving a file around within Docs. Redirects created with `redirects` are permanent (301). 
+
+These paths can be absolute (starting with the root of the site) or relative (to the file in which they are contained). For a `/file/at/path/`,
+
+   - Absolute: `/path/to/file/` - redirects requests for /path/to/file to /file/at/path/ 
+   - Relative: `former_child/` - redirects requests for /file/at/path/former_child/ to /file/at/path/
+   - Relative: `../sibling/` - redirects requests for /file/at/sibling/ to /file/at/path/
+
+#### Netlify-specific redirects
+
+Netlify is the hosting service we use for Docs. Netlify-specific redirects can be found in [`/static/_redirects`](static/_redirects). These are generally used for large-scale redirects, such as when renaming or removing an entire product version.
 
 ### Docs 1.0 to Docs 2.0 redirects
 

--- a/docs/how-tos/avoid-breaking-links.md
+++ b/docs/how-tos/avoid-breaking-links.md
@@ -1,0 +1,121 @@
+# How to avoid breaking links when reorganizing, consolidating or deprecating content
+
+Once a page has been published, links to it proliferate on the Internet: some in public (documentation, blog posts, search engine results) and some in private (emails, chat history, bookmarks, browser histories). When those links are broken, it results in frustration for readers, loss of traffic, and loss of trust - both the algorithmic "trust" endowed by search engines and the real sort of trust granted by people.
+
+We should do our best to avoid causing frustration. We need that trust! 
+
+Yet, we cannot and should not keep every published file around in the same location forever. It is often necessary to reorganize content, moving files around, moving topics between files, consolidating information from multiple files into one, even removing files, directories, or entire sets of documentation (as when a product version reaches its end of life). 
+
+Fortunately, we have tools available to us in the form of [redirects](https://github.com/EnterpriseDB/docs#redirects) that can allow us to preserve the utility of outstanding links without hindering our ability to curate and manage content. This guide covers their use in several common scenarios.
+
+## Renaming a file
+
+Suppose I have a file: `/product_docs/docs/epas/13/epas_inst_linux/02_supported_platforms.mdx`. The URL for the published version of this file when EPAS 13 is the latest version will be https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/02_supported_platforms/ (once EPAS 14 is released, it will be https://www.enterprisedb.com/docs/epas/13/epas_inst_linux/02_supported_platforms/). 
+
+I would like to rename this file to be simply, `supported_platforms.mdx`. The URL would then be https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/supported_platforms/. But I would like the old URL to continue to work!
+
+I can add a redirect rule to the page's Frontmatter for this:
+
+```yaml
+---
+#...
+
+redirects:
+  # note that this is the absolute URL path (not including /docs), NOT a filesystem path
+  - /epas/13/epas_inst_linux/02_supported_platforms  
+---
+```
+
+Now requests to https://www.enterprisedb.com/docs/epas/13/epas_inst_linux/02_supported_platforms/ OR https://www.enterprisedb.com/docs/epas/13/epas_inst_linux/supported_platforms/ will take me to the same file.
+
+But what about https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/02_supported_platforms/? That will work too - up UNTIL version 13 is no longer the latest version. Suppose I want to write this redirect rule such that it will work for EPAS 13 OR any later version (assuming the file is copied into later versions without modifications to the Frontmatter)? To accomplish this, I can use a relative path:
+
+```yaml
+---
+#...
+
+redirects:
+  # this is relative to /epas/13/epas_inst_linux/02_supported_platforms/ and indicates a (missing) "sibling" 
+  # - so I have to go "up" a level first (with ../) 
+  - ../02_supported_platforms  
+---
+```
+
+This same rule will work, without modification, for ANY version in which `supported_platforms.mdx` exists and `02_supported_platforms.mdx` does not. It thus avoids the housekeeping task of having to modify versions contained within
+redirects when forking a version of the documentation (though do note that if a documentation tree has ALREADY been forked when I rename the file I'll need to make the same changes to both the current version and the next version).
+
+## Relocating a file
+
+Suppose I have a file, `/[whatever]/installation/connecting.mdx`. And I wish to move it to a more appropriate location under `/[whatever]/usage`. I need only include the former path in the redirects to avoid breaking links:
+
+```yaml
+---
+#...
+
+redirects:
+  - /[whatever]/installation/connecting/
+---
+```
+
+This is just a variation on what is shown above (renaming). I could also use a relative path here as well.
+
+## Consolidating files
+
+Suppose I have a collection of files that each tackle part of a topic:
+
+- `/[whatever]/installation/index.mdx` overview of an installer
+- `/[whatever]/installation/supported_platforms.mdx` covers the platforms that are supported by an installer
+- `/[whatever]/installation/prerequesites.mdx` covers what is needed before installation can begin
+- `/[whatever]/installation/download.mdx` covers obtaining the installer
+- `/[whatever]/installation/running.mdx` covers the steps involved in actually running the installer
+- `/[whatever]/installation/post_install.mdx` covers any actions needed after the installer has completed
+
+I decide to move all of these into sections in a single file, `/[whatever]/installation.mdx`. 
+In order to avoid breaking the links, I'll need five `redirects` values:
+
+```yaml
+---
+#...
+
+redirects:
+  # these are relative to /[whatever]/installation/
+  - supported_platforms
+  - prerequesites
+  - download
+  - running
+  - post_install
+---
+```
+
+As in the previous example, by using relative paths I'm able to avoid pinning these to a specific 
+version of the product. Because the new `installation.mdx` is replacing the former `installation/index.mdx` (and will have the same URL path), it does not need to be included.
+
+## Removing an End-of-Life version
+
+The previous examples have all concerned content that must continue to exist in some form, but all good things must come to an end: product versions eventually stop being supported and their documentation is archived and removed. Even then, we can provide a better experience than a 404 (Not Found) result! Consider what we might do for the removal of a product version, let's say EPAS 9.6: instead of dropping all links, we can redirect them to `/epas/latest/` - thus providing a stable link that will not soon go out of date and can provide access to at least *some* relevant information!
+
+Adding these redirects via Frontmatter would be prohibitive: we'd have to add thousands of entries for each deprecated version! A more maintainable solution can be found via [Netlify redirects](../../static/_redirects) - you can view that file for more details, but for our example a rule would look like this:
+
+```
+/docs/epas/9.6/*   /docs/epas/latest/   301
+# ^           ^                 ^ type of redirect (301 == permanent, 302 or 307 == temporary)
+# |           + path to redirect to
+# + path to redirect (with asterisk wildcard to match all paths starting with that pattern)
+```
+
+Note: UNLIKE the Gatsby redirects shown above, these paths *do* include the `/docs` prefix.
+
+## Consolidating versions
+
+This is similar to the previous example, but concerns a version of documentation that is being eliminated in favor of a more comprehensive version - for example, consolidating all 7.* versions of PEM into one set of Version 7 documentation. Once again, using Frontmatter redirects would result in an unacceptable amount of error-prone work; we'll use [Netlify redirects](../../static/_redirects) here too, but introduce the `:splat` keyword:
+
+```
+/docs/pem/7.12/*  /docs/pem/7/:splat  301
+/docs/pem/7.13/*  /docs/pem/7/:splat  301
+/docs/pem/7.14/*  /docs/pem/7/:splat  301
+/docs/pem/7.15/*  /docs/pem/7/:splat  301
+/docs/pem/7.16/*  /docs/pem/7/:splat  301
+```
+
+As with the EOL'd product version, these rules match all paths starting with the eliminated version prefix (e.g. /docs/pem/7.12), with the asterisk matching the rest of the path. However, instead of redirecting all such requests to the root of the product docs, the path will be rewritten to start with `/docs/pem/7` while preserving the rest! The `:splat` keyword takes whatever the asterisk (also known as a "splat") matches, and includes it in the redirected destination.
+

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -219,8 +219,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     // set computed frontmatter
     node.frontmatter = computeFrontmatterForTreeNode(curr);
 
-    configureRedirects(node.fields.path, node.frontmatter.redirects, actions);
-
     // build navigation tree
     const navigationDepth = 2;
     let navRoot = curr;
@@ -231,6 +229,18 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     const prevNext = findPrevNextNavNodes(navTree, curr);
 
     const { docType } = node.fields;
+
+    const isLatest =
+      docType === "doc"
+        ? productVersions[node.fields.product][0] === node.fields.version
+        : false;
+    configureRedirects(
+      node.fields.path,
+      isLatest,
+      node.frontmatter.redirects,
+      actions,
+    );
+
     if (docType === "doc") {
       createDoc(navTree, prevNext, node, productVersions, actions);
     } else if (docType === "advocacy") {

--- a/product_docs/docs/epas/13/edb_plus/03_installing_edb_plus.mdx
+++ b/product_docs/docs/epas/13/edb_plus/03_installing_edb_plus.mdx
@@ -2,6 +2,10 @@
 title: "Installing EDB*Plus"
 legacyRedirects:
   - "/edb-docs/d/edbplus/user-guides/edbplus-users-guide/39/installing_edb_plus.html"
+redirects:
+  - "01_installing_prereq"
+  - "02_rpm_installation"
+  - "03_using_gui"
 ---
 
 <div id="installing_edb_plus" class="registered_link"></div>

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 
 const sortVersionArray = (versions) => {
   return versions.sort((a, b) =>
@@ -251,9 +252,17 @@ const findPrevNextNavNodes = (navTree, currNode) => {
   return prevNext;
 };
 
-const configureRedirects = (toPath, redirects, actions, config = {}) => {
+const configureRedirects = (
+  toPath,
+  toIsLatest,
+  redirects,
+  actions,
+  config = {},
+) => {
   if (!redirects) return;
   redirects.forEach((fromPath) => {
+    // allow relative paths in redirects
+    fromPath = path.resolve("/", toPath, fromPath).replace(/\/*$/, "/");
     actions.createRedirect(
       Object.assign(
         {
@@ -265,6 +274,20 @@ const configureRedirects = (toPath, redirects, actions, config = {}) => {
         config,
       ),
     );
+    if (toIsLatest) {
+      actions.createRedirect(
+        Object.assign(
+          {
+            fromPath: replacePathVersion(fromPath),
+            toPath: replacePathVersion(toPath),
+            redirectInBrowser: true,
+            isPermanent: false,
+            force: true,
+          },
+          config,
+        ),
+      );
+    }
   });
 };
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,28 @@
-# see https://docs.netlify.com/routing/redirects/redirect-options/
+# Redirect rules in this file apply to Netlify only!
+# For hosting-agnostic Gatsby redirects, use the `redirects` key in page frontmatter
+# Also prefer the `redirects` key for localized changes, such as renaming a single file,
+# consolidating a few files into one page, moving a file to a new location, etc.
+# See also: 
+
+# Usage guidance:
+#   For EOL / deprecated product MAJOR versions, include a rule that redirects 
+#   all pages under that product and version to the root of the "latest" version
+#   Ex:
+#      /docs/bart/2.4/* /docs/bart/latest/ 301
+#
+#   For product versions that have been consolidated or renamed, or for MINOR versions
+#   that have reached EOL, redirect all pages under the old route to an equivalent page
+#   under the new route via the use of a :splat placeholder (this will be expanded to
+#   the sub-path matched by the wildcard (*) in the rule)
+#   Ex:
+#      /docs/bart/2.5.9/* /docs/bart/2.5/:splat 301
+#   
+#   301 vs 302: use 301 for routes that are guaranteed to never be used again. Use 302 if
+#   there is ANY chance that a route might see use in the future. For example: if a product
+#   was released with version 3.1.1 and then quickly reversioned to 3.1, use a 302 redirect
+#   - this ensures that if a version 3.1.1 IS ever needed, the redirect won't be cached.
+#
+# See also: https://docs.netlify.com/routing/redirects/redirect-options/
 
 # Docs 2.0 Redirects
 /docs/kubernetes/cloud_native_operator/*  /docs/kubernetes/cloud_native_postgresql/:splat  302
@@ -9,24 +33,26 @@
 
 # BART
 /docs/bart/2.4/*  /docs/bart/latest/  301
-/docs/bart/2.5.1/*  /docs/bart/latest/  301
-/docs/bart/2.5.2/*  /docs/bart/latest/  301
-/docs/bart/2.5.3/*  /docs/bart/latest/  301
-/docs/bart/2.5.4/*  /docs/bart/latest/  301
-/docs/bart/2.5.5/*  /docs/bart/latest/  301
-/docs/bart/2.5.7/*  /docs/bart/latest/  301
-/docs/bart/2.5.9/*  /docs/bart/latest/  301
-/docs/bart/2.6.1/*  /docs/bart/latest/  301
-/docs/bart/2.6.2/*  /docs/bart/latest/  301
+/docs/bart/2.5.1/*  /docs/bart/2.5/:splat  301
+/docs/bart/2.5.2/*  /docs/bart/2.5/:splat  301
+/docs/bart/2.5.3/*  /docs/bart/2.5/:splat  301
+/docs/bart/2.5.4/*  /docs/bart/2.5/:splat  301
+/docs/bart/2.5.5/*  /docs/bart/2.5/:splat  301
+/docs/bart/2.5.7/*  /docs/bart/2.5/:splat  301
+/docs/bart/2.5.9/*  /docs/bart/2.5/:splat  301
+/docs/bart/2.6.1/*  /docs/bart/2.6/:splat  301
+/docs/bart/2.6.2/*  /docs/bart/2.6/:splat  301
 
 # EPAS
 /docs/epas/9.5/*  /docs/epas/latest/  301
 
 # PEM
-/docs/pem/7.6/*  /docs/pem/latest/  301
-/docs/pem/7.7/*  /docs/pem/latest/  301
-/docs/pem/7.8/*  /docs/pem/latest/  301
-/docs/pem/7.9/*  /docs/pem/latest/  301
+#   EOL'd versions
+/docs/pem/7.6/*  /docs/pem/7/:splat  301
+/docs/pem/7.7/*  /docs/pem/7/:splat  301
+/docs/pem/7.8/*  /docs/pem/7/:splat  301
+/docs/pem/7.9/*  /docs/pem/7/:splat  301
+# Collapsed versions
 /docs/pem/7.12/*  /docs/pem/7/:splat  301
 /docs/pem/7.13/*  /docs/pem/7/:splat  301
 /docs/pem/7.14/*  /docs/pem/7/:splat  301
@@ -40,15 +66,15 @@
 
 # EFM
 #   EOL'd versions
-/docs/efm/3.6/*  /docs/efm/latest/  301
-/docs/efm/3.7/*  /docs/efm/latest/  301
+/docs/efm/3.6/*  /docs/efm/latest/:splat  301
+/docs/efm/3.7/*  /docs/efm/latest/:splat  301
 #   collapsed versions
-/docs/efm/3.8/*  /docs/efm/3/  301
-/docs/efm/3.9/*  /docs/efm/3/  301
-/docs/efm/3.10/*  /docs/efm/3/  301
-/docs/efm/4.0/*  /docs/efm/4/  301
-/docs/efm/4.1/*  /docs/efm/4/  301
-/docs/efm/4.2/*  /docs/efm/4/  301
+/docs/efm/3.8/*  /docs/efm/3/:splat  301
+/docs/efm/3.9/*  /docs/efm/3/:splat  301
+/docs/efm/3.10/*  /docs/efm/3/:splat  301
+/docs/efm/4.0/*  /docs/efm/4/:splat  301
+/docs/efm/4.1/*  /docs/efm/4/:splat  301
+/docs/efm/4.2/*  /docs/efm/4/:splat  301
 
 # MTK
 /docs/migration_toolkit/53.0.1/*  /docs/migration_toolkit/latest/  301


### PR DESCRIPTION
## What Changed?

This started as a quick fix for a few files that were consolidated in the EPAS 13 docs, and turned into a tweak to Frontmatter redirect functionality, a review of existing Netlify redirects, and an expansion of the guidance available for using redirects.

When you get a chance,

- @jericson would you mind reviewing the changes / additions to README.md, docs/how-tos/avoid-breaking-links.md, and _redirects for accuracy and narrative flow?
- @drothery-edb and @nidhibhammar could you review the same for applicability to your work and unanswered questions?
- @frago12 would you mind doing a quick sanity-check of my changes to gatsby-node.js and gatsby-util.js?

