### PR TITLE
Add documentation for LCR usage during upgrade

### DIFF
--- a/product_docs/docs/pgd/4/upgrades/index.mdx
+++ b/product_docs/docs/pgd/4/upgrades/index.mdx
@@ -2,7 +2,7 @@
 title: "Upgrading"
 ---
 
-Because EDB Distributed Postgres consists in multiple software components,
+Because EDB Postgres Distributed consists in multiple software components,
 the upgrade strategy depends partially on which components are being upgraded.
 
 In general it's possible to upgrade the cluster with almost zero upgrade, by
@@ -16,7 +16,7 @@ mixed versions of software and therefore is the simplest, but obviously incurs
 some downtime and is not recommended unless the Rolling Upgrade is not possible
 for some reason.
 
-To upgrade an EDB Distributed Postgres cluster, perform the following steps:
+To upgrade an EDB Postgres Distributed cluster, perform the following steps:
 
 1. plan the upgrade
 1. prepare for the upgrade

--- a/product_docs/docs/pgd/4/upgrades/index.mdx
+++ b/product_docs/docs/pgd/4/upgrades/index.mdx
@@ -46,6 +46,15 @@ in case of this example), so any new features provided by the newer version
 which require changes in the protocol will be disabled. Once all nodes are
 upgraded to the same version, the new features are automatically enabled.
 
+Similarly, when a cluster with WAL decoder enabled nodes is going through
+rolling upgrade, WAL decoder on higher version of BDR node will produce LCRs
+with higher pglogical version and WAL decoder on lower version of BDR node will
+produce LCRs with lower pglogical version. As a result, WAL senders on higher
+version of BDR node/s are not expected to use LCRs due to mismatch in protocol
+version while on lower version of BDR node/s, WAL senders may continue to use
+LCRs. Once all the BDR nodes are on the same BDR version, WAL senders will use
+LCRs.
+
 A rolling upgrade starts with a cluster with all nodes at a prior release,
 then proceeds by upgrading one node at a time to the newer release, until
 all nodes are at the newer release. There should never be more than 2 versions

--- a/product_docs/docs/pgd/4/upgrades/index.mdx
+++ b/product_docs/docs/pgd/4/upgrades/index.mdx
@@ -18,10 +18,10 @@ for some reason.
 
 To upgrade an EDB Postgres Distributed cluster, perform the following steps:
 
-1. plan the upgrade
-1. prepare for the upgrade
-1. upgrade the server software
-1. check and validate the upgrade
+1. Plan the upgrade.
+1. Prepare for the upgrade.
+1. Upgrade the server software.
+1. Check and validate the upgrade.
 
 ## Upgrade Planning
 
@@ -74,11 +74,11 @@ be used to change the Postgres variant.
 ### Rolling Server Software Upgrades
 
 A rolling upgrade is the process where the [Server
-Software Upgrade](server-software-upgrade) process is performed on each node in the
+Software Upgrade](#server-software-upgrade) process is performed on each node in the
 cluster one after another, while keeping the remainder of the cluster
 operational.
 
-The actual procedure here depends on whether the Postgres component is being
+The actual procedure depends on whether the Postgres component is being
 upgraded to a new major version or not.
 
 During the upgrade process, the application can be switched over to a node
@@ -122,7 +122,7 @@ compatibility with previous releases. These may affect the Postgres
 configuration, deployment scripts, as well as applications using BDR. We
 recommend to consider and possibly adjust in advance of the upgrade.
 
-Please see individual changes mentioned in [release notes](pgd/latest/rel_notes/) and any version
+Please see individual changes mentioned in [release notes](/pgd/latest/rel_notes/) and any version
 specific upgrade notes in this topic.
 
 ## Server Software Upgrade
@@ -217,8 +217,7 @@ standby nodes for reporting or testing.
     Careful scripting is required to make this work correctly
     on production clusters. Extensive testing is advised.
 
-Details of this are covered here
-[Replicating between nodes with differences](/bdr/latest/appusage).
+See [Replicating between nodes with differences](/bdr/latest/appusage) for details.
 
 When one node runs DDL that adds a new table, nodes that have not
 yet received the latest DDL need to handle the extra table.
@@ -276,5 +275,5 @@ underlying column type. Rewrite of a table is normally restricted.
 However, in controlled DBA environments, it is possible to change
 the type of a column to an automatically castable one by adopting
 a rolling upgrade for the type of this column in a non-replicated
-environment on all the nodes, one by one. See [ALTER TABLE](/bdr/latest/ddl)for more details.
+environment on all the nodes, one by one. See [ALTER TABLE](/bdr/latest/ddl) for more details.
  section.

--- a/product_docs/docs/pgd/4/upgrades/index.mdx
+++ b/product_docs/docs/pgd/4/upgrades/index.mdx
@@ -2,63 +2,60 @@
 title: "Upgrading"
 ---
 
-Because EDB Distributed Postgres consist in multiple software components,
-the upgrade strategy depends somewhat on which components are being upgraded.
+Because EDB Distributed Postgres consists in multiple software components,
+the upgrade strategy depends partially on which components are being upgraded.
 
 In general it's possible to upgrade the cluster with almost zero upgrade, by
-using approach called Rolling Upgrade where nodes are upgraded one by one, and
+using an approach called Rolling Upgrade where nodes are upgraded one by one, and
 the application connections are switched over to already upgraded nodes.
 
 Ii's also possible to stop all nodes, perform the upgrade on all nodes and
-only then restart the entire cluster, just like with standard PostgreSQL setup.
+only then restart the entire cluster, just like with a standard PostgreSQL setup.
 This strategy of upgrading all nodes at the same time avoids running with
 mixed versions of software and therefore is the simplest, but obviously incurs
 some downtime and is not recommended unless the Rolling Upgrade is not possible
 for some reason.
 
-To upgrade EDB Distributed Postgres cluster, the following steps need to be
-performed:
+To upgrade an EDB Distributed Postgres cluster, perform the following steps:
 
-* plan the upgrade
-* prepare for the upgrade
-* upgrade the server software
-* check and validate the upgrade
+1. plan the upgrade
+1. prepare for the upgrade
+1. upgrade the server software
+1. check and validate the upgrade
 
 ## Upgrade Planning
 
 There are broadly two ways to upgrade each node.
 
-* Upgrading nodes in-place to the newer software version, this is referred to
-  as Rolling Server Software Upgrades bellow.
+* Upgrading nodes in-place to the newer software version, see [Rolling Server Software Upgrades](#rolling-server-software-upgrades).
 
-* Replacing nodes with ones that have newer version installed, this is referred
-  to as Rolling Upgrade Using Node Join bellow.
+* Replacing nodes with ones that have the newer version installed, see [Rolling Upgrade Using Node Join](#rolling-upgrade-using-node-join).
 
-Both of these approaches can be done in rolling manner.
+Both of these approaches can be done in a rolling manner.
 
 ### Rolling Upgrade considerations
 
 While the cluster is going through a rolling upgrade, mixed versions of software
-are running in the cluster. For example, nodeA will have BDR 3.7.16, while
-nodeB and nodeC will have 4.1.0. In this state, the replication and group
-management will use the protocol and features from the oldest version (3.7.16
+are running in the cluster. For example, nodeA has BDR 3.7.16, while
+nodeB and nodeC has 4.1.0. In this state, the replication and group
+management uses the protocol and features from the oldest version (3.7.16
 in case of this example), so any new features provided by the newer version
-which require changes in the protocol will be disabled. Once all nodes are
+which require changes in the protocol are disabled. Once all nodes are
 upgraded to the same version, the new features are automatically enabled.
 
-Similarly, when a cluster with WAL decoder enabled nodes is going through
-rolling upgrade, WAL decoder on higher version of BDR node will produce LCRs
-with higher pglogical version and WAL decoder on lower version of BDR node will
-produce LCRs with lower pglogical version. As a result, WAL senders on higher
-version of BDR node/s are not expected to use LCRs due to mismatch in protocol
-version while on lower version of BDR node/s, WAL senders may continue to use
-LCRs. Once all the BDR nodes are on the same BDR version, WAL senders will use
+Similarly, when a cluster with WAL decoder enabled nodes is going through a
+rolling upgrade, WAL decoder on a higher version of BDR node produces LCRs
+with a higher pglogical version and WAL decoder on a lower version of BDR node 
+produces LCRs with lower pglogical version. As a result, WAL senders on a higher
+version of BDR nodes are not expected to use LCRs due to a mismatch in protocol
+versions while on a lower version of BDR nodes, WAL senders may continue to use
+LCRs. Once all the BDR nodes are on the same BDR version, WAL senders use
 LCRs.
 
 A rolling upgrade starts with a cluster with all nodes at a prior release,
 then proceeds by upgrading one node at a time to the newer release, until
-all nodes are at the newer release. There should never be more than 2 versions
-of any component running at the same time which means the new upgrade must not
+all nodes are at the newer release. There should never be more than two versions
+of any component running at the same time, which means the new upgrade must not
 be initiated until the previous upgrade process has fully finished on all nodes.
 
 An upgrade process may take an extended period of time when the user decides
@@ -67,22 +64,22 @@ to run the mixed versions of the software indefinitely.
 
 While Rolling Upgrade can be used for upgrading major version of the software
 it is not supported to mix PostgreSQL, EDB Postgres Extended and
-EDB Postgres Advanced in one cluster at the moment, so this approach cannot
+EDB Postgres Advanced Server in one cluster, so this approach cannot
 be used to change the Postgres variant.
 
 !!! Warning
-    Downgrades of the EDB Distributed Postgres are *not* supported and require
+    Downgrades of the EDB Postgres Distributed are *not* supported and require
     manual rebuild of the cluster.
 
 ### Rolling Server Software Upgrades
 
-A rolling upgrade is the process where the below [Server
-Software Upgrade](#Server-Software-Upgrade) is performed on each node in the
+A rolling upgrade is the process where the [Server
+Software Upgrade](server-software-upgrade) process is performed on each node in the
 cluster one after another, while keeping the remainder of the cluster
 operational.
 
 The actual procedure here depends on whether the Postgres component is being
-upgraded to new major version or not.
+upgraded to a new major version or not.
 
 During the upgrade process, the application can be switched over to a node
 which is currently not being upgraded to provide continuous availability of
@@ -90,7 +87,7 @@ the database for applications.
 
 ### Rolling Upgrade Using Node Join
 
-The other method of upgrade of the Server Software, is to join a new node
+The other method of upgrade of the server software, is to join a new node
 to the cluster and later drop one of the existing nodes running
 the older version of the software.
 
@@ -100,15 +97,14 @@ includes node join, the potentially large data transfer is required.
 Care must be taken to not use features that are available only in
 the newer Postgres versions, until all nodes are upgraded to the
 newer and same release of Postgres. This is especially true for any
-new DDL syntax that may have been added to newer release of Postgres.
+new DDL syntax that may have been added to a newer release of Postgres.
 
 !!! Note
-    Note that `bdr_init_physical` makes a byte-by-byte of the source node.
-    So it cannot be used while upgrading from one major Postgres version
-    to another. In fact, currently `bdr_init_physical` requires that even
-    BDR version of the source and the joining node is exactly the same. So
-    it cannot be used for rolling upgrades via joining a new node method. In
-    all such cases, a logical join must be used.
+    `bdr_init_physical` makes a byte-by-byte of the source node
+    so it cannot be used while upgrading from one major Postgres version
+    to another. In fact, currently `bdr_init_physical` requires that even the
+    BDR version of the source and the joining node is exactly the same. 
+    It cannot be used for rolling upgrades via joining a new node method. Instead, a logical join must be used.
 
 ### Upgrading a CAMO-Enabled Cluster
 
@@ -123,15 +119,15 @@ due to the upgrade.
 
 Each major release of the software contains several changes that may affect
 compatibility with previous releases. These may affect the Postgres
-configuration, deployment scripts as well as applications using BDR. We
+configuration, deployment scripts, as well as applications using BDR. We
 recommend to consider and possibly adjust in advance of the upgrade.
 
-Please see individual changes mentioned in release notes and the version
-specific upgrade notes at the end of this chapter.
+Please see individual changes mentioned in [release notes](pgd/latest/rel_notes/) and any version
+specific upgrade notes in this topic.
 
 ## Server Software Upgrade
 
-The upgrade of EDB Distributed Postgres on individual nodes happens in-place.
+The upgrade of EDB Postgres Distributed on individual nodes happens in-place.
 There is no need for backup and restore when upgrading the BDR extension.
 
 ### BDR Extension Upgrade
@@ -147,13 +143,12 @@ of unexpected restart during the upgrade.
 #### Upgrade Packages
 
 The first step in the upgrade is to install the new version of the BDR packages, which
-will install both the new binary and the extension SQL script. This step depends
-on the operating system used
+installs both the new binary and the extension SQL script. This step is operating system-specific.
 
 #### Start Postgres
 
-Once packages are upgrade the Postgres instance can be started, the BDR
-extension will automatically be upgraded upon start when the new binaries
+Once packages are upgraded the Postgres instance can be started, the BDR
+extension is automatically upgraded upon start when the new binaries
 detect older version of the extension.
 
 ### Postgres Upgrade
@@ -163,20 +158,20 @@ upgrading to new minor version of Postgres of to new major version of Postgres.
 
 #### Minor Version Postgres Upgrade
 
-Upgrading to a new minor version of Postgres is pretty much same as upgrading
-the BDR extension as described above. Stopping Postgres, upgrading packages
-and starting Postgres again is normally all that's needed.
+Upgrading to a new minor version of Postgres is similar to [upgrading
+the BDR extension](#bdr-extension-upgrade). Stopping Postgres, upgrading packages,
+and starting Postgres again is typically all that's needed.
 
 However, sometimes additional steps like reindexing may be recommended for
-specific minor version upgrade. Please refer to the Release Notes of the
+specific minor version upgrades. Refer to the Release Notes of the
 specific version of Postgres you are upgrading to.
 
 #### Major Version Postgres Upgrade
 
-Upgrading to new major version of Postgres is more complicated process.
+Upgrading to a new major version of Postgres is a more complicated process.
 
-EDB Postgres Distributed provides command-line utility called `bdr_pg_upgrade`
-which can be used to do [In-place Postgres Major Version Upgrades](bdr_pg_upgrade).
+EDB Postgres Distributed provides a `bdr_pg_upgrade` command line utility,
+which can be used to do a [In-place Postgres Major Version Upgrades](bdr_pg_upgrade).
 
 !!! Note
     When upgrading to new major version of any software, including Postgres, the
@@ -199,18 +194,18 @@ that the upgraded node is working as expected.
 
 Similar to the upgrade of BDR itself, there are two approaches to
 upgrading the application schema.  The simpler option is to stop all
-applications affected, preform the schema upgrade and restart the
-application upgraded to use the new schema variant.  Again, this
+applications affected, preform the schema upgrade, and restart the
+application upgraded to use the new schema variant. Again, this
 imposes some downtime.
 
 To eliminate this downtime, BDR offers ways to perform a rolling
-application schema upgrade as documented in the following section.
+application schema upgrade.
 
 ### Rolling Application Schema Upgrades
 
 By default, DDL will automatically be sent to all nodes. This can be
 controlled manually, as described in
-[DDL Replication](https://www.enterprisedb.com/docs/bdr/ddl), which
+[DDL Replication](/bdr/latest/ddl/), which
 could be used to create differences between database schemas across nodes.
 BDR is designed to allow replication to continue even while minor
 differences exist between nodes. These features are designed to allow
@@ -218,19 +213,19 @@ application schema migration without downtime, or to allow logical
 standby nodes for reporting or testing.
 
 !!! Warning
-    Rolling Application Schema Upgrades have to be managed, not by BDR.
-    Careful scripting will be required to make this work correctly
+    Rolling Application Schema Upgrades have to be managed outside of BDR.
+    Careful scripting is required to make this work correctly
     on production clusters. Extensive testing is advised.
 
 Details of this are covered here
-[Replicating between nodes with differences](https://www.enterprisedb.com/docs/bdr/latest/appusage).
+[Replicating between nodes with differences](/bdr/latest/appusage).
 
 When one node runs DDL that adds a new table, nodes that have not
-yet received the latest DDL will need to cope with the extra table.
+yet received the latest DDL need to handle the extra table.
 In view of this, the appropriate setting for rolling schema upgrades
 is to configure all nodes to apply the `skip` resolver in case of a
 `target_table_missing` conflict. This must be performed before any
-node has additional tables added, and is intended to be a permanent
+node has additional tables added and is intended to be a permanent
 setting.
 
 This is done with the following query, that must be **executed
@@ -243,7 +238,7 @@ SELECT bdr.alter_node_set_conflict_resolver('node1',
 ```
 
 When one node runs DDL that adds a column to a table, nodes that have not
-yet received the latest DDL will need to cope with the extra columns.
+yet received the latest DDL need to handle the extra columns.
 In view of this, the appropriate setting for rolling schema
 upgrades is to configure all nodes to apply the `ignore` resolver in
 case of a `target_column_missing` conflict. This must be performed
@@ -260,17 +255,17 @@ SELECT bdr.alter_node_set_conflict_resolver('node1',
 ```
 
 When one node runs DDL that removes a column from a table, nodes that
-have not yet received the latest DDL will need to cope with the missing column.
+have not yet received the latest DDL need to handle the missing column.
 This situation will cause a `source_column_missing` conflict, which uses
 the `use_default_value` resolver. Thus, columns that neither
-accept NULLs nor have a DEFAULT value will require a two step process:
+accept NULLs nor have a DEFAULT value require a two step process:
 
 1. Remove NOT NULL constraint or add a DEFAULT value for a column
    on all nodes.
 2. Remove the column.
 
 Constraints can be removed in a rolling manner.
-There is currently no supported way for coping with adding table
+There is currently no supported way for handling adding table
 constraints in a rolling manner, one node at a time.
 
 When one node runs a DDL that changes the type of an existing column,
@@ -281,5 +276,5 @@ underlying column type. Rewrite of a table is normally restricted.
 However, in controlled DBA environments, it is possible to change
 the type of a column to an automatically castable one by adopting
 a rolling upgrade for the type of this column in a non-replicated
-environment on all the nodes, one by one. More details are provided in the
-[ALTER TABLE](https://www.enterprisedb.com/docs/bdr/latest/ddl) section.
+environment on all the nodes, one by one. See [ALTER TABLE](/bdr/latest/ddl)for more details.
+ section.


### PR DESCRIPTION
During major version upgrade, WAL senders on higher BDR version nodes
are not expected to use LCRs due to proto_version mismatch. Update the
upgrade documentation with the details.

BDR-2195