### PR TITLE
Alter BDR, etc. source scripts to sync w/ deletion

### DIFF
--- a/scripts/source/dispatch_product.py
+++ b/scripts/source/dispatch_product.py
@@ -16,7 +16,7 @@ commands = {
     "EnterpriseDB/LiveCompare": f"node {args.workspace}/destination/scripts/source/livecompare.js {args.workspace}/source {args.workspace}/destination --unhandled-rejections=strict",
     "EnterpriseDB/bdr": f"node {args.workspace}/destination/scripts/source/bdr.js {args.workspace}/source {args.workspace}/destination --unhandled-rejections=strict",
     "EnterpriseDB/pglogical": f"node {args.workspace}/destination/scripts/source/pglogical.js {args.workspace}/source {args.workspace}/destination --unhandled-rejections=strict",
-    "EnterpriseDB/harp": f"rsync -a --delete {args.workspace}/source/docs/user_guide/* {args.workspace}/destination/product_docs/docs/harp/2.0",
+    "EnterpriseDB/harp": f"rsync -a --delete {args.workspace}/source/docs/user_guide/ {args.workspace}/destination/product_docs/docs/harp/2.0/",
 }
 
 ret = os.system(

--- a/scripts/source/livecompare.js
+++ b/scripts/source/livecompare.js
@@ -15,6 +15,7 @@ const yaml = require("js-yaml");
 const visit = require("unist-util-visit");
 const visitAncestors = require("unist-util-visit-parents");
 const mdast2string = require("mdast-util-to-string");
+const { exec } = require("child_process");
 const isAbsoluteUrl = require("is-absolute-url");
 
 const fileToMetadata = {};
@@ -38,7 +39,7 @@ const destination = path.resolve(args[1]);
     file.path = destFilepath;
     try {
       await fs.mkdir(path.dirname(file.path), { recursive: true });
-    } catch {}
+    } catch { }
     await write(file);
   };
 
@@ -65,7 +66,7 @@ const destination = path.resolve(args[1]);
       const fileAbsolutePath = path.resolve(basePath, dirEntry[navTitle]);
       const filename = path.relative(basePath, fileAbsolutePath);
       const destFilepath = path.resolve(
-        destPath,
+        basePath,
         filename.replace(/\//g, "_") + "x",
       );
 
@@ -79,16 +80,19 @@ const destination = path.resolve(args[1]);
       );
 
       if (filename === indexFilename) continue;
-      process(fileAbsolutePath, filename, destFilepath);
+      await process(fileAbsolutePath, filename, destFilepath);
     }
   }
 
   // write out index w/ navigation tree
-  process(
+  await process(
     path.resolve(basePath, indexFilename),
     indexFilename,
-    path.resolve(destPath, indexFilename + "x"),
+    path.resolve(basePath, indexFilename + "x"),
   );
+
+  // copy select files, removing those that have been deleted
+  await exec(`rsync --archive --recursive --delete --include="*/" --include="*.mdx" --include="*.png" --include="*.jpg" --include="*.jpeg" --include="*.svg" --exclude="*" ${basePath}/ ${destPath}/`);
 })();
 
 // GPP leaves the files littered with these; they alter parsing by flipping sections to HTML context
@@ -153,7 +157,7 @@ function livecompareTransformer() {
       if (node.value.trim())
         console.warn(
           `${file.path}:${node.position.start.line}:${node.position.start.column} Stripping HTML content:\n\t ` +
-            node.value,
+          node.value,
         );
 
       parent.children.splice(index, 1);
@@ -182,8 +186,8 @@ function livecompareTransformer() {
       const blockTypes = ["root", "paragraph", "listItem", "blockquote"];
       for (
         let i = ancestors.length - 1,
-          parent = ancestors[ancestors.length - 1],
-          child = node;
+        parent = ancestors[ancestors.length - 1],
+        child = node;
         i >= 0;
         --i, child = parent, parent = ancestors[i]
       ) {

--- a/scripts/source/test/sync-bdr.json
+++ b/scripts/source/test/sync-bdr.json
@@ -1,8 +1,7 @@
 {
   "client_payload": {
-     "repo": "EnterpriseDB/bdr",
-     "ref": "2461cd8dbad961935e7cf91e81903d42a1997e5f",
-     "sha": "2461cd8dbad961935e7cf91e81903d42a1997e5f"
-      
+    "repo": "EnterpriseDB/bdr",
+    "ref": "45b2304e8e67e88a2020b6c8a087a3d62d36f47d",
+    "sha": "45b2304e8e67e88a2020b6c8a087a3d62d36f47d"
   }
 }


### PR DESCRIPTION
## What Changed?

BDR, Harp, LiveCompare, pgLogical all need to behave in the same way: newly-added files get brought in, deleted files get removed. 

This was not happening consistently, mostly because these conversion scripts were written to be run manually and sorta expected to be dumping their output in a scratch directory. 

I've altered them to process files in place, and then copy over only select files (mdx, jpg, jpeg, png, svg) - deleting any files of these types that aren't found in the destination subtree. 

(for Harp, only this last sync step is performed)

One small hitch is the images for BDR, which 

1. live in the parent directory from the rest of the content, and
2. don't seem to exist at all in the last sync ref

...so I'm ignoring those for now (using the old sync logic) to avoid deleting them (they're still referenced in the docs). That can be fixed in the future. 