### PR TITLE
Removed any platform support information from EPAS doc

### DIFF
--- a/product_docs/docs/epas/10/epas_inst_linux/02_supported_platforms.mdx
+++ b/product_docs/docs/epas/10/epas_inst_linux/02_supported_platforms.mdx
@@ -8,9 +8,7 @@ legacyRedirectsGenerated:
 
 <div id="supported_platorms" class="registered_link"></div>
 
-For information about the platforms and versions supported by Advanced Server, visit the EnterpriseDB website at:
-
-<https://www.enterprisedb.com/product-compatibility>
+For information about the platforms and versions supported by Advanced Server, see [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas).
 
 !!! Note
     Advanced Server is no longer supported on RHEL/CentOS/OL 6.x platforms. It is strongly recommended that EDB products running on these platforms be migrated to a supported platform.

--- a/product_docs/docs/epas/11/epas_platform_support/index.mdx
+++ b/product_docs/docs/epas/11/epas_platform_support/index.mdx
@@ -6,33 +6,18 @@ redirects:
  - /epas/11/epas_upgrade_guide/01_supported_platforms
 ---
 
-EDB Postgres Advanced Server v11 installers support 64 bit Linux and Windows server platforms. The Advanced Server 11 RPM packages are supported on the following 64-bit Linux platforms:
-
--   Red Hat Enterprise Linux (x86_64) 6.x and 7.x
--   CentOS (x86_64) 6.x and 7.x
--   PPC-LE 8 running CentOS/RHEL 7.x
--   SLES 12
-
-The EDB Postgres Advanced Server 11 native packages are supported on the following 64-bit Linux platforms:
-
--   Debian 9.x 
--   Ubuntu 18.04 LTS
-
-Graphical installers are supported on the following 64-bit Windows platforms:
-
--   Windows Server 2016
--   Windows Server 2012 R2 Server 
+EDB Postgres Advanced Server v11 installers support Linux and Windows server platforms. 
 
 !!! Note
-    Connectors Installer will be supported on Windows 7, 8, & 10.
+    Connectors Installer is supported on Windows 7, 8, and 10.
 
 !!! Note
     Advanced Server is no longer supported on RHEL/CentOS/OL 6.x platforms. It is strongly recommended that EDB products running on these platforms be migrated to a supported platform.
 
-See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility)
+See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas)
  for additional information about supported platforms.
 
-**Limitations**
+## Limitations
 
 The following limitations apply to EDB Postgres Advanced Server:
 

--- a/product_docs/docs/epas/12/epas_platform_support/index.mdx
+++ b/product_docs/docs/epas/12/epas_platform_support/index.mdx
@@ -11,27 +11,9 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-advanced-server/installation-getting-started/installation-guide-for-windows/12/EDB_Postgres_Advanced_Server_Installation_Guide_Windows.1.05.html"
 ---
 
-EDB Postgres Advanced Server v12 installers support 64 bit Linux and Windows server platforms. The Advanced Server 12 RPM packages are supported on the following 64-bit Linux platforms:
+EDB Postgres Advanced Server v12 installers support Linux and Windows server platforms. See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for additional information about supported platforms.
 
--   Red Hat Enterprise Linux (x86_64) 7.x and 8.x
--   CentOS (x86_64) 7.x and 8.x
--   OL (x86_64) 7.x and 8.x
--   PPC64LE 8 running CentOS/RHEL 7.x
-
-The EDB Postgres Advanced Server 12 native packages are supported on the following 64-bit Linux platforms:
-
--   Debian 9.x and 10.x
--   Ubuntu 18.04 LTS
-
-Graphical installers are supported on the following 64-bit Windows platforms:
-
--   Windows 2019
--   Windows Server 2016
--   Windows Server 2012 R2 Server 
-
-See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility) for additional information about supported platforms.
-
-**Limitations**
+## Limitations
 
 The following limitations apply to EDB Postgres Advanced Server:
 

--- a/product_docs/docs/epas/13/epas_platform_support/index.mdx
+++ b/product_docs/docs/epas/13/epas_platform_support/index.mdx
@@ -7,24 +7,7 @@ legacyRedirects:
   - "/edb-docs/d/edb-postgres-advanced-server/installation-getting-started/installation-guide-for-linux/13/EDB_Postgres_Advanced_Server_Installation_Guide_Linux.1.04.html"
 ---
 
-EDB Postgres Advanced Server v13 installers support 64 bit Linux and Windows server platforms. The Advanced Server 13 RPM packages are supported on the following 64-bit Linux platforms:
-
-- Red Hat Enterprise Linux (x86_64) 7.x and 8.x
-- CentOS (x86_64) 7.x and 8.x
-- OL (x86_64) 7.x and 8.x
-- PPC64LE 8 running CentOS/RHEL 7.x
-
-The EDB Postgres Advanced Server 13 native packages are supported on the following 64-bit Linux platforms:
-
-- Debian 9.x and 10.x
-- Ubuntu 18.04 and 20.04
-
-Graphical installers are supported on the following 64-bit Windows platforms:
-
-- Windows 2019
-- Windows Server 2016
-
-See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility) for additional information.
+EDB Postgres Advanced Server v13 installers Linux and Windows server platforms. See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for additional information.
 
 
 ## Limitations

--- a/product_docs/docs/epas/14/epas_platform_support/index.mdx
+++ b/product_docs/docs/epas/14/epas_platform_support/index.mdx
@@ -4,19 +4,7 @@ redirects:
  - ../epas_inst_linux/02_supported_platforms
 ---
 
-EDB Postgres Advanced Server v14 Beta 1 supports installations on the following Linux and Windows platforms:
-
--  CentOS 7 (PPCLE64)
--  CentOS 7 (x86_64)
--  Red Hat Enterprise Linux 7 (x86_64)
--  Red Hat Enterprise Linux 8 (x86_64)
--  Debian 9 (Stretch) x86_64
--  Debian 10 (Buster) x86_64
--  Ubuntu 18.04 LTS (Bionic) x86_64 
--  Ubuntu 20.04 LTS (Focal)- x86_64
--  Windows x86_64
-
-See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility) for additional information.
+EDB Postgres Advanced Server v14 supports installations on Linux and Windows platforms. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
 
 ## Limitations


### PR DESCRIPTION
We are linking to the platform support page on the corporate web site as the single point of truth.

## What Changed?

- Removed redundant content
- added jump link
- other minor edits