### PR TITLE
addressing typo

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/01_cluster_networking.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/01_cluster_networking.mdx
@@ -32,7 +32,7 @@ additional IP addresses to the existing load balancer.
 
 ## Private cluster load balancing
 
-When a cluster is created with public network access, an Azure
+When a cluster is created with private network access, an Azure
 Standard SKU Load Balancer is created and configured with an IP
 address that always routes to the leader of your cluster. Once
 assigned, this IP address does not change unless you change the


### PR DESCRIPTION
## What Changed?

Fixes typo on BigAnimal Cluster networking architecture page