### PR TITLE
BigAnimal: updated definition of replicas

### DIFF
--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -10,7 +10,7 @@ BigAnimal enables deploying a cluster with or without high availability. The opt
 
 The high availability option is provided to minimize downtime in cases of failures. High-availability clusters—one *primary* and two *replicas*—are configured automatically, with replicas staying up to date through physical streaming replication. In cloud regions with availability zones, clusters are provisioned across multiple availability zones to provide fault tolerance in the face of a datacenter failure.
 
--   Replicas are usually called *standby servers*. You can also use them for read-only workloads.
+-   Replicas are usually called *standby servers*. 
 -   In case of temporary or permanent unavailability of the primary, a standby replica becomes the primary.
 
 ![*BigAnimal Cluster4*](images/high-availability.png)


### PR DESCRIPTION
Removed the line item about connecting to the standby replicas (not yet supported).

## What Changed?

Removed the line item about connecting to the standby replicas (not yet supported).


## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [x] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
