### PR TITLE
Use different list markers for nested ordered lists

### DIFF
--- a/src/styles/_docs.scss
+++ b/src/styles/_docs.scss
@@ -7,6 +7,19 @@ table {
   width: 100% !important; // some docs have table widths set inline :(
 }
 
+// issue #2612: switch up list style for nested ordered lists
+ol ol {
+  list-style: lower-alpha;
+}
+
+ol ol ol {
+  list-style: lower-roman;
+}
+
+ol ol ol ol {
+  list-style: decimal;
+}
+
 .table-with-scroll {
   overflow-x: scroll;
 }
@@ -42,7 +55,8 @@ label.link-label {
   top: 0;
   height: 100vh;
   overflow-x: hidden;
-  overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
+  overflow-y: auto;
+  /* Scrollable contents if viewport is shorter than content. */
 }
 
 @supports ((position: -webkit-sticky) or (position: sticky)) {
@@ -92,6 +106,7 @@ label.link-label {
       color: $gray-300;
     }
   }
+
   &.output-label {
     text-transform: uppercase;
     color: black;
@@ -109,6 +124,7 @@ label.link-label {
   .codeblock-controls {
     background: #d1d1d1;
   }
+
   pre {
     background: #d1d1d1;
     color: #272822;
@@ -149,12 +165,14 @@ html.katacoda-panel-active .katacoda-exec-button {
 .katacoda-start-button {
   min-width: 180px;
   text-align: left;
+
   .cta {
     font-size: 1.2rem;
   }
 }
 
 @media print {
+
   .topbar,
   .sidebar,
   nav {
@@ -166,6 +184,7 @@ html.katacoda-panel-active .katacoda-exec-button {
     body {
       margin-bottom: unset;
     }
+
     .katacoda-panel {
       display: none;
     }
@@ -193,6 +212,7 @@ html.katacoda-panel-active .katacoda-exec-button {
     //font-size: 12px;
     margin-right: 2px;
   }
+
   position: relative;
   top: -0.75rem;
   margin-bottom: -0.75rem;
@@ -213,6 +233,7 @@ html.katacoda-panel-active .katacoda-exec-button {
 .new-thing-header {
   position: relative;
   display: inline;
+
   &::before {
     content: "";
     border-top: 1px solid rgba($orange, 0.3);
@@ -222,6 +243,7 @@ html.katacoda-panel-active .katacoda-exec-button {
     height: 100%;
     position: absolute;
   }
+
   .badge-text {
     color: $orange;
     padding: 4px 10px 4px 5px;


### PR DESCRIPTION
## What Changed?

Fixes #2612

Per @drothery-edb 's request, this alters the styling used for nested ordered lists to make distinguishing the nesting level a bit easier.

![image](https://user-images.githubusercontent.com/63653723/168395514-72fef5e4-db5c-4772-8c91-c1c6c77585f0.png)

There are only about 17 nested ordered lists in the current docs. The only one that looked a bit odd to me can be found here: https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/okta/#:~:text=On%20the%20Assignments%20tab - that's an ordered list within an ordered list within an ordered list. An unusual occurrence... But I added a case for that just to be on the safe side - at 3 levels deep it'll switch to roman numerals. Any deeper than that, it'll switch back to digits.

![image](https://user-images.githubusercontent.com/63653723/168394705-72350e31-7bf5-421c-b2d0-fc5ae97496c6.png)


## Testing

Here are some pages to check:

- product_docs/docs/biganimal/release/migration/cold_migration.mdx:12:5
        http://localhost:8000/biganimal/latest/migration/cold_migration/#:~:text=logical%20export%20using%20pg_dump 
- product_docs/docs/biganimal/release/using_cluster/04_backup_and_restore.mdx:39:5
        http://localhost:8000/biganimal/latest/using_cluster/04_backup_and_restore/#:~:text=Fill%20in%20the%20required%20fields 
- product_docs/docs/ocl_connector/13.1.4.2/04_open_client_library/01_installing_and_configuring_the_ocl_connector.mdx:358:5
        http://localhost:8000/ocl_connector/13.1.4.2/04_open_client_library/01_installing_and_configuring_the_ocl_connector/#:~:text=Set%20up%20the%20EDB%20repository:
- product_docs/docs/odbc_connector/12/03_edb-odbc_overview/01_installing_edb-odbc.mdx:356:5
        http://localhost:8000/odbc_connector/12/03_edb-odbc_overview/01_installing_edb-odbc/#:~:text=Set%20up%20the%20EDB%20repository:
- product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx:37:5
        http://localhost:8000/biganimal/latest/getting_started/creating_a_cluster/#:~:text=Select%20the%20type%20of%20Postgres%20you%20want%20to%20use%20in%20the%20Postgres 
- product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx:46:5
        http://localhost:8000/biganimal/latest/getting_started/creating_a_cluster/#:~:text=Select%20the%20category%20that%20works%20best%20for%20your%20applications 
- product_docs/docs/biganimal/release/getting_started/identity_provider/azure_ad.mdx:26:4
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/azure_ad/#:~:text=Select%20New%20application
- product_docs/docs/biganimal/release/getting_started/identity_provider/azure_ad.mdx:31:4
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/azure_ad/#:~:text=Select%20SAML%20as%20your%20single%20signon%20method 
- product_docs/docs/biganimal/release/getting_started/identity_provider/azure_ad.mdx:55:4
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/azure_ad/#:~:text=Paste%20the%20Login%20URL%20value
- product_docs/docs/biganimal/release/getting_started/identity_provider/okta.mdx:28:4
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/okta/#:~:text=Select%20Create%20App%20Integration 
- product_docs/docs/biganimal/release/getting_started/identity_provider/okta.mdx:35:4
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/okta/#:~:text=Copy%20and%20paste%20the%20following%20information
- product_docs/docs/biganimal/release/getting_started/identity_provider/okta.mdx:54:4
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/okta/#:~:text=On%20the%20Assignments%20tab
- product_docs/docs/biganimal/release/getting_started/identity_provider/okta.mdx:56:8
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/okta/#:~:text=Copy%20from%20the%20Identity%20Provider
- product_docs/docs/biganimal/release/getting_started/identity_provider/okta.mdx:60:7
        http://localhost:8000/biganimal/latest/getting_started/identity_provider/okta/#:~:text=Paste%20the%20Identity%20Provider%20Single
- product_docs/docs/biganimal/release/overview/support/index.mdx:39:5
        http://localhost:8000/biganimal/latest/overview/support/
- product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/07_jdbc42_ubuntu20_deb10_x86.mdx:18:5
        http://localhost:8000/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/07_jdbc42_ubuntu20_deb10_x86/#:~:text=Set%20up%20the%20EDB%20repository:
- product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/07_odbc13_ubuntu20_deb10_x86.mdx:18:5
        http://localhost:8000/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/07_odbc13_ubuntu20_deb10_x86/#:~:text=Set%20up%20the%20EDB%20repository: