### PR TITLE
Update primary.shutdown.as.failure information

### DIFF
--- a/product_docs/docs/efm/4/efm_user/04_configuring_efm/01_cluster_properties/index.mdx
+++ b/product_docs/docs/efm/4/efm_user/04_configuring_efm/01_cluster_properties/index.mdx
@@ -553,7 +553,7 @@ stop.failed.primary=true
 
 <div id="primary_shutdown_as_failure" class="registered_link"></div>
 
-Use the `primary.shutdown.as.failure` property to treat any shutdown of the Failover Manager agent on the primary node as a failure. If this property is set to `true` and the primary agent is shut down, the rest of the cluster treats the shutdown as a failure. This includes any proper shutdown of the agent, including a shutdown of the whole node. None of the timeout properties apply in this case: when the agent exits, the rest of the cluster is notified immediately. After the agent exits, the rest of the cluster performs the regular failover steps that happen in the case of agent failure (attempt to connect to the primary database, see if the VIP is reachable if used, etc).
+Use the `primary.shutdown.as.failure` property to treat any shutdown of the Failover Manager agent on the primary node as a failure. If this property is set to `true` and the primary agent is shut down, the rest of the cluster treats the shutdown as a failure. This includes any proper shutdown of the agent such as a shutdown of the whole node. None of the timeout properties apply in this case: when the agent exits, the rest of the cluster is notified immediately. After the agent exits, the rest of the cluster performs the regular failover steps that happen in the case of agent failure. The regular failover steps include attempting to connect to the primary database, seeing if the VIP is reachable if used, and so on).
 
 -   If the database is reached, a notification is sent informing you of the agent status.
 -   If the database isn't reached, a failover occurs.

--- a/product_docs/docs/efm/4/efm_user/04_configuring_efm/01_cluster_properties/index.mdx
+++ b/product_docs/docs/efm/4/efm_user/04_configuring_efm/01_cluster_properties/index.mdx
@@ -553,7 +553,7 @@ stop.failed.primary=true
 
 <div id="primary_shutdown_as_failure" class="registered_link"></div>
 
-Use the `primary.shutdown.as.failure` property to treat any shutdown of the Failover Manager agent on the primary node as a failure. If this property is set to `true` and the primary agent stops for any reason, the cluster attempts to confirm whether the database on the primary node is running.
+Use the `primary.shutdown.as.failure` property to treat any shutdown of the Failover Manager agent on the primary node as a failure. If this property is set to `true` and the primary agent is shut down, the rest of the cluster treats the shutdown as a failure. This includes any proper shutdown of the agent, including a shutdown of the whole node. None of the timeout properties apply in this case: when the agent exits, the rest of the cluster is notified immediately. After the agent exits, the rest of the cluster performs the regular failover steps that happen in the case of agent failure (attempt to connect to the primary database, see if the VIP is reachable if used, etc).
 
 -   If the database is reached, a notification is sent informing you of the agent status.
 -   If the database isn't reached, a failover occurs.


### PR DESCRIPTION
Added information that timeouts do not apply to this case when the agent exits and that it's treated like agent failures.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
