### PR TITLE
Use '-kvno 0' while generating the keytab files.

### DIFF
--- a/product_docs/docs/pem/8/pem_inst_guide_linux/04_installing_postgres_enterprise_manager/07_configuring_the_pem_server_to_use_windows_kerberos_server.mdx
+++ b/product_docs/docs/pem/8/pem_inst_guide_linux/04_installing_postgres_enterprise_manager/07_configuring_the_pem_server_to_use_windows_kerberos_server.mdx
@@ -54,8 +54,8 @@ Follow the steps to configure the Kerberos Authentication for the PEM Server:
 a.  Open `Windows PowerShell` as an `Administrator` user, create a Key Table for HTTP Service Principal mapping with user `pemserverweb` and a Key Table for Postgres Service Principal mappping with user `pemserverdb`.
 
 ```text
-ktpass /out pemserver.keytab /princ HTTP/pem.edbpem.internal@EDBPEM.INTERNAL /mapuser pemserverweb /crypto AES256-SHA1 +rndpass /target EDBPEM.INTERNAL -ptype KRB5_NT_PRINCIPAL
-ktpass /out pemdb.keytab /princ postgres/pem.edbpem.internal@EDBPEM.INTERNAL /mapuser pemserverdb /crypto AES256-SHA1 +rndpass /target EDBPEM.INTERNAL -ptype KRB5_NT_PRINCIPAL
+ktpass /out pemserver.keytab /princ HTTP/pem.edbpem.internal@EDBPEM.INTERNAL /mapuser pemserverweb /crypto AES256-SHA1 +rndpass /target EDBPEM.INTERNAL -ptype KRB5_NT_PRINCIPAL -kvno 0
+ktpass /out pemdb.keytab /princ postgres/pem.edbpem.internal@EDBPEM.INTERNAL /mapuser pemserverdb /crypto AES256-SHA1 +rndpass /target EDBPEM.INTERNAL -ptype KRB5_NT_PRINCIPAL -kvno 0
 ```
 
 Where,


### PR DESCRIPTION
## What Changed?

When customer uses the same SPN (Domain User) for generating the keytab files, it ends up updating 'kvno' on every newly generated keytab files, and he won't be able to login to PEM Server ever.
