### PR TITLE
Normalize spacing to placate Pandoc (PDF generation)

### DIFF
--- a/product_docs/docs/biganimal/release/administering_cluster/01_portal_access.mdx
+++ b/product_docs/docs/biganimal/release/administering_cluster/01_portal_access.mdx
@@ -15,12 +15,14 @@ Each BigAnimal organization is associated with an Azure AD tenant. Azure AD esta
 BigAnimal supports role-based access control policies. A user with the owner role can assign roles to other users in the same organization.
 
 ## Roles
+
 Access to BigAnimal is controlled by roles. Roles are sets of permissions. You use roles to manage permissions assigned to users.
 
 Each organization has three default roles available:
-  * owner
-  * reader
-  * contributor
+
+-   owner
+-   reader
+-   contributor
 
 You can edit these roles by changing their name or description.
 
@@ -28,9 +30,9 @@ You can edit these roles by changing their name or description.
 
 Permissions are generally represented in the format *action*:*object* where *action* represents an operation to perform and *object* represents a category of portal functionality.
 
-* The available actions are: create, read, update, and delete.
+-   The available actions are: create, read, update, and delete.
 
-* The available objects are: backups, billing, clusters, events, permissions, roles, users, and versions.
+-   The available objects are: backups, billing, clusters, events, permissions, roles, users, and versions.
 
 !!! Note
     Not every object supports all the actions. For example, versions objects are always read-only.
@@ -39,44 +41,46 @@ Permissions are generally represented in the format *action*:*object* where *act
 
 The following are the default permission by role:
 
-| Role        | Action |backups | billing | clusters  | events | roles | permissions |  users | versions |
-|-------------|--------|--------|---------|-----------|--------|-------|-------------|--------|----------|
-| owner       | create |   x    |         |     x     |        |       |             |        |          |
-|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |    x   |    x     |
-|             | update |   x    |         |     x     |        |       |             |    x   |          |
-|             | delete |   x    |         |     x     |        |       |             |        |          |
-| contributor | create |   x    |         |     x     |        |       |             |        |          |
-|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |    x   |    x     |
-|             | update |   x    |         |     x     |        |       |             |        |          |
-|             | delete |   x    |         |     x     |        |       |             |        |          |
-| reader      | create |        |         |           |        |       |             |        |          |
-|             | read   |   x    |    x    |     x     |   x    |    x  |       x     |    x   |    x     |
-|             | update |        |         |           |        |       |             |        |          |
-|             | delete |        |         |           |        |       |             |        |          |
-
+| Role        | Action | backups | billing | clusters | events | roles | permissions | users | versions |
+| ----------- | ------ | ------- | ------- | -------- | ------ | ----- | ----------- | ----- | -------- |
+| owner       | create | x       |         | x        |        |       |             |       |          |
+|             | read   | x       | x       | x        | x      | x     | x           | x     | x        |
+|             | update | x       |         | x        |        |       |             | x     |          |
+|             | delete | x       |         | x        |        |       |             |       |          |
+| contributor | create | x       |         | x        |        |       |             |       |          |
+|             | read   | x       | x       | x        | x      | x     | x           | x     | x        |
+|             | update | x       |         | x        |        |       |             |       |          |
+|             | delete | x       |         | x        |        |       |             |       |          |
+| reader      | create |         |         |          |        |       |             |       |          |
+|             | read   | x       | x       | x        | x      | x     | x           | x     | x        |
+|             | update |         |         |          |        |       |             |       |          |
+|             | delete |         |         |          |        |       |             |       |          |
 
 ### Edit roles
 
-1. Navigate to **Admin > Roles**.
+1.  Navigate to **Admin > Roles**.
 
-3. Select the edit icon for the role in the list.
+2.  Select the edit icon for the role in the list.
 
 #### Change role name
 
-1. Select the **Settings** tab.
+1.  Select the **Settings** tab.
 
-2. Edit **Name** or **Description**.
-3. Select **Save**.
+2.  Edit **Name** or **Description**.
+
+3.  Select **Save**.
 
 #### Change role permissions
 
 You can change permissions associated with the role.
 
-1. Select the **Permissions** tab.
+1.  Select the **Permissions** tab.
 
-2. Select **Change Permissions** in the top right.
-3. Select the list of permissions you want to associate with the role.
-4. Select **Submit**.
+2.  Select **Change Permissions** in the top right.
+
+3.  Select the list of permissions you want to associate with the role.
+
+4.  Select **Submit**.
 
 !!! Note
     Changing role permissions affects every user who is assigned that role.
@@ -87,12 +91,15 @@ When you configured your Azure subscription, you also enabled BigAnimal to authe
 
 ### Assign roles to users
 
-1. Navigate to **Admin > Users**.
+1.  Navigate to **Admin > Users**.
 
-2. Select the edit icon for the user.
-3. Select **Assign Roles**.
-4. Select or clear roles for the user.
-5. Select **Submit**.
+2.  Select the edit icon for the user.
+
+3.  Select **Assign Roles**.
+
+4.  Select or clear roles for the user.
+
+5.  Select **Submit**.
 
 !!! Note
     For a user's role assignment to take effect, the user must log out from BigAnimal and log in again.
@@ -101,16 +108,18 @@ When you configured your Azure subscription, you also enabled BigAnimal to authe
 
 You can view all users from your organization who have logged in at least once.
 
-1. Navigate to **Admin > Users**.
+1.  Navigate to **Admin > Users**.
 
-2. View the list of users sorted by most recent login.
+2.  View the list of users sorted by most recent login.
 
 ## Example scenario
 
-1. The BigAnimal organization is created, and Tom logs in and is granted the owner role.
+1.  The BigAnimal organization is created, and Tom logs in and is granted the owner role.
 
-2. Tom asks Jerry to log in, using his Azure AD account. Jerry's account in BigAnimal is created.
-3. Tom grants Sally the contributor role. Sally logs out and back in. She can now create BigAnimal clusters.
-4. Sally asks Jerry to log in and grants him the reader role.
-5. Jerry logs out and back in. He can now see the clusters that Sally created.
+2.  Tom asks Jerry to log in, using his Azure AD account. Jerry's account in BigAnimal is created.
 
+3.  Tom grants Sally the contributor role. Sally logs out and back in. She can now create BigAnimal clusters.
+
+4.  Sally asks Jerry to log in and grants him the reader role.
+
+5.  Jerry logs out and back in. He can now see the clusters that Sally created.

--- a/product_docs/docs/biganimal/release/administering_cluster/03_account_activity.mdx
+++ b/product_docs/docs/biganimal/release/administering_cluster/03_account_activity.mdx
@@ -1,23 +1,26 @@
 ---
 title: "Reviewing account activity"
 ---
+
 The activity log collects BigAnimal events based on user activity in the portal. You can use the log to audit activities performed by users from your organizations or research activities that might have affected your account.
 
 ## Events
 
 Events describe actions performed by users. The available actions are:
-* create
-* read
-* update
-* delete
+
+-   create
+-   read
+-   update
+-   delete
 
 Events are related to the following resource types:
-* cluster
-* data plane
-* user
-* user roles
-* role permissions
-* organization
+
+-   cluster
+-   data plane
+-   user
+-   user roles
+-   role permissions
+-   organization
 
 !!! Note
     Database events are not logging activity on the Postgres server. They are logging the use of the portal to create or modify database clusters.
