### PR TITLE
update EDB cloud administration permission names from database to cluster

### DIFF
--- a/product_docs/docs/edbcloud/beta/administering_cluster/01_portal_access.mdx
+++ b/product_docs/docs/edbcloud/beta/administering_cluster/01_portal_access.mdx
@@ -27,13 +27,13 @@ Permissions are generally represented in the format *action*:*object* where *act
 
 The available *actions* are: create, read, update, delete
 
-The available *objects* are: backups, billing, databases, events, permissions, roles, tickets, users,  versions
+The available *objects* are: backups, billing, clusters, events, permissions, roles, tickets, users,  versions
 
 ### Permissions by Role
 
 The following are the default permission by role:
 
-| Role        | Action |backups | billing | databases | events | roles | permissions | tickets | users | versions |
+| Role        | Action |backups | billing | clusters  | events | roles | permissions | tickets | users | versions |
 |-------------|--------|--------|---------|-----------|--------|-------|-------------|---------|-------|----------|
 | owner       | create |   x    |         |     x     |        |    x  |       x     |     x   |   x   |    x     |
 |             | read   |   x    |    x    |     x     |   x    |    x  |       x     |     x   |   x   |    x     |

--- a/product_docs/docs/edbcloud/beta/administering_cluster/03_account_activity.mdx
+++ b/product_docs/docs/edbcloud/beta/administering_cluster/03_account_activity.mdx
@@ -12,7 +12,8 @@ Events describe actions performed by users. The available actions are:
 * delete
 
 Events are related to the following resource types:
-* database
+* cluster
+* data plane
 * user
 * user roles
 * role permissions
@@ -21,7 +22,7 @@ Events are related to the following resource types:
 !!! Note
     Database events are **not** logging activity on the Postgres server. They are logging the use of the portal to create or modify database clusters.
 
-## Viewing and Searching the Activity Log 
+## Viewing and Searching the Activity Log
 
 To view events, navigate to the [Activity Log](https://portal.edbcloud.com/activityLog) page on the [EDB Cloud](https://portal.edbcloud.com) portal. To search events, use the filters at the top of the page.
 


### PR DESCRIPTION
## What Changed?

This PR changes 

- the EDB Cloud product documentation to use the correct term mentioned from https://enterprisedb.atlassian.net/browse/UPM-1752 which is defined by the offering manager to 
- use "cluster" to replace the original "database" term to stand for one customer's EDB Cloud PG cluster. 

The corresponding changes of the product will be released today. 

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
