### PR TITLE
Use netlify deploy action instead of netlify-cli

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -5,6 +5,10 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+  
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
@@ -22,18 +26,30 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+          
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: update npm
         run: npm install -g npm@7
         env:
           NODE_ENV: ${{ secrets.NODE_ENV }}
-      - name: npm install
+      - name: Install dependencies
         run: |
           npm run presetup
           npm ci
         env:
           NODE_ENV: ${{ secrets.NODE_ENV }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+          
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
@@ -71,15 +87,22 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_INDEX_NAME: edb-docs-staging
           INDEX_ON_BUILD: true
-
-      - name: Netlify deploy
-        run: |
-          sudo npm install -g netlify-cli
-          netlify deploy --dir=public --prod
+          
+      - name: Deploy to Netlify
+        id: netlify-deploy
+        uses: nwtgck/actions-netlify@v1.2.2
+        with:
+          publish-dir: "./public"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: ${{ github.event.pull_request.title }}
+          enable-commit-comment: false
+          enable-pull-request-comment: false
+          production-deploy: true
+          production-branch: develop # this isn't needed because production-deploy is set to true, but could be used instead to force a production build when building against develop
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_DEVELOP_SITE_ID }}
-
+          
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -8,7 +8,7 @@ on:
 concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
-  
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
@@ -49,7 +49,7 @@ jobs:
         env:
           NODE_ENV: ${{ secrets.NODE_ENV }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
+
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
@@ -87,7 +87,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_INDEX_NAME: edb-docs-staging
           INDEX_ON_BUILD: true
-          
+
       - name: Deploy to Netlify
         id: netlify-deploy
         uses: nwtgck/actions-netlify@v1.2.2
@@ -102,7 +102,7 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_DEVELOP_SITE_ID }}
-          
+
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy-draft.yml
+++ b/.github/workflows/deploy-draft.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Adjust file watchers limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
 

--- a/.github/workflows/sync-and-process-files.yml
+++ b/.github/workflows/sync-and-process-files.yml
@@ -35,7 +35,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
 
       - name: update npm
         run: npm install -g npm@7


### PR DESCRIPTION
## What Changed?

...since netlify-cli is now suddenly failing to install on the runner (see: [1](https://github.com/EnterpriseDB/docs/runs/4537965585?check_suite_focus=true), [2](https://github.com/EnterpriseDB/docs/runs/4540134421?check_suite_focus=true))

Been using this action for draft deploys for a while now, seems stable. Also added caching for npm and the option to kill concurrent staging builds, since why not speed this up a bit.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
