### PR TITLE
Use www. prefix to minimize 301 redirects

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -141,9 +141,9 @@ module.exports = {
   pathPrefix: "/docs",
   siteMetadata: {
     title: "EDB Docs",
-    baseUrl: "https://enterprisedb.com/docs",
-    imageUrl: "https://enterprisedb.com/docs/images/social.jpg",
-    siteUrl: "https://enterprisedb.com/docs",
+    baseUrl: "https://www.enterprisedb.com/docs",
+    imageUrl: "https://www.enterprisedb.com/docs/images/social.jpg",
+    siteUrl: "https://www.enterprisedb.com/docs",
     algoliaIndex: algoliaIndex,
     isDevelopment: !isBuild,
     cacheBuster: 2, // for busting gh actions cache if needed

--- a/src/components/index-sub-nav.js
+++ b/src/components/index-sub-nav.js
@@ -16,7 +16,7 @@ const IndexSubNav = () => (
       <IndexSubLink url="https://support.enterprisedb.com/support/s/">
         Knowledge Base
       </IndexSubLink>
-      <IndexSubLink url="https://enterprisedb.com/contact">
+      <IndexSubLink url="https://www.enterprisedb.com/contact">
         Contact Us
       </IndexSubLink>
       <IndexSubLink url="/community/contributing/">Have feedback?</IndexSubLink>

--- a/src/components/side-navigation.js
+++ b/src/components/side-navigation.js
@@ -25,7 +25,9 @@ const SideNavigationFooter = () => (
     <FooterItem url="https://support.enterprisedb.com/support/s/">
       Knowledge Base
     </FooterItem>
-    <FooterItem url="https://enterprisedb.com/contact">Contact Us</FooterItem>
+    <FooterItem url="https://www.enterprisedb.com/contact">
+      Contact Us
+    </FooterItem>
     <FooterItem url="/community/contributing/">Have feedback?</FooterItem>
     <DarkModeToggle className="mt-1" />
   </ul>


### PR DESCRIPTION
## What Changed?

Use www.enterprisedb.com for docs links. Not sure off-hand if this was always wrong or if there's some recent change here, but... Ton of unnecessary 301 redirects and inaccurate rel=canonical URLs due to Gatsby writing out www-less URLs.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
