### PR TITLE
Update EDB Cloud portal access with latest permissions changes

### DIFF
--- a/product_docs/docs/edbcloud/beta/administering_cluster/01_portal_access.mdx
+++ b/product_docs/docs/edbcloud/beta/administering_cluster/01_portal_access.mdx
@@ -27,26 +27,29 @@ Permissions are generally represented in the format *action*:*object* where *act
 
 The available *actions* are: create, read, update, delete
 
-The available *objects* are: backups, billing, clusters, events, permissions, roles, tickets, users,  versions
+The available *objects* are: backups, billing, clusters, events, permissions, roles, users,  versions
+
+!!! Note
+    Not every object supports all the actions. A typical example is *versions* object is always *read* only.
 
 ### Permissions by Role
 
 The following are the default permission by role:
 
-| Role        | Action |backups | billing | clusters  | events | roles | permissions | tickets | users | versions |
-|-------------|--------|--------|---------|-----------|--------|-------|-------------|---------|-------|----------|
-| owner       | create |   x    |         |     x     |        |    x  |       x     |     x   |   x   |    x     |
-|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |     x   |   x   |    x     |
-|             | update |   x    |         |     x     |        |    x  |       x     |     x   |   x   |    x     |
-|             | delete |   x    |         |     x     |        |    x  |       x     |     x   |   x   |    x     |
-| contributor | create |   x    |         |     x     |        |       |             |     x   |       |          |
-|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |     x   |   x   |    x     |
-|             | update |   x    |         |     x     |        |       |             |     x   |       |          |
-|             | delete |   x    |         |     x     |        |       |             |     x   |       |          |
-| reader      | create |        |         |           |        |       |             |         |       |          |
-|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |     x   |   x   |    x     |
-|             | update |        |         |           |        |       |             |         |       |          |
-|             | delete |        |         |           |        |       |             |         |       |          |
+| Role        | Action |backups | billing | clusters  | events | roles | permissions |  users | versions |
+|-------------|--------|--------|---------|-----------|--------|-------|-------------|--------|----------|
+| owner       | create |   x    |         |     x     |        |    x  |       x     |        |          |
+|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |    x   |    x     |
+|             | update |   x    |         |     x     |        |    x  |       x     |    x   |          |
+|             | delete |   x    |         |     x     |        |    x  |       x     |        |          |
+| contributor | create |   x    |         |     x     |        |       |             |        |          |
+|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |    x   |    x     |
+|             | update |   x    |         |     x     |        |       |             |        |          |
+|             | delete |   x    |         |     x     |        |       |             |        |          |
+| reader      | create |        |         |           |        |       |             |        |          |
+|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |    x   |    x     |
+|             | update |        |         |           |        |       |             |        |          |
+|             | delete |        |         |           |        |       |             |        |          |
 
 
 ### Editing Roles
@@ -104,8 +107,8 @@ To view all users from your organization that have logged in at least once:
 
 1. The EDB Cloud organization is created, and Tom logs in and is granted the owner role.
 
-1. Tom asks Jerry to log in, using his Azure AD account; Jerry's account in EDB Cloud is created.
-1. Tom grants Sally the contributor role. Sally logs out and back in, and she can now create EDB Cloud clusters.
-1. Sally asks Jerry to log in, and grants him the reader role.
-1. Jerry logs out and back in, and he can now see the clusters that Sally has created.
+2. Tom asks Jerry to log in, using his Azure AD account; Jerry's account in EDB Cloud is created.
+3. Tom grants Sally the contributor role. Sally logs out and back in, and she can now create EDB Cloud clusters.
+4. Sally asks Jerry to log in, and grants him the reader role.
+5. Jerry logs out and back in, and he can now see the clusters that Sally has created.
 


### PR DESCRIPTION
## What Changed?

This PR 

- changed the EDB Cloud documentation in the page of "Portal Access" to update the permission matrix.
So that the documentation can reflect to the latest production environment's changes on permission definition. 

The latest production EDB Cloud removes the useless and meaningless permission names from the system, so that
- the user won't be confused on why what these permissions are
- we can avoid leaking the future plan on feature development and delivery. e.g. we are going to support inviting user and requires the `create:users` permission, but that is not ready to be shipped now.  

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
