### PR TITLE
Typo in parameter name

### DIFF
--- a/product_docs/docs/bdr/4.0/conflicts.mdx
+++ b/product_docs/docs/bdr/4.0/conflicts.mdx
@@ -790,7 +790,7 @@ is not the case, conflict resolution will tend to favour the node that
 is further ahead. Clock skew between nodes can be managed using the
 parameters `bdr.maximum_clock_skew` and `bdr.maximum_clock_skew_action`.
 
-Row origins are only available if track_commit_timestamps = on.
+Row origins are only available if track_commit_timestamp = on.
 
 Conflicts are initially detected based upon whether the replication
 origin has changed or not, so conflict triggers will be called in


### PR DESCRIPTION
## What Changed?

Fixed typo in the parameter name `track_commit_timestamp`.

## Checklist


**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
