### PR TITLE
typo in word "primary"

### DIFF
--- a/product_docs/docs/efm/4/05_using_efm.mdx
+++ b/product_docs/docs/efm/4/05_using_efm.mdx
@@ -95,7 +95,7 @@ For example, if the properties file on node `10.0.1.10` includes a setting of `p
 efm set-priority acctg 10.0.1.10 1
 ```
 
-In the event of a failover, Failover Manager first retrieves information from Postgres streaming replication to confirm which standby node has the most recent data and promote the node with the least chance of data loss. If two standby nodes contain equally up-to-date data, the node with a higher user-specified priority value is promoted to orimary unless [use.replay.tiebreaker](04_configuring_efm/01_cluster_properties/#use_replay_tiebreaker) is set to `true`. To check the priority value of your standby nodes, use the command:
+In the event of a failover, Failover Manager first retrieves information from Postgres streaming replication to confirm which standby node has the most recent data and promote the node with the least chance of data loss. If two standby nodes contain equally up-to-date data, the node with a higher user-specified priority value is promoted to primary unless [use.replay.tiebreaker](04_configuring_efm/01_cluster_properties/#use_replay_tiebreaker) is set to `true`. To check the priority value of your standby nodes, use the command:
 
 `efm cluster-status <cluster_name>`
 


### PR DESCRIPTION
change "orimary" to "primary". EFM-1508


**Content**

- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