@@ -28,10 +31,9 @@ To view events, navigate to the [Activity Log](https://portal.biganimal.com/acti
 
 The following fields are in the activity log:
 
-| Field                | Description                                                                  |
-| ---------------------| ---------------------------------------------------------------------------- |
-| **Activity Name**    | Name of an event in the format _Action Resource-Type, Resource-name_           |
-| **User**             | User responsible for the event                                               |
-| **Date**             | Date when the action was performed                                           |
-| **Resource**         | Resource type of the resource                                                |
-
+| Field             | Description                                                          |
+| ----------------- | -------------------------------------------------------------------- |
+| **Activity Name** | Name of an event in the format *Action Resource-Type, Resource-name* |
+| **User**          | User responsible for the event                                       |
+| **Date**          | Date when the action was performed                                   |
+| **Resource**      | Resource type of the resource                                        |

--- a/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/01_understanding_qotas_in_azure.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/01_understanding_qotas_in_azure.mdx
@@ -11,21 +11,20 @@ BigAnimal creates and manages some of the resources using resource providers. Fo
 
 To prevent failures while creating your clusters, ensure that each of the following Azure resource providers are registered in your Azure subscription.
 
-
-| Provider Namespace             | Description                                                                                                     |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| Microsoft.Compute              | Runs cluster workloads on a virtual machine managed by the Azure Kubernetes Service.                            |
-| Microsoft.ContainerInstance    | Manages the Azure resource and regular maintenance job. |
-| Microsoft.Capacity             | Checks the Azure resource quota.  |
-| Microsoft.AlertsManagement     | Monitors failure anomalies.   |
-| Microsoft.ContainerService     | Manages cluster workloads run on the Azure Kubernetes Service.                                  |
-| Microsoft.KeyVault             | Encrypts and stores keys of the clusters' data volume and Azure's credential information.  |
-| Microsoft.Storage              | Backs up data to the Azure Service Account. |
-| Microsoft.ManagedIdentity      | Manages software access to the local Azure services using Azure Managed-Identity.     |
-| Microsoft.Network              | Manages cluster workloads run in the Azure Kubernetes Service in the dedicated VNet.                              |
-| Microsoft.OperationalInsights  | Manages clusters and performs workload logging (log workspace)..                                          |
-| Microsoft.OperationsManagement | Monitors workloads and provides container insight.                                                                   |
-| Microsoft.Portal               | Provides a dashboard to monitor the running status of the clusters (using aggregated logs and metrics).    |
+| Provider Namespace             | Description                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Microsoft.Compute              | Runs cluster workloads on a virtual machine managed by the Azure Kubernetes Service.                    |
+| Microsoft.ContainerInstance    | Manages the Azure resource and regular maintenance job.                                                 |
+| Microsoft.Capacity             | Checks the Azure resource quota.                                                                        |
+| Microsoft.AlertsManagement     | Monitors failure anomalies.                                                                             |
+| Microsoft.ContainerService     | Manages cluster workloads run on the Azure Kubernetes Service.                                          |
+| Microsoft.KeyVault             | Encrypts and stores keys of the clusters' data volume and Azure's credential information.               |
+| Microsoft.Storage              | Backs up data to the Azure Service Account.                                                             |
+| Microsoft.ManagedIdentity      | Manages software access to the local Azure services using Azure Managed-Identity.                       |
+| Microsoft.Network              | Manages cluster workloads run in the Azure Kubernetes Service in the dedicated VNet.                    |
+| Microsoft.OperationalInsights  | Manages clusters and performs workload logging (log workspace)..                                        |
+| Microsoft.OperationsManagement | Monitors workloads and provides container insight.                                                      |
+| Microsoft.Portal               | Provides a dashboard to monitor the running status of the clusters (using aggregated logs and metrics). |
 
 ## Virtual machine SKU restrictions
 
@@ -49,11 +48,11 @@ Any time a new VM is deployed in Azure, the vCPUs for the VMs must not exceed th
 
 Clusters deployed in the region use Esv3 virtual machine cores. The number of cores depends on the *Instance Type* and *High Availability (HA)* options of the clusters. You can calculate the number of Esv3 cores required for your cluster based on the following:
 
-* A virtual machine instance of type E{N}sv3 uses {N} cores. For example, an instance of type E64sv3 uses 64 Esv3 cores.
-* A cluster running on an E{N}sv3 instance with HA not enabled uses exactly {N} Esv3 cores.
-* A cluster running on an E{N}sv3 instance with HA enabled uses 3 * {N} Esv3 cores.
+-   A virtual machine instance of type E{N}sv3 uses {N} cores. For example, an instance of type E64sv3 uses 64 Esv3 cores.
+-   A cluster running on an E{N}sv3 instance with HA not enabled uses exactly {N} Esv3 cores.
+-   A cluster running on an E{N}sv3 instance with HA enabled uses 3 \* {N} Esv3 cores.
 
-For example, if you provision the largest virtual machine E64sv3 with high availability enabled, it requires (3 * 64) = 192 Esv3 cores per region.
+For example, if you provision the largest virtual machine E64sv3 with high availability enabled, it requires (3 \* 64) = 192 Esv3 cores per region.
 
 BigAnimal requires an additional eight Dv4 virtual machine cores per region.
 
@@ -64,6 +63,7 @@ The default number of total vCPU (cores) per subscription per region is 20. For 
 ##### Recommended limits
 
 BigAnimal recommends the following per region when requesting virtual machine resource limit increases:
-* Total Regional vCPUs: minimum of 60 per designated region
-* Standard Esv3 Family vCPUs: minimum of 50 per designated region
-* Standard Dv4 Family vCPUs: minimum of 10 per designated region
+
+-   Total Regional vCPUs: minimum of 60 per designated region
+-   Standard Esv3 Family vCPUs: minimum of 50 per designated region
+-   Standard Dv4 Family vCPUs: minimum of 10 per designated region

--- a/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
@@ -6,10 +6,10 @@ redirects:
 
 BigAnimal requires you to configure your Azure subscription before you deploy your clusters. The configurations that you perform ensure that your Azure subscription is prepared to meet your clusters' requirements and resource limits, such as: 
 
- * Are the necessary Azure resource providers registered for your subscription?
- * Is there a restriction on SKUs for the Standard Esv3 and Standard Dv4 VM size families?
- * Is there a sufficient limit on the number of vCPU or Public IP addresses in your region?
-  
+-   Are the necessary Azure resource providers registered for your subscription?
+-   Is there a restriction on SKUs for the Standard Esv3 and Standard Dv4 VM size families?
+-   Is there a sufficient limit on the number of vCPU or Public IP addresses in your region?
+
 !!! Note
     Before proceeding, see [Understanding requirements in Azure](../01_preparing_azure/01_understanding_qotas_in_azure) for details on planning for your clusters' requirements and resource limits in Azure.
 
@@ -17,102 +17,103 @@ BigAnimal requires you to configure your Azure subscription before you deploy yo
 
 EDB recommends using the `biganimal-preflight-azure` script to check whether all requirements and resource limits are met in your subscription. However, you can also manually check the requirements using the Azure CLI or the Azure Portal.
 
- * [Method 1: Use EDB's shell script](#method-1-use-edbs-shell-script) (recommended)
- * [Method 2: Manually check requirements](#method-2-manually-check-requirements)
+-   [Method 1: Use EDB's shell script](#method-1-use-edbs-shell-script) (recommended)
+-   [Method 2: Manually check requirements](#method-2-manually-check-requirements)
 
 ### Method 1: Use EDB's shell script
 
 EDB provides a shell script called [`biganimal-preflight-azure`](https://github.com/EnterpriseDB/cloud-utilities/blob/main/azure/biganimal-preflight-azure), which automatically checks whether requirements and resource limits are met in your Azure subscription based on the clusters you plan to deploy.
 
-1. Open the [Azure Cloud Shell](https://shell.azure.com/) in your browser.
- 
-1. From the Azure Cloud Shell, use the following command to run the `biganimal-preflight-azure` script.  
+1.  Open the [Azure Cloud Shell](https://shell.azure.com/) in your browser.
+2.  From the Azure Cloud Shell, use the following command to run the `biganimal-preflight-azure` script.  
 
-  ```sh
-   curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
-    -- <subscription-ID> <azure-region> \
-    --instance-type <instance-type> \
+    ```sh
+     curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
+      -- <subscription-ID> <azure-region> \
+      --instance-type <instance-type> \
+      --high-availability \
+      --endpoint <endpoint-type> \
+      --activate-region \
+      --onboard
+    ```
+
+     Replace the variables in the arguments and options as follows:
+
+    -   `<subscription-ID>`: Enter the Azure subscription ID of your BigAnimal deployment.
+    -   `<azure-region>`: Enter the Azure region where your clusters are being deployed.
+    -   `<instance-type>`: Enter **e2s_v3**, which indicates the type of virtual machine instance (Esv3 with 2 cores) used in BigAnimal. 
+    -   `--high-availability` or `-a`: Indicates that high availability is enabled in your clusters.
+    -   `<endpoint-type>`: Indicates either **public** or **private** endpoints.
+    -   `--activate-region` or `-r`: Indicates that no clusters are currently deployed in the region.
+    -   `--onboard`: Checks if the user and subscription are correctly configured.
+
+    For example, if you want to deploy a cluster in an Azure subscription having an ID of `12412ab3d-1515-2217-96f5-0338184fcc04`, in the `eastus2` region, in a `public` network, and with no existing cluster deployed, run the following command:
+
+    ```sh
+    curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
+    -- 12412ab3d-1515-2217-96f5-0338184fcc04 eastus2 \
+    --instance-type e2s_v3 \
     --high-availability \
-    --endpoint <endpoint-type> \
-    --activate-region \
-    --onboard
-  ```
-
-  Replace the variables in the arguments and options as follows:
-   - `<subscription-ID>`: Enter the Azure subscription ID of your BigAnimal deployment.
-   - `<azure-region>`: Enter the Azure region where your clusters are being deployed.
-   - `<instance-type>`: Enter **e2s_v3**, which indicates the type of virtual machine instance (Esv3 with 2 cores) used in BigAnimal. 
-   - `--high-availability` or `-a`: Indicates that high availability is enabled in your clusters.
-   - `<endpoint-type>`: Indicates either **public** or **private** endpoints.
-   - `--activate-region` or `-r`: Indicates that no clusters are currently deployed in the region.
-   - `--onboard`: Checks if the user and subscription are correctly configured.
-  
- For example, if you want to deploy a cluster in an Azure subscription having an ID of `12412ab3d-1515-2217-96f5-0338184fcc04`, in the `eastus2` region, in a `public` network, and with no existing cluster deployed, run the following command:
-
- ```sh
- curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
- -- 12412ab3d-1515-2217-96f5-0338184fcc04 eastus2 \
- --instance-type e2s_v3 \
- --high-availability \
- --endpoint public \
- --activate-region
- ```
+    --endpoint public \
+    --activate-region
+    ```
 
 The script displays the following output:  
 
- * A list of required Azure resource providers and their registration status. Ensure that you register the resource providers that are displayed as `NotRegistered` in the `RegistrationState` column. See [Register Azure resource providers](#register-azure-service-providers).
-  ```
-  #######################
-  # Provider            #
-  #######################
+-   A list of required Azure resource providers and their registration status. Ensure that you register the resource providers that are displayed as `NotRegistered` in the `RegistrationState` column. See [Register Azure resource providers](#register-azure-service-providers).
 
-  Namespace                                RegistrationPolicy    RegistrationState    ProviderAuthorizationConsentState
-  ---------------------------------------  --------------------  -----------------
-  Microsoft.Capacity                       RegistrationRequired  NotRegistered
-  Microsoft.ContainerInstance              RegistrationRequired  NotRegistered
-  Microsoft.Compute                        RegistrationRequired  NotRegistered
-  Microsoft.ContainerService               RegistrationRequired  NotRegistered
-  Microsoft.KeyVault                       RegistrationRequired  NotRegistered
-  Microsoft.ManagedIdentity                RegistrationRequired  NotRegistered
-  Microsoft.Network                        RegistrationRequired  NotRegistered
-  Microsoft.OperationalInsights            RegistrationRequired  NotRegistered
-  Microsoft.OperationsManagement           RegistrationRequired  NotRegistered
-  Microsoft.Portal                         RegistrationFree      Registered
-  Microsoft.Storage                        RegistrationRequired  Registered
-  Microsoft.AlertsManagement               RegistrationRequired  NotRegistered
-  ```
- 
- 
- * Whether your Azure subscription restricts vCPUs for the `Standard_D2_v4` and `Standard_E2s_v3` VM size families in your region (and availability zone, if HA is enabled). Open a support request to remove SKU restrictions for the VM families with `NotAvailableForSubscription` displayed in the `Restrictions` column. See [Fix issues with SKU restrictions](#fix-issues-with-sku-restrictions).
-  ```
-  #######################
-  # Virtual-Machine SKU #
-  #######################
-  
-  ResourceType      Locations              Name                    Zones    Restrictions
-  ------------      ---------              ----                    -----    ------------
-  virtualMachines   eastus2                Standard_D2_v4          1,2,3    None
-  virtualMachines   eastus2                Standard_E2s_v3         1,2,3    NotAvailableForSubscription, type: Zone, locations: eastus2, zones: 1,3
-  
-  ```
+    ```
+    #######################
+    # Provider            #
+    #######################
 
- * Whether your Azure subscription has sufficient limits on vCPUs and IP addresses for your region. Open a support request to raise limits for the vCPUs and IP addresses if they exceed the available VM families with `NotAvailableForSubscription` displayed in the `Restrictions` column. See [Increase Public IP addresses](#increase-public-ip-addresses-limits) and [Increase vCPU limits](#increase-vcpu-limits).
+    Namespace                                RegistrationPolicy    RegistrationState    ProviderAuthorizationConsentState
+    ---------------------------------------  --------------------  -----------------
+    Microsoft.Capacity                       RegistrationRequired  NotRegistered
+    Microsoft.ContainerInstance              RegistrationRequired  NotRegistered
+    Microsoft.Compute                        RegistrationRequired  NotRegistered
+    Microsoft.ContainerService               RegistrationRequired  NotRegistered
+    Microsoft.KeyVault                       RegistrationRequired  NotRegistered
+    Microsoft.ManagedIdentity                RegistrationRequired  NotRegistered
+    Microsoft.Network                        RegistrationRequired  NotRegistered
+    Microsoft.OperationalInsights            RegistrationRequired  NotRegistered
+    Microsoft.OperationsManagement           RegistrationRequired  NotRegistered
+    Microsoft.Portal                         RegistrationFree      Registered
+    Microsoft.Storage                        RegistrationRequired  Registered
+    Microsoft.AlertsManagement               RegistrationRequired  NotRegistered
+    ```
 
-  ```
-  ####################### 
-  # Quota Limitation # 
-  ####################### 
-  
-   Resource                        Limit   Used    Available    Gap   Suggestion 
-   Total Regional vCPUs            130     27      103          89    OK 
-   Standard D2v4 Family vCPUs      20      14      6            0     Need Increase 
-   Standard E2sv3 Family vCPUs      20      4       16           8     OK 
-   Public IP Addresses — Basic     20      11      9            8     OK 
-   Public IP Addresses — Standard  20      3       17           16    OK 
-  ```
+-   Whether your Azure subscription restricts vCPUs for the `Standard_D2_v4` and `Standard_E2s_v3` VM size families in your region (and availability zone, if HA is enabled). Open a support request to remove SKU restrictions for the VM families with `NotAvailableForSubscription` displayed in the `Restrictions` column. See [Fix issues with SKU restrictions](#fix-issues-with-sku-restrictions).
 
+    ```
+    #######################
+    # Virtual-Machine SKU #
+    #######################
+
+    ResourceType      Locations              Name                    Zones    Restrictions
+    ------------      ---------              ----                    -----    ------------
+    virtualMachines   eastus2                Standard_D2_v4          1,2,3    None
+    virtualMachines   eastus2                Standard_E2s_v3         1,2,3    NotAvailableForSubscription, type: Zone, locations: eastus2, zones: 1,3
+
+    ```
+
+-   Whether your Azure subscription has sufficient limits on vCPUs and IP addresses for your region. Open a support request to raise limits for the vCPUs and IP addresses if they exceed the available VM families with `NotAvailableForSubscription` displayed in the `Restrictions` column. See [Increase Public IP addresses](#increase-public-ip-addresses-limits) and [Increase vCPU limits](#increase-vcpu-limits).
+
+    ```
+    ####################### 
+    # Quota Limitation # 
+    ####################### 
+
+     Resource                        Limit   Used    Available    Gap   Suggestion 
+     Total Regional vCPUs            130     27      103          89    OK 
+     Standard D2v4 Family vCPUs      20      14      6            0     Need Increase 
+     Standard E2sv3 Family vCPUs      20      4       16           8     OK 
+     Public IP Addresses — Basic     20      11      9            8     OK 
+     Public IP Addresses — Standard  20      3       17           16    OK 
+    ```
 
 ### Method 2: Manually check requirements
+
 If you are manually checking the requirements instead of using the `biganimal-preflight-azure` script, perform the following procedures:
 
 #### Check Azure resource provider registrations using Azure Cloud Shell
@@ -146,12 +147,12 @@ Alternatively, to check for SKU restrictions using the Azure Portal, see [Soluti
 
 To check if you have adequate Azure resources to provision new clusters:
 
-1. In the [Azure Portal](https://portal.azure.com/), select **Subscription**.
-2. Select your specific subscription.
-3. Select **Usage + quotas** in the **Settings** section.
-4. Search for *Total Regional vCPUs* and select the **Location** to check the regional vCPUs limits.
-5. Search for *Dv4* and *Esv3* to view virtual machine limits.
-6. Search for Public IP addresses to view network limits.
+1.  In the [Azure Portal](https://portal.azure.com/), select **Subscription**.
+2.  Select your specific subscription.
+3.  Select **Usage + quotas** in the **Settings** section.
+4.  Search for *Total Regional vCPUs* and select the **Location** to check the regional vCPUs limits.
+5.  Search for *Dv4* and *Esv3* to view virtual machine limits.
+6.  Search for Public IP addresses to view network limits.
 
 ## Configure your Azure subscription
 
@@ -160,13 +161,14 @@ After checking whether the requirements and resource limits are met, configure y
 !!! Note
     Before proceeding, see [Understanding requirements in Azure](../01_preparing_azure/01_understanding_qotas_in_azure) for details on planning for your clusters' requirements and resource limits in Azure.
 
-### Register Azure resource providers 
+### Register Azure resource providers
+
 To register resource providers using the Azure Portal:
 
-1. In the [Azure Portal](https://portal.azure.com/), select **Subscription**.
-2. Select your specific subscription.
-3. In the navigation panel **Settings** group, select **Resource providers**.
-4. Review the status of the required providers. To register a provider, select the provider, and, on the top menu, select **Register**.
+1.  In the [Azure Portal](https://portal.azure.com/), select **Subscription**.
+2.  Select your specific subscription.
+3.  In the navigation panel **Settings** group, select **Resource providers**.
+4.  Review the status of the required providers. To register a provider, select the provider, and, on the top menu, select **Register**.
 
 To register resource providers using the Azure CLI,
 use the [register command](https://docs.microsoft.com/en-us/cli/azure/provider?view=azure-cli-latest#az_provider_register). For example:
@@ -186,15 +188,14 @@ Increase the limit of `Public IP Addresses - Basic` and `Public IP Addresses - S
 
 You can increase the number of public IP addresses for your account either by using the Azure portal or by submitting a support request. See:
 
-* [Request networking quota increase at subscription level using Usages + quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/networking-quota-requests#request-networking-quota-increase-at-subscription-level-using-usage--quotas)
+-   [Request networking quota increase at subscription level using Usages + quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/networking-quota-requests#request-networking-quota-increase-at-subscription-level-using-usage--quotas)
 
-* [Request Networking quota increase at subscription level using Help + support](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/networking-quota-requests#request-networking-quota-increase-at-subscription-level-using-help--support)
-
+-   [Request Networking quota increase at subscription level using Help + support](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/networking-quota-requests#request-networking-quota-increase-at-subscription-level-using-help--support)
 
 ### Increase vCPU limits
 
 You can increase the number of Dv4 or Esv3 family virtual machines per region by using the Azure Portal or by submitting a support request. See: 
 
- * [Request a quota increase at a subscription level using Usages + quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/classic-deployment-model-quota-increase-requests#request-quota-increase-for-the-classic-deployment-model-from-usage--quotas)
+-   [Request a quota increase at a subscription level using Usages + quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/classic-deployment-model-quota-increase-requests#request-quota-increase-for-the-classic-deployment-model-from-usage--quotas)
 
- * [Request a quota increase by region from Help + support](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/regional-quota-requests#request-a-quota-increase-by-region-from-help--support)
+-   [Request a quota increase by region from Help + support](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/regional-quota-requests#request-a-quota-increase-by-region-from-help--support)

--- a/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
@@ -6,56 +6,60 @@ Set up your BigAnimal account on Azure Marketplace. Your Azure subscription for 
 
 ## Before you connect your cloud account
 
-1. Ensure you have an active Microsoft Azure subscription. If you need to create one, see [Create an additional Azure subscription](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/create-subscription).
+1.  Ensure you have an active Microsoft Azure subscription. If you need to create one, see [Create an additional Azure subscription](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/create-subscription).
 
-1. In Azure Active Directory, ensure your role is owner and your user type is member (not guest) for the subscription you are using.
+2.  In Azure Active Directory, ensure your role is owner and your user type is member (not guest) for the subscription you are using.
 
-1. Create an Azure Active Directory Application client to delegate Identity and Access Management functions to Azure Active Directory (AD). You can create the Azure Active Directory Application using the Azure Portal, but a simpler and less error-prone approach is to use the `create-spn` script (see [Create Azure Active Directory Application using `create-spn`](#create-azure-active-directory-application-using-create-spn)). The script approach requires the Azure API.
+3.  Create an Azure Active Directory Application client to delegate Identity and Access Management functions to Azure Active Directory (AD). You can create the Azure Active Directory Application using the Azure Portal, but a simpler and less error-prone approach is to use the `create-spn` script (see [Create Azure Active Directory Application using `create-spn`](#create-azure-active-directory-application-using-create-spn)). The script approach requires the Azure API.
 
 !!! Note
     Some steps of the subscription process require approval of an Azure AD administrator.
     Your Azure role in the Azure AD must be either:
-      - Global Administrator
-      - Privileged Role Administrator
-    
+
+    -   Global Administrator
+    -   Privileged Role Administrator
+
     or you need the cooperation of a user with one of those roles in your organization.
-
-
 
 ### Create Azure Active Directory Application using the Azure portal
 
 !!! Note
     Create your Azure AD Application in the same tenant as the subscription you want to associate it with. 
 
-1. Register an application with Azure AD and create a service principal. See [Register an application with Azure AD and create a service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#register-an-application-with-azure-ad-and-create-a-service-principal) for instructions.
-Take note of the **Application (client) ID**, as you need it to configure your BigAnimal account. Also take note of the **Display name** value of the Azure AD application. You need to enter this value later.
+1.  Register an application with Azure AD and create a service principal. See [Register an application with Azure AD and create a service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#register-an-application-with-azure-ad-and-create-a-service-principal) for instructions.
+    Take note of the **Application (client) ID**, as you need it to configure your BigAnimal account. Also take note of the **Display name** value of the Azure AD application. You need to enter this value later.
 
-1. Select _application secret_ as an authentication option for the application. See [Create a new Azure AD application secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#option-2-create-a-new-application-secret) for instructions. Take note of the Azure AD App Secret, as you need it to configure your cloud account.
-1. Select _API permissions_ to configure API permissions for the application. See [Configure a client application to access Azure Active Directory API](https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/howto-configure-prerequisites-for-reporting-api) for instructions. Add Application permissions with Microsoft Graph _Application.ReadWrite.OwnedBy_ and _Directory.Read.All_ to your application and grant admin consent for your cloud account.
-1. Assign the owner role to the application. See [Assign a role to the application](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#assign-a-role-to-the-application) for instructions. In the **Select** field of the **Add role assignment** panel, enter the display name of the Azure AD application. See [Open the Add role assignment pane](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal?tabs=current#step-2-open-the-add-role-assignment-page) for instructions.
+2.  Select *application secret* as an authentication option for the application. See [Create a new Azure AD application secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#option-2-create-a-new-application-secret) for instructions. Take note of the Azure AD App Secret, as you need it to configure your cloud account.
+
+3.  Select *API permissions* to configure API permissions for the application. See [Configure a client application to access Azure Active Directory API](https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/howto-configure-prerequisites-for-reporting-api) for instructions. Add Application permissions with Microsoft Graph *Application.ReadWrite.OwnedBy* and *Directory.Read.All* to your application and grant admin consent for your cloud account.
+
+4.  Assign the owner role to the application. See [Assign a role to the application](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#assign-a-role-to-the-application) for instructions. In the **Select** field of the **Add role assignment** panel, enter the display name of the Azure AD application. See [Open the Add role assignment pane](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal?tabs=current#step-2-open-the-add-role-assignment-page) for instructions.
 
 ### Create Azure Active Directory Application using `create-spn`
 
 To simplify the process of creating an Azure AD Application, EDB provides the [`create-spn`](https://github.com/EnterpriseDB/cloud-utilities/blob/main/azure/create-spn.sh) script for Azure API users. The script automates the creation of the Active Directory Application. You can download the script [here](https://github.com/EnterpriseDB/cloud-utilities/tree/main/azure).
 Before using the script, ensure that these utilities are installed on your machine:
-* [jq command-line JSON processor](https://stedolan.github.io/jq/)
-* [azure cli](https://docs.microsoft.com/en-us/cli/azure/) v2.26 or above
+
+-   [jq command-line JSON processor](https://stedolan.github.io/jq/)
+-   [azure cli](https://docs.microsoft.com/en-us/cli/azure/) v2.26 or above
 
 The syntax of the command is:
+
 ```
 curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s \
   -- --display-name <display-name> \
   ----subscription <subscription> \
   --years <years>
 ```
+
 Flag and option details:
 
-| Flag/option shortcut | Flag/option long name | Description |
-| -------------------- | --------------------- | ----------- |
-| -d *NAME* |  --display-name *NAME* | Name of Azure AD Application. |
-|  -s *SUBSCRIPTION_ID* | --subscription *SUBSCRIPTION_ID* | Azure Subscription ID used by BigAnimal. |
-|  -y *YEARS* | --years *YEARS* | Integer value specifying the number of years for which the credentials are valid. The default is one year. |
-|  -h | --help | Displays information on the syntax and usage of the script. |
+| Flag/option shortcut | Flag/option long name            | Description                                                                                                |
+| -------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| -d *NAME*            | --display-name *NAME*            | Name of Azure AD Application.                                                                              |
+| -s *SUBSCRIPTION_ID* | --subscription *SUBSCRIPTION_ID* | Azure Subscription ID used by BigAnimal.                                                                   |
+| -y *YEARS*           | --years *YEARS*                  | Integer value specifying the number of years for which the credentials are valid. The default is one year. |
+| -h                   | --help                           | Displays information on the syntax and usage of the script.                                                |
 
 The script creates the Azure AD Service Principal and configures its access to Azure resources in the specified subscription.
 
@@ -94,7 +98,9 @@ Add Azure AD Service Principal Owners...
   "subscription": "c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712"
 }
 ```
+
 If you receive the following error message, you need to request admin consent for your cloud account. Only users with the Azure AD Global Administrator or Privileged Role Administrator role can grant admin consent.
+
 ```
 ...
 Error: Please request Azure AD Global Administrator or Privileged Role Administrator to grant admin consent permissions for Service Principal hello-s(77bbxxxx-xxxx-xxxx-xxxx-xxxxxxxx7c54)
@@ -106,39 +112,46 @@ Connect your cloud account with your Azure subscription.
 
 #### 1. Select the EDB offer in the Azure portal.
 
-1. Sign in to the [Azure portal](https://portal.azure.com/) and go to Azure **Marketplace**.
+1.  Sign in to the [Azure portal](https://portal.azure.com/) and go to Azure **Marketplace**.
 
-2. Find an offer from **EnterpriseDB Corporation** and select it.
-3. From the **Select Plan** list, select an available plan.
-4. Select **Set up + subscribe**.
+2.  Find an offer from **EnterpriseDB Corporation** and select it.
+
+3.  From the **Select Plan** list, select an available plan.
+
+4.  Select **Set up + subscribe**.
 
 #### 2. Fill out the details for your plan.
-1. In the **Project details** section, enter or create a resource group for your subscription. See [What is a resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal#what-is-a-resource-group) for more information.
 
-2. In the **SaaS details** section, enter the SaaS subscription name.
-3. Select **Review + subscribe**.
+1.  In the **Project details** section, enter or create a resource group for your subscription. See [What is a resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal#what-is-a-resource-group) for more information.
+
+2.  In the **SaaS details** section, enter the SaaS subscription name.
+
+3.  Select **Review + subscribe**.
 
 #### 3. Accept terms of use.
-1. Review the terms of use provided by EDB.
 
-2. Select **Subscribe**.
+1.  Review the terms of use provided by EDB.
+
+2.  Select **Subscribe**.
 
 #### 4. Configure your account.
+
 !!! Note
     After step 1, you are prompted for approval by an Azure AD administrator with either the Global Administrator or Privileged Role Administrator role.
-1. To configure BigAnimal to use your Azure subscription and your Azure AD Application. select **Configure account now**.
+
+1.  To configure BigAnimal to use your Azure subscription and your Azure AD Application. select **Configure account now**.
 
 
-2. Fill in the parameters in the form:
+2.  Fill in the parameters in the form:
 
-   | Parameter                                            | Description                                                                  |
-   | ---------------------------------------------------- | ---------------------------------------------------------------------------- |
-   | **Azure AD: Application Client ID**                  | Application client ID you noted when [creating your Azure AD Application](#create-azure-active-directory-application-using-the-azure-portal) or that was generated from the [`create-spn`](#create-azure-active-directory-application-using-create-spn) script.|
-   | **Azure AD: Application Client Secret Value** | Application client secret value you noted when [creating your Azure AD Application](#create-azure-active-directory-application-using-the-azure-portal) or that was generated from the [`create-spn`](#create-azure-active-directory-application-using-create-spn) script.|
-   | **Azure Subscription ID**                            | Azure subscription ID for BigAnimal available from the Subscriptions page of your Azure account.  |
-   | **Your BigAnimal Organization Name**                 | SaaS Subscription Name you assigned as your BigAnimal Organization (see [Step 2. Fill out the details for your plan.](#2-fill-out-the-details-for-your-plan)).  |
+    | Parameter                                     | Description                                                                                                                                                                                                                                                               |
+    | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | **Azure AD: Application Client ID**           | Application client ID you noted when [creating your Azure AD Application](#create-azure-active-directory-application-using-the-azure-portal) or that was generated from the [`create-spn`](#create-azure-active-directory-application-using-create-spn) script.           |
+    | **Azure AD: Application Client Secret Value** | Application client secret value you noted when [creating your Azure AD Application](#create-azure-active-directory-application-using-the-azure-portal) or that was generated from the [`create-spn`](#create-azure-active-directory-application-using-create-spn) script. |
+    | **Azure Subscription ID**                     | Azure subscription ID for BigAnimal available from the Subscriptions page of your Azure account.                                                                                                                                                                          |
+    | **Your BigAnimal Organization Name**          | SaaS Subscription Name you assigned as your BigAnimal Organization (see [Step 2. Fill out the details for your plan.](#2-fill-out-the-details-for-your-plan)).                                                                                                            |
 
-11. Select **Submit**.
+3.  Select **Submit**.
 
 ## What's next
 

--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/01_cluster_networking.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/01_cluster_networking.mdx
@@ -3,9 +3,10 @@ title: Cluster networking architecture
 ---
 
 BigAnimal clusters can be exposed to client applications in two ways:
-- Public — The cluster is available on the Internet.
-- Private — Access to the cluster is restricted to specific
-sources, and network traffic never leaves the Azure network.
+
+-   Public — The cluster is available on the Internet.
+-   Private — Access to the cluster is restricted to specific
+    sources, and network traffic never leaves the Azure network.
 
 ## Basic architecture
 
@@ -59,5 +60,3 @@ Clusters can be changed from public to private and vice versa at any
 time. When this happens, the IP address previously assigned to the
 cluster is deallocated, a new one is assigned, and DNS is updated
 accordingly.
-
-

--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -6,64 +6,73 @@ redirects:
   - ../03_create_cluster/
 ---
 
-!!! Note
+!!!Note
 Prior to creating your cluster, make sure you have adequate Azure resources or your request to create a cluster will fail. See [Raising your Azure resource limits](../01_check_resource_limits).
 !!!
 
 ## Create a cluster
 
-1. Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
+1.  Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
 
-3. Select **Create New Cluster** in the top right of the **Overview** page or **Clusters** page.
-4. On the **Create Cluster** page, specify the cluster settings on the following tabs:
-   - [**Cluster Info**](#cluster-info-tab)
+2.  Select **Create New Cluster** in the top right of the **Overview** page or **Clusters** page.
 
-   - [**Operational Settings**](#operational-settings-tab)
-   - [**DB Configuration** ](#db-configuration-tab) (optional)
-   - [ **Availability** ](#availability-tab) (optional)
+3.  On the **Create Cluster** page, specify the cluster settings on the following tabs:
 
-8. Select **Create Cluster**. It might take a few minutes to deploy.
+    -   [**Cluster Info**](#cluster-info-tab)
+
+    -   [**Operational Settings**](#operational-settings-tab)
+
+    -   [**DB Configuration** ](#db-configuration-tab) (optional)
+
+    -   [ **Availability** ](#availability-tab) (optional)
+
+4.  Select **Create Cluster**. It might take a few minutes to deploy.
 
 !!! Note
     When you don't configure settings on optional tabs, the default values are used.
 
 ### Cluster Info tab
-1. Enter the name for your cluster in the **Cluster Name** field.
 
-2. Enter a password for your cluster in the **Password** field. This is the password for the user edb_admin.
-3. Select **Next: Operational Settings**. 
+1.  Enter the name for your cluster in the **Cluster Name** field.
+
+2.  Enter a password for your cluster in the **Password** field. This is the password for the user edb_admin.
+
+3.  Select **Next: Operational Settings**. 
 
 ### Operational Settings tab
-1. In the **Database Type** section:
-   1. Select the type of Postgres you want to use in the **Postgres Type** field:
-      - [*PostgreSQL*](/supported-open-source/postgresql/) is an open-source object-relational database management system.
 
-      - [*EDB Postgres Advanced Server*](/epas/latest/) is EDB’s secure, Oracle-compatible PostgreSQL. View [a quick demonstration of Oracle compatibility on EDB Cloud](../../using_cluster/06_demonstration_oracle_compatibility).
+1.  In the **Database Type** section:
 
-   2. In the **Version** field, select the version of Postgres that you want to use. See [Database Version Policy](../../overview/05_database_version_policy) for more information.
-2. In the **Provider** field, select the cloud provider for your cluster.
-   !!! Note
-       Microsoft Azure is the only option for the Preview.
-3. In the **Region** field, select the region where you want to deploy your cluster. For the best performance, EDB typically recommends that this region be the same as other resources you have that communicate with your cluster.
-4. In the **Instance Type** section, select the number of vCPUs and amount of memory you want.
-5. In the **Storage** section, select **Volume Type**. In **Volume Properties**, select the type and amount of storage needed for your cluster.
-   !!! Note
-       BigAnimal currently supports Azure Premium SSD storage types. See [the Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds) for more information.
-6. In the **Networking** section, you specify whether to use private or public networking. Networking is set to Public by default. Public means that any client can connect to your cluster’s public IP address over the internet. Optionally, you can limit traffic to your public cluster by specifying an IP allowlist, which only allows access to certain blocks of IP addresses. To limit access, add one or more Classless Inter-Domain Routing (CIDR) blocks in the **IP Allowlists** section. CIDR is a method for allocating IP addresses and IP routing to a whole network or subnet. If you have any CIDR block entries, access is limited to those IP addresses. If none are specified, all network traffic is allowed.
+    1.  Select the type of Postgres you want to use in the **Postgres Type** field:
 
-   Private networking allows only IP addresses within your private network to connect to your cluster. See [Cluster networking architecture](01_cluster_networking) for more information.
+        -   [*PostgreSQL*](/supported-open-source/postgresql/) is an open-source object-relational database management system.
+
+        -   [*EDB Postgres Advanced Server*](/epas/latest/) is EDB’s secure, Oracle-compatible PostgreSQL. View [a quick demonstration of Oracle compatibility on EDB Cloud](../../using_cluster/06_demonstration_oracle_compatibility).
+
+    2.  In the **Version** field, select the version of Postgres that you want to use. See [Database Version Policy](../../overview/05_database_version_policy) for more information.
+2.  In the **Provider** field, select the cloud provider for your cluster.
+    !!! Note
+        Microsoft Azure is the only option for the Preview.
+3.  In the **Region** field, select the region where you want to deploy your cluster. For the best performance, EDB typically recommends that this region be the same as other resources you have that communicate with your cluster.
+4.  In the **Instance Type** section, select the number of vCPUs and amount of memory you want.
+5.  In the **Storage** section, select **Volume Type**. In **Volume Properties**, select the type and amount of storage needed for your cluster.
+    !!! Note
+        BigAnimal currently supports Azure Premium SSD storage types. See [the Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds) for more information.
+6.  In the **Networking** section, you specify whether to use private or public networking. Networking is set to Public by default. Public means that any client can connect to your cluster’s public IP address over the internet. Optionally, you can limit traffic to your public cluster by specifying an IP allowlist, which only allows access to certain blocks of IP addresses. To limit access, add one or more Classless Inter-Domain Routing (CIDR) blocks in the **IP Allowlists** section. CIDR is a method for allocating IP addresses and IP routing to a whole network or subnet. If you have any CIDR block entries, access is limited to those IP addresses. If none are specified, all network traffic is allowed.
+
+    Private networking allows only IP addresses within your private network to connect to your cluster. See [Cluster networking architecture](01_cluster_networking) for more information.
 
 
-7. To optionally make updates to your database configuration parameters, select **Next: DB Configuration**.
+7.  To optionally make updates to your database configuration parameters, select **Next: DB Configuration**.
 
 ### DB Configuration tab
+
 In the **Parameters** section, you can update the value of the database configuration parameters, as needed. 
 
 To update the parameter values, see [Modifying Your Database Configuration Parameters](../../using_cluster/03_modifying_your_cluster/05_db_configuration_parameters).
 
-
-
 ### Availability tab
+
  Enable or disable high availability using the **High Availability** control. High availability is enabled by default.
  When high availability is enabled, clusters are configured with one primary and two replicas with synchronous streaming replication.
  Clusters are configured across availability zones in regions with availability zones. When high availability is disabled, only one instance is provisioned.
@@ -73,6 +82,5 @@ To update the parameter values, see [Modifying Your Database Configuration Param
 
 After you create your cluster, use these resources to learn about cluster use and management:
 
-* [Using your cluster](../../using_cluster/)
-* [Managing Postgres access](../../using_cluster/01_postgres_access/)
-
+-   [Using your cluster](../../using_cluster/)
+-   [Managing Postgres access](../../using_cluster/01_postgres_access/)

--- a/product_docs/docs/biganimal/release/getting_started/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/index.mdx
@@ -4,5 +4,3 @@ indexCards: simple
 ---
 
 As an Azure subscription administrators, you can set up your BigAnimal account, invite others to join you in exploring what EDB has to offer, and create initial clusters as an account owner so that development can begin.
-
-

--- a/product_docs/docs/biganimal/release/migration/cold_migration.mdx
+++ b/product_docs/docs/biganimal/release/migration/cold_migration.mdx
@@ -6,11 +6,11 @@ The simplest way to import a database into BigAnimal is using logical backups ta
 
 The high-level steps are:
 
-1. [Export existing roles](#export-existing-roles).
-1. [Import existing roles](#import-the-roles).
-1. For each database, you are migrating:
-   1. [logical export using `pg_dump`](#export-a-database)
-   1. [logical import with `pg_restore`](#import-a-database)
+1.  [Export existing roles](#export-existing-roles).
+2.  [Import existing roles](#import-the-roles).
+3.  For each database, you are migrating:
+    1.  [logical export using `pg_dump`](#export-a-database)
+    2.  [logical import with `pg_restore`](#import-a-database)
 
 In case your source PostgreSQL instance hosts multiple databases, you can segment them in multiple BigAnimal clusters for easier management, better performance, increased predictability, and finer control of resources. For example, if your host has 10 databases, you can import one database (and related users) on a different BigAnimal cluster, one at a time.
 
@@ -19,36 +19,37 @@ In case your source PostgreSQL instance hosts multiple databases, you can segmen
 This approach requires suspending write operations to the database application for the duration of the export/import process. You can then resume the write operations on the new system. This is because `pg_dump` takes an online snapshot of the source database. As a result, the changes after the backup starts aren't included in the output.
 
 The required downtime depends on many factors, including:
- - Size of the database
- - Speed of the network between the two systems
- - Your team's familiarity with the migration procedure
+
+-   Size of the database
+-   Speed of the network between the two systems
+-   Your team's familiarity with the migration procedure
 
 To minimize the downtime, you can test the process as many times as needed before the actual migration. You can perform the export with `pg_dump` online, and the process is repeatable and measurable.
 
 ## Before you begin
 
 Make sure that you:
- - Understand the [terminology conventions](#terminology-conventions) used in this topic.
- - Have the [required Postgres client binaries and libraries](#postgres-client-libraries).
- - Can [access the source and target databases](#access-to-the-source-and-target-database).
+
+-   Understand the [terminology conventions](#terminology-conventions) used in this topic.
+-   Have the [required Postgres client binaries and libraries](#postgres-client-libraries).
+-   Can [access the source and target databases](#access-to-the-source-and-target-database).
 
 ### Terminology conventions
 
-| Term | Alias | Description |
-| ---- | ----- | ---------- |
-| source database | `pg-source` | Postgres instance from which you want to import your data. |
-| target database | `pg-target` | Postgres cluster in BigAnimal where you want to import your data. |
-| migration host | `pg-migration` | Temporary Linux machine in your trusted network from which to execute the export of the database and the subsequent import into BigAnimal. The migration host needs access to both the source and target databases. Or, if your source and target databases are on the same version of Postgres, the source host can serve as your migration host. |
-
+| Term            | Alias          | Description                                                                                                                                                                                                                                                                                                                                        |
+| --------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| source database | `pg-source`    | Postgres instance from which you want to import your data.                                                                                                                                                                                                                                                                                         |
+| target database | `pg-target`    | Postgres cluster in BigAnimal where you want to import your data.                                                                                                                                                                                                                                                                                  |
+| migration host  | `pg-migration` | Temporary Linux machine in your trusted network from which to execute the export of the database and the subsequent import into BigAnimal. The migration host needs access to both the source and target databases. Or, if your source and target databases are on the same version of Postgres, the source host can serve as your migration host. |
 
 ### Postgres client libraries
 
 The following client binaries must be on the migration host:
 
-- `pg_dumpall`
-- `pg_dump`
-- `pg_restore`
-- `psql`
+-   `pg_dumpall`
+-   `pg_dump`
+-   `pg_restore`
+-   `psql`
 
 They must be the same version as the Postgres version of the target database. For example, if you want to import a PostgreSQL 10 database from your private network into a PostgreSQL 14 database in BigAnimal, use the client libraries and binaries from version 14.
 
@@ -56,26 +57,27 @@ They must be the same version as the Postgres version of the target database. Fo
 
 Access requirements:
 
-- PostgreSQL superuser access to the source database. This could be the `postgres` user or another user with `SUPERUSER` privileges.
-- Access to the target database in BigAnimal as the `edb_admin` user.
-
+-   PostgreSQL superuser access to the source database. This could be the `postgres` user or another user with `SUPERUSER` privileges.
+-   Access to the target database in BigAnimal as the `edb_admin` user.
 
 #### Verify your access
 
-1. Connect to the source database using `psql`. For example:
-   ```
-   psql -d "host=pg-source user=postgres dbname=postgres"
-   ```
-   Replace `pg-source` with the actual hostname or IP address of the source database and the `user` and `dbname` values as appropriate. If the connection doesn't work, contact your system and database administrators to make sure that you can access the source database. This might require changes to your `pg_hba.conf` and network settings. If `pg_hba.conf` changes, reload the configuration with either `SELECT pg_reload_conf();` via a psql connection or `pg_ctl reload` in a shell connection to the database host.
+1.  Connect to the source database using `psql`. For example:
+    ```
+    psql -d "host=pg-source user=postgres dbname=postgres"
+    ```
+    Replace `pg-source` with the actual hostname or IP address of the source database and the `user` and `dbname` values as appropriate. If the connection doesn't work, contact your system and database administrators to make sure that you can access the source database. This might require changes to your `pg_hba.conf` and network settings. If `pg_hba.conf` changes, reload the configuration with either `SELECT pg_reload_conf();` via a psql connection or `pg_ctl reload` in a shell connection to the database host.
 
-1. Connect to the target database using the `edb_admin` user. For example:
-   ```
-   psql -d "host=pg-target user=edb_admin dbname=edb_admin"
-   ```
-   Replace `pg-target` with the actual hostname of your BigAnimal cluster.
+2.  Connect to the target database using the `edb_admin` user. For example:
+    ```
+    psql -d "host=pg-target user=edb_admin dbname=edb_admin"
+    ```
+    Replace `pg-target` with the actual hostname of your BigAnimal cluster.
 
 ## Export existing roles
+
 Export the existing roles from your source Postgres instance by running the following command on the migration host:
+
 ```
 pg_dumpall -r -d "host=pg-source user=postgres dbname=postgres" > roles.sql
 ```
@@ -103,49 +105,51 @@ SET standard_conforming_strings = on;
 --
 ```
 
-
-
 ## Import the roles
 
-1. Your BigAnimal cluster already contains the `edb_admin` user, as well as the following system required roles:
-  - `postgres` (the superuser, needed by the BigAnimal to manage the cluster)
-  - `streaming_replica` (required to manage streaming replication)
+1.  Your BigAnimal cluster already contains the `edb_admin` user, as well as the following system required roles:
 
-  As a result, you need to modify the `roles.sql` file to:
-   1. Remove the lines involving the `postgres` user. For example, remove lines like these:
-      ```
-      CREATE ROLE postgres;
-      ALTER ROLE postgres WITH SUPERUSER ….;
-      ```
-    2. Remove any role with superuser or replication privileges. For example, remove lines like these:
-       ```
-       CREATE ROLE admin;
-       ALTER ROLE admin WITH SUPERUSER ….;
-       ```
-    3. For every role that is created, grant the new role to the `edb_admin` user immediately after creating the user. For example:
-       ```
-       CREATE ROLE my_role;
-       GRANT my_role TO edb_admin;
-       ```
-    4. Remove the `NOSUPERUSER`, `NOCREATEROLE`, `NOCREATEDB`, `NOREPLICATION`, `NOBYPASSRLS` permission attributes on the other users.
+-   `postgres` (the superuser, needed by the BigAnimal to manage the cluster)
+-   `streaming_replica` (required to manage streaming replication)
 
-   The role section in the modified file, then, looks similar to:
-   ```
-   CREATE ROLE my_role;
-   GRANT my_role TO edb_admin;
-   ALTER ROLE my_role WITH INHERIT LOGIN PASSWORD 'SCRAM-SHA-256$4096:my-Scrambled-Password';
-   ```
-1. From the migration host, execute:
+    As a result, you need to modify the `roles.sql` file to:
 
-   ```
-   psql -1 -f roles.sql -d "postgres://edb_admin@pg-target:5432/edb_admin?sslmode=verify-full"
-   ```
-   (Replace `pg-target` with the Fully Qualified Domain Name (FQDN) of your BigAnimal cluster).
+1.  Remove the lines involving the `postgres` user. For example, remove lines like these:
+    ```
+    CREATE ROLE postgres;
+    ALTER ROLE postgres WITH SUPERUSER ….;
+    ```
+2.  Remove any role with superuser or replication privileges. For example, remove lines like these:
+    ```
+    CREATE ROLE admin;
+    ALTER ROLE admin WITH SUPERUSER ….;
+    ```
+3.  For every role that is created, grant the new role to the `edb_admin` user immediately after creating the user. For example:
+    ```
+    CREATE ROLE my_role;
+    GRANT my_role TO edb_admin;
+    ```
+4.  Remove the `NOSUPERUSER`, `NOCREATEROLE`, `NOCREATEDB`, `NOREPLICATION`, `NOBYPASSRLS` permission attributes on the other users.
 
+    The role section in the modified file, then, looks similar to:
+
+    ```
+    CREATE ROLE my_role;
+    GRANT my_role TO edb_admin;
+    ALTER ROLE my_role WITH INHERIT LOGIN PASSWORD 'SCRAM-SHA-256$4096:my-Scrambled-Password';
+    ```
+5.  From the migration host, execute:
+
+    ```
+    psql -1 -f roles.sql -d "postgres://edb_admin@pg-target:5432/edb_admin?sslmode=verify-full"
+    ```
+
+    (Replace `pg-target` with the Fully Qualified Domain Name (FQDN) of your BigAnimal cluster).
 
    This command tries to create the roles in a single transaction. In case of errors, the transaction is rolled back, leaving the database cluster in the same state as before the import attempt. This behavior is enforced using the `-1` option of `psql`.
 
 ## Export a database
+
 From the migration host, use the `pg_dump` command to export the source database into the target database in BigAnimal. For example:
 
 ```
@@ -158,17 +162,20 @@ pg_dump -Fc -d "host=pg-source user=postgres dbname=app" -f app.dump
 The command generates a custom .dump archive (`app.dump` in this example), which contains the compressed dump of the source database. The duration of the command execution varies depending on several variables including size of the database, network speed, disk speed, and CPU of both the source instance and the migration host. You can inspect the table of contents of the dump with `pg_restore -l <db_name>.dump`.
 
 As with any other custom format dump produced with `pg_dump`, you can take advantage of the features that `pg_restore` provides you with, including:
-- Selecting a subset of the import tasks by editing the table of contents and passing it to the `-L` option.
-- Running the command in parallel using the `-j` option with the directory format.
+
+-   Selecting a subset of the import tasks by editing the table of contents and passing it to the `-L` option.
+-   Running the command in parallel using the `-j` option with the directory format.
 
 For further information, see the [`pg_restore` documentation](https://www.postgresql.org/docs/current/app-pgrestore.html).
 
 ## Import a database
+
 Use the `pg_restore` command and the .dump file you created when exporting the source database to import the database into BigAnimal. For example:
 
 ```
 pg_restore -C -d  "postgres://edb_admin@pg-target:5432/edb_admin?sslmode=verify-full" app.dump
 ```
+
 This process might take some time depending on the size of the database and the speed of the network.
 
 In case of error, repeat the restore operation once you have deleted the database using the following command:

--- a/product_docs/docs/biganimal/release/migration/index.mdx
+++ b/product_docs/docs/biganimal/release/migration/index.mdx
@@ -4,21 +4,17 @@ title: Migrating databases to BigAnimal
 
 EDB provides migration tools to bring data from Oracle, PostgresSQL, and EDB Postgres Advanced Server databases into BigAnimal. These tools include Migration Portal and Migration Toolkit for Oracle migrations. More sophisticated migration processes can use tools such as [Replication Server](/eprs/latest/) for ongoing migrations and [LiveCompare](/livecompare/latest/) for data comparisons. 
 
-
-
 ## Migrating from Oracle
 
 The [Migration Portal documentation](/migration_portal/latest) provides the details for executing the migration steps using Migration Portal: 
 
- 1. [Schema extraction](/migration_portal/latest/04_mp_migrating_database/01_mp_schema_extraction/)
- 1. [Schema assessment](/migration_portal/latest/04_mp_migrating_database/02_mp_schema_assessment/)
- 1. [Schema migration](/migration_portal/latest/04_mp_migrating_database/03_mp_schema_migration/)
- 1. [Data migration](/migration_portal/latest/04_mp_migrating_database/04_mp_data_migration/)
-   
+1.  [Schema extraction](/migration_portal/latest/04_mp_migrating_database/01_mp_schema_extraction/)
+2.  [Schema assessment](/migration_portal/latest/04_mp_migrating_database/02_mp_schema_assessment/)
+3.  [Schema migration](/migration_portal/latest/04_mp_migrating_database/03_mp_schema_migration/)
+4.  [Data migration](/migration_portal/latest/04_mp_migrating_database/04_mp_data_migration/)
+
 The Migration Portal documentation describes how to use Migration Toolkit for the data migration step. This toolkit is a good option for smaller databases. 
 
 ## Migrating from Postgres
+
 Several options are available for migrating EDB Postgres Advanced Server and PostgreSQL databases to BigAnimal. One option is to use the Migration Toolkit. Another simple option for many use cases is to import an existing PostgreSQL or EDB Postgres Advanced Server database BigAnimal. See [Importing an existing Postgres database](cold_migration).
-
-
-

--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -8,11 +8,10 @@ BigAnimal enables deploying a cluster with or without high availability. The opt
 
 ## High availability—enabled
 
-The high availability option is provided to minimize downtime in cases of failures. High-availability clusters—one _primary_ and two _replicas_—are configured automatically, with replicas staying up to date through physical streaming replication. In cloud regions with availability zones, clusters are provisioned across multiple availability zones to provide fault tolerance in the face of a datacenter failure.
+The high availability option is provided to minimize downtime in cases of failures. High-availability clusters—one *primary* and two *replicas*—are configured automatically, with replicas staying up to date through physical streaming replication. In cloud regions with availability zones, clusters are provisioned across multiple availability zones to provide fault tolerance in the face of a datacenter failure.
 
-
-* Replicas are usually called _standby servers_. You can also use them for read-only workloads.
-* In case of temporary or permanent unavailability of the primary, a standby replica becomes the primary.
+-   Replicas are usually called *standby servers*. You can also use them for read-only workloads.
+-   In case of temporary or permanent unavailability of the primary, a standby replica becomes the primary.
 
 ![*BigAnimal Cluster4*](images/high-availability.png)
 
@@ -26,4 +25,4 @@ For nonproduction use cases where high availability is not a primary concern, a 
 
 In case of permanent unavailability of the primary, a restore from a backup is required. 
 
-![*BigAnimal Cluster4*](images/ha-not-enabled.png )
+![*BigAnimal Cluster4*](images/ha-not-enabled.png)

--- a/product_docs/docs/biganimal/release/overview/03_security.mdx
+++ b/product_docs/docs/biganimal/release/overview/03_security.mdx
@@ -3,12 +3,16 @@ title: "Security"
 ---
 
 BigAnimal runs in your own cloud account, isolates your data from other users, and gives you control over our access to it. The key security features are:
-- **Data isolation:** Clusters are installed and managed in your cloud environment. Complete segregation of your data is ensured. Your data never leaves your cloud account, and compromise of another BigAnimal customer's systems doesn't put your data at risk.
 
-- **Granular access control:** You can use single sign-on (SSO) and define your own sets of roles and role-based access control (RBAC) policies to manage your individual cloud environments. See [Managing portal access](../administering_cluster/01_portal_access) for more information. 
-- **Data encryption:** All data in BigAnimal is encrypted in motion and at rest. Network traffic is encrypted using Transport Layer Security (TLS) v1.2 or greater, where applicable. Data at rest is encrypted using AES with 256-bit keys. Data encryption keys are envelope encrypted, and the wrapped data encryption keys are securely stored in an Azure Key Vault instance in your account. Encryption keys never leave your environment.
-- **Portal audit logging:** Activities in the portal, such as those related to user roles, organization updates, and cluster creation and deletion, are tracked and viewed in the activity log.  
-- **Database logging and auditing:** Functionality to track and analyze database activities is enabled automatically. For PostgreSQL, the PostgreSQL Audit Extension (pgAudit) is enabled for you when deploying a Postgres cluster. For EDB Postgres Advanced Server, the EDB Audit extension (edbAudit) is enabled for you. 
-    - **pgAudit:** The classes of statements being logged for pgAudit are set globally on a cluster with `pgaudit.log = 'write,ddl'`. The following statements made on tables are logged by default when the cluster type is PostgreSQL: `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, AND `COPY`. All `DDL` is logged. 
-    
-- **Database cluster permissions** The edb_admin account created during the *create cluster* process includes the `CREATEDB` and `CREATEROLE` database roles. EDB recommends using the edb_admin account to create a new application user and new application database for further isolation. See [Managing Postgres access](../using_cluster/01_postgres_access) for more information.
+-   **Data isolation:** Clusters are installed and managed in your cloud environment. Complete segregation of your data is ensured. Your data never leaves your cloud account, and compromise of another BigAnimal customer's systems doesn't put your data at risk.
+
+-   **Granular access control:** You can use single sign-on (SSO) and define your own sets of roles and role-based access control (RBAC) policies to manage your individual cloud environments. See [Managing portal access](../administering_cluster/01_portal_access) for more information. 
+
+-   **Data encryption:** All data in BigAnimal is encrypted in motion and at rest. Network traffic is encrypted using Transport Layer Security (TLS) v1.2 or greater, where applicable. Data at rest is encrypted using AES with 256-bit keys. Data encryption keys are envelope encrypted, and the wrapped data encryption keys are securely stored in an Azure Key Vault instance in your account. Encryption keys never leave your environment.
+
+-   **Portal audit logging:** Activities in the portal, such as those related to user roles, organization updates, and cluster creation and deletion, are tracked and viewed in the activity log.  
+
+-   **Database logging and auditing:** Functionality to track and analyze database activities is enabled automatically. For PostgreSQL, the PostgreSQL Audit Extension (pgAudit) is enabled for you when deploying a Postgres cluster. For EDB Postgres Advanced Server, the EDB Audit extension (edbAudit) is enabled for you. 
+    -   **pgAudit:** The classes of statements being logged for pgAudit are set globally on a cluster with `pgaudit.log = 'write,ddl'`. The following statements made on tables are logged by default when the cluster type is PostgreSQL: `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, AND `COPY`. All `DDL` is logged. 
+
+-   **Database cluster permissions** The edb_admin account created during the *create cluster* process includes the `CREATEDB` and `CREATEROLE` database roles. EDB recommends using the edb_admin account to create a new application user and new application database for further isolation. See [Managing Postgres access](../using_cluster/01_postgres_access) for more information.

--- a/product_docs/docs/biganimal/release/overview/04_responsibility_model.mdx
+++ b/product_docs/docs/biganimal/release/overview/04_responsibility_model.mdx
@@ -6,28 +6,32 @@ Security and confidentiality are a shared responsibility between you and EDB. ED
 
 The following responsibility model describes the distribution of specific responsibilities between you and EDB.
 
-
 ## High availability
-- EDB is responsible for deploying clusters with one primary and two replicas. In cloud regions with availability zones, clusters are deployed across multiple availability zones. 
-- You are responsible for choosing whether to enable high availability. 
 
+-   EDB is responsible for deploying clusters with one primary and two replicas. In cloud regions with availability zones, clusters are deployed across multiple availability zones. 
+-   You are responsible for choosing whether to enable high availability. 
 
 ## Database performance
-- EDB is responsible for managing and monitoring the underlying infrastructure resources. 
-- You are responsible for data modeling, query performance, and scaling the cluster to meet your performance needs. 
 
-## Scaling 
-- EDB is responsible for managing and monitoring the underlying infrastructure.
-- You are responsible for choosing the appropriate resources for your workload, including instance type, storage, and connections. You are also responsible for managing your Azure resource limits to ensure the underlying infrastructure can scale.
+-   EDB is responsible for managing and monitoring the underlying infrastructure resources. 
+-   You are responsible for data modeling, query performance, and scaling the cluster to meet your performance needs. 
+
+## Scaling
+
+-   EDB is responsible for managing and monitoring the underlying infrastructure.
+-   You are responsible for choosing the appropriate resources for your workload, including instance type, storage, and connections. You are also responsible for managing your Azure resource limits to ensure the underlying infrastructure can scale.
 
 ## Backups and restores
-- EDB is responsible for taking automatic backups and storing them in cross-regional Azure Blob Storage. 
-- You are responsible for periodically restoring and verifying the restores to ensure that archives are completing frequently and successfully to meet your needs. 
+
+-   EDB is responsible for taking automatic backups and storing them in cross-regional Azure Blob Storage. 
+-   You are responsible for periodically restoring and verifying the restores to ensure that archives are completing frequently and successfully to meet your needs. 
 
 ## Encryption
-- EDB is responsible for data encryption at rest and in transit. EDB is also responsible for encrypting backups.
-- You are responsible for column-level encryption to protect sensitive database attributes from unauthorized access by authorized users and applications of the database.
 
-## Credential management 
-- EDB is responsible for making credentials available to you.
-- You are responsible for managing and securing your passwords, both for BigAnimal and for your database.
+-   EDB is responsible for data encryption at rest and in transit. EDB is also responsible for encrypting backups.
+-   You are responsible for column-level encryption to protect sensitive database attributes from unauthorized access by authorized users and applications of the database.
+
+## Credential management
+
+-   EDB is responsible for making credentials available to you.
+-   You are responsible for managing and securing your passwords, both for BigAnimal and for your database.

--- a/product_docs/docs/biganimal/release/overview/05_database_version_policy.mdx
+++ b/product_docs/docs/biganimal/release/overview/05_database_version_policy.mdx
@@ -4,22 +4,17 @@ title: "Database version policy"
 
 ## Supported Postgres types and versions
 
-
-| **Postgres type**  | **Major versions**  | 
-| ----- | ------------------------- |
-| PostgreSQL  | 11–14  |
-| EDB Postgres Advanced Server  | 11–14  |
-
+| **Postgres type**            | **Major versions** |
+| ---------------------------- | ------------------ |
+| PostgreSQL                   | 11–14              |
+| EDB Postgres Advanced Server | 11–14              |
 
 ## Major version support
 
 PostgreSQL and EDB Postgres Advanced Server major versions are supported from the date they are made available until the version is retired by EDB (generally five years). See [Platform Compatibility ](https://www.enterprisedb.com/platform-compatibility#epas) for more details.
-
-
 
 ## Minor version support
 
 EDB performs periodic maintenance to ensure stability and security. EDB performs minor version upgrades and patch updates as part of periodic maintenance. Customers are notified in the BigAnimal portal prior to maintenance occurring. You cannot configure minor versions. 
 
 EDB reserves the right to upgrade customers to the latest minor version without prior notice in an extraordinary circumstance.
-

--- a/product_docs/docs/biganimal/release/overview/06_support.mdx
+++ b/product_docs/docs/biganimal/release/overview/06_support.mdx
@@ -8,41 +8,47 @@ If you can’t log in to your account, send us an email at [cloudsupport@enterpr
 
 ## Create a support case from the Support portal (recommended)
 
-1. Start a support case using any one of these options:
+1.  Start a support case using any one of these options:
 
-    - Go to the [Support portal](https://support.biganimal.com/hc/en-us) and select **Submit a request** at the top right of the page.
+    -   Go to the [Support portal](https://support.biganimal.com/hc/en-us) and select **Submit a request** at the top right of the page.
 
-    - Log in to [BigAnimal](https://portal.biganimal.com), select the question mark (?) at the top right of the page, select **Support Portal**, and select **Submit a request** at the top right of the page.
-    - Log in to [BigAnimal](https://portal.biganimal.com), select the question mark (?) at the top right of the page, and select **Create Support ticket**.
-1. Enter a description in the **Subject** field.
+    -   Log in to [BigAnimal](https://portal.biganimal.com), select the question mark (?) at the top right of the page, select **Support Portal**, and select **Submit a request** at the top right of the page.
 
-1. (Optional) Select the cluster name from the **Cluster name** list.
-1. Enter values for **Severity Level** and **Description**.
-1. (Optional) Attach files to provide more details about the issue.
-1. Select **Submit**.
+    -   Log in to [BigAnimal](https://portal.biganimal.com), select the question mark (?) at the top right of the page, and select **Create Support ticket**.
+
+2.  Enter a description in the **Subject** field.
+
+3.  (Optional) Select the cluster name from the **Cluster name** list.
+
+4.  Enter values for **Severity Level** and **Description**.
+
+5.  (Optional) Attach files to provide more details about the issue.
+
+6.  Select **Submit**.
 
 ## Create a support case from the **Support** widget
 
-1. Log in to BigAnimal and select **Support** on the bottom of the left navigation pane. 
+1.  Log in to BigAnimal and select **Support** on the bottom of the left navigation pane. 
 
-1. Fill in the **Leave us a message** form.
-    1. (Optional) The **Your Name** field is prefilled, but you can edit it.
-  
-    3. The **Email Address** field is prefilled, but you can edit it.
-    4. (Optional) Select the cluster name from the **Cluster name** list.
-    5. Enter values for **Severity Level** and **Description**.
-    6. (Optional) Attach files to provide more details about the issue.
-    7. Select **Submit**.
+2.  Fill in the **Leave us a message** form.
+
+    1.  (Optional) The **Your Name** field is prefilled, but you can edit it.
+
+    2.  The **Email Address** field is prefilled, but you can edit it.
+
+    3.  (Optional) Select the cluster name from the **Cluster name** list.
+
+    4.  Enter values for **Severity Level** and **Description**.
+
+    5.  (Optional) Attach files to provide more details about the issue.
+
+    6.  Select **Submit**.
 
 ## Case severity level
 
-| Level | Description |
-| -------- | ----------- |
-| Severity 1  | The cloud service is down or there's an error with critical impact on your production environment. Covers urgent problems including database service outage, data loss, and cluster provisioning failure. |
-| Severity 2  | There's a cloud service error or an issue significantly impacting your production environment. The system is functioning but in a severely reduced capacity. Covers problems including database service interruption and backup failures. |
-| Severity 3 | There's an error or issue that doesn't have a significant impact on your production environment. Covers problems including API issues, monitoring metrics, and logging issues.
-| Severity 4  | General questions, inquiries, or nontechnical requests.
-
-
-
-
+| Level      | Description                                                                                                                                                                                                                               |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Severity 1 | The cloud service is down or there's an error with critical impact on your production environment. Covers urgent problems including database service outage, data loss, and cluster provisioning failure.                                 |
+| Severity 2 | There's a cloud service error or an issue significantly impacting your production environment. The system is functioning but in a severely reduced capacity. Covers problems including database service interruption and backup failures. |
+| Severity 3 | There's an error or issue that doesn't have a significant impact on your production environment. Covers problems including API issues, monitoring metrics, and logging issues.                                                            |
+| Severity 4 | General questions, inquiries, or nontechnical requests.                                                                                                                                                                                   |

--- a/product_docs/docs/biganimal/release/overview/index.mdx
+++ b/product_docs/docs/biganimal/release/overview/index.mdx
@@ -1,12 +1,7 @@
 ---
 title: "Overview of service"
 ---
+
 <div id="requirements_overview" class="registered_link"></div>
 
 BigAnimal is a fully managed database-as-a-service with built-in Oracle compatibility, running in your cloud account and operated by the Postgres experts. BigAnimal makes it easy to set up, manage, and scale your databases. Provision [PostgreSQL](https://www.enterprisedb.com/docs/supported-open-source/postgresql/) or [EDB Postgres Advanced Server](https://www.enterprisedb.com/docs/epas/latest/) with Oracle compatibility. 
-
-
-
-
-
-

--- a/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
+++ b/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
@@ -2,20 +2,21 @@
 title: "Pricing and billing "
 ---
 
-
 This section covers the pricing breakdown for BigAnimal as well as how to view invoices and infrastructure usage through Microsoft Azure. It also covers management costs.
 
 ## Pricing
+
 Pricing is based on the number of virtual central processing units (vCPUs) provisioned for the database software offering. Consumption of vCPUs is metered hourly. A deployment is made up of either one instance or one primary and two replica instances of either PostgreSQL or EDB Postgres Advanced Server. When high availability is enabled, multiply the number of vCPUs per instance by three to calculate the full price for all resources used. The table shows the cost breakdown:
 
-| Database type         | Hourly price   | Monthly price\* |
-| --------------------- | -------------- | -------------- |
-| PostgreSQL            | $0.1655 / vCPU | $120.82 / vCPU |
-| EDB Postgres Advanced Server | $0.2397 / vCPU | $174.98 / vCPU |
+| Database type                | Hourly price   | Monthly price\* |
+| ---------------------------- | -------------- | --------------- |
+| PostgreSQL                   | $0.1655 / vCPU | $120.82 / vCPU  |
+| EDB Postgres Advanced Server | $0.2397 / vCPU | $174.98 / vCPU  |
 
 \* The monthly cost is approximate and assumes 730 hours in a month. Microsoft bills on actual hours in a given month. 
 
 ## Billing
+
 All billing is handled directly by Microsoft Azure. You can view invoices and usage on the Azure Portal billing page. [Learn more](https://docs.microsoft.com/en-us/azure/cost-management-billing/).
 
 ## Cloud infrastructure costs
@@ -23,16 +24,17 @@ All billing is handled directly by Microsoft Azure. You can view invoices and us
 EDB doesn't bill you for cloud infrastructure such as compute, storage, data transfer, monitoring, and logging. BigAnimal clusters run in your Microsoft Azure account. Azure bills you directly for the cloud infrastructure provisioned according to the terms of your account agreement. You can view invoices and usage on the Azure Portal billing page. [Learn more](https://docs.microsoft.com/en-us/azure/cost-management-billing/).
 
 ## Management costs
+
 To give you full control over your data, BigAnimal deploys infrastructure in each region to manage the clusters in that region. BigAnimal doesn’t charge you for this infrastructure. Azure bills directly for the infrastructure according to the terms of your account agreement.
 
 The table shows a breakdown of management costs.
 
-| Type   | Details |
-|--------|---------|
-| Azure Kubernetes Service (AKS) | BigAnimal uses AKS to orchestrate and manage the database service Managed Kubernetes Virtual Machines provisioned on Windows and Linux. |
-| Azure Monitor | BigAnimal feeds all logs and metrics to [Azure Monitor](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/05_monitoring_and_logging/). |
-| Azure blob storage | BigAnimal uses blob storage to store metadata about your account. |
-| Key vault | BigAnimal uses key vault to securely store credentials for managing your infrastructure. |
+| Type                           | Details                                                                                                                                               |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Azure Kubernetes Service (AKS) | BigAnimal uses AKS to orchestrate and manage the database service Managed Kubernetes Virtual Machines provisioned on Windows and Linux.               |
+| Azure Monitor                  | BigAnimal feeds all logs and metrics to [Azure Monitor](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/05_monitoring_and_logging/). |
+| Azure blob storage             | BigAnimal uses blob storage to store metadata about your account.                                                                                     |
+| Key vault                      | BigAnimal uses key vault to securely store credentials for managing your infrastructure.                                                              |
 
 At list price, estimated overall management costs are $400–$700 for a single cluster. Check with your Azure account manager for specifics that apply to your account. 
 
@@ -41,5 +43,3 @@ If you deploy a large number of clusters in a single region, for example, more t
 To get a better sense of your Azure costs, check out the Azure pricing [calculator](https://azure.microsoft.com/en-us/pricing/calculator/) and speak with your BigAnimal representative. 
 
 If you want to remove management resources provisioned from Azure, reach out to [Customer Support](../overview/06_support).
-
-

--- a/product_docs/docs/biganimal/release/reference/api.mdx
+++ b/product_docs/docs/biganimal/release/reference/api.mdx
@@ -4,32 +4,31 @@ title: Using the BigAnimal API
 
 Use the BigAnimal API to integrate directly with BigAnimal for management activities such as cluster provisioning, de-provisioning, and scaling.
 
-The API reference documentation is available from the [BigAnimal portal](https://portal.biganimal.com). The direct documentation link is [https://portal.biganimal.com/api/docs/](https://portal.biganimal.com/api/docs/).
+The API reference documentation is available from the [BigAnimal portal](https://portal.biganimal.com). The direct documentation link is <https://portal.biganimal.com/api/docs/>.
 
 To access the API, you need a token. The high-level steps to obtain a token are:
-1. [Query the authentication endpoint](#query-the-authentication-endpoint).
-2. [Request the device code](#request-the-device-code-using-curl).
-3. [Authorize as a user](#authorize-as-a-user).
-4. [Request the raw token](#request-the-raw-token-using-curl).
-5. [Exchange for the raw token for the BigAnimal token](#exchange-the-biganimal-token-using-curl).
 
+1.  [Query the authentication endpoint](#query-the-authentication-endpoint).
+2.  [Request the device code](#request-the-device-code-using-curl).
+3.  [Authorize as a user](#authorize-as-a-user).
+4.  [Request the raw token](#request-the-raw-token-using-curl).
+5.  [Exchange for the raw token for the BigAnimal token](#exchange-the-biganimal-token-using-curl).
 
 EDB provides an optional script to simplify getting your device code and getting and refreshing your tokens. See [Using the `get-token` script](#using-the-get-token-script) for details.
-
 
 ## Query the authentication endpoint
 
 This call returns the information that either:
 
-- You need later if you are using `curl` to request the device code and tokens.
-- The `get-token` script uses to generate the tokens for you.
-
+-   You need later if you are using `curl` to request the device code and tokens.
+-   The `get-token` script uses to generate the tokens for you.
 
 ```
 curl https://portal.biganimal.com/api/v1/auth/provider
 ```
 
 The response returns the `clientId`, `issuerUri`, `scope`, and `audience`. For example:
+
 ```
 {
   "clientId": "pM8PRguGtW9yVnrsvrvpaPyyeS9fVvFh",
@@ -47,13 +46,17 @@ ISSUER_URL=https://auth.biganimal.com
 SCOPE="openid profile email offline_access"
 AUDIENCE="https://portal.biganimal.com/api"
 ```
+
 The following example calls use these environment variables.
 
 ## Request the device code using `curl`
+
 !!!note
    The `get-token` script executes this step. You don't need to make this call if you are using the script.
 !!!
+
 This call gets a device code:
+
 ```
 curl --request POST \
   --url "$ISSUER_URL/oauth/device/code" \
@@ -65,14 +68,15 @@ curl --request POST \
 
 The response returns:
 
-- `device_code` — The unique code for the device. When you go to the `verification_uri` in your browser-based device, this code is bound to your session. You use this code in your [request for a token](#request-the-raw-token-using-curl).
-- `user_code` — The code you input at the `verification_uri` to authorize the device. You use this code when you [authorize yourself as a user](#authorize-as-a-user).
-- `verification_uri` — The URL you use to authorize your device.
-- `verification_uri_complete` — The complete URL you use to authorize the device. You can use this URL to embed the user code in your app's URL.
-- `expires_in` — The lifetime (in seconds) of the `device_code` and `user_code`.
-- `interval` — The interval (in seconds) at which the app polls the token URL to request a token.
+-   `device_code` — The unique code for the device. When you go to the `verification_uri` in your browser-based device, this code is bound to your session. You use this code in your [request for a token](#request-the-raw-token-using-curl).
+-   `user_code` — The code you input at the `verification_uri` to authorize the device. You use this code when you [authorize yourself as a user](#authorize-as-a-user).
+-   `verification_uri` — The URL you use to authorize your device.
+-   `verification_uri_complete` — The complete URL you use to authorize the device. You can use this URL to embed the user code in your app's URL.
+-   `expires_in` — The lifetime (in seconds) of the `device_code` and `user_code`.
+-   `interval` — The interval (in seconds) at which the app polls the token URL to request a token.
 
 For example:
+
 ```
 {
   "device_code": "KEOY2_5YjuVsRuIrrR-aq5gs",
@@ -92,21 +96,22 @@ DEVICE_CODE=KEOY2_5YjuVsRuIrrR-aq5gs
 
 ## Authorize as a user
 
-1. Go to the `verification_uri` in your web browser, enter your `user_code`, and select **Continue**.
+1.  Go to the `verification_uri` in your web browser, enter your `user_code`, and select **Continue**.
 
-2. On the Device Confirmation dialog, select **Confirm**.
+2.  On the Device Confirmation dialog, select **Confirm**.
 
-3. On the BigAnimal Welcome screen, select **Continue with Microsoft Azure AD**.
+3.  On the BigAnimal Welcome screen, select **Continue with Microsoft Azure AD**.
 
-4. Log in with your Azure AD credentials.
-
+4.  Log in with your Azure AD credentials.
 
 ## Request the raw token using `curl`
+
 !!!note
    The `get-token` script executes this step. You don't need to make this call if you are using the script. See [Request your token using `get-token`](#request-your-token-using-get-token).
 !!!
 
 The `curl --request POST` call requests a token. For example:
+
 ```
 curl --request POST \
   --url "$ISSUER_URL/oauth/token" \
@@ -115,14 +120,17 @@ curl --request POST \
   --data "device_code=$DEVICE_CODE" \
   --data "client_id=$CLIENT_ID"
 ```
+
 If successful, the call returns:
-- `access_token` — Use to exchange for the token to access BigAnimal API.
 
-- `refresh_token` — Use to obtain a new access token or ID token after the previous one expires. (See [Refresh tokens](https://auth0.com/docs/tokens/refresh-tokens) for more information.) Refresh tokens expire after 30 days.
+-   `access_token` — Use to exchange for the token to access BigAnimal API.
 
-- `expires_in` — Means the token expires after 24 hours from its creation.
+-   `refresh_token` — Use to obtain a new access token or ID token after the previous one expires. (See [Refresh tokens](https://auth0.com/docs/tokens/refresh-tokens) for more information.) Refresh tokens expire after 30 days.
+
+-   `expires_in` — Means the token expires after 24 hours from its creation.
 
 For example:
+
 ```
 {
   "access_token": "eyJhbGc.......1Qtkaw2fyho",
@@ -146,13 +154,17 @@ The access token obtained at this step is used only in the next step to exchange
 !!!
 
 If not successful, you receive one of the following errors:
-- `authorization_pending` — Continue polling using the suggested interval retrieved when you [requested the device code](#request-the-device-code-using-curl).
 
-- `slow_down` — Slow down and use the suggested interval retrieved when you [requested the device code](#request-the-device-code-using-curl). To avoid receiving this error due to network latency, start counting each interval after receipt of the last polling request's response.
-- `expired_token` — You didn't authorize the device quickly enough, so the `device_code` expired. Your application notifies you that it has expired and to restore it.
-- `access_denied`
+-   `authorization_pending` — Continue polling using the suggested interval retrieved when you [requested the device code](#request-the-device-code-using-curl).
+
+-   `slow_down` — Slow down and use the suggested interval retrieved when you [requested the device code](#request-the-device-code-using-curl). To avoid receiving this error due to network latency, start counting each interval after receipt of the last polling request's response.
+
+-   `expired_token` — You didn't authorize the device quickly enough, so the `device_code` expired. Your application notifies you that it has expired and to restore it.
+
+-   `access_denied`
 
 ## Exchange the BigAnimal token using `curl`
+
 !!!note
    The `get-token` script executes this step. You don't need to make this call if you are using the script.
 !!!
@@ -167,9 +179,11 @@ curl -s --request POST \
 ```
 
 If successful, the call returns:
-- `token` — The bearer token used to access the BigAnimal API.
+
+-   `token` — The bearer token used to access the BigAnimal API.
 
 For example:
+
 ```
 {
   "token": "eyJhbGc.......0HFkr_19Vr7w"
@@ -183,7 +197,7 @@ Store this token in environment variables for future use. For example:
 ACCESS_TOKEN="eyJhbGc.......0HFkr_19Vr7w"
 ```
 
-!!! Tip
+!!!Tip
 Contact [Customer Support](../overview/06_support) if you have trouble obtaining a valid access token to access the BigAnimal API.
 !!!
 
@@ -199,6 +213,7 @@ curl --request GET \
 ```
 
 Example response:
+
 ```
 {
   "pgTypesList": [
@@ -218,17 +233,18 @@ Example response:
 }
 ```
 
-
 ## Refresh your token
 
 You use the refresh token to get a new raw-access token. Usually you need a new access token only after the previous one expires or when gaining access to a new resource for the first time. Don't call the endpoint to get a new access token every time you call an API. Rate limits can throttle the amount of requests to the endpoint that can be executed using the same token from the same IP.
 
 ### Refresh your token using `curl`
+
 !!!note
 The `get-token` script has an option to execute this step. See [Refresh the token using `get-token`](#refresh-the-token-using-get-token).
 !!!
 
 If you aren't using the `get-token` script to refresh your token, make a POST request to the `/oauth/token` endpoint in the Authentication API, using `grant_type=refresh_token`. For example:
+
 ```
 curl --request POST \
   --url "$ISSUER_URL/oauth/token" \
@@ -237,11 +253,13 @@ curl --request POST \
   --data "client_id=$CLIENT_ID" \
   --data "refresh_token=$REFRESH_TOKEN"
 ```
+
 The `refresh_token` is in the response when you [requested the token](#request-the-device-code-using-curl).
 
 The `client_id` is always the same one in the response when you [queried the authentication endpoint](#query-the-authentication-endpoint).
 
 The response of this API call includes the `access_token`. For example:
+
 ```
 {
   "access_token": "eyJ...MoQ",
@@ -265,10 +283,7 @@ The token you obtain from this step is the raw-access token. You need to exchang
 !!! Note
     You need to save the refresh token retrieved from this response for the next refresh call. The refresh token in the response when you originally [requested the token](#request-the-raw-token-using-curl) becomes obsolete once you use it.
 
-
-
 ## Using the `get-token` script
-
 
 To simplify the process of getting tokens, EDB provides the `get-token` script. You can download it [here](https://github.com/EnterpriseDB/cloud-utilities/tree/main/api).
 
@@ -295,6 +310,7 @@ Reference: https://www.enterprisedb.com/docs/biganimal/latest/reference/
 ```
 
 ### Request your token using `get-token`
+
 To use the `get-token` script to get your tokens, use the script without the `--refresh` option. For example:
 
 ```
@@ -313,7 +329,9 @@ xxxxxxxxxx
 #####   Expires In Seconds ##########
 86400
 ```
-###  Refresh the token using `get-token`
+
+### Refresh the token using `get-token`
+
 To use the `get-token` script to refresh your token, use the script with the `--refresh  <refresh_token>` option. For example:
 
 ```
@@ -326,4 +344,3 @@ To use the `get-token` script to refresh your token, use the script with the `--
   "token_type": "Bearer"
 }
 ```
-

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -2,46 +2,46 @@
 title: Using the BigAnimal CLI
 ---
 
-
 Use the command line interface (CLI) for BigAnimal management activities such as cluster provisioning and getting cluster status from your terminal. The CLI is an efficient way to integrate with BigAnimal and enables system administrators and developers to script and automate the BigAnimal administrative operations.
 
-
-
 ## Installing the CLI
+
 The CLI is available for Linux, MacOS, and Windows operating systems.
 
 ### Download the binary executable
 
-- For Linux operating systems, use the following command to get the latest version of the binary executable:
-   ```
-   curl -LO "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal"
-   ```
+-   For Linux operating systems, use the following command to get the latest version of the binary executable:
+    ```
+    curl -LO "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal"
+    ```
 
-- For all operating systems, download the executable binary [here](http://cli.biganimal.com/).
-
+-   For all operating systems, download the executable binary [here](http://cli.biganimal.com/).
 
 ### (Optional) Validate the download
 
-- For Linux operating systems, including Linux running from MacOS platforms:
-  1. Download the `checksum` file with following command:
-     ```
-     curl -L0 "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal.sha256"
-     ```
-  1. From a shell, validate the binary executable file against the `checksum` file:
-      ```
-      echo "$(<big_animal.sha256) biganimal" | sha256sum --check
-      ```
+-   For Linux operating systems, including Linux running from MacOS platforms:
+    1.  Download the `checksum` file with following command:
+        ```
+        curl -L0 "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal.sha256"
+        ```
+    2.  From a shell, validate the binary executable file against the `checksum` file:
+        ```
+        echo "$(<big_animal.sha256) biganimal" | sha256sum --check
+        ```
 
-- For Windows:
-  1. Download the `checksum` file [here](http://cli.biganimal.com/).
-  2. Validate the binary executable file against the checksum file using `CertUtil`:
-     ```
-     CertUtil -hashfile biganimal.exe SHA256 type biganiml.sha256
-    ```
+-   For Windows:
+    1.  Download the `checksum` file [here](http://cli.biganimal.com/).
+    2.  Validate the binary executable file against the checksum file using `CertUtil`:
+        ```
+        CertUtil -hashfile biganimal.exe SHA256 type biganiml.sha256
+        ```
+
 ## Command reference
+
 Use the `-h` or `--help` flags for more information on the CLI commands. You can use the flag on the `biganimal` command to get a listing of all the available commands (`biganimal -h`) or on a subcommand to get information on that particular command (for example, `biganimal create-cluster -h`).
 
 ## Authenticate as a valid user
+
 Before using the CLI to manage BigAnimal, you need to authenticate as a valid BigAnimal user. Use the `create-credential` command to authenticate, get an access token, and store it in a local credential. For example:
 
 ```
@@ -54,7 +54,9 @@ press [Enter] to continue in the web browser...
 
 Credential "ba-user1" created!
 ```
+
 You can create multiple credentials for different BigAnimal accounts and then set one as context of your current management session. Use `show-credentials` to list all available credentials and use `set-context-credential` to set a default credential for the current context. For example:
+
 ```
 $ biganimal show-credentials
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -69,7 +71,6 @@ $ biganimal set-context-credentials ba-user1
 The credential ba-user1 has been set up
 ```
 
-
 ## Configuring
 
 The initial running of the CLI creates a hidden configuration folder in your user root directory. For example, for Linux it’s `${HOME}/.edb-cli`. The CLI persists the configuration file in this directory as well as the credentials.
@@ -78,43 +79,45 @@ Don’t edit files in this directory directly. Instead, use the following comman
 
 ### Confirmation commands
 
-| Command | Description |
-| ------- | ----------- |
-| `get-confirm` | Get the current value for the confirmation mode |
-| `enable-confirm` | Enable confirmation when creating/deleting/updating resources |
+| Command           | Description                                                      |
+| ----------------- | ---------------------------------------------------------------- |
+| `get-confirm`     | Get the current value for the confirmation mode                  |
+| `enable-confirm`  | Enable confirmation when creating/deleting/updating resources    |
 | `disable-confirm` | Disable confirmation before creating/deleting/updating resources |
 
 ### Prompt mode commands
 
-| Command | Description |
-| ------- | ----------- |
-| `get-prompt` | Get the current value for the prompt mode |
-| `enable-prompt` | Enable prompting for missing required parameters |
+| Command          | Description                                       |
+| ---------------- | ------------------------------------------------- |
+| `get-prompt`     | Get the current value for the prompt mode         |
+| `enable-prompt`  | Enable prompting for missing required parameters  |
 | `disable-prompt` | Disable prompting for missing required parameters |
 
 ### Output format commands
 
-| Command | Description |
-| ------- | ----------- |
-| `get-output` | Get the current output mode |
-| `set-output` | Set the output mode, valid modes are [ json, yaml, xml, table ]
-
+| Command      | Description                                                     |
+| ------------ | --------------------------------------------------------------- |
+| `get-output` | Get the current output mode                                     |
+| `set-output` | Set the output mode, valid modes are [ json, yaml, xml, table ] |
 
 ### Auto Completion
+
 The CLI supports command line auto completion for bash, fish, powershell, and zsh. The following command describes how to set auto completion up in bash:
+
 ```sh
 $ ba completion bash --help
 ```
 
-
 ## Sample use cases
 
 ### Create a cluster in interactive mode
+
 The default mode for the `create-cluster` command is an interactive mode that guides you through the required cluster configuration by providing you with the valid values.
 
-!!! Tip
+!!!Tip
 You can turn off prompting by first using the `biganimal disable-prompt` command. With prompting disabled, if there are any missing required flags, the CLI exits.
 !!!
+
 ```sh
 $ biganimal create-cluster
 Cluster Name: my-biganimal-cluster
@@ -145,7 +148,9 @@ Volume Properties?
 
 
 ```
+
 You are prompted to confirm you want to create the cluster. After the cluster creation process is completed, it generates a cluster ID.
+
 ```
 $ biganimal create-cluster
 ........
@@ -156,14 +161,18 @@ To check current state, run: biganimal status-cluster --id p-c5rrnksgkgomjq0139s
 ```
 
 Check your cluster was created successfully using the `show-cluster-status` command:
+
 ```
 $ biganimal show-cluster-status --id p-c5rrnksgkgomjq0139s0
 Cluster "my-biganimal-cluster" status is "Cluster in healthy state"
 ```
+
 ### Create a cluster using a configuration file
+
 You can use the `--clusterConfigFile` command to create one or more clusters with the same configuration in a noninteractive mode.
 
 Here is a sample configuration file in YAML format:
+
 ```
 # config_file.yaml
         ---
@@ -182,13 +191,15 @@ Here is a sample configuration file in YAML format:
 ```
 
 To create the cluster using the sample configuration file `config_file.yaml`:
+
 ```sh
 biganimal create-cluster --clusterConfigFile ./config_file.yaml
 ```
 
-!!! Tip
+!!!Tip
 You can turn off the confirmation step with the `biganimal disable-confirm` command.
 !!!
+
 ### Get cluster connection information
 
 To use your BigAnimal cluster, you first need to get your cluster's connection information. To get your cluster's connection information, use the `show-cluster-connection` command:
@@ -202,36 +213,43 @@ $ biganimal show-cluster-connection --name my-biganimal-cluster --provider azure
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 ```
 
-!!! tip
+!!!tip
 You can query the complete connection information with other output formats, like JSON or YAML. For example:
+
 ```
 biganimal show-cluster-connection --name my-biganimal-cluster --provider azure --region eastus --ouput json
 ```
 !!!
 
 ### Update cluster
+
 After the cluster is created, you can update attributes of the cluster including both the cluster’s profile and its deployment architecture. You can update the following attributes:
-- Cluster name
-- Password of administrator account
-- Private networking
-- High-availability
-- Postgres database configuration
+
+-   Cluster name
+-   Password of administrator account
+-   Private networking
+-   High-availability
+-   Postgres database configuration
 
 For example, to enable high availability, use the `--high-availability` option:
+
 ```sh
 $ biganimal update-cluster --name my-biganimal-cluster --provider azure --region eastus --high-availability true
 ```
 
 To check whether the setting took effect, use the `show-clusters` command and view the detailed cluster information output in JSON format. For example,
+
 ```sh
 $ biganimal show-clusters --name my-biganimal-cluster --provider azure --region eastus --output json | grep zone
     "zoneRedundantHa": true,
 ```
 
 ### Delete a cluster
+
 To delete a cluster you no longer need, use the `delete-cluster` command. For example:
+
 ```sh
 $ biganimal delete-cluster --name my-biganimal-cluster --provider azure --region e\
 ```
-You can list all deleted clusters with the `show-deleted-clusters` command and restore them from their history backups as needed.
 
+You can list all deleted clusters with the `show-deleted-clusters` command and restore them from their history backups as needed.

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -9,33 +9,34 @@ To create a new role and database, first connect using `psql`:
 ```
 psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmode=require"
 ```
+
 ## Notes on the edb_admin role
 
-- The `edb_admin` role does not have superuser priviledges by default. Contact [Support](../overview/06_support) to request superuser priviledges for `edb_admin`.
+-   The `edb_admin` role does not have superuser priviledges by default. Contact [Support](../overview/06_support) to request superuser priviledges for `edb_admin`.
 
-- superuser setting changes are not retained after a restart. To avoid issues, do not run the system out of superuser connections.
+-   superuser setting changes are not retained after a restart. To avoid issues, do not run the system out of superuser connections.
 
-- You have to remember your `edb_admin` password as EDB does not have access to it. If you forget it, you can set a new one in the BigAnimal portal on the Edit Cluster page.
+-   You have to remember your `edb_admin` password as EDB does not have access to it. If you forget it, you can set a new one in the BigAnimal portal on the Edit Cluster page.
 
-- Don't use the `edb_admin` user or the `edb_admin` database in your applications. Instead, use `CREATE USER; GRANT; CREATE DATABASE.`
+-   Don't use the `edb_admin` user or the `edb_admin` database in your applications. Instead, use `CREATE USER; GRANT; CREATE DATABASE.`
 
-- BigAnimal stores all database-level authentication securely and directly in PostgreSQL. The `edb_admin` user password is SCRAM-SHA-256 hashed prior to storage. This hash, even if compromised, cannot be replayed by an attacker to gain access to the system.
+-   BigAnimal stores all database-level authentication securely and directly in PostgreSQL. The `edb_admin` user password is SCRAM-SHA-256 hashed prior to storage. This hash, even if compromised, cannot be replayed by an attacker to gain access to the system.
 
 ## One database with one application
 
 For one database hosting a single application, replace app1 with your preferred user name:
 
-1. Create a new database user. For example,
+1.  Create a new database user. For example,
     ```
     edb_admin=# create user app1 with password 'app1_pwd';
     ```
 
-1. Assign the new role to your `edb_admin` user. Assigning this role allows you to assign ownership to the new user in the next step. For example:
+2.  Assign the new role to your `edb_admin` user. Assigning this role allows you to assign ownership to the new user in the next step. For example:
     ```
     edb_admin=# grant app1 to edb_admin;
     ```
 
-1. Create a new database to store application data. For example:
+3.  Create a new database to store application data. For example:
     ```
     edb_admin=# create database app1 with owner app1;
     ```
@@ -46,17 +47,19 @@ Using this example, the username and database in your connection string is `app1
 
 If a single database is used to host multiple schemas, create a database owner and then roles and schemas for each application. This example shows creating two database roles and two schemas. The default `search_path` for database roles in BigAnimal is `"$user",public`. If the role name and schema match, then objects in that schema match first, and no `search_path` changes or fully qualifying of objects are needed. The [PostgreSQL documentation](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH) covers the schema search path in detail.
 
-1. Create a database owner and new database. For example:
+1.  Create a database owner and new database. For example:
     ```
     edb_admin=# create user prod_admin with password 'prod_pwd';
     edb_admin=# create database prod1 with owner prod_admin;
     ```
 
-1. Connect to the new database. For example:
+2.  Connect to the new database. For example:
     ```
     edb_admin=# \c prod1
     ```
-1. Create new application roles. For example:
+
+3.  Create new application roles. For example:
+
     ```
     prod1=# create user app1 with password 'app1_pwd';
     prod1=# grant app1 to edb_admin;
@@ -64,7 +67,8 @@ If a single database is used to host multiple schemas, create a database owner a
     prod1=# create user app2 with password 'app2_pwd';
     prod1=# grant app2 to edb_admin;
     ```
-1. Create a new schema for each application with the AUTHORIZATION clause for the application owner. For example:
+
+4.  Create a new schema for each application with the AUTHORIZATION clause for the application owner. For example:
     ```
     prod1=# create schema app1 authorization app1;
     prod1=# create schema app2 authorization app2;

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
@@ -8,152 +8,151 @@ This exammple shows how to connect your cluster using Azure Private Endpoint.
 
 Assume that your cluster is on a subscription called `development` and is being accessed from a Linux client VM on another subscription called `test` with the following properties:
 
-- Cluster:
-  - Subscription: `development`
-  - Cluster ID: `p-c4j0jfcmp3af2ieok5eg` 
-  - Account ID: `brcxzr08qr7rbei1` 
-  - Organization's domain name: `biganimal.io` 
+-   Cluster:
+    -   Subscription: `development`
+    -   Cluster ID: `p-c4j0jfcmp3af2ieok5eg` 
+    -   Account ID: `brcxzr08qr7rbei1` 
+    -   Organization's domain name: `biganimal.io` 
 
 
-- Linux client VM called `vm-client`:
-  - Subscription: `test`
-  - Resource group: `rg-client`
-  - Virtual network: `vnet-client`
-  - Virtual network subnet: `snet-client`
+-   Linux client VM called `vm-client`:
+    -   Subscription: `test`
+    -   Resource group: `rg-client`
+    -   Virtual network: `vnet-client`
+    -   Virtual network subnet: `snet-client`
 
 #### Prerequisites
 
 To walk through an example in your own environment, you need:
 
-- Your cluster URL. You can find the URL in the **Connect** tab of your cluster instance in the BigAnimal portal.
- 
-- The IP address of your cluster. You can find the IP address of your cluster using the following command:
+-   Your cluster URL. You can find the URL in the **Connect** tab of your cluster instance in the BigAnimal portal.
+-   The IP address of your cluster. You can find the IP address of your cluster using the following command:
 
- ```
- $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
- 10.240.1.218
- ```
- 
-- A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
+    ```
+    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    10.240.1.218
+    ```
+-   A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
 
 #### Step 1: Create an Azure Private Link service for your cluster
- 
+
   In this example, you create an [Azure Private Link service](https://docs.microsoft.com/en-us/azure/private-link/private-link-service-overview) in your cluster's resource group. You must perform this procedure for every cluster that you want to connect to in Azure.
 
-  1. Get the resource group details from the Azure CLI or the Azure portal and note the resource group name. For example, if the cluster's virtual network is `vnet-japaneast`, use the following command: 
- 
-     ```
-       $ az network vnet list --query "[?name==\'vnet-japaneast\'].resourceGroup" -o json
+1.  Get the resource group details from the Azure CLI or the Azure portal and note the resource group name. For example, if the cluster's virtual network is `vnet-japaneast`, use the following command: 
 
-     ```
-  
-  1. On the upper-left part of the page in the Azure portal, select **Create a resource**.
-  
-  1. In the **Search the Marketplace** box, search for _Private Link_.
+    ```
+      $ az network vnet list --query "[?name==\'vnet-japaneast\'].resourceGroup" -o json
 
-  1. Select **Create**.
+    ```
 
-  1. Enter the details for the Azure Private Link. Use a unique name for the Azure Private Link. 
-   
-   For example, `p-c4j0jfcmp3af2ieok5eg-service-private-link`, where `p-c4j0jfcmp3af2ieok5eg` is the cluster ID. 
-    
-    ![Create private link service](../images/image5.png)
+2.  On the upper-left part of the page in the Azure portal, select **Create a resource**.
 
-  1. Enter the resource group name from step 1. 
+3.  In the **Search the Marketplace** box, search for *Private Link*.
 
-  3. In the **Outbound settings** page, select the `kubernetes-internal` load balancer
-    and select the IP address of your cluster in the **Load balancer frontend IP
-    address** field. 
-    
-    You can get the IP address of your cluster with the following command:
+4.  Select **Create**.
 
-   ```
-   $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
-   10.240.1.218
-   ```
+5.  Enter the details for the Azure Private Link. Use a unique name for the Azure Private Link. 
 
-     ![Outbound settings](../images/image1.png)
+    For example, `p-c4j0jfcmp3af2ieok5eg-service-private-link`, where `p-c4j0jfcmp3af2ieok5eg` is the cluster ID. 
 
-  4. On the **Access security** page, configure the level of access for the private link service. See [control service exposure](https://docs.microsoft.com/en-us/azure/private-link/private-link-service-overview#control-service-exposure) for details.
-  
-   ![](../images/image21.png)  
+     ![Create private link service](../images/image5.png)
 
-   !!! Note
-       If the required access is not provided to the account or subscription accessing the cluster, you must manually approve the connection request from the **Pending connections** page in **Private Link Center**.
-   
+6.  Enter the resource group name from step 1. 
 
-  5. After the private link service is created, note its alias. The alias is the unique ID for your private service, which you can share with the service consumers. Obtain the alias either from the Azure portal or by using the following CLI command:
+7.  In the **Outbound settings** page, select the `kubernetes-internal` load balancer
+     and select the IP address of your cluster in the **Load balancer frontend IP
+     address** field. 
 
-     ```
-       $ az network private-link-service list --query "[?name=='p-c4j0jfcmp3af2ieok5eg-service-private-link'].alias" -o tsv
-       p-c4j0jfcmp3af2ieok5eg-service-private-link.48f26b42-45dc-4e80-8e3d-307d58d7d274.japaneast.azure.privatelinkservice
-     ```
+     You can get the IP address of your cluster with the following command:
 
-  6. Select **Review + Create**.
+    ```
+    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    10.240.1.218
+    ```
 
-  7. Select **Create**.
+      ![Outbound settings](../images/image1.png)
+
+8.  On the **Access security** page, configure the level of access for the private link service. See [control service exposure](https://docs.microsoft.com/en-us/azure/private-link/private-link-service-overview#control-service-exposure) for details.
+
+    ![](../images/image21.png)  
+
+    !!! Note
+        If the required access is not provided to the account or subscription accessing the cluster, you must manually approve the connection request from the **Pending connections** page in **Private Link Center**.
+
+
+5.  After the private link service is created, note its alias. The alias is the unique ID for your private service, which you can share with the service consumers. Obtain the alias either from the Azure portal or by using the following CLI command:
+
+    ```
+      $ az network private-link-service list --query "[?name=='p-c4j0jfcmp3af2ieok5eg-service-private-link'].alias" -o tsv
+      p-c4j0jfcmp3af2ieok5eg-service-private-link.48f26b42-45dc-4e80-8e3d-307d58d7d274.japaneast.azure.privatelinkservice
+    ```
+
+6.  Select **Review + Create**.
+
+7.  Select **Create**.
 
 #### Step 2: Create an Azure Private Endpoint in each client virtual network
 
   In this example, you create an Azure Private Endpoint in your client VM's virtual network. After you create the private endpoint, you can use its private IP address to access the cluster. You must perform this procedure for every virtual network you want to connect from.
-  
-  1. On the upper-left side of the screen in the Azure portal, select **Create a resource > Networking > Private Link**, or in the search box enter _Private Link_.
-  
-  1. Select **Create**.
 
-  1. In Private Link Center, select **Private endpoints** in the menu on the left.
+1.  On the upper-left side of the screen in the Azure portal, select **Create a resource > Networking > Private Link**, or in the search box enter *Private Link*.
 
-  1. In Private endpoints, select **Add**.
+2.  Select **Create**.
 
-  1. Enter the details for the private endpoint as shown in the following image. Use a unique name for the private endpoint. 
-   
-   For example, enter `vnet-client-private-pg-service`, where `vnet-client` is the client VNet ID. 
-   
-   !!! Note
-       In a later step, you need the private endpoint's name to get its private IP address.
-   
-   ![](../images/image12.png)
+3.  In Private Link Center, select **Private endpoints** in the menu on the left.
 
-  1. Connect the private endpoint to the private link service that you created by entering its alias.
+4.  In Private endpoints, select **Add**.
 
-   ![](../images/image17.png)
+5.  Enter the details for the private endpoint as shown in the following image. Use a unique name for the private endpoint. 
 
-  1. In the **Configuration** page, enter the client VM's Virtual Network `vnet-client`.
+    For example, enter `vnet-client-private-pg-service`, where `vnet-client` is the client VNet ID. 
 
-  1. Select **Review + Create**.
+    !!! Note
+        In a later step, you need the private endpoint's name to get its private IP address.
 
-  7. Select **Create**.
-   
-   !!! Note
-      If the private endpoint's status appears as **Pending**, your account or subscription might not be authorized to access the private link service. 
-  
-      To resolve this issue, the connection must be manually approved from the Pending connections page in Private Link Center, from the BigAnimal Azure subscription.
+    ![](../images/image12.png)
 
-      ![](../images/image3.png)
+6.  Connect the private endpoint to the private link service that you created by entering its alias.
+
+    ![](../images/image17.png)
+
+7.  In the **Configuration** page, enter the client VM's Virtual Network `vnet-client`.
+
+8.  Select **Review + Create**.
+
+9.  Select **Create**.
+
+    !!!Note
+       If the private endpoint's status appears as **Pending**, your account or subscription might not be authorized to access the private link service. 
+
+       To resolve this issue, the connection must be manually approved from the Pending connections page in Private Link Center, from the BigAnimal Azure subscription.
+
+       ![](../images/image3.png)
+    !!!
 
 
 11. You have successfully built a tunnel between your client VM's virtual network and the cluster. You can now access the cluster from the private endpoint in your client VM. The private endpoint's private IP address is associated with an independent virtual network NIC. Get the private endpoint's private IP address using the following commands:
 
- ```
-  $ NICID=$(az network private-endpoint show -n vnet-client-private-pg-service -g rg-client --query "networkInterfaces[0].id" -o tsv)
-  $ az network nic show -n ${NICID##*/} -g rg-client --query "ipConfigurations[0].privateIpAddress" -o tsv
-  100.64.111.5
- ``` 
+    ```
+     $ NICID=$(az network private-endpoint show -n vnet-client-private-pg-service -g rg-client --query "networkInterfaces[0].id" -o tsv)
+     $ az network nic show -n ${NICID##*/} -g rg-client --query "ipConfigurations[0].privateIpAddress" -o tsv
+     100.64.111.5
+    ```
 
 12. From the client VM `vm-client`, access the cluster by using the private IP address:
 
- ```
- $ psql -h 100.64.111.5 -U edb_admin 
- 
- Password for user edb_admin : 
- 
- psql (13.4 (Ubuntu 13.4-1.pgdg20.04+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
- WARNING : psql major version 13, server major version 13. Some psql features might not work. 
- SSL connection (protocol : TLSV1.3, cipher : TLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
- 
- edb_admin=>
+    ```
+    $ psql -h 100.64.111.5 -U edb_admin 
 
- ```
+    Password for user edb_admin : 
+
+    psql (13.4 (Ubuntu 13.4-1.pgdg20.04+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
+    WARNING : psql major version 13, server major version 13. Some psql features might not work. 
+    SSL connection (protocol : TLSV1.3, cipher : TLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
+
+    edb_admin=>
+
+    ```
 
 #### Step 3: Create an Azure Private DNS Zone for the private endpoint
 
@@ -163,47 +162,46 @@ With a Private DNS Zone, you configure a DNS entry for your cluster's public hos
 
 !!! Note
      You need to create a single Azure Private DNS Zone for each VNet, even if you are connecting to multiple clusters. If you've already created a DNS Zone for this VNet, you can skip to step 6.
-    
 
-1. In the Azure portal search for _Private DNS Zones_.
- 
-1. Select **Private DNS zone**.
+1.  In the Azure portal search for *Private DNS Zones*.
 
-1. Select **Create private DNS zone**.
+2.  Select **Private DNS zone**.
 
-1. Create a private DNS zone using your organization's domain name as an apex domain. The organization's domain name must be unique to your BigAnimal organization. For example, use `biganimal.io`.
- 
- ![](../images/image6.png)
+3.  Select **Create private DNS zone**.
 
-1. Select the **Virtual network** link on the **Private DNS Zone** page of `brcxzr08qr7rbei1.biganimal.io` and link the private DNS Zone to the client VM's virtual network
-`vnet-client`.
+4.  Create a private DNS zone using your organization's domain name as an apex domain. The organization's domain name must be unique to your BigAnimal organization. For example, use `biganimal.io`.
 
- ![](../images/image10.png)
+    ![](../images/image6.png)
 
-1. Add a record for the private endpoint. The address is a private IP address—the one created with the private endpoint in the previous step.
+5.  Select the **Virtual network** link on the **Private DNS Zone** page of `brcxzr08qr7rbei1.biganimal.io` and link the private DNS Zone to the client VM's virtual network
+    `vnet-client`.
 
- ![](../images/image4.png)
+     ![](../images/image10.png)
 
-1. You can now access your cluster with this private domain name.
+6.  Add a record for the private endpoint. The address is a private IP address—the one created with the private endpoint in the previous step.
 
- ```
- $ dig +short p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io 
- 10.240.1.123 
-       
- $ psql -h p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
- Password for user edb_admin: 
- 
- psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
- WARNING : psql major version 13, server major version 13. Some psql features might not work. 
- SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
- 
- edb_admin=>
- 
- ```
+    ![](../images/image4.png)
 
- !!! Tip
-    You might need to flush your local DNS cache to resolve your domain name to the new private IP address after adding the private endpoint. For example, on Ubuntu, run the following command:
+7.  You can now access your cluster with this private domain name.
 
-  ```
-  $ sudo systemd-resolve --flush-caches
-  ```
+    ```
+    $ dig +short p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io 
+    10.240.1.123 
+          
+    $ psql -h p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
+    Password for user edb_admin: 
+
+    psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
+    WARNING : psql major version 13, server major version 13. Some psql features might not work. 
+    SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
+
+    edb_admin=>
+
+    ```
+
+    !!! Tip
+        You might need to flush your local DNS cache to resolve your domain name to the new private IP address after adding the private endpoint. For example, on Ubuntu, run the following command:
+
+        ```
+        $ sudo systemd-resolve --flush-caches
+        ```

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/02_virtual_network_peering.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/02_virtual_network_peering.mdx
@@ -11,33 +11,31 @@ This example shows how to connect using virtual network peering.
 
 Assume that your cluster is on a subscription called `development` and is being accessed from a Linux client VM on another subscription called `test` with the following properties:
 
-- Cluster:
-  - Subscription: `development`
-  - Cluster ID: `p-c4j0jfcmp3af2ieok5eg` 
-  - Account ID: `brcxzr08qr7rbei1` 
-  - Organization's domain name: `biganimal.io` 
+-   Cluster:
+    -   Subscription: `development`
+    -   Cluster ID: `p-c4j0jfcmp3af2ieok5eg` 
+    -   Account ID: `brcxzr08qr7rbei1` 
+    -   Organization's domain name: `biganimal.io` 
 
 
-- Linux client VM called `vm-client`:
-  - Subscription: `test`
-  - Resource group: `rg-client`
-  - Virtual network: `vnet-client`
-  - Virtual network subnet: `snet-client`
+-   Linux client VM called `vm-client`:
+    -   Subscription: `test`
+    -   Resource group: `rg-client`
+    -   Virtual network: `vnet-client`
+    -   Virtual network subnet: `snet-client`
 
 #### Prerequisites
 
 To walk through an example in your own environment, you need:
 
-- Your cluster URL. You can find the URL in the **Connect** tab of your cluster instance in the BigAnimal portal.
- 
-- The IP address of your cluster. You can find the IP address of your cluster using the following command:
+-   Your cluster URL. You can find the URL in the **Connect** tab of your cluster instance in the BigAnimal portal.
+-   The IP address of your cluster. You can find the IP address of your cluster using the following command:
 
- ```
- $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
- 10.240.1.218
- ```
- 
-- A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
+    ```
+    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    10.240.1.218
+    ```
+-   A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
 
 #### Step 1: Create a virtual network peering link
 
@@ -45,36 +43,36 @@ You need to add two peering links, one from the client VM's VNet `vnet-client` a
 
 !!! Note
     In this example, you create virtual network peering for virtual networks that belong to subscriptions in the same Azure Active Directory tenants. For steps to create virtual network peering for virtual networks that belong to subscriptions in different Azure Active Directory tenants, see [peering virtual networks from different Azure Active Directory tenants](https://docs.microsoft.com/azure/virtual-network/create-peering-different-subscriptions).
-    
-1. In the Azure portal, search for _Virtual networks_. When **Virtual networks** appears in the search results, select it. Don't select **Virtual networks (classic)**, as you can't create a peering from a virtual network deployed through the classic deployment model.
 
-1. Select the client VM's Virtual Network `vnet-client` from the list that you want to create a peering for.
+1.  In the Azure portal, search for *Virtual networks*. When **Virtual networks** appears in the search results, select it. Don't select **Virtual networks (classic)**, as you can't create a peering from a virtual network deployed through the classic deployment model.
 
-1. Under **Settings**, select **Peerings** and then select **+ Add**.
+2.  Select the client VM's Virtual Network `vnet-client` from the list that you want to create a peering for.
 
-1. From the Peerings page of the client VM's Virtual Network `vnet-client`, add two peering links called `peer-client-edb` and `peer-edb-client` to join the address space of two virtual networks together. 
+3.  Under **Settings**, select **Peerings** and then select **+ Add**.
 
- To simplify the process, Azure creates both peering links for you when you add peering from either side.
+4.  From the Peerings page of the client VM's Virtual Network `vnet-client`, add two peering links called `peer-client-edb` and `peer-edb-client` to join the address space of two virtual networks together. 
 
- ![](../images/image25.png)
+    To simplify the process, Azure creates both peering links for you when you add peering from either side.
 
- ![](../images/image7.png)
+    ![](../images/image25.png)
+
+    ![](../images/image7.png)
 
 #### Step 2: Access the cluster
 
 Access the cluster with its domain name from your cluster's connection string. It's accessible from `vnet-client` after peering.
 
- ```
- $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
- 10.240.1.123 
-       
- $ psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
- Password for user edb_admin: 
- 
- psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
- WARNING : psql major version 13, server major version 13. Some psql features might not work. 
- SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
- 
- edb_admin=>
- 
- ```
+```
+$ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+10.240.1.123 
+      
+$ psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
+Password for user edb_admin: 
+
+psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
+WARNING : psql major version 13, server major version 13. Some psql features might not work. 
+SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
+
+edb_admin=>
+
+```

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/03_vnet_vnet.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/03_vnet_vnet.mdx
@@ -4,7 +4,6 @@ redirects:
  - /biganimal/release/using_cluster/connecting_your_cluster/01_connecting_from_azure/03_vnet_vnet/
 ---
 
-    
 This example shows how to connect using VNet-VNet connections. 
 
 To use this method, you need to create [Azure VPN Gateways](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpngateways) in each connected virtual network.  
@@ -14,43 +13,41 @@ To use this method, you need to create [Azure VPN Gateways](https://docs.microso
 
 Assume that your cluster is on a subscription called `development` and is being accessed from a Linux client VM on another subscription called `test` with the following properties:
 
-- Cluster:
-  - Subscription: `development`
-  - Cluster ID: `p-c4j0jfcmp3af2ieok5eg` 
-  - Account ID: `brcxzr08qr7rbei1` 
-  - Organization's domain name: `biganimal.io` 
+-   Cluster:
+    -   Subscription: `development`
+    -   Cluster ID: `p-c4j0jfcmp3af2ieok5eg` 
+    -   Account ID: `brcxzr08qr7rbei1` 
+    -   Organization's domain name: `biganimal.io` 
 
 
-- Linux client VM called `vm-client`:
-  - Subscription: `test`
-  - Resource group: `rg-client`
-  - Virtual network: `vnet-client`
-  - Virtual network subnet: `snet-client`
+-   Linux client VM called `vm-client`:
+    -   Subscription: `test`
+    -   Resource group: `rg-client`
+    -   Virtual network: `vnet-client`
+    -   Virtual network subnet: `snet-client`
 
 #### Prerequisites
 
 To walk through an example in your own environment, you need:
 
-- Your cluster URL. You can find the URL in the **Connect** tab of your cluster instance in the BigAnimal portal.
- 
-- The IP address of your cluster. You can find the IP address of your cluster using the following command:
+-   Your cluster URL. You can find the URL in the **Connect** tab of your cluster instance in the BigAnimal portal.
+-   The IP address of your cluster. You can find the IP address of your cluster using the following command:
 
- ```
- $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
- 10.240.1.218
- ```
- 
-- A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
+    ```
+    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    10.240.1.218
+    ```
+-   A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
 
 #### Step 1: Create a VPN gateway for the cluster's virtual network
 
-1. In the Azure portal, search for _Virtual network gateways_. Locate **Virtual network gateways** in the search results and select it.
+1.  In the Azure portal, search for *Virtual network gateways*. Locate **Virtual network gateways** in the search results and select it.
 
-1. On the Virtual network gateways page, select **+ Create**.
+2.  On the Virtual network gateways page, select **+ Create**.
 
-1. On the Create virtual network gateway page, create the VPN gateway for the cluster's resource virtual network `vnet-japaneast`. Name the VPN gateway `vpng-biganimal`.
+3.  On the Create virtual network gateway page, create the VPN gateway for the cluster's resource virtual network `vnet-japaneast`. Name the VPN gateway `vpng-biganimal`.
 
- ![](../images/image8.png)
+    ![](../images/image8.png)
 
 !!! Note
     The VPN gateway automatically creates a dedicated subnet to accommodate its gateway VMs. Ensure that your cluster's virtual network address space has enough IP range for the subnet to prevent errors in the virtual network. For more information, see [Add a subnet](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-manage-subnet#add-a-subnet).
@@ -66,32 +63,32 @@ Use the Azure CLI (or [PowerShell](https://docs.microsoft.com/en-us/azure/vpn-ga
 !!! Note
     The Azure portal allows you to create VPN gateway connections only between virtual networks belonging to the same subscription.
 
-1. Get the VPN gateway ID of `vpng-client`.
+1.  Get the VPN gateway ID of `vpng-client`.
 
- **From the BigAnimal subscription**:
+    **From the BigAnimal subscription**:
 
     ```
-   $ az network vnet-gateway show -n vpng-biganimal -g brCxzr08qr7RBEi1-rg-japaneast-management --query "[id]" -otsv
-   subscriptions/.../vpng-biganimal
-   ```
+    $ az network vnet-gateway show -n vpng-biganimal -g brCxzr08qr7RBEi1-rg-japaneast-management --query "[id]" -otsv
+    subscriptions/.../vpng-biganimal
+    ```
 
- **From the client VM's subscription**:
+    **From the client VM's subscription**:
 
-   ```
-   $ az network vnet-gateway show -n vpng-client -g rg-client --query "[id]" -o tsv
-   /subscriptions/.../vpng-client
-   ```
+    ```
+    $ az network vnet-gateway show -n vpng-client -g rg-client --query "[id]" -o tsv
+    /subscriptions/.../vpng-client
+    ```
 
-2. From the BigAnimal subscription, create a connection from `vpng-biganimal` to `vpng-client`.
+2.  From the BigAnimal subscription, create a connection from `vpng-biganimal` to `vpng-client`.
 
-  ```
-  $ az network vpn-connection create -n vpnc-biganimal-client -g brCxzr08qr7RBEi1-rg-japaneast-management --vnet-gateway1 /subscriptions/.../vpng-biganimal -l japaneast --shared-key "a_very_long_and_complex_psk" \--vnet-gateway2 /subscriptions/.../vpng-client
+    ```
+    $ az network vpn-connection create -n vpnc-biganimal-client -g brCxzr08qr7RBEi1-rg-japaneast-management --vnet-gateway1 /subscriptions/.../vpng-biganimal -l japaneast --shared-key "a_very_long_and_complex_psk" \--vnet-gateway2 /subscriptions/.../vpng-client
 
-  ```
+    ```
 
- Note the value for `--shared-key`. It is a PSK for pairing authentication from both sides needed in the next step.
+    Note the value for `--shared-key`. It is a PSK for pairing authentication from both sides needed in the next step.
 
-3. From the client VM's subscription, create another connection from `vpng-client` to `vpng-ebdcloud`.
+3.  From the client VM's subscription, create another connection from `vpng-client` to `vpng-ebdcloud`.
 
     ```
     $ az network vpn-connection create -n vpnc-client-biganimal -g rg-client --vnet-gateway1 /subscriptions/.../vpng-client -l japaneast --shared-key "a_very_long_and_complex_psk!" --vnet-gateway2 /subscriptions/.../vpng-biganimal
@@ -99,27 +96,26 @@ Use the Azure CLI (or [PowerShell](https://docs.microsoft.com/en-us/azure/vpn-ga
 
 #### Step 4: Verify the connection
 
-1. After a few minutes, verify the gateway connection status from either virtual networks with the following command:
+1.  After a few minutes, verify the gateway connection status from either virtual networks with the following command:
 
- ```
- $ az network vpn-connection show --name vpnc-client-biganimal -g rg-client --query "[connectionStatus]" -o tsv
-Connected
- ```
+    ```
+    $ az network vpn-connection show --name vpnc-client-biganimal -g rg-client --query "[connectionStatus]" -o tsv
+    Connected
+    ```
 
-2. Verify the connectivity to the cluster:
+2.  Verify the connectivity to the cluster:
 
- ```
- $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
- 10.240.1.123 
-       
- $ psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
- Password for user edb_admin: 
- 
- psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
- WARNING : psql major version 13, server major version 13. Some psql features might not work. 
- SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
- 
- edb_admin=>
- 
- ```
+    ```
+    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    10.240.1.123 
+          
+    $ psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
+    Password for user edb_admin: 
 
+    psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
+    WARNING : psql major version 13, server major version 13. Some psql features might not work. 
+    SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
+
+    edb_admin=>
+
+    ```

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/index.mdx
@@ -6,9 +6,9 @@ redirects:
 
 Three different methods enable you to connect to your cluster from your application's virtual network in Azure. Each method offers different levels of accessibility and security. The Azure Private Endpoint method is recommended and is most commonly used. However, you can implement either of the other solutions depending on your organization's requirements.
 
-- [Azure Private Endpoint (recommended)](#azure-private-endpoint-recommended)
-- [Virtual network peering](#virtual-network-peering)
-- [Azure VNet-VNet connection](#azure-vnet-vnet-connection)
+-   [Azure Private Endpoint (recommended)](#azure-private-endpoint-recommended)
+-   [Virtual network peering](#virtual-network-peering)
+-   [Azure VNet-VNet connection](#azure-vnet-vnet-connection)
 
 ## Azure Private Endpoint (recommended)
 
@@ -16,11 +16,13 @@ Three different methods enable you to connect to your cluster from your applicat
  address from your Azure Virtual Network (VNet) to an external service. You grant access only to a single cluster instead of the entire BigAnimal resource virtual network, thus ensuring maximum network isolation. Private Endpoints are the same mechanism used by first-party Azure services such as CosmosDB for private VNet connectivity. For more information, see [What is an Azure Private Endpoint?](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-overview).
 
 **Pros**
- - You need to configure the Private Link only once. Then you can use multiple Private Links to connect applications from many different VNets.
- - There's no risk of IP address conflicts.
+
+-   You need to configure the Private Link only once. Then you can use multiple Private Links to connect applications from many different VNets.
+-   There's no risk of IP address conflicts.
 
 **Cons**
- - Private Links (required by Private Endpoints) are not free. See [Azure Private Link pricing](https://azure.microsoft.com/en-us/pricing/details/private-link/#pricing).
+
+-   Private Links (required by Private Endpoints) are not free. See [Azure Private Link pricing](https://azure.microsoft.com/en-us/pricing/details/private-link/#pricing).
 
 See the [Private Endpoint Example](01_private_endpoint) for the steps for connecting using this method.
 
@@ -29,11 +31,13 @@ See the [Private Endpoint Example](01_private_endpoint) for the steps for connec
 Virtual network peering connects two Azure Virtual Networks, allowing traffic to be freely routed between the two. Once peered, the two virtual networks act as one with respect to connectivity. Network Security Group rules are still observed.
 
 **Pros**
-- Simple and easy to set up.
+
+-   Simple and easy to set up.
 
 **Cons**
-- There is an associated cost. See [pricing for virtual network peering](https://azure.microsoft.com/en-us/pricing/details/virtual-network/#pricing) for details.
-- The IP ranges of two peered virtual networks can't overlap. BigAnimal VNets use the 10.240.0.0/16 address space and can't be peered with VNets using this same space.
+
+-   There is an associated cost. See [pricing for virtual network peering](https://azure.microsoft.com/en-us/pricing/details/virtual-network/#pricing) for details.
+-   The IP ranges of two peered virtual networks can't overlap. BigAnimal VNets use the 10.240.0.0/16 address space and can't be peered with VNets using this same space.
 
 See the [Viritual Network Peering Example](02_virtual_network_peering) for the steps to connect using this VNet Peering.
 
@@ -42,12 +46,14 @@ See the [Viritual Network Peering Example](02_virtual_network_peering) for the s
 VNet-VNet connections use VPN gateways to send encrypted traffic between Azure virtual networks.
 
 **Pros**
-- Cluster domain name is directly accessible without a NAT. 
-- VNets from different subscriptions don't need to be associated with the same Active Directory tenant.
+
+-   Cluster domain name is directly accessible without a NAT. 
+-   VNets from different subscriptions don't need to be associated with the same Active Directory tenant.
 
 **Cons**
-- Bandwidth is limited. See [virtual network gateway planning table](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpngateways#planningtable). 
-- Configuration is complicated.
-- There is an associated cost. See [virtual network gateway planning table](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpngateways#planningtable).
+
+-   Bandwidth is limited. See [virtual network gateway planning table](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpngateways#planningtable). 
+-   Configuration is complicated.
+-   There is an associated cost. See [virtual network gateway planning table](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpngateways#planningtable).
 
 See the [VNet-VNet Example](03_vnet_vnet) for the steps for connecting using VNet-VNet Connection.

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/index.mdx
@@ -8,27 +8,31 @@ redirects:
 ---
 
 You can connect to your cluster using [`psql`](http://postgresguide.com/utilities/psql.html), the terminal-based client for Postgres, or another client. For additional security measures see:
-- [Recommendations for Settings for SSL Mode](#recommended-settings-for-ssl-mode) 
-- [Using a private network to connect to your cluster](#setting-up-azure-infrastructure-to-connect-to-a-private-network-cluster)
+
+-   [Recommendations for Settings for SSL Mode](#recommended-settings-for-ssl-mode) 
+-   [Using a private network to connect to your cluster](#setting-up-azure-infrastructure-to-connect-to-a-private-network-cluster)
 
 ## Connect to your cluster using `psql`
 
-1. Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
+1.  Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
 
-1. Go to the [Clusters](https://portal.biganimal.com/clusters) page.
+2.  Go to the [Clusters](https://portal.biganimal.com/clusters) page.
 
-3. Select the name of your cluster.
-4. On the **Overview** tab, select the copy icon to the right of the **Quick Connect** field to copy the command for connecting to your cluster using `psql` to your clipboard. `psql` prompts for the edb_admin user password you selected when you created the cluster.
-5. Paste the command in your terminal.
+3.  Select the name of your cluster.
+
+4.  On the **Overview** tab, select the copy icon to the right of the **Quick Connect** field to copy the command for connecting to your cluster using `psql` to your clipboard. `psql` prompts for the edb_admin user password you selected when you created the cluster.
+
+5.  Paste the command in your terminal.
 
 ## Connect to your cluster using a client other than `psql`
 
-1. Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
+1.  Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
 
-1. Go to the [Clusters](https://portal.biganimal.com/clusters) page.
+2.  Go to the [Clusters](https://portal.biganimal.com/clusters) page.
 
-2. Select the name of your cluster.
-3. Select the **Connect** tab. You can review and copy all the relevant information you need from this screen except for the edb_admin user password. Consult the client driver documentation for the connection string format the driver uses.
+3.  Select the name of your cluster.
+
+4.  Select the **Connect** tab. You can review and copy all the relevant information you need from this screen except for the edb_admin user password. Consult the client driver documentation for the connection string format the driver uses.
 
 ## Recommended settings for SSL mode
 

--- a/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters.mdx
@@ -6,11 +6,12 @@ The database parameters listed on the DB Configuration tab are also referred to 
 
 The list of parameters is populated based on the type of database you selected on the **Operational Settings** tab when you created your cluster. For more information about the parameters for your database type:
 
-- For Postgres parameters, see [Setting Parameters](https://www.postgresql.org/docs/current/config-setting.html) and [Server Configuration](https://www.postgresql.org/docs/current/runtime-config.html) in the Postgres documentation.
-   
-- For EDB Postgres Advanced Server, see [Summary of Configuration Parameters](https://www.enterprisedb.com/docs/epas/latest/epas_guide/03_database_administration/01_configuration_parameters/02_summary_of_configuration_parameters/#summary_of_configuration_parameters) and [Configuration Parameters](https://www.enterprisedb.com/docs/epas/latest/epas_guide/03_database_administration/01_configuration_parameters/).
+-   For Postgres parameters, see [Setting Parameters](https://www.postgresql.org/docs/current/config-setting.html) and [Server Configuration](https://www.postgresql.org/docs/current/runtime-config.html) in the Postgres documentation.
+     
 
-- For additional information on parameters, see [postgresqlco.nf](https://postgresqlco.nf/).
+-   For EDB Postgres Advanced Server, see [Summary of Configuration Parameters](https://www.enterprisedb.com/docs/epas/latest/epas_guide/03_database_administration/01_configuration_parameters/02_summary_of_configuration_parameters/#summary_of_configuration_parameters) and [Configuration Parameters](https://www.enterprisedb.com/docs/epas/latest/epas_guide/03_database_administration/01_configuration_parameters/).
+
+-   For additional information on parameters, see [postgresqlco.nf](https://postgresqlco.nf/).
 
 !!!note
 Not all database configuration parameters are supported by BigAnimal. Some parameters, such as `wal_level` and `restore_command`, are reserved for EDB to provide the managed database features of BigAnimal. 
@@ -18,12 +19,12 @@ Not all database configuration parameters are supported by BigAnimal. Some param
 
 ## Modify a parameter
 
-1. Go to the parameter you want to modify using these methods:
-   - To search for a specific parameter, use the search field. 
-   - To filter the parameters that show, select one of the following in the **Show only** list:
-      - Custom Values — Shows only parameters that changed from the default values, either in the current session or modified in a previous session and applied to the cluster.
-      - Currently Edited Values — Shows only parameters that changed during the current editing session.
+1.  Go to the parameter you want to modify using these methods:
+    -   To search for a specific parameter, use the search field. 
+    -   To filter the parameters that show, select one of the following in the **Show only** list:
+        -   Custom Values — Shows only parameters that changed from the default values, either in the current session or modified in a previous session and applied to the cluster.
+        -   Currently Edited Values — Shows only parameters that changed during the current editing session.
 
-1. Enter the new value in the parameter value field. See [Parameter Names and Values](https://www.postgresql.org/docs/current/config-setting.html#CONFIG-SETTING-NAMES-VALUES) for more information on the types of values parameters accept.
+2.  Enter the new value in the parameter value field. See [Parameter Names and Values](https://www.postgresql.org/docs/current/config-setting.html#CONFIG-SETTING-NAMES-VALUES) for more information on the types of values parameters accept.
 
-1. Save your changes.
+3.  Save your changes.

--- a/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/index.mdx
@@ -4,35 +4,36 @@ title: Modifying your cluster
 redirects:
   - ../03_modify_and_scale_cluster
 ---
+
 You can modify your cluster by modifying:
 
-- Cluster name and password
-- Instance type
-- Networking type
-- Database configuration parameters
-- High availability
+-   Cluster name and password
+-   Instance type
+-   Networking type
+-   Database configuration parameters
+-   High availability
 
 ## Modify your cluster
 
-1. Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
+1.  Sign in to the [BigAnimal](https://portal.biganimal.com) portal.
 
-1. From the [**Clusters**](https://portal.biganimal.com/clusters) page, select the name of the cluster you want to edit.
+2.  From the [**Clusters**](https://portal.biganimal.com/clusters) page, select the name of the cluster you want to edit.
 
-2. Select **Edit Cluster** from the top right corner of the **Cluster Info** panel.
+3.  Select **Edit Cluster** from the top right corner of the **Cluster Info** panel.
 
-1. You can modify the following settings on the corresponding tab of the Edit Cluster page:
+4.  You can modify the following settings on the corresponding tab of the Edit Cluster page:
 
-   | Settings | Tab | 
-   | ------- | ----------- |
-   | Cluster name and password | [Cluster info](../../getting_started/03_create_cluster/#cluster-info-tab) |
-   | Instance type (vCPUs and memory)* | [Operational settings](../../getting_started/03_create_cluster/#operational-settings-tab) |
-   | Networking type (public or private) | [Operational settings](../../getting_started/03_create_cluster/#operational-settings-tab) |
-   | Database configuration parameters | [Database configuration parameters](05_db_configuration_parameters)
-   | High availability (on or off) | [Availability](../../getting_started/03_create_cluster/#availability-tab) |
+    | Settings                            | Tab                                                                                       |
+    | ----------------------------------- | ----------------------------------------------------------------------------------------- |
+    | Cluster name and password           | [Cluster info](../../getting_started/03_create_cluster/#cluster-info-tab)                 |
+    | Instance type (vCPUs and memory)\*  | [Operational settings](../../getting_started/03_create_cluster/#operational-settings-tab) |
+    | Networking type (public or private) | [Operational settings](../../getting_started/03_create_cluster/#operational-settings-tab) |
+    | Database configuration parameters   | [Database configuration parameters](05_db_configuration_parameters)                       |
+    | High availability (on or off)       | [Availability](../../getting_started/03_create_cluster/#availability-tab)                 |
 
-   *Changing the instance type could incur higher cloud infrastructure charges.
+    \*Changing the instance type could incur higher cloud infrastructure charges.
 
-   !!! Note
-       Saving changes might require a database restart.
+    !!! Note
+        Saving changes might require a database restart.
 
-1. Save your changes.
+5.  Save your changes.

--- a/product_docs/docs/biganimal/release/using_cluster/04_backup_and_restore.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/04_backup_and_restore.mdx
@@ -18,18 +18,16 @@ You can restore backups into a new cluster in any region supported by BigAnimal.
 
 #### Perform a cluster restore
 
-1. Select the cluster you want to restore on the [Clusters](https://portal.biganimal.com/clusters) page in the [BigAnimal](https://portal.biganimal.com) portal. 
+1.  Select the cluster you want to restore on the [Clusters](https://portal.biganimal.com/clusters) page in the [BigAnimal](https://portal.biganimal.com) portal. 
 
-2. From **Quick Actions**, select **Restore**.
+2.  From **Quick Actions**, select **Restore**.
 
-2. On the Restore Cluster page: 
+3.  On the Restore Cluster page: 
 
-    1. Fill in the required fields.
+    1.  Fill in the required fields.
 
-    3. In the **Source** section, in the **Point in Time Restore** field, select **Now** on the calendar to restore to the last possible recovery point. Or, choose a timestamp to restore further back in time. 
+    2.  In the **Source** section, in the **Point in Time Restore** field, select **Now** on the calendar to restore to the last possible recovery point. Or, choose a timestamp to restore further back in time. 
 
-    4. Review your selections in **Cluster Summary** and select **Restore Cluster** to begin the restore process.  
+    3.  Review your selections in **Cluster Summary** and select **Restore Cluster** to begin the restore process.  
 
-5. The new cluster is now available on the [Clusters](https://portal.biganimal.com/clusters) page.
-
-
+4.  The new cluster is now available on the [Clusters](https://portal.biganimal.com/clusters) page.

--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/06_metrics.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/06_metrics.mdx
@@ -29,11 +29,11 @@ time-series functions, seasonally adjusted statistics, and alert generation.
 The following tables in the Customer Log Analytic workspace contain entries
 specific to BigAnimal:
 
-| Table name | Description |
-| ---------- | ----------- |
-| PostgresLogs_CL  | Logs of the Customer clusters databases (all postgres related logs) |
-| PostgresAuditLogs_CL  | Audit Logs of the Customer clusters databases, if enabled |
-| InsightsMetrics | Metrics streams from BigAnimal Prometheus and Azure Monitor. BigAnimal metrics have `namespace == "prometheus"` |
+| Table name           | Description                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------- |
+| PostgresLogs_CL      | Logs of the Customer clusters databases (all postgres related logs)                                             |
+| PostgresAuditLogs_CL | Audit Logs of the Customer clusters databases, if enabled                                                       |
+| InsightsMetrics      | Metrics streams from BigAnimal Prometheus and Azure Monitor. BigAnimal metrics have `namespace == "prometheus"` |
 
 You can use the KQL Query editor in the Log Workspace view to compose queries
 over these tables.
@@ -97,15 +97,15 @@ the metrics streams.
 All Postgres metrics share a common tagging scheme. Entries generally
 have at least the following tags:
 
-| Name                           | Description |
-|--------------------------------|-------------|
-| address                        | IP address of the host the metric originated from |
-| postgresql                     | BigAnimal postgres cluster identifier, e.g., `p-abcdef012345` |
-| role                           | Postgres instance role, "primary" or "replica" |
-| datname                        | Postgres database name (where applicable) |
-| pod_name                       | k8s pod name |
-| hostName                       | AKS node host name |
-| container.azm.ms/clusterName   | AKS cluster name |
+| Name                         | Description                                                   |
+| ---------------------------- | ------------------------------------------------------------- |
+| address                      | IP address of the host the metric originated from             |
+| postgresql                   | BigAnimal postgres cluster identifier, e.g., `p-abcdef012345` |
+| role                         | Postgres instance role, "primary" or "replica"                |
+| datname                      | Postgres database name (where applicable)                     |
+| pod_name                     | k8s pod name                                                  |
+| hostName                     | AKS node host name                                            |
+| container.azm.ms/clusterName | AKS cluster name                                              |
 
 When querying for tags, for best performance apply filters that don't
 require inspection of tags (for example, filters by metric name) before tag-based filters.
@@ -126,7 +126,7 @@ InsightsMetrics
 | distinct postgres_cluster_id, dbname
 ```
 
-[comment1]: # (Generated content see upm-substrate repo config monitoring dir)
+[comment1]: # "Generated content see upm-substrate repo config monitoring dir"
 
 #### Group `cnp_backends`
 
@@ -138,23 +138,22 @@ Derived from the `pg_stat_activity` view.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_backends_total` | GAUGE | Number of backends |
+| Metric                                 | Usage | Description                                  |
+| -------------------------------------- | ----- | -------------------------------------------- |
+| `cnp_backends_total`                   | GAUGE | Number of backends                           |
 | `cnp_backends_max_tx_duration_seconds` | GAUGE | Maximum duration of a transaction in seconds |
-
 
 ##### Labels
 
 The metrics in this group can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
-| `datname` | Name of the database |
-| `usename` | Name of the user |
+| Label              | Description             |
+| ------------------ | ----------------------- |
+| `datname`          | Name of the database    |
+| `usename`          | Name of the user        |
 | `application_name` | Name of the application |
-| `state` | State of the backend |
+| `state`            | State of the backend    |
 
 #### Group `cnp_backends_waiting`
 
@@ -166,8 +165,8 @@ Derived from the `pg_locks` view.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
+| Metric                       | Usage | Description                                                          |
+| ---------------------------- | ----- | -------------------------------------------------------------------- |
 | `cnp_backends_waiting_total` | GAUGE | Total number of backends that are currently waiting on other queries |
 
 #### Group `cnp_pg_database`
@@ -181,20 +180,19 @@ See also `cnp_pg_stat_database`.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_database_size_bytes` | GAUGE | Disk space used by the database |
-| `cnp_pg_database_xid_age` | GAUGE | Number of transactions from the frozen XID to the current one |
-| `cnp_pg_database_mxid_age` | GAUGE | Number of multiple transactions (Multixact) from the frozen XID to the current one |
-
+| Metric                       | Usage | Description                                                                        |
+| ---------------------------- | ----- | ---------------------------------------------------------------------------------- |
+| `cnp_pg_database_size_bytes` | GAUGE | Disk space used by the database                                                    |
+| `cnp_pg_database_xid_age`    | GAUGE | Number of transactions from the frozen XID to the current one                      |
+| `cnp_pg_database_mxid_age`   | GAUGE | Number of multiple transactions (Multixact) from the frozen XID to the current one |
 
 ##### Labels
 
 The metrics in this group can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
+| Label     | Description          |
+| --------- | -------------------- |
 | `datname` | Name of the database |
 
 #### Group `cnp_pg_postmaster`
@@ -205,8 +203,8 @@ Derived from the `pg_postmaster_start_time()` function.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
+| Metric                         | Usage | Description                                 |
+| ------------------------------ | ----- | ------------------------------------------- |
 | `cnp_pg_postmaster_start_time` | GAUGE | Time when postgres started (based on epoch) |
 
 #### Group `cnp_pg_replication`
@@ -222,10 +220,10 @@ See also `cnp_pg_stat_replication`, `cnp_pg_replication_slots`.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_replication_lag` | GAUGE | Replication lag behind primary in seconds |
-| `cnp_pg_replication_in_recovery` | GAUGE | Whether the instance is in recovery |
+| Metric                           | Usage | Description                               |
+| -------------------------------- | ----- | ----------------------------------------- |
+| `cnp_pg_replication_lag`         | GAUGE | Replication lag behind primary in seconds |
+| `cnp_pg_replication_in_recovery` | GAUGE | Whether the instance is in recovery       |
 
 #### Group `cnp_pg_replication_slots`
 
@@ -243,21 +241,20 @@ See also `cnp_pg_stat_replication`, `cnp_pg_replication`.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_replication_slots_active` | GAUGE | Flag indicating if the slot is active |
-| `cnp_pg_replication_slots_pg_wal_lsn_diff` | GAUGE | Replication lag in bytes |
-
+| Metric                                     | Usage | Description                           |
+| ------------------------------------------ | ----- | ------------------------------------- |
+| `cnp_pg_replication_slots_active`          | GAUGE | Flag indicating if the slot is active |
+| `cnp_pg_replication_slots_pg_wal_lsn_diff` | GAUGE | Replication lag in bytes              |
 
 ##### Labels
 
 The metrics in this group can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
+| Label       | Description                  |
+| ----------- | ---------------------------- |
 | `slot_name` | Name of the replication slot |
-| `database` | Name of the database |
+| `database`  | Name of the database         |
 
 #### Group `cnp_pg_stat_archiver`
 
@@ -279,17 +276,17 @@ Derived from the `pg_stat_archiver` view.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_stat_archiver_archived_count` | COUNTER | Number of WAL files that were successfully archived |
-| `cnp_pg_stat_archiver_failed_count` | COUNTER | Number of failed attempts for archiving WAL files |
-| `cnp_pg_stat_archiver_seconds_since_last_archival` | GAUGE | Seconds since the last successful archival operation |
-| `cnp_pg_stat_archiver_seconds_since_last_failure` | GAUGE | Seconds since the last failed archival operation |
-| `cnp_pg_stat_archiver_last_archived_time` | GAUGE | Epoch of the last time WAL archiving succeeded |
-| `cnp_pg_stat_archiver_last_failed_time` | GAUGE | Epoch of the last time WAL archiving failed |
-| `cnp_pg_stat_archiver_last_archived_wal_start_lsn` | GAUGE | Archived WAL start LSN |
-| `cnp_pg_stat_archiver_last_failed_wal_start_lsn` | GAUGE | Last failed WAL LSN |
-| `cnp_pg_stat_archiver_stats_reset_time` | GAUGE | Time when these statistics were last reset |
+| Metric                                             | Usage   | Description                                          |
+| -------------------------------------------------- | ------- | ---------------------------------------------------- |
+| `cnp_pg_stat_archiver_archived_count`              | COUNTER | Number of WAL files that were successfully archived  |
+| `cnp_pg_stat_archiver_failed_count`                | COUNTER | Number of failed attempts for archiving WAL files    |
+| `cnp_pg_stat_archiver_seconds_since_last_archival` | GAUGE   | Seconds since the last successful archival operation |
+| `cnp_pg_stat_archiver_seconds_since_last_failure`  | GAUGE   | Seconds since the last failed archival operation     |
+| `cnp_pg_stat_archiver_last_archived_time`          | GAUGE   | Epoch of the last time WAL archiving succeeded       |
+| `cnp_pg_stat_archiver_last_failed_time`            | GAUGE   | Epoch of the last time WAL archiving failed          |
+| `cnp_pg_stat_archiver_last_archived_wal_start_lsn` | GAUGE   | Archived WAL start LSN                               |
+| `cnp_pg_stat_archiver_last_failed_wal_start_lsn`   | GAUGE   | Last failed WAL LSN                                  |
+| `cnp_pg_stat_archiver_stats_reset_time`            | GAUGE   | Time when these statistics were last reset           |
 
 #### Group `cnp_pg_stat_bgwriter`
 
@@ -311,18 +308,18 @@ Derived from the `pg_stat_bgwriter` catalog.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_stat_bgwriter_checkpoints_timed` | COUNTER | Number of scheduled checkpoints that were performed |
-| `cnp_pg_stat_bgwriter_checkpoints_req` | COUNTER | Number of requested checkpoints that were performed |
-| `cnp_pg_stat_bgwriter_checkpoint_write_time` | COUNTER | Total amount of time that was spent in the portion of checkpoint processing where files are written to disk, in milliseconds |
-| `cnp_pg_stat_bgwriter_checkpoint_sync_time` | COUNTER | Total amount of time that was spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds |
-| `cnp_pg_stat_bgwriter_buffers_checkpoint` | COUNTER | Number of buffers written during checkpoints |
-| `cnp_pg_stat_bgwriter_buffers_clean` | COUNTER | Number of buffers written by the background writer |
-| `cnp_pg_stat_bgwriter_maxwritten_clean` | COUNTER | Number of times the background writer stopped a cleaning scan because it wrote too many buffers |
-| `cnp_pg_stat_bgwriter_buffers_backend` | COUNTER | Number of buffers written directly by a backend |
+| Metric                                       | Usage   | Description                                                                                                                                         |
+| -------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cnp_pg_stat_bgwriter_checkpoints_timed`     | COUNTER | Number of scheduled checkpoints that were performed                                                                                                 |
+| `cnp_pg_stat_bgwriter_checkpoints_req`       | COUNTER | Number of requested checkpoints that were performed                                                                                                 |
+| `cnp_pg_stat_bgwriter_checkpoint_write_time` | COUNTER | Total amount of time that was spent in the portion of checkpoint processing where files are written to disk, in milliseconds                        |
+| `cnp_pg_stat_bgwriter_checkpoint_sync_time`  | COUNTER | Total amount of time that was spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds                   |
+| `cnp_pg_stat_bgwriter_buffers_checkpoint`    | COUNTER | Number of buffers written during checkpoints                                                                                                        |
+| `cnp_pg_stat_bgwriter_buffers_clean`         | COUNTER | Number of buffers written by the background writer                                                                                                  |
+| `cnp_pg_stat_bgwriter_maxwritten_clean`      | COUNTER | Number of times the background writer stopped a cleaning scan because it wrote too many buffers                                                     |
+| `cnp_pg_stat_bgwriter_buffers_backend`       | COUNTER | Number of buffers written directly by a backend                                                                                                     |
 | `cnp_pg_stat_bgwriter_buffers_backend_fsync` | COUNTER | Number of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write) |
-| `cnp_pg_stat_bgwriter_buffers_alloc` | COUNTER | Number of buffers allocated |
+| `cnp_pg_stat_bgwriter_buffers_alloc`         | COUNTER | Number of buffers allocated                                                                                                                         |
 
 #### Group `cnp_pg_stat_database`
 
@@ -339,32 +336,31 @@ See also `cnp_pg_database`.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_stat_database_xact_commit` | COUNTER | Number of transactions in this database that were committed |
-| `cnp_pg_stat_database_xact_rollback` | COUNTER | Number of transactions in this database that were rolled back |
-| `cnp_pg_stat_database_blks_read` | COUNTER | Number of disk blocks read in this database |
-| `cnp_pg_stat_database_blks_hit` | COUNTER | Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache) |
-| `cnp_pg_stat_database_tup_returned` | COUNTER | Number of rows returned by queries in this database |
-| `cnp_pg_stat_database_tup_fetched` | COUNTER | Number of rows fetched by queries in this database |
-| `cnp_pg_stat_database_tup_inserted` | COUNTER | Number of rows inserted by queries in this database |
-| `cnp_pg_stat_database_tup_updated` | COUNTER | Number of rows updated by queries in this database |
-| `cnp_pg_stat_database_tup_deleted` | COUNTER | Number of rows deleted by queries in this database |
-| `cnp_pg_stat_database_conflicts` | COUNTER | Number of queries canceled due to conflicts with recovery in this database |
-| `cnp_pg_stat_database_temp_files` | COUNTER | Number of temporary files created by queries in this database |
-| `cnp_pg_stat_database_temp_bytes` | COUNTER | Total amount of data written to temporary files by queries in this database |
-| `cnp_pg_stat_database_deadlocks` | COUNTER | Number of deadlocks detected in this database |
-| `cnp_pg_stat_database_blk_read_time` | COUNTER | Time spent reading data file blocks by backends in this database, in milliseconds |
-| `cnp_pg_stat_database_blk_write_time` | COUNTER | Time spent writing data file blocks by backends in this database, in milliseconds |
-
+| Metric                                | Usage   | Description                                                                                                                                                                                                 |
+| ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cnp_pg_stat_database_xact_commit`    | COUNTER | Number of transactions in this database that were committed                                                                                                                                                 |
+| `cnp_pg_stat_database_xact_rollback`  | COUNTER | Number of transactions in this database that were rolled back                                                                                                                                               |
+| `cnp_pg_stat_database_blks_read`      | COUNTER | Number of disk blocks read in this database                                                                                                                                                                 |
+| `cnp_pg_stat_database_blks_hit`       | COUNTER | Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache) |
+| `cnp_pg_stat_database_tup_returned`   | COUNTER | Number of rows returned by queries in this database                                                                                                                                                         |
+| `cnp_pg_stat_database_tup_fetched`    | COUNTER | Number of rows fetched by queries in this database                                                                                                                                                          |
+| `cnp_pg_stat_database_tup_inserted`   | COUNTER | Number of rows inserted by queries in this database                                                                                                                                                         |
+| `cnp_pg_stat_database_tup_updated`    | COUNTER | Number of rows updated by queries in this database                                                                                                                                                          |
+| `cnp_pg_stat_database_tup_deleted`    | COUNTER | Number of rows deleted by queries in this database                                                                                                                                                          |
+| `cnp_pg_stat_database_conflicts`      | COUNTER | Number of queries canceled due to conflicts with recovery in this database                                                                                                                                  |
+| `cnp_pg_stat_database_temp_files`     | COUNTER | Number of temporary files created by queries in this database                                                                                                                                               |
+| `cnp_pg_stat_database_temp_bytes`     | COUNTER | Total amount of data written to temporary files by queries in this database                                                                                                                                 |
+| `cnp_pg_stat_database_deadlocks`      | COUNTER | Number of deadlocks detected in this database                                                                                                                                                               |
+| `cnp_pg_stat_database_blk_read_time`  | COUNTER | Time spent reading data file blocks by backends in this database, in milliseconds                                                                                                                           |
+| `cnp_pg_stat_database_blk_write_time` | COUNTER | Time spent writing data file blocks by backends in this database, in milliseconds                                                                                                                           |
 
 ##### Labels
 
 This group of metrics can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
+| Label     | Description           |
+| --------- | --------------------- |
 | `datname` | Name of this database |
 
 #### Group `cnp_pg_stat_database_conflicts`
@@ -386,22 +382,21 @@ Derived from the `pg_stat_database_conflicts` view.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
+| Metric                                            | Usage   | Description                                                                      |
+| ------------------------------------------------- | ------- | -------------------------------------------------------------------------------- |
 | `cnp_pg_stat_database_conflicts_confl_tablespace` | COUNTER | Number of queries in this database that were canceled due to dropped tablespaces |
-| `cnp_pg_stat_database_conflicts_confl_lock` | COUNTER | Number of queries in this database that were canceled due to lock timeouts |
-| `cnp_pg_stat_database_conflicts_confl_snapshot` | COUNTER | Number of queries in this database were canceled due to old snapshots |
-| `cnp_pg_stat_database_conflicts_confl_bufferpin` | COUNTER | Number of queries in this database that were canceled due to pinned buffers |
-| `cnp_pg_stat_database_conflicts_confl_deadlock` | COUNTER | Number of queries in this database that were canceled due to deadlocks |
-
+| `cnp_pg_stat_database_conflicts_confl_lock`       | COUNTER | Number of queries in this database that were canceled due to lock timeouts       |
+| `cnp_pg_stat_database_conflicts_confl_snapshot`   | COUNTER | Number of queries in this database were canceled due to old snapshots            |
+| `cnp_pg_stat_database_conflicts_confl_bufferpin`  | COUNTER | Number of queries in this database that were canceled due to pinned buffers      |
+| `cnp_pg_stat_database_conflicts_confl_deadlock`   | COUNTER | Number of queries in this database that were canceled due to deadlocks           |
 
 ##### Labels
 
 This group of metrics can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
+| Label     | Description          |
+| --------- | -------------------- |
 | `datname` | Name of the database |
 
 #### Group `cnp_pg_stat_user_tables`
@@ -417,39 +412,38 @@ See also `cnp_pg_statio_user_tables`.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_stat_user_tables_seq_scan` | COUNTER | Number of sequential scans initiated on this table |
-| `cnp_pg_stat_user_tables_seq_tup_read` | COUNTER | Number of live rows fetched by sequential scans |
-| `cnp_pg_stat_user_tables_idx_scan` | COUNTER | Number of index scans initiated on this table |
-| `cnp_pg_stat_user_tables_idx_tup_fetch` | COUNTER | Number of live rows fetched by index scans |
-| `cnp_pg_stat_user_tables_n_tup_ins` | COUNTER | Number of rows inserted |
-| `cnp_pg_stat_user_tables_n_tup_upd` | COUNTER | Number of rows updated |
-| `cnp_pg_stat_user_tables_n_tup_del` | COUNTER | Number of rows deleted |
-| `cnp_pg_stat_user_tables_n_tup_hot_upd` | COUNTER | Number of rows HOT updated (i.e., with no separate index update required) |
-| `cnp_pg_stat_user_tables_n_live_tup` | GAUGE | Estimated number of live rows |
-| `cnp_pg_stat_user_tables_n_dead_tup` | GAUGE | Estimated number of dead rows |
-| `cnp_pg_stat_user_tables_n_mod_since_analyze` | GAUGE | Estimated number of rows changed since last analyze |
-| `cnp_pg_stat_user_tables_last_vacuum` | GAUGE | Last time when this table was manually vacuumed (not counting VACUUM FULL) |
-| `cnp_pg_stat_user_tables_last_autovacuum` | GAUGE | Last time when this table was vacuumed by the autovacuum daemon |
-| `cnp_pg_stat_user_tables_last_analyze` | GAUGE | Last time when this table was manually analyzed |
-| `cnp_pg_stat_user_tables_last_autoanalyze` | GAUGE | Last time when this table was analyzed by the autovacuum daemon |
-| `cnp_pg_stat_user_tables_vacuum_count` | COUNTER | Number of times this table was manually vacuumed (not counting VACUUM FULL) |
-| `cnp_pg_stat_user_tables_autovacuum_count` | COUNTER | Number of times this table was vacuumed by the autovacuum daemon |
-| `cnp_pg_stat_user_tables_analyze_count` | COUNTER | Number of times this table was manually analyzed |
-| `cnp_pg_stat_user_tables_autoanalyze_count` | COUNTER | Number of times this table was analyzed by the autovacuum daemon |
-
+| Metric                                        | Usage   | Description                                                                 |
+| --------------------------------------------- | ------- | --------------------------------------------------------------------------- |
+| `cnp_pg_stat_user_tables_seq_scan`            | COUNTER | Number of sequential scans initiated on this table                          |
+| `cnp_pg_stat_user_tables_seq_tup_read`        | COUNTER | Number of live rows fetched by sequential scans                             |
+| `cnp_pg_stat_user_tables_idx_scan`            | COUNTER | Number of index scans initiated on this table                               |
+| `cnp_pg_stat_user_tables_idx_tup_fetch`       | COUNTER | Number of live rows fetched by index scans                                  |
+| `cnp_pg_stat_user_tables_n_tup_ins`           | COUNTER | Number of rows inserted                                                     |
+| `cnp_pg_stat_user_tables_n_tup_upd`           | COUNTER | Number of rows updated                                                      |
+| `cnp_pg_stat_user_tables_n_tup_del`           | COUNTER | Number of rows deleted                                                      |
+| `cnp_pg_stat_user_tables_n_tup_hot_upd`       | COUNTER | Number of rows HOT updated (i.e., with no separate index update required)   |
+| `cnp_pg_stat_user_tables_n_live_tup`          | GAUGE   | Estimated number of live rows                                               |
+| `cnp_pg_stat_user_tables_n_dead_tup`          | GAUGE   | Estimated number of dead rows                                               |
+| `cnp_pg_stat_user_tables_n_mod_since_analyze` | GAUGE   | Estimated number of rows changed since last analyze                         |
+| `cnp_pg_stat_user_tables_last_vacuum`         | GAUGE   | Last time when this table was manually vacuumed (not counting VACUUM FULL)  |
+| `cnp_pg_stat_user_tables_last_autovacuum`     | GAUGE   | Last time when this table was vacuumed by the autovacuum daemon             |
+| `cnp_pg_stat_user_tables_last_analyze`        | GAUGE   | Last time when this table was manually analyzed                             |
+| `cnp_pg_stat_user_tables_last_autoanalyze`    | GAUGE   | Last time when this table was analyzed by the autovacuum daemon             |
+| `cnp_pg_stat_user_tables_vacuum_count`        | COUNTER | Number of times this table was manually vacuumed (not counting VACUUM FULL) |
+| `cnp_pg_stat_user_tables_autovacuum_count`    | COUNTER | Number of times this table was vacuumed by the autovacuum daemon            |
+| `cnp_pg_stat_user_tables_analyze_count`       | COUNTER | Number of times this table was manually analyzed                            |
+| `cnp_pg_stat_user_tables_autoanalyze_count`   | COUNTER | Number of times this table was analyzed by the autovacuum daemon            |
 
 ##### Labels
 
 This group of metrics can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
-| `datname` | Name of current database |
+| Label        | Description                              |
+| ------------ | ---------------------------------------- |
+| `datname`    | Name of current database                 |
 | `schemaname` | Name of the schema that this table is in |
-| `relname` | Name of this table |
+| `relname`    | Name of this table                       |
 
 #### Group `cnp_pg_stat_replication`
 
@@ -466,29 +460,28 @@ See also `cnp_pg_replication_slots`, `cnp_pg_replication`.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_stat_replication_backend_start` | COUNTER | Time when this process started |
-| `cnp_pg_stat_replication_backend_xmin_age` | COUNTER | The age of this standby's xmin horizon |
-| `cnp_pg_stat_replication_sent_diff_bytes` | GAUGE | Difference in bytes from the last write-ahead log location sent on this connection |
-| `cnp_pg_stat_replication_write_diff_bytes` | GAUGE | Difference in bytes from the last write-ahead log location written to disk by this standby server |
-| `cnp_pg_stat_replication_flush_diff_bytes` | GAUGE | Difference in bytes from the last write-ahead log location flushed to disk by this standby server |
-| `cnp_pg_stat_replication_replay_diff_bytes` | GAUGE | Difference in bytes from the last write-ahead log location replayed into the database on this standby server |
-| `cnp_pg_stat_replication_write_lag_seconds` | GAUGE | Time elapsed between flushing recent WAL locally and receiving notification that this standby server wrote it |
-| `cnp_pg_stat_replication_flush_lag_seconds` | GAUGE | Time elapsed between flushing recent WAL locally and receiving notification that this standby server wrote and flushed it |
-| `cnp_pg_stat_replication_replay_lag_seconds` | GAUGE | Time elapsed between flushing recent WAL locally and receiving notification that this standby server wrote, flushed, and applied it |
-
+| Metric                                       | Usage   | Description                                                                                                                         |
+| -------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `cnp_pg_stat_replication_backend_start`      | COUNTER | Time when this process started                                                                                                      |
+| `cnp_pg_stat_replication_backend_xmin_age`   | COUNTER | The age of this standby's xmin horizon                                                                                              |
+| `cnp_pg_stat_replication_sent_diff_bytes`    | GAUGE   | Difference in bytes from the last write-ahead log location sent on this connection                                                  |
+| `cnp_pg_stat_replication_write_diff_bytes`   | GAUGE   | Difference in bytes from the last write-ahead log location written to disk by this standby server                                   |
+| `cnp_pg_stat_replication_flush_diff_bytes`   | GAUGE   | Difference in bytes from the last write-ahead log location flushed to disk by this standby server                                   |
+| `cnp_pg_stat_replication_replay_diff_bytes`  | GAUGE   | Difference in bytes from the last write-ahead log location replayed into the database on this standby server                        |
+| `cnp_pg_stat_replication_write_lag_seconds`  | GAUGE   | Time elapsed between flushing recent WAL locally and receiving notification that this standby server wrote it                       |
+| `cnp_pg_stat_replication_flush_lag_seconds`  | GAUGE   | Time elapsed between flushing recent WAL locally and receiving notification that this standby server wrote and flushed it           |
+| `cnp_pg_stat_replication_replay_lag_seconds` | GAUGE   | Time elapsed between flushing recent WAL locally and receiving notification that this standby server wrote, flushed, and applied it |
 
 ##### Labels
 
 This group of metrics can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
-| `usename` | Name of the replication user |
-| `application_name` | Name of the application |
-| `client_addr` | Client IP address |
+| Label              | Description                  |
+| ------------------ | ---------------------------- |
+| `usename`          | Name of the replication user |
+| `application_name` | Name of the application      |
+| `client_addr`      | Client IP address            |
 
 #### Group `cnp_pg_statio_user_tables`
 
@@ -503,28 +496,27 @@ See also `cnp_pg_stat_user_tables`.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_pg_statio_user_tables_heap_blks_read` | COUNTER | Number of disk blocks read from this table |
-| `cnp_pg_statio_user_tables_heap_blks_hit` | COUNTER | Number of buffer hits in this table |
-| `cnp_pg_statio_user_tables_idx_blks_read` | COUNTER | Number of disk blocks read from all indexes on this table |
-| `cnp_pg_statio_user_tables_idx_blks_hit` | COUNTER | Number of buffer hits in all indexes on this table |
-| `cnp_pg_statio_user_tables_toast_blks_read` | COUNTER | Number of disk blocks read from this table's TOAST table (if any) |
-| `cnp_pg_statio_user_tables_toast_blks_hit` | COUNTER | Number of buffer hits in this table's TOAST table (if any) |
-| `cnp_pg_statio_user_tables_tidx_blks_read` | COUNTER | Number of disk blocks read from this table's TOAST table indexes (if any) |
-| `cnp_pg_statio_user_tables_tidx_blks_hit` | COUNTER | Number of buffer hits in this table's TOAST table indexes (if any) |
-
+| Metric                                      | Usage   | Description                                                               |
+| ------------------------------------------- | ------- | ------------------------------------------------------------------------- |
+| `cnp_pg_statio_user_tables_heap_blks_read`  | COUNTER | Number of disk blocks read from this table                                |
+| `cnp_pg_statio_user_tables_heap_blks_hit`   | COUNTER | Number of buffer hits in this table                                       |
+| `cnp_pg_statio_user_tables_idx_blks_read`   | COUNTER | Number of disk blocks read from all indexes on this table                 |
+| `cnp_pg_statio_user_tables_idx_blks_hit`    | COUNTER | Number of buffer hits in all indexes on this table                        |
+| `cnp_pg_statio_user_tables_toast_blks_read` | COUNTER | Number of disk blocks read from this table's TOAST table (if any)         |
+| `cnp_pg_statio_user_tables_toast_blks_hit`  | COUNTER | Number of buffer hits in this table's TOAST table (if any)                |
+| `cnp_pg_statio_user_tables_tidx_blks_read`  | COUNTER | Number of disk blocks read from this table's TOAST table indexes (if any) |
+| `cnp_pg_statio_user_tables_tidx_blks_hit`   | COUNTER | Number of buffer hits in this table's TOAST table indexes (if any)        |
 
 ##### Labels
 
 This group of metrics can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
-| `datname` | Name of current database |
+| Label        | Description                              |
+| ------------ | ---------------------------------------- |
+| `datname`    | Name of current database                 |
 | `schemaname` | Name of the schema that this table is in |
-| `relname` | Name of this table |
+| `relname`    | Name of this table                       |
 
 #### Group `cnp_pg_settings`
 
@@ -543,21 +535,20 @@ Derived from the `pg_settings` view.
 
 ##### Metrics
 
-| Metric   | Usage | Description |
-|----------|-------|-------------|
+| Metric                    | Usage | Description   |
+| ------------------------- | ----- | ------------- |
 | `cnp_pg_settings_setting` | GAUGE | Setting value |
-
 
 ##### Labels
 
 This group of metrics can have these labels, represented
 as dimensions in Azure Monitor:
 
-| Label | Description |
-|-------|-------------|
+| Label  | Description         |
+| ------ | ------------------- |
 | `name` | Name of the setting |
 
-[comment2]: # (End generated content)
+[comment2]: # "End generated content"
 
 ### Other metrics streams
 
@@ -573,7 +564,7 @@ metrics.
 
 See also:
 
-* [Kubernetes cluster metrics](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/).
+-   [Kubernetes cluster metrics](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/).
 
 The cloud platform can supply additional streams of metrics 
 directly to your metrics, analytics, and dashboarding endpoint.
@@ -582,12 +573,12 @@ directly to your metrics, analytics, and dashboarding endpoint.
 
 Other capabilities available in the Azure portal, outside the scope of this documentation, include the ability to:
 
-* Discover metrics in the Azure Monitor Metrics Explorer (**Monitor > Metrics**)
-* Query logs and metrics from the Azure Monitor Logs view (**Monitor > Logs**)
-* Create dashboards backed by metrics queries in the Portal
-* Define alerting rules to trigger notifications based on queries
-* Use AI-assisted analytics assistant capabilities ("Metrics Advisers") to find
-  patterns in metrics
-* Apply complex analytic tools for time-series data in Application Insights,
-  including seasonally adjusted statistics to discover patterns, anomalies, and
-  trends.
+-   Discover metrics in the Azure Monitor Metrics Explorer (**Monitor > Metrics**)
+-   Query logs and metrics from the Azure Monitor Logs view (**Monitor > Logs**)
+-   Create dashboards backed by metrics queries in the Portal
+-   Define alerting rules to trigger notifications based on queries
+-   Use AI-assisted analytics assistant capabilities ("Metrics Advisers") to find
+    patterns in metrics
+-   Apply complex analytic tools for time-series data in Application Insights,
+    including seasonally adjusted statistics to discover patterns, anomalies, and
+    trends.

--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/index.mdx
@@ -15,31 +15,28 @@ BigAnimal sends all metrics and logs from PostgreSQL clusters to Azure. The foll
 When BigAnimal deploys workloads on Azure, the logs from the PostgreSQL clusters are forwarded to the Azure Log Workspace.
 To query BigAnimal logs, you must use [Azure Log Analytics](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overview) and [Kusto Query language](https://azure-training.com/azure-data-science/the-kusto-query-language/).
 
-
-
 ### Query PostgreSQL cluster logs
 
+All logs from your PostgreSQL clusters are stored in the *Customer Log Analytics workspace*. To find your *Customer Log Analytics workspace*.
 
-All logs from your PostgreSQL clusters are stored in the _Customer Log Analytics workspace_. To find your _Customer Log Analytics workspace_.
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+2.  Select **Resource Groups**.
 
-2. Select **Resource Groups**.
+3.  Select the resource group corresponding to the region where you choose to deploy your BigAnimal cluster. You see resources included in that resource group.
 
-2. Select the resource group corresponding to the region where you choose to deploy your BigAnimal cluster. You see resources included in that resource group.
+4.  Select the resource of type *Log Analytics workspace* with the suffix -customer.
 
-3. Select the resource of type _Log Analytics workspace_ with the suffix -customer.
+5.  Select the logs in the menu on the left in the General section.
 
-4. Select the logs in the menu on the left in the General section.
+6.  Close the dashboard with prebuilt queries. This brings you to the KQL Editor.
 
-5. Close the dashboard with prebuilt queries. This brings you to the KQL Editor.
+The following tables are available in the *Customer Log Analytic workspace*.
 
-The following tables are available in the _Customer Log Analytic workspace_.
-
-| Table name | Description | Logger |
-| ---------- | ----------- | ------ |
-| PostgresLogs_CL  | Logs of the Customer clusters databases (all postgres related logs) | `logger = postgres` |
-| PostgresAuditLogs_CL  | Audit Logs of the Customer clusters databases | `logger = pgaudit or edb_audit`  |
+| Table name           | Description                                                         | Logger                          |
+| -------------------- | ------------------------------------------------------------------- | ------------------------------- |
+| PostgresLogs_CL      | Logs of the Customer clusters databases (all postgres related logs) | `logger = postgres`             |
+| PostgresAuditLogs_CL | Audit Logs of the Customer clusters databases                       | `logger = pgaudit or edb_audit` |
 
 You can use the KQL Query editor to compose your queries over these tables. For example,
 
@@ -59,17 +56,16 @@ PostgresAuditLogs_CL
 | sort by record_log_time_s desc
 ```
 
-###  Use shared dashboards to view PostgreSQL cluster logs
+### Use shared dashboards to view PostgreSQL cluster logs
 
 You can view logs from your PostgreSQL clusters using Shared Dashboard.
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
+1.  Sign in to the [Azure portal](https://portal.azure.com).
 
-2. Select **Resource Groups**.
+2.  Select **Resource Groups**.
 
-2. Select the resource group corresponding to the region where you choose to deploy your BigAnimal cluster. You see resources included in that resource group.
+3.  Select the resource group corresponding to the region where you choose to deploy your BigAnimal cluster. You see resources included in that resource group.
 
-3. Select the resource of type _Shared Dashboard_ with the suffix -customer.
+4.  Select the resource of type *Shared Dashboard* with the suffix -customer.
 
-4. Select the **Go to dashboard** link located at the top of the page.
-
+5.  Select the **Go to dashboard** link located at the top of the page.

--- a/product_docs/docs/biganimal/release/using_cluster/05a_deleting_your_cluster.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05a_deleting_your_cluster.mdx
@@ -5,22 +5,19 @@ title: "Deleting your cluster"
 If you no longer need a particular cluster, you can delete it from the BigAnimal portal.  You can restore a cluster for up to 30 days after you delete it, but after 30 days the data is permanently deleted. To stop the management costs on the cluster, contact EDB's BigAnimal Support team; otherwise, costs may continue to accumulate.
 
 ## Delete your cluster
-1. Go to the [**Clusters**](https://portal.biganimal.com/clusters) page in the [BigAnimal](https://portal.biganimal.com) portal. 
-1. Do one of the following to delete the cluster:
-   - Select the Delete cluster icon in the row for the cluster.
-   - Select the cluster you wish to delete and from **Quick Actions** on the cluster details page, select **Delete**.
-3. Confirm you want to delete the cluster. When the process completes, the cluster is listed on the **Deleted** tab of the **Clusters** page.
-1. Contact [Support](../overview/06_support/) to stop the associated management costs. For more information on management costs see [Pricing and billing](../pricing_and_billing/#management-costs).
 
-## Restore your cluster 
+1.  Go to the [**Clusters**](https://portal.biganimal.com/clusters) page in the [BigAnimal](https://portal.biganimal.com) portal. 
+2.  Do one of the following to delete the cluster:
+    -   Select the Delete cluster icon in the row for the cluster.
+    -   Select the cluster you wish to delete and from **Quick Actions** on the cluster details page, select **Delete**.
+3.  Confirm you want to delete the cluster. When the process completes, the cluster is listed on the **Deleted** tab of the **Clusters** page.
+4.  Contact [Support](../overview/06_support/) to stop the associated management costs. For more information on management costs see [Pricing and billing](../pricing_and_billing/#management-costs).
+
+## Restore your cluster
 
 You can restore your cluster within 30 days of deletion.
 
-1. Select the **Delete** tab on the [**Clusters**](https://portal.biganimal.com/clusters) page in the [BigAnimal](https://portal.biganimal.com) portal. 
-1. Select the Restore icon for the cluster you wish to restore. 
-1. On the Restore Cluster page, review your selections in the **Cluster Summary** and select **Restore Cluster** to begin the restore process.
-When the process completes, the restored cluster is available on the [**Clusters**](https://portal.biganimal.com/clusters) page.
-
-
-
-
+1.  Select the **Delete** tab on the [**Clusters**](https://portal.biganimal.com/clusters) page in the [BigAnimal](https://portal.biganimal.com) portal. 
+2.  Select the Restore icon for the cluster you wish to restore. 
+3.  On the Restore Cluster page, review your selections in the **Cluster Summary** and select **Restore Cluster** to begin the restore process.
+    When the process completes, the restored cluster is available on the [**Clusters**](https://portal.biganimal.com/clusters) page.

--- a/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
@@ -37,17 +37,18 @@ postgres://demo:password@p-c64p9a3h5vfavr7tfrjg.qsbilba3hlgp1vqr.biganimal.io:54
 
 In case you're unfamiliar with [PostgreSQL connection URIs](https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6), let's break that down:
 
-- `demo` is the user role we're connecting as. This is a user set up with select privileges on the database.
-- `password` is the password for this user.
-  !!! Warning Passwords in connection strings.
-  This example illustrates a complete connection URL, including the password. This is fine for a demonstration,
-  and may also be acceptable for applications configuration if access to the configuration is limited.
-  Avoid this practice for admin, superuser, or other roles used interactively - psql will prompt for a password
-  if none is supplied.
-- `p-c64p9a3h5vfavr7tfrjg.qsbilba3hlgp1vqr.biganimal.io` is the host name for the Advanced Server cluster on BigAnimal that I'm connecting to.
-- `5432` is the usual PostgreSQL port number.
-- `chinook` is the name of the database.
-- `sslmode=require` ensures that we establish a secure connection.
+-   `demo` is the user role we're connecting as. This is a user set up with select privileges on the database.
+-   `password` is the password for this user.
+    !!!Warning Passwords in connection strings.
+    This example illustrates a complete connection URL, including the password. This is fine for a demonstration,
+    and may also be acceptable for applications configuration if access to the configuration is limited.
+    Avoid this practice for admin, superuser, or other roles used interactively - psql will prompt for a password
+    if none is supplied.
+    !!!
+-   `p-c64p9a3h5vfavr7tfrjg.qsbilba3hlgp1vqr.biganimal.io` is the host name for the Advanced Server cluster on BigAnimal that I'm connecting to.
+-   `5432` is the usual PostgreSQL port number.
+-   `chinook` is the name of the database.
+-   `sslmode=require` ensures that we establish a secure connection.
 
 With that in hand, we can launch psql:
 
@@ -143,6 +144,7 @@ __OUTPUT__
  Laura     | Callahan | Mitchell, Adams
 (8 rows)
 ```
+
 Here, we use `CONNECT BY` and the `LISTAGG` function in a subquery to generate the chain of command for each employee: who they report to, who *that* person reports to, etc.
 
 Now, the `LISTAGG()` function was introduced in Oracle 11g Release 2. Very few database systems support it. PostgreSQL *does* support [`string_agg()`](https://www.postgresql.org/docs/current/functions-aggregate.html#id-1.5.8.27.5.2.4.18.1.1.1), and in the previous example that could be used as a drop-in replacement...
@@ -238,6 +240,6 @@ you to focus your time and expertise on solving new problems.
 
 ### Next steps
 
-- Read more on Oracle compatibility features in EDB Postgres Advanced Server: [EDB Advanced Server documentation](https://www.enterprisedb.com/docs/epas/latest/).
+-   Read more on Oracle compatibility features in EDB Postgres Advanced Server: [EDB Advanced Server documentation](https://www.enterprisedb.com/docs/epas/latest/).
 
-- Learn about [migrating existing Oracle databases to BigAnimal](/biganimal/latest/migration/#migrating-from-oracle)
+-   Learn about [migrating existing Oracle databases to BigAnimal](/biganimal/latest/migration/#migrating-from-oracle)

--- a/product_docs/docs/biganimal/release/using_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/index.mdx
@@ -3,5 +3,3 @@ title: "Using your cluster"
 ---
 
 Account owners and contributors can connect, edit, scale, and monitor clusters through the BigAnimal portal. You can also restore clusters from BigAnimal automatic backups.
-
-


### PR DESCRIPTION
## What Changed?

Pandoc is much more sensitive to inconsistent spacing in lists and tables than our parser (Remark). Did a round-trip through Remark to normalize spacing. Fixes #2166 (specifically the changes in product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/03_vnet_vnet.mdx, though others are needed to completely eliminate the issue)

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
