### PR TITLE
BigAnimal: removing note re parameters

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters.mdx
@@ -25,16 +25,8 @@ Not all database configuration parameters are supported by BigAnimal. Some param
 
 2.  Enter the new value in the parameter value field. See [Parameter Names and Values](https://www.postgresql.org/docs/current/config-setting.html#CONFIG-SETTING-NAMES-VALUES) for more information on the types of values parameters accept.
 
-   !!! note
-       You can't decrease the values of the following parameters: 
-       - max_connections
-       - max_locks_per_transaction 
-       - max_prepared_transactions
-       - max_wal_senders
-       - max_worker_processes
-
-   !!! Danger 
-   Parameters identified with a yellow exclamation point icon trigger a restart when you save your changes. The restart terminates all open connections and takes a few minutes to complete. It takes a few more seconds for the new connection to establish. During this process, it isn't possible to connect to the database.
-   !!!
+    !!! Danger 
+    Parameters identified with a yellow exclamation point icon trigger a restart when you save your changes. The restart terminates all open connections and takes a few minutes to complete. It takes a few more seconds for the new connection to establish. During this process, it isn't possible to connect to the database.
+    !!!
 
 3.  Save your changes.


### PR DESCRIPTION
## What Changed?

Removed note saying you can't decrease the values of some parameters