### PR TITLE
Use netlify deploy action instead of netlify-cli

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -94,7 +94,6 @@ jobs:
         with:
           publish-dir: "./public"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: ${{ github.event.pull_request.title }}
           enable-commit-comment: false
           enable-pull-request-comment: false
           production-deploy: true

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -5,6 +5,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
@@ -24,11 +28,20 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
       - name: update npm
         run: npm install -g npm@7
         env:
           NODE_ENV: ${{ secrets.NODE_ENV }}
-      - name: npm install
+      - name: Install dependencies
         run: |
           npm run presetup
           npm ci
@@ -75,10 +88,15 @@ jobs:
           GTM_ID: GTM-5W8M67
           INDEX_ON_BUILD: true
 
-      - name: Netlify deploy
-        run: |
-          sudo npm install -g netlify-cli
-          netlify deploy --dir=public --prod
+      - name: Deploy to Netlify
+        id: netlify-deploy
+        uses: nwtgck/actions-netlify@v1.2.2
+        with:
+          publish-dir: "./public"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-commit-comment: false
+          enable-pull-request-comment: false
+          production-deploy: true
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_MAIN_SITE_ID }}


### PR DESCRIPTION
## What Changed?

Second try (follows #2137): replace netlify-cli with deploy action, since netlify-cli is now suddenly failing to install on the runner (see: [1](https://github.com/EnterpriseDB/docs/runs/4537965585?check_suite_focus=true), [2](https://github.com/EnterpriseDB/docs/runs/4540134421?check_suite_focus=true))

Based on the workflow we've used for draft deploys for a while, but removes PR-specific values (and sets production flag for netlify). 