### PR TITLE
Added link to Repostor Guide on Docs Homepage

### DIFF
--- a/product_docs/docs/pem/8/pem_online_help/images/tuning_wiz_apply_changes.png
+++ b/product_docs/docs/pem/8/pem_online_help/images/tuning_wiz_apply_changes.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d16234ff35f1b9bb28100852e6cbdfe6e2c08569fb7c5e168165cad405c4362c
-size 83566

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -241,6 +241,9 @@ const Page = () => (
             <IndexCardLink to="/partner_docs/NutanixGuide">
               Nutanix AHV
             </IndexCardLink>
+            <IndexCardLink to="/partner_docs/RepostorGuide">
+              Repostor Data Protector for PostgresSQL
+            </IndexCardLink>
             <IndexCardLink to="/partner_docs/ThalesGuide">
               Thales CipherTrust Transparent Encryption
             </IndexCardLink>


### PR DESCRIPTION
Link to Repostor Guide is added between Nutanix Guide and Thales Guide