### PR TITLE
use 'shell' as language, not 'sh'

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,20 +89,20 @@ If you are still experiencing errors or other issues with the site, try the foll
 
 You will need to follow these instructions if you want to build PDFs locally, or get started quickly with Docker.
 
-```sh
+```shell
 brew install --cask docker
 ```
 
 If you get a message saying that you already have Docker installed, check which version is installed using these commands:
 
-```sh
+```shell
 brew ls --formula docker
 brew ls --cask docker
 ```
 
 If the first command yields results, enter the following command to uninstall the formula version and to install the cask version:
 
-```sh
+```shell
 brew uninstall -f docker && brew install --cask docker
 ```
 
@@ -165,19 +165,19 @@ To build PDFs locally, you'll need to use a Docker container.
 
 1. Create the Docker image (optional):
 
-   ```sh
+   ```shell
    npm run pdf:rebuild-docker-image
    ```
 
 1. Run the following command inside the docs project to create a PDF:
 
-   ```sh
+   ```shell
    npm run pdf:build product_docs/docs/<product_folder>/<version>
    ```
 
    For example, to build a PDF for the EPAS 13 documentation:
 
-   ```sh
+   ```shell
    npm run pdf:build product_docs/docs/epas/13
    ```
 

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/backup_recovery.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/backup_recovery.mdx
@@ -57,7 +57,7 @@ The access key used must have permission to upload files in
 the bucket. Given that, you must create a k8s secret with the
 credentials, and you can do that with the following command:
 
-```sh
+```shell
 kubectl create secret generic aws-creds \
   --from-literal=ACCESS_KEY_ID=<access key here> \
   --from-literal=ACCESS_SECRET_KEY=<secret key here>
@@ -135,7 +135,7 @@ MinIO Gateway as an endpoint, using previously created credentials and service.
 MinIO secrets will be used by both the PostgreSQL cluster and the MinIO instance.
 Therefore you must create them in the same namespace:
 
-```sh
+```shell
 kubectl create secret generic minio-creds \
   --from-literal=MINIO_ACCESS_KEY=<minio access key here> \
   --from-literal=MINIO_SECRET_KEY=<minio secret key here>

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/cnp-plugin.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/cnp-plugin.mdx
@@ -11,7 +11,7 @@ The plugin also works with `oc` in an OpenShift environment.
 
 You can install the plugin in your system with:
 
-```sh
+```shell
 curl -sSfL \
   https://github.com/EnterpriseDB/kubectl-cnp/raw/main/install.sh | \
   sudo sh -s -- -b /usr/local/bin

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/expose_pg_services.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/expose_pg_services.mdx
@@ -107,14 +107,14 @@ Now you will be able to reach the PostgreSQL Cluster from outside your Kubernete
 
 On Minikube you can setup the ingress controller running:
 
-```sh
+```shell
 minikube addons enable ingress
 ```
 
 Then, patch the `tcp-service` ConfigMap to redirect to the primary the
 connections on port 5432 of the Ingress:
 
-```sh
+```shell
 kubectl patch configmap tcp-services -n kube-system \
   --patch '{"data":{"5432":"default/cluster-example-rw:5432"}}'
 ```
@@ -135,12 +135,12 @@ spec:
 
 and apply it to the `nginx-ingress-controller deployment`:
 
-```sh
+```shell
 kubectl patch deployment nginx-ingress-controller --patch "$(cat patch.yaml)" -n kube-system
 ```
 
 You can access the primary from your machine running:
 
-```sh
+```shell
 psql -h $(minikube ip) -p 5432 -U postgres
 ```

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/failure_modes.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/failure_modes.mdx
@@ -29,13 +29,13 @@ If you want to prevent the operator from reusing a certain PVC you need to
 remove the PVC before deleting the Pod. For this purpose, you can use the
 following command:
 
-```sh
+```shell
 kubectl delete -n [namespace] pvc/[cluster-name]-[serial] pod/[cluster-name]-[serial]
 ```
 
 For example:
 
-```sh
+```shell
 $ kubectl delete -n default pvc/cluster-example-1 pod/cluster-example-1
 persistentvolumeclaim "cluster-example-1" deleted
 pod "cluster-example-1" deleted

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/installation_upgrade.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/installation_upgrade.mdx
@@ -14,7 +14,7 @@ through a YAML manifest applied via `kubectl`.
 You can install the [latest operator manifest](https://get.enterprisedb.io/cnp/postgresql-operator-1.12.0.yaml)
 as follows:
 
-```sh
+```shell
 kubectl apply -f \
   https://get.enterprisedb.io/cnp/postgresql-operator-1.12.0.yaml
 ```
