### PR TITLE
EPAS:  cleaning up Language Pack content

### DIFF
--- a/product_docs/docs/epas/10/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/10/language_pack/01_supported_database_server_versions.mdx
@@ -4,7 +4,4 @@ title: "Supported Database Server Versions"
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack v10 is tested on:
-
-- EDB Postgres Advanced Server version 10
-- PostgreSQL version 10
+Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 10, use Language Pack Version 1.

--- a/product_docs/docs/epas/10/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/10/language_pack/01_supported_database_server_versions.mdx
@@ -4,4 +4,4 @@ title: "Supported Database Server Versions"
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 10, use Language Pack Version 1.
+Language Pack installers are version specific. For EDB Postgres Advanced Server 10, use Language Pack Version 1.

--- a/product_docs/docs/epas/10/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/10/language_pack/03_using_the_procedural_languages.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use a native package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/10/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/10/language_pack/03_using_the_procedural_languages.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Java) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. For more information about using an RPM package, see the *EDB Postgres Advanced Server Installation Guide*.
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/10/language_pack/index.mdx
+++ b/product_docs/docs/epas/10/language_pack/index.mdx
@@ -7,17 +7,17 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-advanced-server/user-guides/language-pack-guide/10/EDB_Postgres_Language_Pack_Guide.1.01.html"
 ---
 
-This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/TCL).
+This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/Tcl).
 
-Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, TCL/TK, and Python without installing supporting software from third-party vendors.
+Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, Tcl/TK, and Python without installing supporting software from third-party vendors.
 
 The Language Pack installer includes:
 
--   TCL with TK version 8.6
+-   Tcl with TK version 8.6
 -   Perl version 5.24
 -   Python version 3.4
 
-The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for TCL/TK.
+The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for Tcl/TK.
 
 In previous Postgres releases, `plpython` was statically linked with ActiveState's python library. The Language Pack Installer dynamically links with our shared object for python. In ActiveState Linux installers for Python, there is no dynamic library. As a result of these changes, `plpython` will no longer work with ActiveState installers.
 
@@ -25,8 +25,4 @@ In previous Postgres releases, `plpython` was statically linked with ActiveState
 
 The term *Postgres* refers to either PostgreSQL or EDB Postgres Advanced Server.
 
-<div class="toctree" maxdepth="3">
 
-supported_database_server_versions installing_language_pack using_the_procedural_languages uninstalling_language_pack conclusion
-
-</div>

--- a/product_docs/docs/epas/11/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/11/language_pack/01_supported_database_server_versions.mdx
@@ -4,4 +4,4 @@ title: "Supported Database Server Versions"
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 11, use Language Pack Version 1.
+Language Pack installers are version specific. For EDB Postgres Advanced Server 11, use Language Pack Version 1.

--- a/product_docs/docs/epas/11/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/11/language_pack/01_supported_database_server_versions.mdx
@@ -4,7 +4,4 @@ title: "Supported Database Server Versions"
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack v11 is tested on:
-
-- EDB Postgres Advanced Server version 11
-- PostgreSQL version 11
+Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 11, use Language Pack Version 1.

--- a/product_docs/docs/epas/11/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/11/language_pack/03_using_the_procedural_languages.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use a native package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/11/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/11/language_pack/03_using_the_procedural_languages.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Java) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. For more information about using an RPM package, see the *EDB Postgres Advanced Server Installation Guide*.
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/11/language_pack/index.mdx
+++ b/product_docs/docs/epas/11/language_pack/index.mdx
@@ -7,17 +7,17 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-advanced-server/user-guides/language-pack-guide/11/toc.html"
 ---
 
-This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/TCL).
+This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/Tcl).
 
-Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, TCL/TK, and Python without installing supporting software from third-party vendors.
+Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, Tcl/TK, and Python without installing supporting software from third-party vendors.
 
 The Language Pack installer includes:
 
--   TCL with TK version 8.6.8
+-   Tcl with TK version 8.6.8
 -   Perl version 5.26.2
 -   Python version 3.6.8
 
-The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for TCL/TK.
+The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for Tcl/TK.
 
 In previous Postgres releases, `plpython` was statically linked with ActiveState's python library. The Language Pack Installer dynamically links with our shared object for python. In ActiveState Linux installers for Python, there is no dynamic library. As a result of these changes, `plpython` will no longer work with ActiveState installers.
 

--- a/product_docs/docs/epas/12/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/12/language_pack/01_supported_database_server_versions.mdx
@@ -7,15 +7,4 @@ legacyRedirectsGenerated:
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific. Select the Language Pack installer that corresponds to your EDB Postgres Advanced Server or PostgreSQL server version that are installed through interactive installer.
-
-| Operating System     | Product and Version                                   | Language Pack Version | Procedural Language Version          |
-| -----------------    | ----------------------------------------------------- | ----------------------| ------------------------------------ |
-| Linux (64-bit)       | EDB Postgres Advanced Server `9.6`,`10`               | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| Linux (32-bit/64-bit)| PostgreSQL `9.6`, `10`                                | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| MacOS                | PostgreSQL `9.6`,`10`,`11`,`12`                       | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| Windows (32-bit)     | PostgreSQL `9.6`,`10`                                 | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| Windows (64-bit)     | PostgreSQL `9.6`,`10`,`11`,`12`                       | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.8` |
-| Windows (64-bit)     | EDB Postgres Advanced Server `9.6`,`10`,`11`,`12`     | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-
-For detailed information, please see the *EDB Postgres Advanced Server Installation Guide*, available at the [EDB website](/epas/12/).
+Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 12, use Language Pack Version 1.

--- a/product_docs/docs/epas/12/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/12/language_pack/01_supported_database_server_versions.mdx
@@ -7,4 +7,4 @@ legacyRedirectsGenerated:
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 12, use Language Pack Version 1.
+Language Pack installers are version specific. For EDB Postgres Advanced Server 12, use Language Pack Version 1.

--- a/product_docs/docs/epas/12/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/12/language_pack/03_using_the_procedural_languages.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Java) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. For more information about using an RPM package, please see the *EDB Postgres Advanced Server Installation Guide*, available at the [EDB website](/epas/12/).
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/12/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/12/language_pack/03_using_the_procedural_languages.mdx
@@ -10,7 +10,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use a native package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/12/language_pack/index.mdx
+++ b/product_docs/docs/epas/12/language_pack/index.mdx
@@ -7,17 +7,17 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-advanced-server/user-guides/language-pack-guide/12/toc.html"
 ---
 
-This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/TCL).
+This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/Tcl).
 
-Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, TCL/TK, and Python without installing supporting software from third-party vendors.
+Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, Tcl/TK, and Python without installing supporting software from third-party vendors.
 
 The Language Pack 1.0 installer includes:
 
--   TCL with TK version 8.6
+-   Tcl with TK version 8.6
 -   Perl version 5.26
 -   Python version 3.7
 
-The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for TCL/TK.
+The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for Tcl/TK.
 
 In previous Postgres releases, `plpython` was statically linked with ActiveState's python library. The Language Pack Installer dynamically links with our shared object for python. In ActiveState Linux installers for Python, there is no dynamic library. As a result of these changes, `plpython` will no longer work with ActiveState installers.
 

--- a/product_docs/docs/epas/13/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/13/language_pack/01_supported_database_server_versions.mdx
@@ -10,15 +10,4 @@ legacyRedirectsGenerated:
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific. Select the Language Pack installer that corresponds to your EDB Postgres Advanced Server or PostgreSQL server version that are installed through interactive installer.
-
-| Operating System     | Product and Version                                   | Language Pack Version | Procedural Language Version          |
-| -----------------    | ----------------------------------------------------- | ----------------------| ------------------------------------ |
-| Linux (64-bit)       | EDB Postgres Advanced Server `9.6`,`10`               | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| Linux (32-bit/64-bit)| PostgreSQL `9.6`, `10`                                | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| MacOS                | PostgreSQL `9.6`,`10`,`11`,`12`,`13`                  | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| Windows (32-bit)     | PostgreSQL `9.6`,`10`                                 | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-| Windows (64-bit)     | PostgreSQL `9.6`,`10`,`11`,`12`,`13`                  | 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.8` |
-| Windows (64-bit)     | EDB Postgres Advanced Server `9.6`,`10`,`11`,`12`,`13`| 1.0                   | Perl `5.26`, Python `3.7`, Tcl `8.6` |
-
-For detailed information, please see the *EDB Postgres Advanced Server Installation Guide*, available at the [EDB website](/epas/latest/).
+Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 13, use Language Pack Version 1.

