### PR TITLE
Pgbapi fix for selinux

### DIFF
--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/01-installation.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/01-installation.mdx
@@ -79,6 +79,12 @@ Once the packages are installed you can start the pg-backup-api service:
 sudo systemctl start pg-backup-api
 ```
 
+Enable the service so that it is started automatically on reboot:
+
+```bash
+sudo systemctl enable pg-backup-api
+```
+
 Postgres backup API is now serving requests on localhost port 7480.
 Test everything is ok by making a request to the `status` endpoint:
 

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
@@ -194,6 +194,12 @@ sudo chown -R www-data /usr/local/lib/pgbapi
 sudo chown -R apache:apache /usr/local/lib/pgbapi
 ```
 
+If SELinux is enabled you will also need to reset the security context for these files:
+
+```bash
+sudo restorecon -RvF /usr/local/lib/pgbapi
+```
+
 #### SLES
 
 ```bash
@@ -245,6 +251,12 @@ sudo systemctl reload apache2
 
 ```bash
 sudo systemctl reload httpd
+```
+
+If SELinux is enabled you will also need to allow Apache HTTP Server to connect to pg-backup-api:
+
+```bash
+sudo setsebool -P httpd_can_network_connect on
 ```
 
 ### Client configuration

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
@@ -175,9 +175,9 @@ sudo openssl x509 -req \
 Finally, move the CA certificate, the server key and server certificate to a location accessible by the Apache HTTP Server user and ensure correct permissions on the server key:
 
 ```bash
-sudo mkdir -p /usr/lib/pgbapi
-sudo mv /root/ca.cert /root/server.key /root/server.cert /usr/lib/pgbapi
-sudo chmod 600 /usr/lib/pgbapi/server.key
+sudo mkdir -p /usr/local/lib/pgbapi
+sudo mv /root/ca.cert /root/server.key /root/server.cert /usr/local/lib/pgbapi
+sudo chmod 600 /usr/local/lib/pgbapi/server.key
 ```
 
 Setting ownership differs by platform because each Linux distribution flavor runs Apache HTTP Server under a different account.
@@ -185,19 +185,19 @@ Setting ownership differs by platform because each Linux distribution flavor run
 #### Debian/Ubuntu
 
 ```bash
-sudo chown -R www-data /usr/lib/pgbapi
+sudo chown -R www-data /usr/local/lib/pgbapi
 ```
 
 #### RHEL
 
 ```bash
-sudo chown -R apache:apache /usr/lib/pgbapi
+sudo chown -R apache:apache /usr/local/lib/pgbapi
 ```
 
 #### SLES
 
 ```bash
-sudo chown -R wwwrun /usr/lib/pgbapi
+sudo chown -R wwwrun /usr/local/lib/pgbapi
 ```
 
 ### Adding a VirtualHost definition for Postgres backup API
@@ -218,9 +218,9 @@ The contents of `pgbapi.conf` should be as follows:
     ServerName $SERVER_FQDN
     SSLEngine on
 
-    SSLCertificateFile /usr/lib/pgbapi/server.cert
-    SSLCertificateKeyFile /usr/lib/pgbapi/server.key
-    SSLCACertificateFile /usr/lib/pgbapi/ca.cert
+    SSLCertificateFile /usr/local/lib/pgbapi/server.cert
+    SSLCertificateKeyFile /usr/local/lib/pgbapi/server.key
+    SSLCACertificateFile /usr/local/lib/pgbapi/ca.cert
 
     SSLVerifyClient require
     SSLVerifyDepth 1
@@ -229,7 +229,7 @@ The contents of `pgbapi.conf` should be as follows:
     ProxyPassReverse "/" "http://localhost:7480/"
 </VirtualHost>
 ```
-Note that the CA certificate, server certificate and server key are expected to be available in `/usr/lib/pgabi`.
+Note that the CA certificate, server certificate and server key are expected to be available in `/usr/local/lib/pgabi`.
 If your key and certificates are located elsewhere then update the SSL certificate paths as required.
 Be sure to change `$SERVER_FQDN` to its actual value.
 
@@ -257,7 +257,7 @@ The files `/root/ca.cert`, `/root/client.key` and `/root/client.cert` should the
 As an example, curl can be configured to authenticate with a Postgres backup API instance running at `pgbapi.example.com` as follows:
 
 ```bash
-curl --cacert /usr/lib/pgbapi/ca.cert \
+curl --cacert /usr/local/lib/pgbapi/ca.cert \
      --cert /root/client.cert \
      --key /root/client.key \
      https://pgbapi.example.com/status

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
@@ -67,6 +67,12 @@ sudo a2enmod proxy_http
 sudo systemctl restart apache2
 ```
 
+Enable the Apache HTTP Server service so that is started automatically on reboot:
+
+```bash
+sudo systemctl enable apache2
+```
+
 #### RHEL
 
 Stop Apache HTTP Server from listening on port 80:
@@ -79,6 +85,12 @@ Restart Apache HTTP Server:
 
 ```bash
 sudo systemctl restart httpd
+```
+
+Enable the Apache HTTP Server service so that is started automatically on reboot:
+
+```bash
+sudo systemctl enable httpd
 ```
 
 #### SLES
@@ -100,6 +112,12 @@ Restart Apache HTTP Server:
 
 ```bash
 sudo systemctl restart apache2
+```
+
+Enable the Apache HTTP Server service so that is started automatically on reboot:
+
+```bash
+sudo systemctl enable apache2
 ```
 
 ### Obtaining server and client certificates

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
@@ -75,10 +75,10 @@ Stop Apache HTTP Server from listening on port 80:
 sudo sed -i 's/^Listen 80$/#Listen 80/' /etc/httpd/conf/httpd.conf
 ```
 
-Reload the configuration:
+Restart Apache HTTP Server:
 
 ```bash
-sudo systemctl reload httpd
+sudo systemctl restart httpd
 ```
 
 #### SLES

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/02-securing-pg-backup-api.mdx
@@ -177,7 +177,7 @@ Finally, move the CA certificate, the server key and server certificate to a loc
 ```bash
 sudo mkdir -p /usr/lib/pgbapi
 sudo mv /root/ca.cert /root/server.key /root/server.cert /usr/lib/pgbapi
-sudo chmod 600 /usr/lib/pgapi/server.key
+sudo chmod 600 /usr/lib/pgbapi/server.key
 ```
 
 Setting ownership differs by platform because each Linux distribution flavor runs Apache HTTP Server under a different account.


### PR DESCRIPTION
## What Changed?

Updates the instructions for installing and configuring pg-backup-api for the barman product in the supported-open-source section. These are minor fixes which relate to released versions of the products.

- Restart httpd when securing pg-backup-api on RHEL8
- Fix chmod when securing pg-backup-api
- Change location of keys and certs for pg-backup-api
- Add SELinux commands for securing pg-backup-api
- Enable pg-backup-api and httpd services

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
