### PR TITLE
EPRS 7.0: doc bug fixes

### DIFF
--- a/product_docs/docs/eprs/7.0/02_overview/04_design_replication_system/03_restrictions_on_replicated_database_objects.mdx
+++ b/product_docs/docs/eprs/7.0/02_overview/04_design_replication_system/03_restrictions_on_replicated_database_objects.mdx
@@ -36,7 +36,7 @@ The following are the restrictions on Oracle database objects:
 
 - You can use Oracle tables with the `RAW` data type in snapshot-only publications but not in synchronization replications.
 
-- You can't repllicate Oracle tables that include the following data types:
+- You can't replicate Oracle tables that include the following data types:
     -   `BFILE`
     -   `BINARY_DOUBLE`
     -   `BINARY_FLOAT`

--- a/product_docs/docs/eprs/7.0/08_xdb_cli/03_xdb_cli_commands/41_taking_mmr_snapshot.mdx
+++ b/product_docs/docs/eprs/7.0/08_xdb_cli/03_xdb_cli_commands/41_taking_mmr_snapshot.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Take a multi-master snapshot (doMMRsnapshot)"
+title: "Take a multi-master snapshot (dommrsnapshot)"
 ---
 
 <div id="taking_mmr_snapshot" class="registered_link"></div>
 
-**For MMR only:** The `doMMRsnapshot` command performs snapshot synchronization on the specified primary node in a multi-master replication system.
+**For MMR only:** The `dommrsnapshot` command performs snapshot synchronization on the specified primary node in a multi-master replication system.
 
 ## Synopsis
 
 ```text
--doMMRsnapshot pubname
+-dommrsnapshot pubname
   –repsvrfile pubsvrfile
   -pubhostdbid dbid
 [ -verboseSnapshotOutput { true | false } ]
@@ -38,7 +38,7 @@ Set this option to `true` if you want to display the output from the snapshot. S
 This example performs snapshot replication on publication `emp_pub` to the target primary node identified by publication database ID 9.
 
 ```text
-$ java -jar edb-repcli.jar -doMMRsnapshot emp_pub \
+$ java -jar edb-repcli.jar -dommrsnapshot emp_pub \
 >   -pubhostdbid 9 \
 >   -repsvrfile ~/pubsvrfile.prop
 Performing snapshot...

--- a/product_docs/docs/eprs/7.0/08_xdb_cli/03_xdb_cli_commands/49_clean_shadow_table_history.mdx
+++ b/product_docs/docs/eprs/7.0/08_xdb_cli/03_xdb_cli_commands/49_clean_shadow_table_history.mdx
@@ -11,7 +11,7 @@ The `cleanshadowhistforpub` command deletes the shadow table history for the spe
 ```text
 -cleanshadowhistforpub pubname
   –repsvrfile pubsvrfile
-[ -MMRdbid dbid_1[,dbid_2 ] ...]
+[ -mmrdbid dbid_1[,dbid_2 ] ...]
 ```
 
 See [Cleaning up shadow table history](#clean_shadow_table_history) for more information.


### PR DESCRIPTION
## What Changed?

Addressed typo mentioned on [XDB-1093](https://enterprisedb.atlassian.net/browse/XDB-1093) (replicate misspelled on (https://www.enterprisedb.com/docs/eprs/latest/02_overview/04_design_replication_system/03_restrictions_on_replicated_database_objects/)

Addressed https://enterprisedb.atlassian.net/browse/XDB-1092 (changed case of MMW in Take a Multi-Master Snapshot (dommrsnapshot)  and Cleaning Up Shadow Table History
(cleanshadowhistforpub) CLI commands