### PR TITLE
Fix a couple of links in the openshift doc that referenced docs in the opensource docs

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
@@ -607,7 +607,7 @@ levels (e.g. TLS certificates).
 
 For more information about the reasons why the operator needs these elevated
 permissions, refer to the
-["Security / Cluster / RBAC" section](security.md#role-based-access-control-rbac).
+["Security / Cluster / RBAC" section](https://cloudnative-pg.io/documentation/1.15.0/security/#role-based-access-control-rbac).
 
 ## Users and Permissions
 
@@ -708,7 +708,7 @@ that runs with the `quay.io/enterprisedb/pgbouncer` image.
 
 !!! Note "There's more"
     For more details about pod customization for the pooler, refer to
-    [Pod templates](connection_pooling.md#podtemplates) in the
+    [Pod templates](https://cloudnative-pg.io/documentation/1.15.0/connection_pooling/#podtemplates) in the
     connection pooling documentation.
 
 You can change the image name from the advanced interface, specifically by


### PR DESCRIPTION
## What Changed?

Change a few links to reference content in the open source operator docs

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
