### PR TITLE
Replication Server 6.2.16: Missing rel note

### DIFF
--- a/product_docs/docs/eprs/6.2/eprs_rel_notes/13_eprs_rel_notes_6.2.16.mdx
+++ b/product_docs/docs/eprs/6.2/eprs_rel_notes/13_eprs_rel_notes_6.2.16.mdx
@@ -22,7 +22,7 @@ New features, enhancements, bug fixes, and other changes in EDB Postgres Replica
 | Bug Fix | Fixed an error that prevented creation of a row-level Filter based on the `->` operator for JSONB data type. |
 | Bug Fix | Fixed the issue related with the reporting of incorrect missing privileges while registering Oracle Publication database. |
 | Bug Fix | In a hybrid cluster, batch is always applied using BUS (batch update using simple Statement) mode even when the user has opted for BUP mode (batch update using PreparedStatement).  This issue is now fixed. |
-| Bug Fix | Fixed an issue where an INSERT conflict in MMR Publication is subject to failure of Synchronize operation for a target SMR Subscription in a hybrid cluster. |
+| Bug Fix | Fixed an issue where an INSERT conflict in MMR Publication is subject to failure of Synchronize operation for a target SMR Subscription in a hybrid cluster. [Support Ticket #75608]|
 | Bug Fix | Fixed an issue so that a validation  error is reported when the CLI command `createpub` is executed without registering a Publication database. |
 | Bug Fix | Fixed the NoClassDefFoundError error (org/postgresql/replication/LogSequenceNumber) observed during data Snapshot operation for a RPM based installation on RHEL8/CENTOS8. |
 | Bug Fix | Fixed the error `libpq JNI wrapper library is not available` that occured while adding a database for WAL based replication.


### PR DESCRIPTION
## What Changed?

Added missing support ticket ID. Addresses https://github.com/EnterpriseDB/docs/issues/2206.