### PR TITLE
virtual.ip.interface not a unique property

### DIFF
--- a/product_docs/docs/efm/3/efm_user/05_using_efm.mdx
+++ b/product_docs/docs/efm/3/efm_user/05_using_efm.mdx
@@ -240,8 +240,6 @@ The following parameters must be unique in each cluster properties file:
 
  `virtual.ip` (if used)
 
- `virtual.ip.interface` (if used)
-
 Within each cluster properties file, the `db.port` parameter should specify a unique value for each cluster, while the `db.user` and `db.database` parameter may have the same value or a unique value. For example, the `acctg.properties` file may specify:
 
  `db.user=efm_user`


### PR DESCRIPTION
This can be removed from the list of unique properties. In older versions of EFM a sub-interface was required and this had to be unique. We got rid of the subinterface but not the documentation that went with it. Have filed a PR already for the v4 version of this page.


**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [X] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
