### PR TITLE
updated shortname reference on home page and v14 support notes

### DIFF
--- a/product_docs/docs/bart/2.6/bart_inst/index.mdx
+++ b/product_docs/docs/bart/2.6/bart_inst/index.mdx
@@ -22,8 +22,8 @@ This guide provides information about how to install and configure the EDB Backu
 -   To view a complete list of supported platforms, see [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility).
 
 
-    !!! Note
-        BART 2.6 is no longer supported on CentOS/RHEL/OL 6.x platforms. It is strongly recommended that EDB products running on these platforms be migrated to a supported platform.
+!!! Note
+    BART is not supported by EDB Postgres Advanced Server or PostgreSQL version 14 and later. It is strongly recommended you move to Barman or pgBackRest as your backup recovery tool. See [Moving to a New Backup Tool](../bart_migration) for more information.
 
 -   BART supports the following database versions:
 

--- a/product_docs/docs/bart/2.6/bart_inst/index.mdx
+++ b/product_docs/docs/bart/2.6/bart_inst/index.mdx
@@ -23,7 +23,7 @@ This guide provides information about how to install and configure the EDB Backu
 
 
 !!! Note
-    BART is not supported by EDB Postgres Advanced Server or PostgreSQL version 14 and later. It is strongly recommended you move to Barman or pgBackRest as your backup recovery tool. See [Moving to a New Backup Tool](../bart_migration) for more information.
+    BART is not supported by EDB Postgres Advanced Server or PostgreSQL version 14 and later. EDB strongly recommends you move to Barman or pgBackRest as your backup recovery tool. See [Moving to a New Backup Tool](../bart_migration) for more information.
 
 -   BART supports the following database versions:
 

--- a/product_docs/docs/slony/2.2.10/01_installation/index.mdx
+++ b/product_docs/docs/slony/2.2.10/01_installation/index.mdx
@@ -22,7 +22,7 @@ The following table lists the latest Slony Replication versions and their corres
 | `Slony Replication 2.2`                 | EDB Postgres Advanced and PostgreSQL Server 10 and 9.6 | RHEL 7 - x86_64 <br/>RHEL 7 - ppc64le <br/>Windows x86_64 and Linux graphical installer                                                                                                     |
 
 !!! Note
-    Slony is not supported by EDB Postgres Advanced Server or PostgreSQL version 14 and later. 
+    Slony is not supported by EDB Postgres Advanced Server or PostgreSQL version 14 and later. EDB strongly recommends that you move to [BDR](bdr/latest/) or pglogical(pglogical/latest/) as your logical replication solution. 
 
 <div class="toctree" maxdepth="3">
 

--- a/product_docs/docs/slony/2.2.10/01_installation/index.mdx
+++ b/product_docs/docs/slony/2.2.10/01_installation/index.mdx
@@ -22,7 +22,7 @@ The following table lists the latest Slony Replication versions and their corres
 | `Slony Replication 2.2`                 | EDB Postgres Advanced and PostgreSQL Server 10 and 9.6 | RHEL 7 - x86_64 <br/>RHEL 7 - ppc64le <br/>Windows x86_64 and Linux graphical installer                                                                                                     |
 
 !!! Note
-    Slony is no longer supported on CentOS/RHEL/OL 6.x platforms. It is strongly recommended to migrate all EDB products running on these platforms to a supported platform.
+    Slony is not supported by EDB Postgres Advanced Server or PostgreSQL version 14 and later. 
 
 <div class="toctree" maxdepth="3">
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -218,7 +218,7 @@ const Page = () => (
             </IndexCardLink>
             <IndexCardLink to="/efm/latest">Failover Manager</IndexCardLink>
             <IndexCardLink to="/repmgr/latest">
-              repmgr (Replication Manager)
+              Replication Manager (repmgr)
             </IndexCardLink>
 
             <span className="font-weight-bold mt-4 text-muted text-uppercase small d-block">


### PR DESCRIPTION
Changed order of short and long names for Replication Server on the home page
Added notes about epas v14 not supporting Slony or BART

