### PR TITLE
Redirects & version corrections for Migration Toolkit 

### DIFF
--- a/product_docs/docs/migration_toolkit/54/mtk_rel_notes/08_mkt_5401_rel_notes.mdx
+++ b/product_docs/docs/migration_toolkit/54/mtk_rel_notes/08_mkt_5401_rel_notes.mdx
@@ -1,10 +1,8 @@
 ---
-title: "Version 55.1.0"
-
-# need to add a redirect as this file was originally named 01_whats_new.mdx
+title: "Version 54.0.1"
 ---
 
-New features, enhancements, bug fixes, and other changes in Migration Toolkit 55.1.0 include:
+New features, enhancements, bug fixes, and other changes in Migration Toolkit 54.0.1 include:
 
 | Type | Description |
 | ---- |------------ |

--- a/product_docs/docs/migration_toolkit/54/mtk_rel_notes/09_mkt_54_rel_notes.mdx
+++ b/product_docs/docs/migration_toolkit/54/mtk_rel_notes/09_mkt_54_rel_notes.mdx
@@ -1,10 +1,8 @@
 ---
 title: "Version 54.0.0"
-
-# need to add a redirect as this file was originally named 01_whats_new.mdx
 ---
 
-New features, enhancements, bug fixes, and other changes in Migration Toolkit 55.0.0 include:
+New features, enhancements, bug fixes, and other changes in Migration Toolkit 54.0.0 include:
 
 | Type | Description |
 | ---- |------------ |

--- a/product_docs/docs/migration_toolkit/54/mtk_rel_notes/index.mdx
+++ b/product_docs/docs/migration_toolkit/54/mtk_rel_notes/index.mdx
@@ -1,10 +1,13 @@
 ---
 title: "Release Notes"
+redirects:
+  - ../01_whats_new.mdx
 ---
+
 The Migration Toolkit documentation describes the latest version of Migration Toolkit 54 including minor releases and patches. The release notes in this section provide information on what was new in each release. For new functionality introduced in a minor or patch release, there are also indicators within the content about what release introduced the feature.
 
 | Version | Release Date | 
 | ------- | ------------ | 
 | [54.0.1](08_mkt_5401_rel_notes) | 30 Apr 2021  |
-| [54.0.0](09_mkt_55_rel_notes) | 5 Nov 2020 |
+| [54.0.0](09_mkt_54_rel_notes) | 5 Nov 2020 |
 

--- a/product_docs/docs/migration_toolkit/54/mtk_rel_notes/index.mdx
+++ b/product_docs/docs/migration_toolkit/54/mtk_rel_notes/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Release Notes"
 redirects:
-  - ../01_whats_new.mdx
+  - ../01_whats_new/
 ---
 
 The Migration Toolkit documentation describes the latest version of Migration Toolkit 54 including minor releases and patches. The release notes in this section provide information on what was new in each release. For new functionality introduced in a minor or patch release, there are also indicators within the content about what release introduced the feature.

--- a/product_docs/docs/migration_toolkit/55/mtk_rel_notes/08_mkt_551_rel_notes.mdx
+++ b/product_docs/docs/migration_toolkit/55/mtk_rel_notes/08_mkt_551_rel_notes.mdx
@@ -1,7 +1,5 @@
 ---
 title: "Version 55.1.0"
-
-# need to add a redirect as this file was originally named 01_whats_new.mdx
 ---
 
 New features, enhancements, bug fixes, and other changes in Migration Toolkit 55.1.0 include:

--- a/product_docs/docs/migration_toolkit/55/mtk_rel_notes/09_mkt_55_rel_notes.mdx
+++ b/product_docs/docs/migration_toolkit/55/mtk_rel_notes/09_mkt_55_rel_notes.mdx
@@ -1,7 +1,5 @@
 ---
 title: "Version 55.0.0"
-
-# need to add a redirect as this file was originally named 01_whats_new.mdx
 ---
 
 New features, enhancements, bug fixes, and other changes in Migration Toolkit 55.0.0 include:

--- a/product_docs/docs/migration_toolkit/55/mtk_rel_notes/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/mtk_rel_notes/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Release Notes"
 redirects:
-  - ../01_whats_new.mdx
+  - ../01_whats_new/
 ---
 
 The Migration Toolkit documentation describes the latest version of Migration Toolkit 55 including minor releases and patches. The release notes in this section provide information on what was new in each release. For new functionality introduced in a minor or patch release, there are also indicators within the content about what release introduced the feature.

--- a/product_docs/docs/migration_toolkit/55/mtk_rel_notes/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/mtk_rel_notes/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Release Notes"
+redirects:
+  - ../01_whats_new.mdx
 ---
+
 The Migration Toolkit documentation describes the latest version of Migration Toolkit 55 including minor releases and patches. The release notes in this section provide information on what was new in each release. For new functionality introduced in a minor or patch release, there are also indicators within the content about what release introduced the feature.
 
 | Version | Release Date | 

--- a/static/_redirects
+++ b/static/_redirects
@@ -77,7 +77,11 @@
 /docs/efm/4.2/*  /docs/efm/4/:splat  301
 
 # MTK
+# EOL'd versions
 /docs/migration_toolkit/53.0.1/*  /docs/migration_toolkit/latest/  301
+# Collapsed versions
+/docs/migration_toolkit/54.0.0/*  /docs/migration_toolkit/54/:splat  301
+/docs/migration_toolkit/55.0.0/*  /docs/migration_toolkit/55/:splat  301
 
 # FDWs
 /docs/hadoop_data_adapter/2.0/*  /docs/hadoop_data_adapter/latest/  301


### PR DESCRIPTION
## What Changed?

- Add redirects from old versioning scheme (xx.x.x -> xx) in _redirects
- Add specific redirects for release notes
- Correct several references to v55 in the v54 docs

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
