### PR TITLE
more information for efm slot update property

### DIFF
--- a/product_docs/docs/efm/4/efm_user/04_configuring_efm/01_cluster_properties/index.mdx
+++ b/product_docs/docs/efm/4/efm_user/04_configuring_efm/01_cluster_properties/index.mdx
@@ -576,7 +576,9 @@ To perform maintenance on the primary database when `primary.shutdown.as.failure
 
 <div id="update_physical_slots_period" class="registered_link"></div>
 
-Use the `update.physical.slots.period` property to define the slot advance frequency for database version 12 and above. When `update.physical.slots.period` is set to a non-zero value, the primary agent will read the current `restart_lsn` of the physical replication slots after every `update.physical.slots.period` seconds, and send this information with its `pg_current_wal_lsn` and `primary_slot_name` (If it is set in the postgresql.conf file) to the standbys. If physical slots do not already exist, setting this parameter to a non-zero value will create the slots and then update the `restart_lsn parameter` for these slots. A non-promotable standby will not create new slots but will update them if they exist.
+Use the `update.physical.slots.period` property to define the slot advance frequency for database version 12 and above. When `update.physical.slots.period` is set to a non-zero value, the primary agent will read the current `restart_lsn` of the physical replication slots after every `update.physical.slots.period` seconds, and send this information with its `pg_current_wal_lsn` and `primary_slot_name` (if it is set in the postgresql.conf file) to the standbys. If physical slots do not already exist, setting this parameter to a non-zero value will create the slots and then update the `restart_lsn parameter` for these slots. A non-promotable standby will not create new slots but will update them if they exist.
+
+Note: all slot names, including one set on the current primary if desired, must be unique.
 
 ```text
 # Period in seconds between having the primary agent update promotable


### PR DESCRIPTION
The database itself will enforce a unique slot name for all of the standbys, but the name specified in the primary's configuration isn't used by the database until another node is promoted, so the database doesn't care. If the primary uses the same name that a standby is using, things won't work as expected.

## What Changed?

Please list, at a high level, what changed in your branch. If you changed content, include the product, section, and version as applicable. **Please remove the user instructions including the examples before merging the PR.**

**Examples**

- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
