### PR TITLE
Make the demo text provider agnostic

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
@@ -4,7 +4,7 @@ navTitle: "Oracle SQL compatibility"
 showInteractiveBadge: true
 ---
 
-BigAnimal lets you run Oracle SQL queries in the cloud via [EDB Postgres Advanced Server](https://www.enterprisedb.com/docs/epas/latest/epas_compat_ora_dev_guide/). This topic demonstrates two Oracle SQL-syntax queries running unmodified on a BigAnimal test cluster, populated with the [Chinook sample database](https://github.com/lerocha/chinook-database).
+BigAnimal lets you run Oracle SQL queries in the cloud via [EDB Postgres Advanced Server](/epas/latest/epas_compat_ora_dev_guide/). This topic demonstrates two Oracle SQL-syntax queries running unmodified on a BigAnimal test cluster, populated with the [Chinook sample database](https://github.com/lerocha/chinook-database).
 
 Watch the video, or load up psql and follow along below!
 
@@ -18,18 +18,16 @@ Watch the video, or load up psql and follow along below!
 
 ## Connecting to the demo cluster with psql
 
-You can use any recent version of psql to connect to EDB Postgres Advanced Server. If you choose to use the version that ships with Advanced Server, you'll get a few nice SQL\*Plus compatibility features (with more availability in [EDB\*Plus](https://www.enterprisedb.com/docs/epas/latest/edb_plus/)). The queries and commands that we'll examine here will work the same in either version of psql. For convenience, these examples use the version of psql available in Azure's Cloud Shell; you can launch this directly from the Azure portal, or on your desktop using Windows Terminal:
+You can use any recent version of psql to connect to EDB Postgres Advanced Server. If you choose to use the version that ships with Advanced Server, you'll get a few nice SQL\*Plus compatibility features (with more availability in [EDB\*Plus](https://www.enterprisedb.com/docs/epas/latest/edb_plus/)). The queries and commands that we'll examine here will work the same in either version of psql. For convenience, these examples use the version of psql available in the EDB Postgres Advanced Server container image used by Cloud Native PostgreSQL (and internally by BigAnimal). You can follow along by [installing Docker](https://docs.docker.com/get-docker/) and running:
 
 ```shell
-Welcome to Azure Cloud Shell
-
-Type "az" to use Azure CLI
-Type "help" to learn about Cloud Shell
-
-$
+docker pull quay.io/enterprisedb/edb-postgres-advanced
+docker run --rm -it quay.io/enterprisedb/edb-postgres-advanced /bin/bash
+__OUTPUT__
+[postgres@0fe3c244563c /]$ 
 ```
 
-The connection string for the demo Advanced Server cluster looks like this:
+The connection string for this demo's Advanced Server cluster looks like this:
 
 ```
 postgres://demo:password@p-xj6qj8i1hx.qsbilba3hlgp1vqr.biganimal.io:5432/chinook?sslmode=require
@@ -55,9 +53,7 @@ With that in hand, we can launch psql:
 ```shell
 psql postgres://demo:password@p-xj6qj8i1hx.qsbilba3hlgp1vqr.biganimal.io:5432/chinook?sslmode=require
 __OUTPUT__
-psql (13.0 (Debian 13.0-1.pgdg100+1), server 13.4.8 (Debian 13.4.8-1+deb10))
-WARNING: psql major version 13, server major version 13.
-         Some psql features might not work.
+psql (14.2.1, server 13.6.10 (Debian 13.6.10-1+deb10))
 SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
 Type "help" for help.
 
@@ -69,23 +65,21 @@ Let's take a look at the schema:
 ```
 \dt
 __OUTPUT__
-                          List of relations
- Schema |                Name                 | Type  |     Owner
---------+-------------------------------------+-------+---------------
- public | album                               | table | edb_admin
- public | artist                              | table | edb_admin
- public | customer                            | table | edb_admin
- public | employee                            | table | edb_admin
- public | genre                               | table | edb_admin
- public | invoice                             | table | edb_admin
- public | invoiceline                         | table | edb_admin
- public | mediatype                           | table | edb_admin
- public | playlist                            | table | edb_admin
- public | playlisttrack                       | table | edb_admin
- public | track                               | table | edb_admin
- sys    | callback_queue_table                | table | postgres
- sys    | dual                                | table | postgres
- ...
+             List of relations
+ Schema |     Name      | Type  |   Owner   
+--------+---------------+-------+-----------
+ public | album         | table | edb_admin
+ public | artist        | table | edb_admin
+ public | customer      | table | edb_admin
+ public | employee      | table | edb_admin
+ public | genre         | table | edb_admin
+ public | invoice       | table | edb_admin
+ public | invoiceline   | table | edb_admin
+ public | mediatype     | table | edb_admin
+ public | playlist      | table | edb_admin
+ public | playlisttrack | table | edb_admin
+ public | track         | table | edb_admin
+(11 rows)
 ```
 
 There's an employee table, let's examine its definition:
@@ -94,24 +88,31 @@ There's an employee table, let's examine its definition:
 \d+ employee
 __OUTPUT__
                                               Table "public.employee"
-   Column   |            Type             | Collation | Nullable | Default | Storage  | Stats target | Description
+   Column   |            Type             | Collation | Nullable | Default | Storage  | Stats target | Description 
 ------------+-----------------------------+-----------+----------+---------+----------+--------------+-------------
- employeeid | numeric                     |           | not null |         | main     |              |
- lastname   | character varying(20)       |           | not null |         | extended |              |
- firstname  | character varying(20)       |           | not null |         | extended |              |
- title      | character varying(30)       |           |          |         | extended |              |
- reportsto  | numeric                     |           |          |         | main     |              |
- birthdate  | timestamp without time zone |           |          |         | plain    |              |
- hiredate   | timestamp without time zone |           |          |         | plain    |              |
- address    | character varying(70)       |           |          |         | extended |              |
- city       | character varying(40)       |           |          |         | extended |              |
- state      | character varying(40)       |           |          |         | extended |              |
- country    | character varying(40)       |           |          |         | extended |              |
- postalcode | character varying(10)       |           |          |         | extended |              |
- phone      | character varying(24)       |           |          |         | extended |              |
- fax        | character varying(24)       |           |          |         | extended |              |
- email      | character varying(60)       |           |          |         | extended |              |
-...
+ employeeid | numeric                     |           | not null |         | main     |              | 
+ lastname   | character varying(20)       |           | not null |         | extended |              | 
+ firstname  | character varying(20)       |           | not null |         | extended |              | 
+ title      | character varying(30)       |           |          |         | extended |              | 
+ reportsto  | numeric                     |           |          |         | main     |              | 
+ birthdate  | timestamp without time zone |           |          |         | plain    |              | 
+ hiredate   | timestamp without time zone |           |          |         | plain    |              | 
+ address    | character varying(70)       |           |          |         | extended |              | 
+ city       | character varying(40)       |           |          |         | extended |              | 
+ state      | character varying(40)       |           |          |         | extended |              | 
+ country    | character varying(40)       |           |          |         | extended |              | 
+ postalcode | character varying(10)       |           |          |         | extended |              | 
+ phone      | character varying(24)       |           |          |         | extended |              | 
+ fax        | character varying(24)       |           |          |         | extended |              | 
+ email      | character varying(60)       |           |          |         | extended |              | 
+Indexes:
+    "pk_employee" PRIMARY KEY, btree (employeeid)
+Foreign-key constraints:
+    "fk_employeereportsto" FOREIGN KEY (reportsto) REFERENCES employee(employeeid)
+Referenced by:
+    TABLE "customer" CONSTRAINT "fk_customersupportrepid" FOREIGN KEY (supportrepid) REFERENCES employee(employeeid)
+    TABLE "employee" CONSTRAINT "fk_employeereportsto" FOREIGN KEY (reportsto) REFERENCES employee(employeeid)
+Access method: heap
 ```
 
 This table has a "reportsto" field - that means this is a hierarchical reporting structure, with some employees reporting to
@@ -136,9 +137,9 @@ SELECT firstname, lastname, (
 	) AS "chain of command"
 FROM employee e;
 __OUTPUT__
- firstname | lastname | chain of command
+ firstname | lastname | chain of command 
 -----------+----------+------------------
- Andrew    | Adams    |
+ Andrew    | Adams    | 
  Nancy     | Edwards  | Adams
  Jane      | Peacock  | Edwards, Adams
  Margaret  | Park     | Edwards, Adams
@@ -246,7 +247,7 @@ you to focus your time and expertise on solving new problems.
 
 If you'd like to try these examples on your own BigAnimal cluster, follow these instructions to import the example database.
 
-1. [Connect to your EDB Postgres Advanced Server cluster as edb_admin](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/) using psql. You can grab the command for this from your cluster's Overview tab - it'll look like this (where `<YOUR CLUSTER HOSTNAME>` is specific to your cluster):
+1. [Connect to your EDB Postgres Advanced Server cluster as edb_admin](/biganimal/latest/using_cluster/02_connecting_your_cluster/) using psql. You can grab the command for this from your cluster's Overview tab - it'll look like this (where `<YOUR CLUSTER HOSTNAME>` is specific to your cluster):
 
     ```shell
     psql -W "postgres://edb_admin@<YOUR CLUSTER HOSTNAME>:5432/edb_admin?sslmode=require"
@@ -268,7 +269,7 @@ If you'd like to try these examples on your own BigAnimal cluster, follow these 
     ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO demo;
     ```
 
-    See [Details on managing access in BigAnimal databases](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/01_postgres_access/) for more information.
+    See [Details on managing access in BigAnimal databases](/biganimal/latest/using_cluster/01_postgres_access/) for more information.
 
 4. Quit psql (`\q`).
 
@@ -276,29 +277,24 @@ If you'd like to try these examples on your own BigAnimal cluster, follow these 
 
     ```shell
     docker pull quay.io/enterprisedb/edb-postgres-advanced
+    docker run --rm -it quay.io/enterprisedb/edb-postgres-advanced /bin/bash
     ```
 
 6. Export the Chinook sample database from EDB's cluster using pg_dump:
 
     ```shell
-    docker run --rm quay.io/enterprisedb/edb-postgres-advanced:latest \
-        pg_dump --format custom \
+    pg_dump --format custom \
         "postgres://demo:password@p-xj6qj8i1hx.qsbilba3hlgp1vqr.biganimal.io:5432/chinook?sslmode=require" \
         > chinook.dump
     ```
 
-    If you're not using the Docker container, you can omit the first `docker run` line.
-
 7. Now grab the host name of your cluster from the Connect tab on the BigAnimal portal and use it in place of `<YOUR CLUSTER HOSTNAME>` to invoke pg_restore:
 	
     ```shell
-    docker run --rm -it -v "${PWD}:/tmp/dump" -w /tmp/dump quay.io/enterprisedb/edb-postgres-advanced:latest \
-        pg_restore --no-owner \
+    pg_restore --no-owner \
         -d "postgres://edb_admin@<YOUR CLUSTER HOSTNAME>:5432/chinook?sslmode=require" \
         /tmp/dump/chinook.dump
     ```
-
-    Again, omit the first line if you're using locally-installed tools.
 
     !!! Note 
         You may see an error about pg_stat_statements - you can safely ignore this error.
@@ -317,6 +313,6 @@ If you'd like to try these examples on your own BigAnimal cluster, follow these 
 
 ### Next steps
 
--   Read more on Oracle compatibility features in EDB Postgres Advanced Server: [EDB Advanced Server documentation](https://www.enterprisedb.com/docs/epas/latest/).
+-   Read more on Oracle compatibility features in EDB Postgres Advanced Server: [EDB Advanced Server documentation](/epas/latest/).
 
 -   Learn about [migrating existing databases to BigAnimal](/biganimal/latest/migration/)

--- a/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
@@ -27,6 +27,10 @@ __OUTPUT__
 [postgres@0fe3c244563c /]$ 
 ```
 
+!!! Note
+    If you prefer a graphical tool to execute Oracle syntax compatible queries or run Oracle PL/SQL compatible code, we recommend [pgAdmin](https://www.pgadmin.org/).
+
+
 The connection string for this demo's Advanced Server cluster looks like this:
 
 ```
@@ -117,10 +121,6 @@ Access method: heap
 
 This table has a "reportsto" field - that means this is a hierarchical reporting structure, with some employees reporting to
 other employees who may in turn report to still *other* employees.
-
-!!!note
-If you prefer a graphical tool to execute Oracle syntax compatible queries or run Oracle PL/SQL compatible code, we recommend [pgAdmin](https://www.pgadmin.org/).
-!!!
 
 ## Demo #1: exposing an organization hierarchy with `CONNECT BY`
 


### PR DESCRIPTION
## What Changed?

Resolves #2428 by switching the use of the Azure console to a docker image (which was already used later on for import). 

This is probably more flexible anyway; the Azure console was handy for recording purposes, and served to illustrate the ability to use any ol' psql... But doesn't add a whole lot and could cause confusion with the pending availability of AWS. 

Regarding the video: apart from the use of the Azure console (mentioned briefly near the start) there's nothing at all Azure specific about it; I don't feel like it really benefits from an edit at this point, but if & when I make more substantial revisions in the future I'll probably switch to a Docker setup for that too.

## Preview build 

https://626b19a091409a3c885a846e--edb-docs-staging.netlify.app/docs/biganimal/latest/using_cluster/06_demonstration_oracle_compatibility/

## Requests for review 

@nataliawojcik27 would you mind giving this a look & letting me know if it seems acceptable from the perspective of the AWS launch?

@drothery-edb mind giving my edits a quick sanity check for flow and clarity?

@jericson if you get 10 minutes to spare, please ensure that you're able to complete the demo using the instructions provided?

Thanks, all!

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
