### PR TITLE
Encode <> to avoid breaking MDX compilation

### DIFF
--- a/product_docs/docs/efm/4/efm_user/13_troubleshooting.mdx
+++ b/product_docs/docs/efm/4/efm_user/13_troubleshooting.mdx
@@ -16,7 +16,7 @@ If you invoke an Failover Manager cluster management command and Failover Manage
 Authorization file not found. Is the local agent running?
 ```
 
-## Not authorized to run this command. User '<os user>' is not a member of the \`efm\` group.
+## Not authorized to run this command. User '&lt;os user&gt;' is not a member of the \`efm\` group.
 
 You must have special privileges to invoke some of the `efm` commands documented in [Using the efm utility](07_using_efm_utility/#using_efm_utility). If these commands are invoked by a user who isn't authorized to run them, the `efm` command displays an error:
 


### PR DESCRIPTION
## What Changed?

Unencoded <...> is interpreted as a JSX tag by MDX - since we want this message to render verbatim, I avoid the error by encoding these characters as HTML entities.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
