### PR TITLE
syntax highlight "postgresql" code blocks using sql rules (BDR family)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -224,6 +224,9 @@ module.exports = {
             resolve: "gatsby-remark-prismjs",
             options: {
               noInlineHighlight: true,
+              aliases: {
+                postgresql: "sql",
+              },
             },
           },
         ],


### PR DESCRIPTION
## What Changed?

Several of the BDR ecosystem products have consistently used `postgresql` as a language tag for code blocks. We may wish to standardize on `sql` for these, but for now it'd be nice if they highlighted properly - so add `postgresql` as an alias for `sql`. This may even be desirable for sematic reasons, though I kind of doubt it.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
