### PR TITLE
Fix some broken & obsolete links in the EFM 4 docs

### DIFF
--- a/product_docs/docs/efm/4/03_installing_efm.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm.mdx
@@ -287,14 +287,14 @@ You can use the `zypper` package manager to install a Failover Manager agent on 
 
 ## Performing post-installation tasks
 
-If you are using Failover Manager to monitor a cluster owned by a user other than enterprisedb or postgres, see [Extending Failover Manager permissions](04_configuring_efm/04_extending_efm_permissions/#extending_efm_permissions).
+If you are using Failover Manager to monitor a cluster owned by a user other than enterprisedb or postgres, see [Extending Failover Manager permissions](efm_user/04_configuring_efm/04_extending_efm_permissions/#extending_efm_permissions).
 
 After installing on each node of the cluster:
 
-1.  Modify the [cluster properties file](04_configuring_efm/01_cluster_properties/#cluster_properties) on each node.
-2.  Modify the [cluster members file](04_configuring_efm/03_cluster_members/#cluster_members) on each node.
+1.  Modify the [cluster properties file](efm_user/04_configuring_efm/01_cluster_properties/#cluster_properties) on each node.
+2.  Modify the [cluster members file](efm_user/04_configuring_efm/03_cluster_members/#cluster_members) on each node.
 3.  If applicable, configure and test virtual IP address settings and any scripts that are identified in the cluster properties file.
-4.  Start the agent on each node of the cluster. For more information, see [Controlling the Failover Manager service](08_controlling_efm_service/#controlling-the-failover-manager-service).
+4.  Start the agent on each node of the cluster. For more information, see [Controlling the Failover Manager service](efm_user/08_controlling_efm_service/#controlling-the-failover-manager-service).
 
 ### Installation locations
 

--- a/product_docs/docs/efm/4/05_using_efm.mdx
+++ b/product_docs/docs/efm/4/05_using_efm.mdx
@@ -18,15 +18,15 @@ If a primary node reboots, Failover Manager might detect the database is down on
 
 Once configured, a Failover Manager cluster requires no regular maintenance. However, you can perform management tasks that a Failover Manager cluster might occasionally require.
 
-By default, [some of the efm commands](07_using_efm_utility/#using_efm_utility) must be invoked by efm or an OS superuser. An administrator can selectively permit users to invoke these commands by adding the user to the efm group. The commands are:
+By default, [some of the efm commands](efm_user/07_using_efm_utility/#using_efm_utility) must be invoked by efm or an OS superuser. An administrator can selectively permit users to invoke these commands by adding the user to the efm group. The commands are:
 
--   [efm allow-node](07_using_efm_utility/#efm_allow_node)
--   [efm disallow-node](07_using_efm_utility/#efm_disallow_node)
--   [efm promote](07_using_efm_utility/#efm_promote)
--   [efm resume](07_using_efm_utility/#efm_resume)
--   [efm set-priority](07_using_efm_utility/#efm_set_priority)
--   [efm stop-cluster](07_using_efm_utility/#efm_stop_cluster)
--   [efm upgrade-conf](07_using_efm_utility/#efm_upgrade_conf)
+-   [efm allow-node](efm_user/07_using_efm_utility/#efm_allow_node)
+-   [efm disallow-node](efm_user/07_using_efm_utility/#efm_disallow_node)
+-   [efm promote](efm_user/07_using_efm_utility/#efm_promote)
+-   [efm resume](efm_user/07_using_efm_utility/#efm_resume)
+-   [efm set-priority](efm_user/07_using_efm_utility/#efm_set_priority)
+-   [efm stop-cluster](efm_user/07_using_efm_utility/#efm_stop_cluster)
+-   [efm upgrade-conf](efm_user/07_using_efm_utility/#efm_upgrade_conf)
 
 <div id="starting_efm_cluster" class="registered_link"></div>
 
@@ -60,11 +60,11 @@ You can add a node to a Failover Manager cluster at any time. When you add a nod
 
     `efm allow-node <cluster_name> <address>`
 
-    For more information about using the `efm allow-node` command or controlling a Failover Manager service, see [Using the efm utility](07_using_efm_utility/#efm_allow_node).
+    For more information about using the `efm allow-node` command or controlling a Failover Manager service, see [Using the efm utility](efm_user/07_using_efm_utility/#efm_allow_node).
 
-    Install a Failover Manager agent and configure the cluster properties file on the new node. For more information about modifying the properties file, see [The cluster properties file](04_configuring_efm/01_cluster_properties/#cluster_properties).
+    Install a Failover Manager agent and configure the cluster properties file on the new node. For more information about modifying the properties file, see [The cluster properties file](efm_user/04_configuring_efm/01_cluster_properties/#cluster_properties).
 
-2.  Configure the cluster members file on the new node, adding an entry for the membership coordinator. For more information about modifying the cluster members file, see [The cluster members file](04_configuring_efm/03_cluster_members/#cluster_members).
+2.  Configure the cluster members file on the new node, adding an entry for the membership coordinator. For more information about modifying the cluster members file, see [The cluster members file](efm_user/04_configuring_efm/03_cluster_members/#cluster_members).
 
 3.  Assume superuser privileges on the new node, and start the Failover Manager agent. To start the Failover Manager cluster on RHEL/CentOS 7.x or RHEL/CentOS 8.x, invoke the command:
 
@@ -95,7 +95,7 @@ For example, if the properties file on node `10.0.1.10` includes a setting of `p
 efm set-priority acctg 10.0.1.10 1
 ```
 
-In the event of a failover, Failover Manager first retrieves information from Postgres streaming replication to confirm which standby node has the most recent data and promote the node with the least chance of data loss. If two standby nodes contain equally up-to-date data, the node with a higher user-specified priority value is promoted to orimary unless [use.replay.tiebreaker](04_configuring_efm/01_cluster_properties/#use_replay_tiebreaker) is set to `true`. To check the priority value of your standby nodes, use the command:
+In the event of a failover, Failover Manager first retrieves information from Postgres streaming replication to confirm which standby node has the most recent data and promote the node with the least chance of data loss. If two standby nodes contain equally up-to-date data, the node with a higher user-specified priority value is promoted to orimary unless [use.replay.tiebreaker](efm_user/04_configuring_efm/01_cluster_properties/#use_replay_tiebreaker) is set to `true`. To check the priority value of your standby nodes, use the command:
 
 `efm cluster-status <cluster_name>`
 
@@ -154,7 +154,7 @@ Then, perform a manual promotion:
 
 `efm promote <cluster_name> ‑switchover`
 
-For more information about the efm utility, see [Using the efm utility](07_using_efm_utility/#using_efm_utility).
+For more information about the efm utility, see [Using the efm utility](efm_user/07_using_efm_utility/#using_efm_utility).
 
 <div id="stop_efm_agent" class="registered_link"></div>
 
@@ -169,7 +169,7 @@ To stop the Failover Manager agent on RHEL/CentOS 7.x or RHEL/CentOS 8.x, assume
 Until you invoke the `efm disallow-node` command (removing the node's address from the Allowed Node host list), you can use the `service edb-efm-4.<x> start` command to restart the node later without first running the `efm allow-node` command again.
 
 <div id="stopping_efm_cluster" class="registered_link"></div>
-Stopping an agent doesn't signal the cluster that the agent has failed unless the [primary.shutdown.as.failure](04_configuring_efm/01_cluster_properties/#primary_shutdown_as_failure) property is set to `true`.
+Stopping an agent doesn't signal the cluster that the agent has failed unless the [primary.shutdown.as.failure](efm_user/04_configuring_efm/01_cluster_properties/#primary_shutdown_as_failure) property is set to `true`.
 
 ### Stopping a Failover Manager cluster
 
@@ -190,7 +190,7 @@ The `efm disallow-node` command removes the IP address of a node from the Failov
 
 The `efm disallow-node` command doesn't stop a running agent. The service continues to run on the node until you [stop the agent](#stop_efm_agent). If the agent or cluster is later stopped, the node isn't allowed to rejoin the cluster and is removed from the failover priority list. It becomes ineligible for promotion.
 
-After invoking the `efm disallow-node` command, you must use the [efm allow-node](07_using_efm_utility/#efm_allow_node) command to add the node to the cluster again.
+After invoking the `efm disallow-node` command, you must use the [efm allow-node](efm_user/07_using_efm_utility/#efm_allow_node) command to add the node to the cluster again.
 
 <div id="multiple_agents_single_node" class="registered_link"></div>
 

--- a/product_docs/docs/efm/4/12_upgrading_existing_cluster.mdx
+++ b/product_docs/docs/efm/4/12_upgrading_existing_cluster.mdx
@@ -14,7 +14,7 @@ Failover Manager provides a utility to assist you when upgrading a Failover Mana
 
 1.  Install Failover Manager 4.4 on each node of the cluster. For detailed information about installing Failover Manager, see [Installing Failover Manager](03_installing_efm/#installing_efm).
 
-2.  After installing Failover Manager, invoke the `efm upgrade-conf` utility to create the `.properties` and `.nodes` files for Failover Manager 4.4. The Failover Manager installer installs the upgrade utility ([efm upgrade-conf](07_using_efm_utility/#efm_upgrade_conf)) to the `/usr/edb/efm-4.4/bin directory`. To invoke the utility, assume root privileges, and invoke the command:
+2.  After installing Failover Manager, invoke the `efm upgrade-conf` utility to create the `.properties` and `.nodes` files for Failover Manager 4.4. The Failover Manager installer installs the upgrade utility ([efm upgrade-conf](efm_user/07_using_efm_utility/#efm_upgrade_conf)) to the `/usr/edb/efm-4.4/bin directory`. To invoke the utility, assume root privileges, and invoke the command:
 
     ```text
     efm upgrade-conf <cluster_name>
@@ -22,12 +22,12 @@ Failover Manager provides a utility to assist you when upgrading a Failover Mana
 
      The efm `upgrade-conf` utility locates the `.properties` and `.nodes` files of preexisting clusters and copies the parameter values to a new configuration file for use by Failover Manager. The utility saves the updated copy of the configuration files in the `/etc/edb/efm-4.4` directory.
 
-3.  Modify the `.properties` and `.nodes` files for Failover Manager 4.4, specifying any new preferences. Use your choice of editor to modify any additional properties in the properties file (located in the `/etc/edb/efm-4.4` directory) before starting the service for that node. For detailed information about property settings, see [The cluster properties file](04_configuring_efm/01_cluster_properties/#cluster_properties).
+3.  Modify the `.properties` and `.nodes` files for Failover Manager 4.4, specifying any new preferences. Use your choice of editor to modify any additional properties in the properties file (located in the `/etc/edb/efm-4.4` directory) before starting the service for that node. For detailed information about property settings, see [The cluster properties file](efm_user/04_configuring_efm/01_cluster_properties/#cluster_properties).
 
     !!! Note
     `db.bin` is a required property. When modifying the properties file, ensure that the `db.bin` property specifies the location of the Postgres `bin` directory.
 
-4.  If you're using Eager Failover, you must disable it before stopping the Failover Manager cluster. For more information, see [Disabling Eager Failover](04_configuring_efm/06_configuring_for_eager_failover/#disabling-eager-failover).
+4.  If you're using Eager Failover, you must disable it before stopping the Failover Manager cluster. For more information, see [Disabling Eager Failover](efm_user/04_configuring_efm/06_configuring_for_eager_failover/#disabling-eager-failover).
 
 5. Use a version-specific command to stop the old Failover Manager cluster. For example, you can use the following command to stop a version 4.1 cluster:
 
@@ -35,7 +35,7 @@ Failover Manager provides a utility to assist you when upgrading a Failover Mana
    /usr/efm-4.1/bin/efm stop-cluster efm
    ```
 
-1.  Start the new [Failover Manager service](08_controlling_efm_service/#controlling_efm_service) (`edb-efm-4.4`) on each node of the cluster.
+1.  Start the new [Failover Manager service](efm_user/08_controlling_efm_service/#controlling_efm_service) (`edb-efm-4.4`) on each node of the cluster.
 
 The following example shows invoking the upgrade utility to create the `.properties` and `.nodes` files for a Failover Manager installation:
 
@@ -55,7 +55,7 @@ Upgrade of files is finished. The owner and group for properties and nodes files
 [root@k8s-worker ~]#
 ```
 
-If you're [using a Failover Manager configuration without sudo](04_configuring_efm/04_extending_efm_permissions/#running_efm_without_sudo), include the `-source` flag and specify the name of the directory in which the configuration files reside when invoking `upgrade-conf`. If the directory isn't the configuration default directory, the upgraded files are created in the directory from which the `upgrade-conf` command was invoked.
+If you're [using a Failover Manager configuration without sudo](efm_user/04_configuring_efm/04_extending_efm_permissions/#running_efm_without_sudo), include the `-source` flag and specify the name of the directory in which the configuration files reside when invoking `upgrade-conf`. If the directory isn't the configuration default directory, the upgraded files are created in the directory from which the `upgrade-conf` command was invoked.
 
 !!! Note 
     If you're using a unit file, manually update the file to reflect the new Failover Manager service name when you perform an upgrade.
@@ -104,4 +104,4 @@ On each node of the cluster, perform the following steps to update the database 
 
 For detailed information about controlling the EDB Postgres Advanced Server service or upgrading your version of EDB Postres Advanced Server, see the [EDB Postgres Advanced Server Guide](/epas/latest/)
 
-When your updates are complete, you can use the [efm set-priority](07_using_efm_utility/#efm_set_priority) command to add the old primary to the front of the standby list (if needed), and then switchover to return the cluster to its original state.
+When your updates are complete, you can use the [efm set-priority](efm_user/07_using_efm_utility/#efm_set_priority) command to add the old primary to the front of the standby list (if needed), and then switchover to return the cluster to its original state.

--- a/product_docs/docs/efm/4/efm_user/15_configuring_ssl_authentication.mdx
+++ b/product_docs/docs/efm/4/efm_user/15_configuring_ssl_authentication.mdx
@@ -12,7 +12,7 @@ You can enable SSL authentication for Failover Manager. All connecting clients a
 
 To enable SSL on a Failover Manager cluster:
 
-1.  Place a `server.crt` and `server.key` file in the `data` directory under your EDB Postgres Advanced Server installation. You can purchase a certificate signed by an authority or create your own self-signed certificate. For information about creating a self-signed certificate, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/10/static/ssl-tcp.html#ssl-certificate-creation).
+1.  Place a `server.crt` and `server.key` file in the `data` directory under your EDB Postgres Advanced Server installation. You can purchase a certificate signed by an authority or create your own self-signed certificate. For information about creating a self-signed certificate, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/ssl-tcp.html#SSL-CERTIFICATE-CREATION).
 
 2.  Modify the `postgresql.conf` file on each database in the Failover Manager cluster, enabling SSL:
 
@@ -28,7 +28,7 @@ To enable SSL on a Failover Manager cluster:
     hostnossl all all all reject
     ```
 
-    The line instructs the server to reject any connections that aren't using SSL authentication. This enforces SSL authentication for any connecting clients. For information about modifying the `pg_hba.conf` file, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/10/static/auth-pg-hba-conf.html).
+    The line instructs the server to reject any connections that aren't using SSL authentication. This enforces SSL authentication for any connecting clients. For information about modifying the `pg_hba.conf` file, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html).
 
 1.  After placing the `server.crt` and `server.key` files in the data directory, convert the certificate to a form that Java understands; you can use the command:
 
@@ -36,7 +36,7 @@ To enable SSL on a Failover Manager cluster:
     openssl x509 -in server.crt -out server.crt.der -outform der
     ```
 
-    For more information, see the [Postgres JDBC documentation](https://jdbc.postgresql.org/documentation/94/ssl-client.html).
+    For more information, see the [Postgres JDBC documentation](https://jdbc.postgresql.org/documentation/head/ssl-client.html).
 
 1.  Add the certificate to the Java trusted certificates file:
 
@@ -56,6 +56,6 @@ To enable SSL on a Failover Manager cluster:
     man keytool
     ```
  
-    The certificate from each database server must be imported into the trusted certificates file of each agent. The location of the `cacerts` file can vary on each system. For more information, see the [Postgres JDBC documentation](https://jdbc.postgresql.org/documentation/94/ssl-client.html).
+    The certificate from each database server must be imported into the trusted certificates file of each agent. The location of the `cacerts` file can vary on each system. For more information, see the [Postgres JDBC documentation](https://jdbc.postgresql.org/documentation/head/ssl-client.html).
 
 1.  Modify the [efm.properties file](04_configuring_efm/01_cluster_properties/#jdbc_sslmode) on each node in the cluster, setting the `jdbc.sslmode` property.


### PR DESCRIPTION
## What Changed?

- Relative links that no longer referenced sibling pages
- Postgresql.org links that referenced version 10 vs. current

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
