### PR TITLE
Release/2021-10-07

### DIFF
--- a/product_docs/docs/edbcloud/beta/overview/02_high_availibility.mdx
+++ b/product_docs/docs/edbcloud/beta/overview/02_high_availibility.mdx
@@ -16,7 +16,7 @@ The high availability option is provided to minimize downtime in cases of failur
 
 Incoming client connections are always routed to the current primary. In case of failure of the primary, a standby replica will automatically be promoted to primary and new connections will be routed to the new primary. When the old primary recovers, it will re-join the cluster as a replica.
 
-By default, one replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit - in PostgreSQL terms, `synchronous_commit` is set to `on` and `synchronous_standby_names` is set to `ANY 1 (replica-1, replica-2)`. This behavior can be modified on a per-transaction, per-session, per-user, or per-database basis with appropriate `SET` or `ALTER` commands.
+By default, replication is synchronous to one replica and asynchronous to the other. That is, one replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. In PostgreSQL terms, `synchronous_commit` is set to `on` and `synchronous_standby_names` is set to `ANY 1 (replica-1, replica-2)`. This behavior can be modified on a per-transaction, per-session, per-user, or per-database basis with appropriate `SET` or `ALTER` commands.
 
 ## High Availability - Not Enabled
 


### PR DESCRIPTION
Clarified default behavior of replica servers in HA environments in EDB Cloud docs in response to feedback 