### PR TITLE
Fix auto-gen redirects for pglogical to allow existing links to work

### DIFF
--- a/product_docs/docs/pglogical/3.7/subscriptions/index.mdx
+++ b/product_docs/docs/pglogical/3.7/subscriptions/index.mdx
@@ -2,8 +2,6 @@
 navigation:
   - subscriptions
   - pglogical-writer
-redirects:
-  - ../subscriptions
 navTitle: Subscriptions
 title: Subscription Overview
 originalFilePath: subscriptions.md

--- a/product_docs/docs/pglogical/3.7/subscriptions/pglogical-writer.mdx
+++ b/product_docs/docs/pglogical/3.7/subscriptions/pglogical-writer.mdx
@@ -1,6 +1,6 @@
 ---
 redirects:
-  - ../pglogical-writer
+  - ../../pglogical-writer
 navTitle: pglogical Writer
 title: pglogical writer
 originalFilePath: pglogical-writer.md

--- a/scripts/source/pglogical.js
+++ b/scripts/source/pglogical.js
@@ -5,9 +5,9 @@
 const path = require("path");
 const fs = require("fs/promises");
 const { read, write } = require("to-vfile");
-const remarkParse = require("@mdx-js/mdx/node_modules/remark-parse");
+const remarkParse = require("remark-parse");
 const mdx = require("remark-mdx");
-const unified = require("@mdx-js/mdx/node_modules/unified");
+const unified = require("unified");
 const remarkFrontmatter = require("remark-frontmatter");
 const remarkStringify = require("remark-stringify");
 const admonitions = require("remark-admonitions");
@@ -42,11 +42,13 @@ const basePath = path.resolve("temp_pglogical3/docs/");
           {
             if (subDest && !(subDest instanceof Array))
             {
-              if (!subIndexFilename) subIndexFilename = subDest;
-              fileToMetadata[subDest] = {
-                ...fileToMetadata[subDest], 
-                redirects: ["../" + path.basename(subDest, ".md")]
-              };    
+              if (!subIndexFilename) 
+                subIndexFilename = subDest;
+              else
+                fileToMetadata[subDest] = {
+                  ...fileToMetadata[subDest], 
+                  redirects: ["../../" + path.basename(subDest, ".md")]
+                };    
             }
           }
         }


### PR DESCRIPTION
## What Changed?

I had to make some modifications to paths for pages where the original structure applied a navigation heirarchy in the sidebar but not in the path structure; intended to have redirects to avoid breaking links, but got relative links wrong - probably a sign that my relative redirects logic is... confusing. Not a great sign!

Regardless, that left a link broken for pglogical; this fixes that.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
