### PR TITLE
ensure cnp sync process also deletes files

### DIFF
--- a/scripts/source/process-cnp-docs.sh
+++ b/scripts/source/process-cnp-docs.sh
@@ -25,4 +25,5 @@ node $DESTINATION_CHECKOUT/scripts/fileProcessor/main.mjs \
   -p "cnp/add-frontmatters" \
   -p "cnp/rename-to-mdx"
 
-cp -rf src/* $DESTINATION_CHECKOUT/advocacy_docs/kubernetes/cloud_native_postgresql/
+rsync -a --delete src/ $DESTINATION_CHECKOUT/advocacy_docs/kubernetes/cloud_native_postgresql/
+cp $DESTINATION_CHECKOUT/merge_sources/kubernetes/cloud_native_postgresql/interactive_demo.mdx $DESTINATION_CHECKOUT/advocacy_docs/kubernetes/cloud_native_postgresql/interactive_demo.mdx


### PR DESCRIPTION
## What Changed?

- file sync process for CNP docs updated so that files deleted in the CNP repo are also deleted in the docs repo.
- the `interactive_demo.mdx` file is now being copied from `merge_sources`