### PR TITLE
Update quickstart.mdx

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
@@ -98,6 +98,5 @@ spec:
 ```
 
 !!! Note "There's more"
-    For more detailed information about the available options, refer
-    to [API Reference(api_reference.md).
-
+    For more detailed information about the available options, please refer
+    to the ["API Reference" section](api_reference.md).


### PR DESCRIPTION
Typo that breaks the quickstart link to API Reference

## What Changed?

Fixed a typo in the notes section linking to API Reference. 

Fix: 
```
!!! Note "There's more"
    For more detailed information about the available options, please refer
    to the ["API Reference" section](api_reference.md).
```

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [X ] This PR changes existing content
