### PR TITLE
Really did need to use docs2

### DIFF
--- a/scripts/source/bdr.js
+++ b/scripts/source/bdr.js
@@ -20,7 +20,7 @@ const isAbsoluteUrl = require("is-absolute-url");
 
 const fileToMetadata = {};
 const args = process.argv.slice(2);
-const basePath = path.resolve(args[0], "docs/");
+const basePath = path.resolve(args[0], "docs/docs2/");
 const imgPath = path.resolve(args[0], "docs/img/");
 const destination = path.resolve(args[1]);
 


### PR DESCRIPTION
## What Changed?

I was wrong. We really do need to use docs2 that only shows up in release branches. 