### PR TITLE
Update 01_private_endpoint.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
@@ -41,7 +41,7 @@ To walk through an example in your own environment, you need:
 1.  Get the resource group details from the Azure CLI or the Azure portal and note the resource group name. For example, if the cluster's virtual network is `vnet-japaneast`, use the following command: 
 
     ```
-      $ az network vnet list --query "[?name==\'vnet-japaneast\'].resourceGroup" -o json
+      $ az network vnet list --query "[?name==\`vnet-japaneast\`].resourceGroup" -o json
 
     ```
 


### PR DESCRIPTION
## What Changed?

Fixed an incorrect escaped character on 01_private_endpoint.mdx

**Examples**

- `"[?name==\'vnet-eastus\'].resourceGroup"` changed to "[?name==\`vnet-eastus\`].resourceGroup"

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
