### PR TITLE
BigAnimal: AWS regions

### DIFF
--- a/product_docs/docs/biganimal/release/overview/03a_region_support.mdx
+++ b/product_docs/docs/biganimal/release/overview/03a_region_support.mdx
@@ -7,37 +7,38 @@ title: "Supported regions"
 When using Azure, you can create a cluster in the following regions:
 
 - North America (NA):
-  - (Canada) Canada Central
-  - (South America) Brazil South
-  - (US) Central US
-  - (US) East US
-  - (US) East US 2
-  - (US) South Central US
-  - (US) West US 2
-  - (US) West US 3
+  - Canada Central (Toronto)
+  - Central US (Iowa)
+  - East US (Virginia)
+  - East US 2 (Virigina)
+  - South Central US (Texas)
+  - West US 2 (Washington)
+  - West US 3 (Arizona)
+- South America (SA):
+  - Brazil South (Sao Paulo)
 - Europe, Middle East, Africa (EMEA)
-  - (Europe) France Central
-  - (Europe) North Europe (Ireland)
-  - (Europe) Norway East
-  - (Europe) UK South
-  - (Europe) West Europe (Netherlands)
+  - France Central (Paris)
+  - North Europe (Ireland)
+  - Norway East (Oslo)
+  - UK South (London)
+  - West Europe (Netherlands)
 - Asia Pacific, Japan (APJ)
-  - (Asia Pacific) Australia East
-  - (Asia Pacific) Japan East
-  - (Asia Pacific) South East Asia (Singapore)
+  - Australia East (New South Wales)
+  - Japan East (Tokyo, Saitama)
+  - South East Asia (Singapore)
 
 ## Supported AWS regions
 
 When using the AWS, you can create a cluster in the following regions:
 
 - United States (US):
-  - us-east-1 (N. Virginia)
-  - us-east-2 (Ohio)
-  - us-west-1 (N. California)
+  - US East 1 (N. Virginia)
+  - US East 2 (Ohio)
+  - US West 1 (N. California)
 - Europe (EU)
-  - eu-west-1 (Ireland)
-  - eu-west-2 (London)
+  - Europe 1 (Ireland)
+  - Europe 2 (London)
 - Asia Pacific (AP)
-  - ap-northeast-1 (Tokyo)
-  - ap-northeast-2 (Seoul)
-  - ap-southeast-1 (Singapore)
+  - Asia Pacific Northeast 1 (Tokyo)
+  - Asia Pacific Northeast 2 (Seoul)
+  - Asia Pacific Sountheast 1 (Singapore)

--- a/product_docs/docs/biganimal/release/overview/03a_region_support.mdx
+++ b/product_docs/docs/biganimal/release/overview/03a_region_support.mdx
@@ -26,11 +26,18 @@ When using Azure, you can create a cluster in the following regions:
   - (Asia Pacific) Japan East
   - (Asia Pacific) South East Asia (Singapore)
 
-## Supported AWS regions for Free Trial
+## Supported AWS regions
 
-When using the AWS Free Trial, you can create a cluster in the following regions:
+When using the AWS, you can create a cluster in the following regions:
 
-- North America (NA):
-  - US-East-1 (N. Virginia)
-- Europe, Middle East, Africa (EMEA)
-  - EU-West-1 (Ireland)
+- United States (US):
+  - us-east-1 (N. Virginia)
+  - us-east-2 (Ohio)
+  - us-west-1 (N. California)
+- Europe (EU)
+  - eu-west-1 (Ireland)
+  - eu-west-2 (London)
+- Asia Pacific (AP)
+  - ap-northeast-1 (Tokyo)
+  - ap-northeast-2 (Seoul)
+  - ap-southeast-1 (Singapore)


### PR DESCRIPTION
## What Changed?

replaced AWS free trial regions (not needed because they are documented in the free trial topic) with the AWS regions