### PR TITLE
Avoid inadvertently redirecting page to itself

### DIFF
--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -252,41 +252,29 @@ const findPrevNextNavNodes = (navTree, currNode) => {
   return prevNext;
 };
 
-const configureRedirects = (
-  toPath,
-  toIsLatest,
-  redirects,
-  actions,
-  config = {},
-) => {
+const configureRedirects = (toPath, toIsLatest, redirects, actions) => {
   if (!redirects) return;
   redirects.forEach((fromPath) => {
     // allow relative paths in redirects
     fromPath = path.resolve("/", toPath, fromPath).replace(/\/*$/, "/");
-    actions.createRedirect(
-      Object.assign(
-        {
-          fromPath,
-          toPath: toPath,
-          redirectInBrowser: true,
-          isPermanent: true,
-        },
-        config,
-      ),
-    );
+    if (fromPath !== toPath)
+      actions.createRedirect({
+        fromPath,
+        toPath,
+        redirectInBrowser: true,
+        isPermanent: true,
+      });
     if (toIsLatest) {
-      actions.createRedirect(
-        Object.assign(
-          {
-            fromPath: replacePathVersion(fromPath),
-            toPath: replacePathVersion(toPath),
-            redirectInBrowser: true,
-            isPermanent: false,
-            force: true,
-          },
-          config,
-        ),
-      );
+      fromPath = replacePathVersion(fromPath);
+      toPath = replacePathVersion(toPath);
+      if (fromPath !== toPath)
+        actions.createRedirect({
+          fromPath,
+          toPath,
+          redirectInBrowser: true,
+          isPermanent: false,
+          force: true,
+        });
     }
   });
 };


### PR DESCRIPTION
## What Changed?

In #1852 I added support for stable redirects to the latest version and relative redirects, both as a belt-and-suspenders approach to avoiding broken redirects as versions are forked and superseded. However... Both of these provide a path to inadvertently creating infinite redirects via a page that redirects to itself. 

We shouldn't allow that. Even explicitly. While preventing redirect loops (page redirects to redirect to itself via some out-of-band method) is somewhat more complex, avoiding the obvious mistake of creating an explicit redirect to the URL being requested is trivial - this PR adds a check for that. 

I observed this behavior in https://www.enterprisedb.com/docs/migration_portal/latest/ - it works via navigation from the main page (handled by Gatsby's router) but redirects infinitely when JavaScript is off or the URL is requested cold.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
