### PR TITLE
Catch EVERYTHING going to /edb-docs, send it somewhere sane

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -480,6 +480,48 @@ exports.onPostBuild = async ({ reporter, pathPrefix }) => {
 
   await writeFile(
     "public/_redirects",
-    `${rewrittenRedirects}\n\n# Netlify pathPrefix path rewrite\n${pathPrefix}/*  /:splat  200`,
+    `${rewrittenRedirects}
+
+# Catch-all legacy redirects
+/edb-docs/d/edb-backup-and-recovery-tool/*      /docs/bart/latest/ 301
+/edb-docs/d/edb-postgres-enterprise-manager/*   /docs/pem/latest/ 301
+/edb-docs/d/edb-postgres-advanced-server/*      /docs/epas/latest/ 301
+/edb-docs/d/edb-postgres-failover-manager/*     /docs/efm/latest/ 301
+/edb-docs/d/edb-postgres-replication-server/*   /docs/eprs/latest/ 301
+/edb-docs/d/pgadmin-4/*                         /docs/supported-open-source/pgadmin/ 301
+/edb-docs/d/edb-postgres-language-pack/*        /docs/epas/latest/language_pack/  301
+/edb-docs/d/edb-postgres-migration-toolkit/*    /docs/migration_toolkit/latest/ 301
+/edb-docs/d/edb-postgres-migration-portal/*     /docs/migration_portal/latest/ 301
+/edb-docs/d/edb-postgres-hadoop-data-adapter/*  /docs/hadoop_data_adapter/latest/ 301
+/edb-docs/d/jdbc-connector/*                    /docs/hadoop_data_adapter/latest/ 301
+/edb-docs/d/edb-postgres-ocl-connector/*        /docs/ocl_connector/latest/ 301
+/edb-docs/d/edb-postgres-net-connector/*        /docs/net_connector/latest/ 301
+/edb-docs/d/edb-postgres-odbc-connector/*       /docs/odbc_connector/latest/ 301
+/edb-docs/p/edb-postgres-advanced-server/*      /docs/epas/latest/ 301
+/edb-docs/p/postgresql/*                        /docs/supported-open-source/postgresql/ 301
+/edb-docs/p/edb-postgres-replication-server/*   /docs/eprs/latest/ 301
+/edb-docs/p/edb-postgres-failover-manager/*     /docs/efm/latest/ 301
+/edb-docs/p/pgadmin-4/*                         /docs/supported-open-source/pgadmin/ 301
+/edb-docs/p/edb-postgres-migration-toolkit/*    /docs/migration_toolkit/latest/ 301
+/edb-docs/p/edb-postgres-hadoop-data-adapter/*  /docs/hadoop_data_adapter/latest/ 301
+/edb-docs/p/edb-postgres-language-pack/*        /docs/epas/latest/language_pack/  301
+/edb-docs/p/jdbc-connector/*                    /docs/jdbc_connector/latest/ 301
+/edb-docs/p/edb-postgres-net-connector/*        /docs/net_connector/latest/ 301
+/edb-docs/p/edb-postgres-slony-replication/*    /docs/slony/latest/ 301
+/edb-docs/p/pgpool-ii/*                         /docs/pgpool/latest/ 301
+/edb-docs/p/edb-postgres-mysql-data-adapter/*   /docs/mysql_data_adapter/latest/ 301
+/edb-docs/p/edb-postgres-postgis/*              /docs/postgis/latest/ 301
+/edb-docs/p/pgbouncer/*                         /docs/pgbouncer/latest/ 301
+/edb-docs/p/edb-postgres-mongodb-data-adapter/* /docs/mongo_data_adapter/latest/ 301
+/edb-docs/p/edb-postgres-migration-portal/*     /docs/migration_portal/latest/ 301
+/edb-docs/p/edb-postgres-enterprise-manager/*   /docs/pem/latest/ 301
+/edb-docs/p/edbplus/*                           /docs/epas/latest/edb_plus/ 301
+/edb-docs/p/edb-postgres-odbc-connector/*       /docs/odbc_connector/latest/ 301
+/edb-docs/p/edb-postgres-ocl-connector/*        /docs/ocl_connector/latest/ 301
+/edb-docs/p/edb-backup-and-recovery-tool/*      /docs/bart/latest/ 301
+/edb-docs/*                                     /docs/ 301
+
+# Netlify pathPrefix path rewrite
+${pathPrefix}/*  /:splat  200`,
   );
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -486,6 +486,7 @@ exports.onPostBuild = async ({ reporter, pathPrefix }) => {
 /edb-docs/d/edb-backup-and-recovery-tool/*      /docs/bart/latest/ 301
 /edb-docs/d/edb-postgres-enterprise-manager/*   /docs/pem/latest/ 301
 /edb-docs/d/edb-postgres-advanced-server/*      /docs/epas/latest/ 301
+/edb-docs/d/postgresql/*                        /docs/supported-open-source/postgresql/ 301
 /edb-docs/d/edb-postgres-failover-manager/*     /docs/efm/latest/ 301
 /edb-docs/d/edb-postgres-replication-server/*   /docs/eprs/latest/ 301
 /edb-docs/d/pgadmin-4/*                         /docs/supported-open-source/pgadmin/ 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -100,30 +100,6 @@
 # BigAnimal
 /docs/edbcloud/* /docs/biganimal/:splat  301
 
-# Legacy redirects not captured in Frontmatter (Docs 1.0 -> 2.0)
-# these are "product pages" - on the old site they'd be an index of versions; the closest equivalent is the latest version (where a version selector is available)
-/edb-docs/p/edb-backup-and-recovery-tool/       /docs/bart/latest/ 301
-/edb-docs/p/jdbc-connector/                     /docs/jdbc_connector/latest/ 301
-/edb-docs/p/edb-postgres-net-connector/         /docs/net_connector/latest/ 301
-/edb-docs/p/edb-postgres-ocl-connector/         /docs/ocl_connector/latest/ 301
-/edb-docs/p/edb-postgres-odbc-connector/        /docs/odbc_connector/latest/ 301
-/edb-docs/p/edbplus/                            /docs/epas/latest/edb_plus/ 301
-/edb-docs/p/edb-postgres-advanced-server/       /docs/epas/latest/ 301
-/edb-docs/p/edb-postgres-enterprise-manager/    /docs/pem/latest/ 301
-/edb-docs/p/edb-postgres-failover-manager/      /docs/efm/latest/ 301
-/edb-docs/p/edb-postgres-hadoop-data-adapter/   /docs/hadoop_data_adapter/latest/ 301
-/edb-docs/p/edb-postgres-migration-portal/      /docs/migration_portal/latest/ 301
-/edb-docs/p/edb-postgres-migration-toolkit/     /docs/migration_toolkit/latest/ 301
-/edb-docs/p/edb-postgres-mongodb-data-adapter/  /docs/mongo_data_adapter/latest/ 301
-/edb-docs/p/edb-postgres-mysql-data-adapter/    /docs/mysql_data_adapter/latest/ 301
-/edb-docs/p/pgbouncer/                          /docs/pgbouncer/latest/ 301
-/edb-docs/p/pgpool-ii/                          /docs/pgpool/latest/ 301
-/edb-docs/p/edb-postgres-postgis/               /docs/postgis/latest/ 301
-/edb-docs/p/edb-postgres-replication-server/    /docs/eprs/latest/ 301
-/edb-docs/p/edb-postgres-slony-replication/     /docs/slony/latest/ 301
-/edb-docs/p/postgresql/                         /docs/supported-open-source/postgresql/ 301
-/edb-docs/p/pgadmin-4/                          /docs/supported-open-source/pgadmin/ 301
-
 # Super legacy redirects (Docs 0.5 -> 1.0)
 /docs/en/1.0/EDB_HA_SCALABILITY/*  https://www.enterprisedb.com/edb-docs/d/edb-postgres-failover-manager/user-guides/high-availability-scalability-guide/3.2/:splat  301
 /docs/en/1.0/EDB_Migration_Portal_v1.0/*  https://www.enterprisedb.com/edb-docs/d/edb-postgres-migration-portal/user-guides/user-guide/1.0/:splat  301


### PR DESCRIPTION
## What Changed?

Builds on #2250 - turns out with Netlify rewriting (vs redirecting) /edb-docs paths, 404s on Docs don't... Work. Gatsby does something stupid and you end up with a blank page. 

So, need catch-alls for every path under /edb-docs (at least get you to the right *product* if a specific page didn't get remapped) and /edb-docs itself. 

Had some of this already, but to use wildcards needs to be written to the end of the file so as to avoid interfering with more specific redirects. 