### PR TITLE
Updated supported Oracle versions

### DIFF
--- a/product_docs/docs/migration_toolkit/55/02_supported_operating_systems_and_database_versions.mdx
+++ b/product_docs/docs/migration_toolkit/55/02_supported_operating_systems_and_database_versions.mdx
@@ -11,11 +11,11 @@ You can use the following database product versions with Migration Toolkit:
 
 -   PostgreSQL versions 10, 11, 12, 13, and 14
 -   EDB Postgres Advanced Server versions 10, 11, 12, 13, and 14
--   Oracle 10g Release 2
--   Oracle 11g Release 2
--   Oracle 12c Release 1
--   Oracle 18c Release 1
--   Oracle 19c Release 1
+-   Oracle 10g
+-   Oracle 11g
+-   Oracle 12c
+-   Oracle 18c
+-   Oracle 19c
 -   SQL Server 2008
 -   SQL Server 2012
 -   SQL Server 2014


### PR DESCRIPTION
Removed the release specific information after each listed supported Oracle version on the 02_supported_operating_systems_and_database_versions page.  For example, instead of stating Oracle 12c Release 1, it now simply states Oracle 12c.


