### PR TITLE
Update setup_ha_using_efm.mdx

### DIFF
--- a/product_docs/docs/pem/8/pem_ha_setup/setup_ha_using_efm.mdx
+++ b/product_docs/docs/pem/8/pem_ha_setup/setup_ha_using_efm.mdx
@@ -235,6 +235,15 @@ This ensures that webserver is configured on the standby and is disabled by defa
     $ sudo chmod 640 /root/.pem/agent1.crt
 ```
 
+9. Disable & Stop Httpd & PEM Agent services if they are running on all replica nodes.
+
+```text
+systemctl disable httpd
+systemctl disable pemagent
+systemctl stop httpd
+systemctl stop pemagent
+```
+
 !!! Note
     At this point you should have a PEM Primary Server and two standbys that are ready to take over from the primary whenever needed.
 
@@ -294,17 +303,20 @@ This ensures that webserver is configured on the standby and is disabled by defa
 2.  Create the scripts on each node to start/stop the PEM Agent:
 
     ```text
-        $ sudo cat > /usr/local/bin/start-pemagent.sh << _EOF_
+        $ sudo cat > /usr/local/bin/start-httpd-pemagent.sh << _EOF_
         #!/bin/sh
-
+        /bin/sudo /bin/systemctl enable httpd
+        /bin/sudo /bin/systemctl start httpd
         /bin/sudo /bin/systemctl enable pemagent
         /bin/sudo /bin/systemctl start pemagent
         _EOF_
-        $ sudo cat > /usr/local/bin/stop-pemagent.sh << _EOF_
+        $ sudo cat > /usr/local/bin/stop-httpd-pemagent.sh << _EOF_
         #!/bin/sh
 
         /bin/sudo /bin/systemctl stop pemagent
         /bin/sudo /bin/systemctl disable pemagent
+        /bin/sudo /bin/systemctl stop httpd
+        /bin/sudo /bin/systemctl disable httpd
         _EOF_
         $ sudo chmod 770 /usr/local/bin/start-pemagent.sh
         $ sudo chmod 770 /usr/local/bin/stop-pemagent.sh
@@ -318,6 +330,7 @@ This ensures that webserver is configured on the standby and is disabled by defa
         efm    ALL=(ALL)           NOPASSWD:   /bin/systemctl disable pemagent
         efm    ALL=(ALL)           NOPASSWD:   /bin/systemctl stop pemagent
         efm    ALL=(ALL)           NOPASSWD:   /bin/systemctl start pemagent
+        efm    ALL=(ALL)           NOPASSWD:   /bin/systemctl status pemagent
         _EOF_
     ```
 

--- a/product_docs/docs/pem/8/pem_ha_setup/setup_ha_using_efm.mdx
+++ b/product_docs/docs/pem/8/pem_ha_setup/setup_ha_using_efm.mdx
@@ -238,10 +238,10 @@ This ensures that webserver is configured on the standby and is disabled by defa
 9. Disable & Stop Httpd & PEM Agent services if they are running on all replica nodes.
 
 ```text
-systemctl disable httpd
-systemctl disable pemagent
-systemctl stop httpd
 systemctl stop pemagent
+systemctl stop httpd
+systemctl disable pemagent
+systemctl disable httpd
 ```
 
 !!! Note


### PR DESCRIPTION
Added httpd steps to the document. In PEM HA, only one Httpd & pemagent service will be running which is that time primary, all other nodes the service will be disabled and stopped.

## What Changed?

Please list, at a high level, what changed in your branch. If you changed content, include the product, section, and version as applicable. **Please remove the user instructions including the examples before merging the PR.**

**Examples**

- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