--- a/product_docs/docs/epas/13/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/13/language_pack/01_supported_database_server_versions.mdx
@@ -10,4 +10,4 @@ legacyRedirectsGenerated:
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 13, use Language Pack Version 1.
+Language Pack installers are version specific. For EDB Postgres Advanced Server 13, use Language Pack Version 1.

--- a/product_docs/docs/epas/13/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/13/language_pack/03_using_the_procedural_languages.mdx
@@ -13,7 +13,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use a native package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/13/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/13/language_pack/03_using_the_procedural_languages.mdx
@@ -13,7 +13,7 @@ legacyRedirectsGenerated:
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Java) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. For more information about using an RPM package, please see the *EDB Postgres Advanced Server Installation Guide*, available at the [EDB website](/epas/latest/).
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/13/language_pack/index.mdx
+++ b/product_docs/docs/epas/13/language_pack/index.mdx
@@ -13,17 +13,17 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-advanced-server/user-guides/language-pack-guide/13/genindex.html"
 ---
 
-This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/TCL).
+This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/Tcl).
 
-Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, TCL/TK, and Python without installing supporting software from third-party vendors.
+Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, Tcl/TK, and Python without installing supporting software from third-party vendors.
 
 The Language Pack 1.0 installer includes:
 
--   TCL with TK version 8.6
+-   Tcl with TK version 8.6
 -   Perl version 5.26
 -   Python version 3.7
 
-The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for TCL/TK.
+The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for Tcl/TK.
 
 In previous Postgres releases, `plpython` was statically linked with ActiveState's python library. The Language Pack Installer dynamically links with our shared object for python. In ActiveState Linux installers for Python, there is no dynamic library. As a result of these changes, `plpython` will no longer work with ActiveState installers.
 

--- a/product_docs/docs/epas/14/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/14/language_pack/01_supported_database_server_versions.mdx
@@ -4,5 +4,5 @@ title: "Supported Database Server Versions"
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 14, use Language Pack Version 2. 
+Language Pack installers are version specific. For EDB Postgres Advanced Server 14, use Language Pack Version 2. 
 

--- a/product_docs/docs/epas/14/language_pack/01_supported_database_server_versions.mdx
+++ b/product_docs/docs/epas/14/language_pack/01_supported_database_server_versions.mdx
@@ -4,31 +4,5 @@ title: "Supported Database Server Versions"
 
 <div id="supported_database_server_versions" class="registered_link"></div>
 
-Language Pack installers are version and platform specific; select the Language Pack installer that corresponds to your EDB Postgres Advanced Server or PostgreSQL server version:
+Language Pack installers are version and platform specific. For EDB Postgres Advanced Server 14, use Language Pack Version 2. 
 
