### PR TITLE
virtual.ip.interface not a unique propertie

### DIFF
--- a/product_docs/docs/efm/4/efm_user/05_using_efm.mdx
+++ b/product_docs/docs/efm/4/efm_user/05_using_efm.mdx
@@ -239,8 +239,6 @@ The following parameters must be unique in each cluster properties file:
 
  `virtual.ip` (if used)
 
- `virtual.ip.interface` (if used)
-
 Within each cluster properties file, the `db.port` parameter should specify a unique value for each cluster, while the `db.user` and `db.database` parameter may have the same value or a unique value. For example, the `acctg.properties` file may specify:
 
  `db.user=efm_user`


### PR DESCRIPTION
The virtual.ip.interface property shouldn't be in the list of props that have to be unique if using more than one agent on a node. Something similar used to be a requirement, which is probably how this got here. Will take a look at the v3 docs also.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [X] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
