### PR TITLE
Fixed typo "exammple" to "example"

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
@@ -4,7 +4,7 @@ redirects:
  - /biganimal/release/using_cluster/connecting_your_cluster/01_connecting_from_azure/01_private_endpoint/
 ---
 
-This exammple shows how to connect your cluster using Azure Private Endpoint. 
+This example shows how to connect your cluster using Azure Private Endpoint. 
 
 Assume that your cluster is on a subscription called `development` and is being accessed from a Linux client VM on another subscription called `test` with the following properties:
 


### PR DESCRIPTION
Fixed typo "exammple" to "example"