### PR TITLE
Fix link to "connecting..."

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/01_cluster_networking.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/01_cluster_networking.mdx
@@ -40,7 +40,7 @@ networking configuration for your cluster.
 
 This IP address is private to the VNet hosting your BigAnimal
 services. By default it is not routable from other networks, even in
-your Azure account. See [Setting up Azure infrastructure to connect to a private network cluster](../../using_cluster/connecting_your_cluster/#setting-up-azure-infrastructure-to-connect-to-a-private-network-cluster) for details and instructions
+your Azure account. See [Setting up Azure infrastructure to connect to a private network cluster](../../using_cluster/02_connecting_your_cluster/#setting-up-azure-infrastructure-to-connect-to-a-private-network-cluster) for details and instructions
 on how to properly configure routing for private clusters.
 
 Only one Azure Internal Load Balancer per BigAnimal region is typically deployed in your


### PR DESCRIPTION
## What Changed?

Broken link due to addition of numeric prefix in c36b699eba62eb01b95b6565b4152f74d3d47b1f - there was a redirect added to try to avoid this, but it didn't take because directory renames must use a parent path prefix (../) when intending to redirect index.mdx

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