@@ -23,7 +23,7 @@ Once you have run the `kubectl` command, Cloud Native PostgreSQL will be install
 
 You can verify that with:
 
-```sh
+```shell
 kubectl get deploy -n postgresql-operator-system postgresql-operator-controller-manager
 ```
 
@@ -66,7 +66,7 @@ For more information on this matter see the
 You can add the [`subscription`](../samples/subscription.yaml) to install the operator in all the namespaces
 as follows:
 
-```sh
+```shell
 oc apply -f \
   https://docs.enterprisedb.io/cloud-native-postgresql/latest/samples/subscription.yaml
 ```
@@ -82,7 +82,7 @@ is available in the Openshift documentation.
 In Kubernetes, the operator is by default installed in the `postgresql-operator-system` namespace as a Kubernetes
 `Deployment` called `postgresql-operator-controller-manager`. You can get more information by running:
 
-```sh
+```shell
 kubectl describe deploy \
   -n postgresql-operator-system \
   postgresql-operator-controller-manager

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/license_keys.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/license_keys.mdx
@@ -25,7 +25,7 @@ for a license key).
 Once the company level license is installed, the validity of the
 license key can be checked inside the cluster status.
 
-```sh
+```shell
 kubectl get cluster cluster_example -o yaml
 [...]
 status:
@@ -56,7 +56,7 @@ kubectl create configmap -n [NAMESPACE_NAME_HERE] \
 Operator pods will need to be recreated to apply the new configuration. You
 can use the following command:
 
-```sh
+```shell
 kubectl rollout restart deployment -n [NAMESPACE_NAME_HERE] \
     postgresql-operator-controller-manager
 ```
@@ -82,7 +82,7 @@ kubectl create secret generic -n [NAMESPACE_NAME_HERE] \
 You'll need to delete the current operator pods. New pods will be
 automatically recreated and will use the secret:
 
-```sh
+```shell
 kubectl delete pods -n [NAMESPACE_NAME_HERE] \
   -l app.kubernetes.io/name=cloud-native-postgresql
 ```
@@ -93,7 +93,7 @@ Each `Cluster` resource has a `licenseKey` parameter in its definition.
 You can find the expiration date, as well as more information about the license,
 in the cluster status:
 
-```sh
+```shell
 kubectl get cluster cluster_example -o yaml
 [...]
 status:

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/postgresql_conf.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/postgresql_conf.mdx
@@ -329,7 +329,7 @@ the operator automatically mounts a *memory-bound `EmptyDir` volume* called `shm
 under `/dev/shm`. You can verify the size of such volume inside the running
 Postgres container with:
 
-```sh
+```shell
 mount | grep shm
 ```
 
@@ -350,7 +350,7 @@ dynamic_shared_memory_type: "sysv"
 
 You can check the `SHMMAX`/`SHMALL` from inside a PostgreSQL container, by running:
 
-```sh
+```shell
 ipcs -lm
 ```
 
@@ -369,7 +369,7 @@ setting `dynamic_shared_memory_type` to `sysv`.
 
 An alternate method is to run:
 
-```sh
+```shell
 cat /proc/sys/kernel/shmall
 cat /proc/sys/kernel/shmmax
 ```

--- a/advocacy_docs/kubernetes/cloud_native_postgresql/quickstart.mdx
+++ b/advocacy_docs/kubernetes/cloud_native_postgresql/quickstart.mdx
@@ -59,14 +59,14 @@ You can find more information in the official [Kubernetes documentation on how t
 install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube) in your local personal environment.
 When you installed it, run the following command to create a minikube cluster:
 
-```sh
+```shell
 minikube start
 ```
 
 This will create the Kubernetes cluster, and you will be ready to use it.
 Verify that it works with the following command:
 
-```sh
+```shell
 kubectl get nodes
 ```
 