-**Linux:**
-
-| EDB Postgres Advanced Server/PostgreSQL Version | Language Pack Version | Procedural Language Version    |
-| ----------------------------------------------- | --------------------- | ------------------------------ |
-| `9.6, 10`                                       | 1.0                   | Perl 5.26, Python 3.7, Tcl 8.6 |
-
-For detailed information about using an RPM package to add Language Pack, see the *EDB Postgres Advanced Server Installation Guide*, available at the [EDB website](/epas/latest/).
-
-**Mac OS:**
-
-| PostgreSQL Version         | Language Pack Version | Procedural Language Version    |
-| -------------------------- | --------------------- | ------------------------------ |
-| `9.6, 10, 11, 12, 13`      | 1.0                   | Perl 5.26, Python 3.7, Tcl 8.6 |
-
-**Windows 32:**
-
-| EDB Postgres Advanced Server/PostgreSQL Version | Language Pack Version | Procedural Language Version    |
-| ----------------------------------------------- | --------------------- | ------------------------------ |
-| `9.6, 10`                                       | 1.0                   | Perl 5.26, Python 3.7, Tcl 8.6 |
-
-**Windows 64:**
-
-| EDB Postgres Advanced Server/PostgreSQL Version | Language Pack Version | Procedural Language Version    |
-| ----------------------------------------------- | --------------------- | ------------------------------ |
-| `PostgreSQL 9.6, 10, 11, 12, 13`                | 1.0                   | Perl 5.26, Python 3.7, Tcl 8.8 |
-| `EDB Postgres Advanced Server 12`               | 1.0                   | Perl 5.26, Python 3.7, Tcl 8.6 |

--- a/product_docs/docs/epas/14/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/14/language_pack/03_using_the_procedural_languages.mdx
@@ -4,7 +4,7 @@ title: "Using the Procedural Languages"
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use a native package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/14/language_pack/03_using_the_procedural_languages.mdx
+++ b/product_docs/docs/epas/14/language_pack/03_using_the_procedural_languages.mdx
@@ -4,7 +4,7 @@ title: "Using the Procedural Languages"
 
 <div id="using_the_procedural_langauges" class="registered_link"></div>
 
-The Postgres procedural languages (PL/Perl, PL/Python, and PL/Java) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. For more information about using an RPM package, please see the *EDB Postgres Advanced Server Installation Guide*, available at the [EDB website](/epas/latest/).
+The Postgres procedural languages (PL/Perl, PL/Python, and PL/Tcl) are installed by the Language Pack installer. You can also use an RPM package to add procedural language functionality to your EDB Postgres Advanced Server installation. 
 
 ## PL/Perl
 

--- a/product_docs/docs/epas/14/language_pack/index.mdx
+++ b/product_docs/docs/epas/14/language_pack/index.mdx
@@ -3,17 +3,17 @@ navTitle: Language Pack
 title: "EDB Postgres Language Pack Guide"
 ---
 
-This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/TCL).
+This guide provides information about how to install and configure Language Pack, as well as how to use the procedural languages (PL/Perl, PL/Python, and PL/Tcl).
 
-Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, TCL/TK, and Python without installing supporting software from third-party vendors.
+Language pack installers contain supported languages that may be used with EDB Postgres Advanced Server and EnterpriseDB PostgreSQL database installers. The language pack installer allows you to install Perl, Tcl/TK, and Python without installing supporting software from third-party vendors.
 
 The Language Pack 2.0 installer includes:
 
--   TCL with TK version 8.6
+-   Tcl with TK version 8.6
 -   Perl version 5.26
 -   Python version 3.7
 
-The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for TCL/TK.
+The Perl package contains the `cpan` package manager, and Python contains `pip` and `easy_install` package managers. There is no package manager for Tcl/TK.
 
 In previous Postgres releases, `plpython` was statically linked with ActiveState's python library. The Language Pack Installer dynamically links with our shared object for python. In ActiveState Linux installers for Python, there is no dynamic library. As a result of these changes, `plpython` will no longer work with ActiveState installers.
 


### PR DESCRIPTION
## What Changed?

- Removed circular links 
- Clarified Language pack/ EPAS version mapping
- Removed Java reference
- Standardized Tcl capitalization