### PR TITLE
add property to unique list for >1 agent/node

### DIFF
--- a/product_docs/docs/efm/4/05_using_efm.mdx
+++ b/product_docs/docs/efm/4/05_using_efm.mdx
@@ -221,6 +221,8 @@ The following parameters must be unique in each cluster properties file:
  `db.data.dir`
 
  `virtual.ip` (if used)
+ 
+ `db.service.name` (if used)
 
 In each cluster properties file, the `db.port` parameter specifies a unique value for each cluster. The `db.user` and `db.database` parameter can have the same value or a unique value. For example, the `acctg.properties` file can specify:
 


### PR DESCRIPTION
Each agent has to use a unique service name for the database, or else one cluster might shut down the db being used by another cluster.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [X] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