@@ -80,7 +80,7 @@ local Kubernetes clusters using Docker container "nodes" (Kind stands for "Kuber
 Install `kind` on your environment following the instructions in the [Quickstart](https://kind.sigs.k8s.io/docs/user/quick-start),
 then create a Kubernetes cluster with:
 
-```sh
+```shell
 kind create cluster --name pg
 ```
 
@@ -150,13 +150,13 @@ spec:
 
 In order to create the 3-node PostgreSQL cluster, you need to run the following command:
 
-```sh
+```shell
 kubectl apply -f cluster-example.yaml
 ```
 
 You can check that the pods are being created with the `get pods` command:
 
-```sh
+```shell
 kubectl get pods
 ```
 

--- a/docs/how-tos/sync-cnp-docs.md
+++ b/docs/how-tos/sync-cnp-docs.md
@@ -6,7 +6,7 @@ Documentation from [cloud-native-postgresql][cnp]("CNP") should be synced over a
 1. Run the processor script
 
    **note:** replace `path/to/cnp/checkout` below to the actual path of your CNP checkout. If you are not running the script from this project's root, you will need to update `.` below to be the path to this project's checkout.
-   ```sh
+   ```shell
    scripts/source/process-cnp-docs.sh path/to/cnp/checkout .
    ```
 1. The script will handle updating and moving the files from the [CNP][] repo into place.

--- a/product_docs/docs/bdr/3.7/appusage.mdx
+++ b/product_docs/docs/bdr/3.7/appusage.mdx
@@ -390,7 +390,7 @@ form](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRIN
 
 Here's an example invocation in a CAMO environment:
 
-```sh
+```shell
     pgbench -m camo -p $node1_port -h $node1_host bdrdemo \
         "host=$node2_host user=postgres port=$node2_port dbname=bdrdemo"
 ```

--- a/product_docs/docs/bdr/4.0/appusage.mdx
+++ b/product_docs/docs/bdr/4.0/appusage.mdx
@@ -387,7 +387,7 @@ form](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRIN
 
 Here's an example invocation in a CAMO environment:
 
-```sh
+```shell
     pgbench -m camo -p $node1_port -h $node1_host bdrdemo \
         "host=$node2_host user=postgres port=$node2_port dbname=bdrdemo"
 ```

--- a/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/01_preparing_azure/index.mdx
@@ -27,7 +27,7 @@ EDB provides a shell script called [`biganimal-preflight-azure`](https://github.
 1.  Open the [Azure Cloud Shell](https://shell.azure.com/) in your browser.
 2.  From the Azure Cloud Shell, run the following command:  
 
-    ```sh
+    ```shell
     curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s <target-subscription> <region> [options]
     ```
     Where the required arguments are:
@@ -52,7 +52,7 @@ EDB provides a shell script called [`biganimal-preflight-azure`](https://github.
 
     For example, if you want to deploy a cluster in an Azure subscription having an ID of `12412ab3d-1515-2217-96f5-0338184fcc04`, with an instance type of `e2s_v3`, in the `eastus2` region, in a `public` network, and with no existing cluster deployed, run the following command:
 
-    ```sh
+    ```shell
     curl -sL https://raw.githubusercontent.com/EnterpriseDB/cloud-utilities/main/azure/biganimal-preflight-azure | bash -s \
     12412ab3d-1515-2217-96f5-0338184fcc04 eastus2 \
     --instance-type e2s_v3 \
@@ -136,7 +136,7 @@ Microsoft.ContainerService  RegistrationRequired  Registered
 
 You can check SKU restrictions for the VM size using the Azure Cloud Shell. For example, to check the Standard_E2s_v3 VM SKU restriction in `eastus2` location for all zones, run the following command:
 
-```sh
+```shell
 az vm list-skus -l eastus2 --zone --size Standard_E2s_v3
 
 ResourceType     Locations    Name              Zones    Restrictions
@@ -176,7 +176,7 @@ To register resource providers using the Azure Portal:
 To register resource providers using the Azure CLI,
 use the [register command](https://docs.microsoft.com/en-us/cli/azure/provider?view=azure-cli-latest#az_provider_register). For example:
 
-```sh
+```shell
 az provider register -n Microsoft.ContainerService
 Registering is still on-going. You can monitor using 'az provider show -n Microsoft.ContainerService
 ```

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -104,7 +104,7 @@ Don’t edit files in this directory directly. Instead, use the following comman
 
 The CLI supports command line auto completion for bash, fish, powershell, and zsh. The following command describes how to set auto completion up in bash:
 
-```sh
+```shell
 $ ba completion bash --help
 ```
 
@@ -118,7 +118,7 @@ The default mode for the `create-cluster` command is an interactive mode that gu
 You can turn off prompting by first using the `biganimal disable-prompt` command. With prompting disabled, if there are any missing required flags, the CLI exits.
 !!!
 
-```sh
+```shell
 $ biganimal create-cluster
 Cluster Name: my-biganimal-cluster
 Password: ************
@@ -192,7 +192,7 @@ Here is a sample configuration file in YAML format:
 
 To create the cluster using the sample configuration file `config_file.yaml`:
 
-```sh
+```shell
 biganimal create-cluster --clusterConfigFile ./config_file.yaml
 ```
 
@@ -233,13 +233,13 @@ After the cluster is created, you can update attributes of the cluster including
 
 For example, to enable high availability, use the `--high-availability` option:
 
-```sh
+```shell
 $ biganimal update-cluster --name my-biganimal-cluster --provider azure --region eastus --high-availability true
 ```
 
 To check whether the setting took effect, use the `show-clusters` command and view the detailed cluster information output in JSON format. For example,
 
-```sh
+```shell
 $ biganimal show-clusters --name my-biganimal-cluster --provider azure --region eastus --output json | grep zone
     "zoneRedundantHa": true,
 ```
@@ -248,7 +248,7 @@ $ biganimal show-clusters --name my-biganimal-cluster --provider azure --region 
 
 To delete a cluster you no longer need, use the `delete-cluster` command. For example:
 
-```sh
+```shell
 $ biganimal delete-cluster --name my-biganimal-cluster --provider azure --region e\
 ```
 

--- a/product_docs/docs/efm/4/03_installing_efm.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm.mdx
@@ -118,7 +118,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -128,7 +128,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -136,7 +136,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -145,26 +145,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-efm<xx>
 ```
 where `<xx>` is the version number of Failover Manager.

--- a/product_docs/docs/epas/11/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
@@ -273,7 +273,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -283,7 +283,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -292,32 +292,32 @@ sudo su -
 1. Replace `'USERNAME:PASSWORD'` below with your username and password available from your
    [EDB account](https://www.enterprisedb.com/user) in the edb.repo file:
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
 1. Install EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as11-server
 ```
 

--- a/product_docs/docs/epas/12/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
@@ -305,7 +305,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -315,7 +315,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -324,32 +324,32 @@ sudo su -
 1. Replace `'USERNAME:PASSWORD'` below with your username and password available from your
    [EDB account](https://www.enterprisedb.com/user) in the edb.repo file:
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
 1. Install EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as12-server
 ```
 

--- a/product_docs/docs/epas/13/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
@@ -294,7 +294,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -304,7 +304,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -313,32 +313,32 @@ sudo su -
 1. Replace `'USERNAME:PASSWORD'` below with your username and password available from your
    [EDB account](https://www.enterprisedb.com/user) in the edb.repo file:
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
 1. Install EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as13-server
 ```
 

--- a/product_docs/docs/epas/14/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server.mdx
@@ -290,7 +290,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -300,7 +300,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -309,32 +309,32 @@ sudo su -
 1. Replace `'USERNAME:PASSWORD'` below with your username and password available from your
    [EDB account](https://www.enterprisedb.com/user) in the edb.repo file:
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
 1. Install EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as14-server
 ```
 

--- a/product_docs/docs/eprs/6.2/03_installation/03a_installing_rhel8_ppcle.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/03a_installing_rhel8_ppcle.mdx
@@ -10,7 +10,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -20,7 +20,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -28,7 +28,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -37,25 +37,25 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-xdb
 ```

--- a/product_docs/docs/eprs/7.0/03_installation/03_installing_rpm_package.mdx
+++ b/product_docs/docs/eprs/7.0/03_installation/03_installing_rpm_package.mdx
@@ -260,7 +260,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -270,7 +270,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -278,7 +278,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -287,26 +287,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-xdb
 ```
 

--- a/product_docs/docs/hadoop_data_adapter/2.1.0/05_installing_the_hadoop_data_adapter.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2.1.0/05_installing_the_hadoop_data_adapter.mdx
@@ -246,7 +246,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -256,7 +256,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -264,7 +264,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -273,26 +273,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as<xx>-hdfs_fdw
 ```
 

--- a/product_docs/docs/jdbc_connector/42.2.24.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package.mdx
+++ b/product_docs/docs/jdbc_connector/42.2.24.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package.mdx
@@ -284,7 +284,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -294,7 +294,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -302,7 +302,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -311,26 +311,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-jdbc
 ```
 

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk.mdx
@@ -208,7 +208,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -218,7 +218,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -226,7 +226,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -235,26 +235,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-migrationtoolkit
 ```
 

--- a/product_docs/docs/mongo_data_adapter/5.3.0/04_installing_the_mongo_data_adapter.mdx
+++ b/product_docs/docs/mongo_data_adapter/5.3.0/04_installing_the_mongo_data_adapter.mdx
@@ -253,7 +253,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -263,7 +263,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -271,7 +271,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -280,26 +280,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as<xx>-mongo_fdw
 ```
 

--- a/product_docs/docs/mysql_data_adapter/2.7.0/04_installing_the_mysql_data_adapter.mdx
+++ b/product_docs/docs/mysql_data_adapter/2.7.0/04_installing_the_mysql_data_adapter.mdx
@@ -480,7 +480,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -490,7 +490,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -498,7 +498,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -507,26 +507,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as<xx>-mysql8_fdw
 ```
 

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector.mdx
@@ -290,7 +290,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -300,7 +300,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -308,7 +308,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -317,26 +317,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-oci
 ```
 

--- a/product_docs/docs/odbc_connector/13.1.0.2/03_edb-odbc_overview/01_installing_edb-odbc.mdx
+++ b/product_docs/docs/odbc_connector/13.1.0.2/03_edb-odbc_overview/01_installing_edb-odbc.mdx
@@ -240,7 +240,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -250,7 +250,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -258,7 +258,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -267,26 +267,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-odbc
 ```
 

--- a/product_docs/docs/pem/8/pem_inst_guide_linux/04_installing_postgres_enterprise_manager/03_installing_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/8/pem_inst_guide_linux/04_installing_postgres_enterprise_manager/03_installing_pem_server_on_linux.mdx
@@ -195,7 +195,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -205,7 +205,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -214,33 +214,33 @@ sudo su -
 1. Replace `'USERNAME:PASSWORD'` below with your username and password available from your
    [EDB account](https://www.enterprisedb.com/user) in the edb.repo file:
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
 1. Install EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
    
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 ### Installing the Package
 
-   ```sh
+   ```shell
    dnf -y install edb-pem
    ```
 

--- a/product_docs/docs/pem/8/pem_inst_guide_linux/04_installing_postgres_enterprise_manager/08_installing_pem_agent_on_linux.mdx
+++ b/product_docs/docs/pem/8/pem_inst_guide_linux/04_installing_postgres_enterprise_manager/08_installing_pem_agent_on_linux.mdx
@@ -179,7 +179,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -189,7 +189,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -198,33 +198,33 @@ sudo su -
 1. Replace `'USERNAME:PASSWORD'` below with your username and password available from your
    [EDB account](https://www.enterprisedb.com/user) in the edb.repo file:
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
 1. Install EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
    
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 ### Installing the Package
 
-   ```sh
+   ```shell
    dnf -y install edb-pem-agent
    ```
 

--- a/product_docs/docs/pgbouncer/1.16/01_installation/03a_installing_pgbouncer_on_a_rhel8_ppcle_host.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/03a_installing_pgbouncer_on_a_rhel8_ppcle_host.mdx
@@ -10,7 +10,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -20,7 +20,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -28,7 +28,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -37,26 +37,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-pgbouncer<xxx>
 ```
 where `<xxx>` is the PgBouncer version you want to install.

--- a/product_docs/docs/pgpool/4.2/01_installing_and_configuring_the_pgpool-II.mdx
+++ b/product_docs/docs/pgpool/4.2/01_installing_and_configuring_the_pgpool-II.mdx
@@ -283,7 +283,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -293,7 +293,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -301,7 +301,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -310,26 +310,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-pgpool<xx>
 ```
 

--- a/product_docs/docs/postgis/3.1/01a_installing_postgis.mdx
+++ b/product_docs/docs/postgis/3.1/01a_installing_postgis.mdx
@@ -337,7 +337,7 @@ For each step, you must be logged in as superuser.
 
 To log in as a superuser:
 
-```sh
+```shell
 sudo su -
 ```
 
@@ -347,7 +347,7 @@ sudo su -
 
 1. Set up the EDB repository:
 
-   ```sh
+   ```shell
    dnf -y install https://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm
    ```
 
@@ -355,7 +355,7 @@ sudo su -
 
 1. Add your EDB credentials to the edb.repo file:  
 
-   ```sh
+   ```shell
    sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
    ```
 
@@ -364,26 +364,26 @@ sudo su -
 
 1. Install the EPEL repository and refresh the cache:
 
-   ```sh
+   ```shell
    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
    dnf makecache
    ```
 
 1. Enable the codeready-builder-for-rhel-8-\*-rpms repository since EPEL packages may depend on packages from it:
 
-   ```sh
+   ```shell
    ARCH=$( /bin/arch )
    subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
    ```
 
 1. Disable the built-in PostgreSQL module:
-   ```sh
+   ```shell
    dnf -qy module disable postgresql
    ```
 
 #### Installing the Package
 
-```sh
+```shell
 dnf -y install edb-as<xx>-postgis3
 ```
 


### PR DESCRIPTION
## What Changed?

sh isn't currently a synonym for shell (sh/bash/zsh syntax highlighting)

Maybe it should be. It is, after all, the name of a shell.

But for now, rewrite these so that they're highlighted.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
