### PR TITLE
Redirect old version not new one

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -122,7 +122,7 @@
 /docs/migration_portal/3.4.0/*  /docs/migration_portal/latest/:splat 301
 /docs/migration_portal/3.5.0/*  /docs/migration_portal/latest/:splat 301
 /docs/migration_portal/3.5.1/*  /docs/migration_portal/latest/:splat 301
-/docs/migration_portal/4.0/*   /docs/migration_portal/latest/:splat 301
+/docs/migration_portal/3.5.2/*   /docs/migration_portal/latest/:splat 301
 
 # FDWs and Connectors
 /docs/hadoop_data_adapter/2.0/*  /docs/hadoop_data_adapter/latest/  301


### PR DESCRIPTION
4.0 should already redirect to latest; need 3.5.2 to do so