### PR TITLE
fix(UPM-4584): fix sha256 verification guide bugs

### DIFF
--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -19,21 +19,21 @@ The CLI is available for Linux, MacOS, and Windows operating systems.
 
 ### (Optional) Validate the download
 
--   For Linux user:
-    1. Copy the SHA256 checksum code for Linux distribution from [here](https://cli.biganimal.com) and store it as a local file like `biganimal_linux_amd64.sha256`. You can also download the SHA256 checksum file directly by click code link from above page, make sure to verify that the content of downloaded file is idential with the checksum code showed on the page.
+-   For Linux users:
+    1. Copy the SHA256 checksum code for Linux distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_linux_amd64.sha256`. Alternatively, select **Download** to download the SHA256 checksum file directly. Verify the content of the downloaded file is identical to the checksum code showed on the page.
     2. From your local shell, validate the binary executable file against the checksum file:
         ```
         echo "$(<biganimal_linux_amd64.sha256) biganimal" | sha256sum --check
         ```
 
--   For Windows user:
-    1. Download the SHA256 checksum code for Windows distribution from [here](https://cli.biganimal.com/). and store it as a local file like `biganimal_windows_amd64.sha256`. You can also download the SHA256 checksum file directly by click code link from above page, make sure to verify that the content of downloaded file is idential with the checksum code showed on the page.
+-   For Windows users:
+    1. Download the SHA256 checksum code for Windows distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_windows_amd64.sha256`. Alternatively, select **Download** to download the SHA256 checksum file directly. Verify the content of the downloaded file is identical to the checksum code showed on the page.
     2.  Validate the binary executable file against the checksum file using `CertUtil`:
         ```
         CertUtil -hashfile biganimal.exe SHA256 type biganiml_windows_amd64.sha256
         ```
-- For MacOS user:
-    1. Download the SHA256 checksum code for MacOS distribution from [here](https://cli.biganimal.com/). and store it as a local file, e.g. `biganimal_darwin_amd64.sha256`. You can also download the SHA256 checksum file directly by click code link from above page, make sure to verify that the content of downloaded file is idential with the checksum code showed on the page.
+- For MacOS users:
+    1. Download the SHA256 checksum code for MacOS distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_darwin_amd64.sha256`. Alternatively, select **Download** to download the SHA256 checksum file directly. Verify the content of the downloaded file is identical to the checksum code showed on the page.
     2. From MacOS terminal, validate the binary executable file against the checksum file:
         ```
         echo "$(<biganimal_darwin_amd64.sha256)  biganimal" | shasum -c

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -20,20 +20,20 @@ The CLI is available for Linux, MacOS, and Windows operating systems.
 ### (Optional) Validate the download
 
 -   For Linux users:
-    1. Copy the SHA256 checksum code for Linux distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_linux_amd64.sha256`. Alternatively, select **Download** to download the SHA256 checksum file directly. Verify the content of the downloaded file is identical to the checksum code showed on the page.
+    1. Copy the SHA256 checksum code for Linux distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_linux_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly, verify the content of the downloaded file is identical to the checksum code showed on the page.
     2. From your local shell, validate the binary executable file against the checksum file:
         ```
         echo "$(<biganimal_linux_amd64.sha256) biganimal" | sha256sum --check
         ```
 
 -   For Windows users:
-    1. Download the SHA256 checksum code for Windows distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_windows_amd64.sha256`. Alternatively, select **Download** to download the SHA256 checksum file directly. Verify the content of the downloaded file is identical to the checksum code showed on the page.
+    1. Download the SHA256 checksum code for Windows distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_windows_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly, verify the content of the downloaded file is identical to the checksum code showed on the page.
     2.  Validate the binary executable file against the checksum file using `CertUtil`:
         ```
         CertUtil -hashfile biganimal.exe SHA256 type biganiml_windows_amd64.sha256
         ```
 - For MacOS users:
-    1. Download the SHA256 checksum code for MacOS distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_darwin_amd64.sha256`. Alternatively, select **Download** to download the SHA256 checksum file directly. Verify the content of the downloaded file is identical to the checksum code showed on the page.
+    1. Download the SHA256 checksum code for MacOS distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_darwin_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly, verify the content of the downloaded file is identical to the checksum code showed on the page.
     2. From MacOS terminal, validate the binary executable file against the checksum file:
         ```
         echo "$(<biganimal_darwin_amd64.sha256)  biganimal" | shasum -c

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -20,20 +20,20 @@ The CLI is available for Linux, MacOS, and Windows operating systems.
 ### (Optional) Validate the download
 
 -   For Linux users:
-    1. Copy the SHA256 checksum code for Linux distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_linux_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly, verify the content of the downloaded file is identical to the checksum code showed on the page.
+    1. Copy the SHA256 checksum code for Linux distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_linux_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
     2. From your local shell, validate the binary executable file against the checksum file:
         ```
         echo "$(<biganimal_linux_amd64.sha256) biganimal" | sha256sum --check
         ```
 
 -   For Windows users:
-    1. Download the SHA256 checksum code for Windows distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_windows_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly, verify the content of the downloaded file is identical to the checksum code showed on the page.
+    1. Download the SHA256 checksum code for Windows distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_windows_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
     2.  Validate the binary executable file against the checksum file using `CertUtil`:
         ```
         CertUtil -hashfile biganimal.exe SHA256 type biganiml_windows_amd64.sha256
         ```
 - For MacOS users:
-    1. Download the SHA256 checksum code for MacOS distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_darwin_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly, verify the content of the downloaded file is identical to the checksum code showed on the page.
+    1. Download the SHA256 checksum code for MacOS distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_darwin_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
     2. From MacOS terminal, validate the binary executable file against the checksum file:
         ```
         echo "$(<biganimal_darwin_amd64.sha256)  biganimal" | shasum -c

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -15,27 +15,29 @@ The CLI is available for Linux, MacOS, and Windows operating systems.
     curl -LO "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal"
     ```
 
--   For all operating systems, download the executable binary [here](http://cli.biganimal.com/).
+-   For all operating systems, download the executable binary [here](https://cli.biganimal.com/).
 
 ### (Optional) Validate the download
 
--   For Linux operating systems, including Linux running from MacOS platforms:
-    1.  Download the `checksum` file with following command:
+-   For Linux user:
+    1. Copy the SHA256 checksum code for Linux distribution from [here](https://cli.biganimal.com) and store it as a local file like `biganimal_linux_amd64.sha256`. You can also download the SHA256 checksum file directly by click code link from above page, make sure to verify that the content of downloaded file is idential with the checksum code showed on the page.
+    2. From your local shell, validate the binary executable file against the checksum file:
         ```
-        curl -L0 "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal.sha256"
-        ```
-    2.  From a shell, validate the binary executable file against the `checksum` file:
-        ```
-        echo "$(<big_animal.sha256) biganimal" | sha256sum --check
+        echo "$(<biganimal_linux_amd64.sha256) biganimal" | sha256sum --check
         ```
 
--   For Windows:
-    1.  Download the `checksum` file [here](http://cli.biganimal.com/).
+-   For Windows user:
+    1. Download the SHA256 checksum code for Windows distribution from [here](https://cli.biganimal.com/). and store it as a local file like `biganimal_windows_amd64.sha256`. You can also download the SHA256 checksum file directly by click code link from above page, make sure to verify that the content of downloaded file is idential with the checksum code showed on the page.
     2.  Validate the binary executable file against the checksum file using `CertUtil`:
         ```
-        CertUtil -hashfile biganimal.exe SHA256 type biganiml.sha256
+        CertUtil -hashfile biganimal.exe SHA256 type biganiml_windows_amd64.sha256
         ```
-
+- For MacOS user:
+    1. Download the SHA256 checksum code for MacOS distribution from [here](https://cli.biganimal.com/). and store it as a local file, e.g. `biganimal_darwin_amd64.sha256`. You can also download the SHA256 checksum file directly by click code link from above page, make sure to verify that the content of downloaded file is idential with the checksum code showed on the page.
+    2. From MacOS terminal, validate the binary executable file against the checksum file:
+        ```
+        echo "$(<biganimal_darwin_amd64.sha256)  biganimal" | shasum -c
+        ```
 ## Command reference
 
 Use the `-h` or `--help` flags for more information on the CLI commands. You can use the flag on the `biganimal` command to get a listing of all the available commands (`biganimal -h`) or on a subcommand to get information on that particular command (for example, `biganimal create-cluster -h`).


### PR DESCRIPTION
## What Changed?

biganimal CLI binary checksum verification guide has some inaccurate description and wrong sample commands. This PR is to correct these bugs, and add more sample command for different platforms.

**Examples**

- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
