### PR TITLE
Netlify deploy optimization

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -161,6 +161,11 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
   processFileNodes(result.data.allFile.nodes, actions);
 
+  // this is critical to avoiding excessive Netlify deploy times: it ensures the pages are ordered consistently from build to build
+  result.data.allMdx.nodes = result.data.allMdx.nodes.sort((a, b) =>
+    a.fields.path.localeCompare(b.fields.path),
+  );
+
   const { nodes } = result.data.allMdx;
 
   const productVersions = buildProductVersions(nodes);


### PR DESCRIPTION
## What Changed?

Netlify deploys take too long. A big part of this is that 6K+ files are hashing differently from build to build.

Turns out, a big part of this is the list of client-side redirects stored in app-<hash>.js. If the order changes (and it does) then the hash on that file changes, which in turn is propagated to every HTML file - and now those also hash differently.

There are a few possible solutions to this:

- ensure pages are added in the same order every time
- don't do client-side redirects
- sort the list of pages

Starting off with the last one, because it is easy. Reduces the no-change diff between builds from 6K+ to about 10 files. Which is still... 9 more than it should be (1 will always change as it contains the build timestamp). But, an improvement!