### PR TITLE
fix: link to CNPG docs rather than home page

### DIFF
--- a/advocacy_docs/supported-open-source/cloud_native_pg/index.mdx
+++ b/advocacy_docs/supported-open-source/cloud_native_pg/index.mdx
@@ -10,7 +10,7 @@ directoryDefaults:
 CloudNativePG is the Kubernetes operator that covers the full lifecycle of a highly available Postgres database cluster with a primary/standby architecture, using native streaming replication.
 
 !!! Note
-    Looking for CloudNativePG documentation? Head over to [https://cloudnative-pg.io/](https://cloudnative-pg.io/).
+    Looking for CloudNativePG documentation? Head over to [cloudnative-pg.io/docs/](https://cloudnative-pg.io/docs/).
 
 CloudNativePG was originally built by EDB, then released open source under Apache License 2.0 and submitted for CNCF Sandbox in April 2022. The source code repository is in [Github](https://github.com/cloudnative-pg/cloudnative-pg).
 


### PR DESCRIPTION
Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>

## What Changed?

Set the URL to the CNPG docs rather than homepage

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
