### PR TITLE
Updated link in table to list of supported PL/SQL packages

### DIFF
--- a/advocacy_docs/migrating/oracle/oracle_epas_comparison/app_devel_capabilities.mdx
+++ b/advocacy_docs/migrating/oracle/oracle_epas_comparison/app_devel_capabilities.mdx
@@ -25,7 +25,7 @@ Databases are a foundation of today’s data-driven enterprise, and applications
 | VARRAYS                             | Yes                            | Yes ✓                       |
 | Hierarchical queries                | Yes                            | Yes ✓                       |
 | Parallel query                      | Yes                            | Yes ✓                       |
-| PL/SQL supplied packages            | Yes                            | Yes <br/> (See [EDB Postgres Advanced Server-compatible package support](#edb_postgres_advanced_server_compatible_package_support)) |
+| PL/SQL supplied packages            | Yes                            | Yes <br/> (See [EDB Postgres Advanced Server-compatible package support](#edb-postgres-advanced-server-compatible-package-support)) |
 | PRAGMA RESTRICT_REFERENCES          | Yes                            | Yes ✓                       |
 | PRAGMA EXCEPTION_INIT               | Yes                            | Yes ✓                       |
 | PRAGMA AUTONOMOUS_TRANSACTION       | Yes                            | Yes ✓                       |


### PR DESCRIPTION
## What Changed?

Updated the link location for the list of supported PL/SQL packages.  The references had underscores in the location.  Changed to dashes.