### PR TITLE
Remove double-dash before subscription ID in preflight script examples

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
@@ -29,7 +29,7 @@ EDB provides a shell script called [`biganimal-preflight-azure`](https://github.
 
     ```sh
      curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
-      -- <subscription-ID> <azure-region> \
+      <subscription-ID> <azure-region> \
       --instance-type <instance-type> \
       --high-availability \
       --endpoint <endpoint-type> \
@@ -51,7 +51,7 @@ EDB provides a shell script called [`biganimal-preflight-azure`](https://github.
 
     ```sh
     curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
-    -- 12412ab3d-1515-2217-96f5-0338184fcc04 eastus2 \
+    12412ab3d-1515-2217-96f5-0338184fcc04 eastus2 \
     --instance-type e2s_v3 \
     --high-availability \
     --endpoint public \


### PR DESCRIPTION
## What Changed?

Remove double-dash before subscription ID in preflight script examples.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
