### PR TITLE
Explain limitations of Group Commit and Lag control.

### DIFF
--- a/product_docs/docs/bdr/4/functions.mdx
+++ b/product_docs/docs/bdr/4/functions.mdx
@@ -780,6 +780,44 @@ bdr.get_decoding_worker_stat()  &rarr; setof record (pid integer, decoded_upto_l
 
 For further details see [Monitoring WAL senders using LCR](monitoring.md#monitoring-wal-senders-using-lcr).
 
+### bdr.lag_control
+
+If [Lag Control](lag-control.mdx#configuration) is enabled, this function
+shows information about the commit delay and number of nodes conforming
+to their configured lag measure for the local node and current database.
+
+#### Synopsis
+
+```sql
+bdr.lag_control()
+```
+
+#### Output columns
+
+- `commit_delay` - current runtime commit delay in fractional milliseconds
+
+- `commit_delay_maximum` - configured maximum commit delay in fractional milliseconds
+
+- `commit_delay_adjustment` - Change to runtime commit delay possible during
+  a sample interval in fractional milliseconds
+
+- `conforming_nodes` - current runtime number of nodes conforming to lag measures
+
+- `conforming_nodes_minimum` - configured minimum number of nodes required t
+  conform to lag measures, below which a commit delay adjustment is applied
+
+- `lag_bytes_threshold` - lag size at which a commit delay is applied in kilobytes
+
+- `lag_bytes_maximum` - configured maximum lag size in kilobytes
+
+- `lag_time_threshold` - lag time at which a commit delay is applied in milliseconds
+
+- `lag_time_maximum` - configured maximum lag time in milliseconds
+
+- `sample_interval` - configured minimum time between lag samples and possible
+  commit delay adjustments in milliseconds
+
+
 ## Internal Functions
 
 ### BDR Message Payload Functions

--- a/product_docs/docs/bdr/4/group-commit.mdx
+++ b/product_docs/docs/bdr/4/group-commit.mdx
@@ -178,5 +178,20 @@ bdr.remove_commit_scope(commit_scope_name NAME, origin_node_group NAME)
 
 ## Limitations
 
-Group Commit does not currently work with CAMO or Eager All Node
-replication.
+Group Commit cannot be combined with [CAMO](camo) or [Eager All Node
+replication](eager) nor does it offer support for a timeout of the
+commit after `bdr.global_commit_timeout`.
+
+Parallel apply is not currently supported in combination with Group
+Commit, please make sure to disable it when using Group Commit by
+either setting `num_writers` to 1 for the node group (using
+[`bdr.alter_node_group_config`](nodes#bdralter_node_group_config)) or
+via the GUC `bdr.writers_per_subscription` (see
+[Configuration of Generic Replication](configuration#generic-replication)).
+
+There currently is no protection against altering or removing a commit
+scope. Running transactions in a commit scope that is concurrently
+being altered or removed may lead to the transaction blocking or
+replication stalling completely due to an error on the downstream node
+attempting to apply the transaction. Please ensure no transactions are
+running in a specific commit scope before altering or removing it.

--- a/product_docs/docs/bdr/4/lag-control.mdx
+++ b/product_docs/docs/bdr/4/lag-control.mdx
@@ -180,3 +180,15 @@ In the example objectives list earlier:
     pegged at the BDR configured commit delay limit and the lag
     measures consistency exceed their BDR configured maximum
     levels, it can be a marker for BDR group expansion.
+
+## Limitations
+
+The controlled BDR commit delay does not adjust in any way on a fully
+isolated node, i.e. in case all other nodes are unreachable or not
+operational. As soon as at least one node is connected, Replication
+Lag Control will pick up its work and adjust the BDR commit delay,
+again.
+
+For time based lag control, BDR currently uses the lag time (measured
+by commit timestamps) rather than the estimated catchup time that is
+based on historic apply rate.


### PR DESCRIPTION
## What Changed?

- BDR - explain limits of Group Commit and Lag Control
- Also add documentation for the bdr.lag_control function by Charlie

## Checklist

**Content**

- [x] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
