### PR TITLE
Adding link to EDB Cloud docs and removing Preview text and banner

### DIFF
--- a/product_docs/docs/edbcloud/beta/index.mdx
+++ b/product_docs/docs/edbcloud/beta/index.mdx
@@ -1,9 +1,8 @@
 ---
-title: EDB Cloud Preview
+title: EDB Cloud
 description: "EDB Cloud: DBaaS for PostgresSQL "
 indexCards: simple
 hideVersion: true
-displayBanner: 'edbcloud'
 directoryDefaults:
   iconName: CloudDb
 navigation:

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -107,6 +107,13 @@ const Page = () => (
             </IndexCardLink>
           </IndexCard>
 
+          <IndexCard
+            iconName={iconNames.CLOUD_DB}
+            headingText="Cloud Solutions"
+          >
+            <IndexCardLink to="/edbcloud/latest">EDB Cloud</IndexCardLink>
+          </IndexCard>
+
           <IndexCard iconName={iconNames.KUBERNETES} headingText="Kubernetes">
             <IndexCardLink to="/kubernetes/cloud_native_postgresql/">
               Cloud Native PostgreSQL Operator


### PR DESCRIPTION
## What Changed?

Adding link to EDB Cloud docs from the home page and removing Preview text and banner
