### PR TITLE
Updated MP 3.5 rel notes

### DIFF
--- a/product_docs/docs/migration_portal/3.5.0/01_mp_release_notes/index.mdx
+++ b/product_docs/docs/migration_portal/3.5.0/01_mp_release_notes/index.mdx
@@ -10,9 +10,11 @@ New features, enhancements, bug fixes, and other changes in Migration Portal 3.5
 
 | Type | Description |
 | ---- |------------ |
-| Enhancement | Migration Portal is now certified to support migrations to EDB Postgres Advanced Server 14. |
-| Enhancement | Migration Portal now requires the schema metadata that is uploaded for assessment to be a SQL dump file generated using the Oracle EXPDP and IMPDP Data Pump utilities according to the instructions provided in [Performing a schema extraction](../04_mp_migrating_database/01_mp_schema_extraction/). Schema metadata extracted using the previously supplied EDB DDL Extractor script is not supported in this version of the Migration Portal.|
+| Change | Migration Portal now requires the schema metadata that is uploaded for assessment to be a SQL dump file generated using the Oracle EXPDP and IMPDP Data Pump utilities according to the instructions provided in [Performing a schema extraction](../04_mp_migrating_database/01_mp_schema_extraction/). Schema metadata extracted using the previously supplied EDB DDL Extractor script is not supported in this version of the Migration Portal.|
 | Feature| Updated repair handler to remove OVERFLOW syntax from CREATE TABLE syntax to make it compatible with EDB Postgres Advanced Server compatible syntax. (ERH-2011: ORGANIZATION_INDEX_COMPRESS).|
 | Feature| Added a repair handler to remove the NAME clause and associated label name from SET TRANSACTION statements. (ERH-3002: SET_TRANSACTION).|
 | Enhancement | Improved the user interface for a better user experience. |
+| Enhancement | Migration Portal is now certified to support migrations to EDB Postgres Advanced Server 14. |
+
+
 

--- a/product_docs/docs/migration_portal/3.5.0/01_mp_release_notes/index.mdx
+++ b/product_docs/docs/migration_portal/3.5.0/01_mp_release_notes/index.mdx
@@ -11,7 +11,7 @@ New features, enhancements, bug fixes, and other changes in Migration Portal 3.5
 | Type | Description |
 | ---- |------------ |
 | Enhancement | Migration Portal is now certified to support migrations to EDB Postgres Advanced Server 14. |
-| Enhancement | Migration Portal now uses the metadata information in a SQL dump file to assess the extracted schemas. You no longer have to download the DDL extractor script to extract DDLs for your schemas. |
+| Enhancement | Migration Portal now requires the schema metadata that is uploaded for assessment to be a SQL dump file generated using the Oracle EXPDP and IMPDP Data Pump utilities according to the instructions provided in [Performing a schema extraction](../04_mp_migrating_database/01_mp_schema_extraction/). Schema metadata extracted using the previously supplied EDB DDL Extractor script is not supported in this version of the Migration Portal.|
 | Feature| Updated repair handler to remove OVERFLOW syntax from CREATE TABLE syntax to make it compatible with EDB Postgres Advanced Server compatible syntax. (ERH-2011: ORGANIZATION_INDEX_COMPRESS).|
 | Feature| Added a repair handler to remove the NAME clause and associated label name from SET TRANSACTION statements. (ERH-3002: SET_TRANSACTION).|
 | Enhancement | Improved the user interface for a better user experience. |


### PR DESCRIPTION
## What Changed?

Clarified in the rel notes that Migration Portal 3.5.0 no longer supports the assessment of files generated by the previously provided EDB DDL extractor