### PR TITLE
BigAnimal Connecting your account topic: fixing hyphens in create-spn.sh curl command

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
@@ -48,10 +48,10 @@ Alternatively, you can run the script in [Azure Cloud Shell](https://azure.micro
 The syntax of the command is:
 
 ```
-curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s \
-  -- -display-name <display-name> \
-  -- -subscription <subscription> \
-  -- -years <years>
+curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s -- \
+--display-name "hello-s" \
+--subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712 \
+--years 1
 ```
 
 Flag and option details:
@@ -72,10 +72,10 @@ The specific output includes the client ID and client secret you use when you co
 To create an Azure AD Application with the subscription ID  `c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712` and display name `hello-s`:
 
 ```
-curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s \
-  -- -display-name "hello-s" \
-  -- -subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712 \
-  -- -years 2
+curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s -- \
+--display-name "hello-s" \
+--subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712 \
+--years 2
 Change to use Azure Subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712...
 {
   "environmentName": "AzureCloud",

--- a/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
@@ -49,9 +49,9 @@ The syntax of the command is:
 
 ```
 curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s -- \
---display-name "hello-s" \
---subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712 \
---years 1
+--display-name <display-name> \
+--subscription <subscription> \
+--years <years>
 ```
 
 Flag and option details:

--- a/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connect_cloud_account.mdx
@@ -49,8 +49,8 @@ The syntax of the command is:
 
 ```
 curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s \
-  -- --display-name <display-name> \
-  ----subscription <subscription> \
+  -- -display-name <display-name> \
+  -- -subscription <subscription> \
   -- -years <years>
 ```
 
@@ -73,9 +73,9 @@ To create an Azure AD Application with the subscription ID  `c808xxxx-xxxx-xxxx-
 
 ```
 curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s \
-  -- --display-name "hello-s" \
-  --subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712 \
-  --years 2
+  -- -display-name "hello-s" \
+  -- -subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712 \
+  -- -years 2
 Change to use Azure Subscription c808xxxx-xxxx-xxxx-xxxx-xxxxxxxxb712...
 {
   "environmentName": "AzureCloud",


### PR DESCRIPTION
- Fixed typo in the syntax of the create-spn guidance.
- Original: "The syntax of the command is:

curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s \
  -- --display-name <display-name> \
  ----subscription <subscription> \
  -- -years <years>"

- Corrected: "The syntax of the command is:

curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/create-spn.sh | bash -s \
  -- -display-name <display-name> \
  -- -subscription <subscription> \
  -- -years <years>"

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
