### PR TITLE
noindex generated PDFs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -160,6 +160,7 @@ module.exports = {
       options: {
         headers: {
           "/*": isProduction ? [] : ["X-Robots-Tag: noindex"],
+          "/static/*.pdf": ["X-Robots-Tag: noindex"],
         },
       },
     },


### PR DESCRIPTION
## What Changed?

This arose via an observation from Christina Wong in [EW-7470](https://enterprisedb.atlassian.net/browse/EW-7470): 

> 
![google search results including a EDB Cloud PDF](https://user-images.githubusercontent.com/63653723/138373675-23b9cc47-1d5c-4ff4-94ef-73ae9d69f026.png)

The URL linked is https://www.enterprisedb.com/docs/static/4cb04e2e1f87ba158b607373b3476147/edbcloud_vbeta_documentation.pdf

([Try this search](https://www.google.com/search?q=edb+cloud+preview) in "incognito" mode - link was still listed at the time I wrote this PR)

The hash in that path is going to change every time the PDF changes; that's fairly often, so even if Google re-indexes pretty quickly there's a good chance we'll be seeing broken links.

And... There's no content in that PDF that isn't in the Docs pages themselves. So to avoid issues, I'd like to noindex them.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
