### PR TITLE
Use synchronous processing to avoid race condition with rename plugin

### DIFF
--- a/scripts/fileProcessor/processors/cnp/update-yaml-links.mjs
+++ b/scripts/fileProcessor/processors/cnp/update-yaml-links.mjs
@@ -8,7 +8,7 @@ import admonitions from "remark-admonitions";
 import visit from "unist-util-visit";
 import isAbsoluteUrl from "is-absolute-url";
 
-export const process = async (filename, content) => {
+export const process = (filename, content) => {
 
   const processor = unified()
     .use(remarkParse)
@@ -22,7 +22,7 @@ export const process = async (filename, content) => {
     .use(mdx)
     .use(linkRewriter);
 
-  const output = await processor.process(toVFile({ path: filename, contents: content }));
+  const output = processor.processSync(toVFile({ path: filename, contents: content }));
 
   return {
     newFilename: filename,


### PR DESCRIPTION
## What Changed?

My last change to this file made it asynchronous; that worked fine locally, but appears to hit a race condition when triggered from a workflow on GH. Side-step the issue for now by just processing these synchronously.