### PR TITLE
CloudNativePG doc link

### DIFF
--- a/advocacy_docs/supported-open-source/cloud_native_pg/index.mdx
+++ b/advocacy_docs/supported-open-source/cloud_native_pg/index.mdx
@@ -42,7 +42,7 @@ redirects:
 CloudNativePG is the Kubernetes operator that covers the full lifecycle of a highly available Postgres database cluster with a primary/standby architecture, using native streaming replication.
 
 !!! Note
-    Looking for CloudNativePG documentation? Head over to [cloudnative-pg.io/docs/](https://cloudnative-pg.io/docs/).
+    Looking for CloudNativePG documentation? Head over to [cloudnative-pg.io/docs/](https://cloudnative-pg.io/documentation/1.15.0/).
 
 CloudNativePG was originally built by EDB, then released open source under Apache License 2.0 and submitted for CNCF Sandbox in April 2022. The source code repository is in [Github](https://github.com/cloudnative-pg/cloudnative-pg).
 


### PR DESCRIPTION
## What Changed?

Sending users directly to the 1.15 doc. We'll need to figure out how to set up links to "lastest" later