### PR TITLE
Correctly pass sample code to yaml file module

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -57,7 +57,11 @@ const gitData = (() => {
 exports.onCreateNode = async ({ node, getNode, actions, loadNodeContent }) => {
   const { createNodeField } = actions;
 
-  if (node.internal.mediaType === "text/yaml") loadNodeContent(node);
+  if (node.internal.mediaType === "text/yaml") {
+    // See: https://github.com/gatsbyjs/gatsby/issues/34605
+    const content = await loadNodeContent(node);
+    createNodeField({ node, name: "content", value: content });
+  }
   if (node.internal.type !== "Mdx") return;
 
   const fileNode = getNode(node.parent);

--- a/src/templates/file.js
+++ b/src/templates/file.js
@@ -1,10 +1,11 @@
 import React from "react";
 import { graphql } from "gatsby";
+import CodeBlock from "../components/code-block";
 
 export const query = graphql`
   query ($nodeId: String!) {
     file(id: { eq: $nodeId }) {
-      internal {
+      fields {
         content
       }
     }
@@ -12,7 +13,11 @@ export const query = graphql`
 `;
 
 const FileTemplate = ({ data }) => {
-  return <pre className="p-3">{data.file.internal.content}</pre>;
+  return (
+    <CodeBlock className="p-3 language-yaml">
+      {data.file.fields.content}
+    </CodeBlock>
+  );
 };
 
 export default FileTemplate;


### PR DESCRIPTION
## What Changed?

Apparently later Gatsby 4 releases don't reliably hold onto file content in the graphql database just because it was once retrieved. See: https://github.com/gatsbyjs/gatsby/issues/34605

So... Instead of just retrieving the content and doing nothing with it, explicitly store it in a field and then use that field.