### PR TITLE
Update BigAnimal getting_started doc to reflect latest output of preflight check script

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
@@ -4,10 +4,10 @@ redirects:
  - ../01_check_resource_limits
 ---
 
-BigAnimal requires you to configure your Azure subscription before you deploy your clusters. The configurations that you perform ensure that your Azure subscription is prepared to meet your clusters' requirements and resource limits, such as: 
+BigAnimal requires you to configure your Azure subscription before you deploy your clusters. The configurations that you perform ensure that your Azure subscription is prepared to meet your clusters' requirements and resource limits, such as:
 
 -   Are the necessary Azure resource providers registered for your subscription?
--   Is there a restriction on SKUs for the Standard Esv3 and Standard Dv4 VM size families?
+-   Is there a restriction on SKUs for the Standard Esv3 family and Standard D2_v4 VM size?
 -   Is there a sufficient limit on the number of vCPU or Public IP addresses in your region?
 
 !!! Note
@@ -25,7 +25,7 @@ EDB recommends using the `biganimal-preflight-azure` script to check whether all
 EDB provides a shell script called [`biganimal-preflight-azure`](https://github.com/EnterpriseDB/cloud-utilities/blob/main/azure/biganimal-preflight-azure), which automatically checks whether requirements and resource limits are met in your Azure subscription based on the clusters you plan to deploy.
 
 1.  Open the [Azure Cloud Shell](https://shell.azure.com/) in your browser.
-2.  From the Azure Cloud Shell, use the following command to run the `biganimal-preflight-azure` script.  
+2.  From the Azure Cloud Shell, use the following command to run the `biganimal-preflight-azure` script.
 
     ```sh
      curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
@@ -41,7 +41,7 @@ EDB provides a shell script called [`biganimal-preflight-azure`](https://github.
 
     -   `<subscription-ID>`: Enter the Azure subscription ID of your BigAnimal deployment.
     -   `<azure-region>`: Enter the Azure region where your clusters are being deployed.
-    -   `<instance-type>`: Enter **e2s_v3**, which indicates the type of virtual machine instance (Esv3 with 2 cores) used in BigAnimal. 
+    -   `<instance-type>`: Enter **e2s_v3**, which indicates the type of virtual machine instance (Esv3 with 2 cores) used in BigAnimal.
     -   `--high-availability` or `-a`: Indicates that high availability is enabled in your clusters.
     -   `<endpoint-type>`: Indicates either **public** or **private** endpoints.
     -   `--activate-region` or `-r`: Indicates that no clusters are currently deployed in the region.
@@ -58,7 +58,7 @@ EDB provides a shell script called [`biganimal-preflight-azure`](https://github.
     --activate-region
     ```
 
-The script displays the following output:  
+The script displays the following output:
 
 -   A list of required Azure resource providers and their registration status. Ensure that you register the resource providers that are displayed as `NotRegistered` in the `RegistrationState` column. See [Register Azure resource providers](#register-azure-service-providers).
 
@@ -100,16 +100,16 @@ The script displays the following output:
 -   Whether your Azure subscription has sufficient limits on vCPUs and IP addresses for your region. Open a support request to raise limits for the vCPUs and IP addresses if they exceed the available VM families with `NotAvailableForSubscription` displayed in the `Restrictions` column. See [Increase Public IP addresses](#increase-public-ip-addresses-limits) and [Increase vCPU limits](#increase-vcpu-limits).
 
     ```
-    ####################### 
-    # Quota Limitation # 
-    ####################### 
+    #######################
+    # Quota Limitation #
+    #######################
 
-     Resource                        Limit   Used    Available    Gap   Suggestion 
-     Total Regional vCPUs            130     27      103          89    OK 
-     Standard D2v4 Family vCPUs      20      14      6            0     Need Increase 
-     Standard E2sv3 Family vCPUs      20      4       16           8     OK 
-     Public IP Addresses — Basic     20      11      9            8     OK 
-     Public IP Addresses — Standard  20      3       17           16    OK 
+     Resource                        Limit   Used    Available    Gap   Suggestion
+     Total Regional vCPUs            130     27      103          89    OK
+     Standard Dv4 Family vCPUs       20      14      6            0     Need Increase
+     Standard ESv3 Family vCPUs      20      4       16           8     OK
+     Public IP Addresses — Basic     20      11      9            8     OK
+     Public IP Addresses — Standard  20      3       17           16    OK
     ```
 
 ### Method 2: Manually check requirements
@@ -118,7 +118,7 @@ If you are manually checking the requirements instead of using the `biganimal-pr
 
 #### Check Azure resource provider registrations using Azure Cloud Shell
 
-To check if an Azure resource provider is registered, use the following command. 
+To check if an Azure resource provider is registered, use the following command.
 
 ```
 az provider show -n Microsoft.ContainerService
@@ -129,16 +129,16 @@ Microsoft.ContainerService  RegistrationRequired  Registered
 
 ```
 
-#### Check for vCPU restrictions for the VM size family
+#### Check for SKU restrictions for the specific VM size
 
-You can check vCPU limits for the VM size family using the Azure Cloud Shell. For example, to check the Standard_D2_v4 VM SKU restriction in `eastus2` location for all zones, run the following command:
+You can check SKU restrictions for the VM size using the Azure Cloud Shell. For example, to check the Standard_E2s_v3 VM SKU restriction in `eastus2` location for all zones, run the following command:
 
 ```sh
-az vm list-skus -l eastus2 --zone --size Standard_D2_v4
+az vm list-skus -l eastus2 --zone --size Standard_E2s_v3
 
-ResourceType     Locations    Name             Zones    Restrictions
----------------  -----------  ---------------  -------  ------------
-virtualMachines  eastus2      Standard_D2_v4   1,2,3    NotAvailableForSubscription, type: Zone, locations: eastus2, zones: 3,2
+ResourceType     Locations    Name              Zones    Restrictions
+---------------  -----------  ---------------   -------  ------------
+virtualMachines  eastus2      Standard_E2s_v3   1,2,3    NotAvailableForSubscription, type: Zone, locations: eastus2, zones: 3,2
 ```
 
 Alternatively, to check for SKU restrictions using the Azure Portal, see [Solution 3 - Azure portal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/error-sku-not-available#solution-3---azure-portal).
@@ -156,7 +156,7 @@ To check if you have adequate Azure resources to provision new clusters:
 
 ## Configure your Azure subscription
 
-After checking whether the requirements and resource limits are met, configure your Azure subscription. 
+After checking whether the requirements and resource limits are met, configure your Azure subscription.
 
 !!! Note
     Before proceeding, see [Understanding requirements in Azure](../01_preparing_azure/01_understanding_qotas_in_azure) for details on planning for your clusters' requirements and resource limits in Azure.
@@ -194,7 +194,7 @@ You can increase the number of public IP addresses for your account either by us
 
 ### Increase vCPU limits
 
-You can increase the number of Dv4 or Esv3 family virtual machines per region by using the Azure Portal or by submitting a support request. See: 
+You can increase the number of Dv4 or Esv3 family virtual machines per region by using the Azure Portal or by submitting a support request. See:
 
 -   [Request a quota increase at a subscription level using Usages + quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/classic-deployment-model-quota-increase-requests#request-quota-increase-for-the-classic-deployment-model-from-usage--quotas)
 


### PR DESCRIPTION
## What Changed?

- Update the BigAnimal getting_started documentation to pickup latest changes (bug fix) of the biganimal-preflight-check script
- adjust slightly the terms used in the documentation to say:
  * SKU restriction: because the SKU limitation is what Azure put to indicate is this specific type of VM available in our data-center/POD? rather than the vCPU cores, which is a Azure customer's subscription quota limitation.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
