### PR TITLE
BDR/Group Commit cosmetics and typos

### DIFF
--- a/product_docs/docs/bdr/4/group-commit.mdx
+++ b/product_docs/docs/bdr/4/group-commit.mdx
@@ -9,7 +9,7 @@ confirm a transaction at COMMIT time.
 
 ## Requirements
 
-During normal operation, Group Commit it completely transparent to the
+During normal operation, Group Commit is completely transparent to the
 application.  Upon failover, the reconciliation phase needs to be
 explicitly triggered or consolidated by either the application or a
 proxy in between.  HARP provides native support for Group Commit and
@@ -71,14 +71,19 @@ remote one.
 
 ```sql
 -- create sub-groups
-SELECT bdr.create_node_group(node_group_name := 'left_dc',
-                             parent_group_name := 'top_group',
-                             join_node_group := false);
-SELECT bdr.create_node_group(node_group_name := 'right_dc',
-                             parent_group_name := 'top_group',
-                             join_node_group := false);
+SELECT bdr.create_node_group(
+    node_group_name := 'left_dc',
+    parent_group_name := 'top_group',
+    join_node_group := false
+);
+SELECT bdr.create_node_group(
+    node_group_name := 'right_dc',
+    parent_group_name := 'top_group',
+    join_node_group := false
+);
 
--- create a commit scope with individual rules for each sub-group
+-- create a commit scope with individual rules
+-- for each sub-group
 SELECT bdr.add_commit_scope(
     commit_scope_name := 'example_scope',
     origin_node_group := 'left_dc',
@@ -111,27 +116,39 @@ these are:
 In rules for Commit Scopes, these confirmation levels may be appended
 to the node group definition (in parenthesis) with `ON` as follows:
 
-* `ANY 1 (right_dc) ON remote_write`
-* `ALL (left_dc) ON remote_commit_flush` (default and may as well be
+* `ANY 2 (right_dc) ON replicated`
+* `ALL (left_dc) ON visible` (default and may as well be
   omitted)
-* `ALL (left_dc) ON remote_commit_async AND ANY 1 (right_dc) ON remote_write`
+* `ALL (left_dc) ON received AND ANY 1 (right_dc) ON durable`
 
 ## Reference
 
 ### Commit Scope Grammar
 
-For reference, the grammar for commit scopes is as follows:
+For reference, the grammar for commit scopes is composed as follows:
 
 ```
-commit_scope: confirmation
-              | confirmation AND commit_scope
+commit_scope:
+    confirmation [AND ...]
 
-confirmation: node_def (ON [received|replicated|durable|visible])
+confirmation:
+    node_def (ON [received|replicated|durable|visible])
 
-node_def:     ANY num (node_group [, ...])
-              | MAJORITY (node_group [, ...])
-              | ALL (node_group [, ...])
+node_def:
+    ANY num (node_group [, ...])
+    | MAJORITY (node_group [, ...])
+    | ALL (node_group [, ...])
 ```
+
+!!! Note
+    While the grammar for `synchronous_standby_names` and Commit
+    Scopes looks very similar, it is important to note that the former
+    does not account for the origin node, but the latter does.
+    Therefore, for example `synchronous_standby_names = 'ANY 1 (..)'`
+    is equivalent to a Commit Scope of `ANY 2 (...)`.  This choice
+    makes reasoning about majority easier and reflects that the origin
+    node also contributes to the durability and visibility of the
+    transaction.
 
 ### Adding a commit scope rule
 
@@ -147,8 +164,10 @@ commit scopes that vary depending on the origin of the transaction.
 #### Synopsis
 
 ```sql
-bdr.add_commit_scope(commit_scope_name NAME, origin_node_group NAME,
-                     rule TEXT)
+bdr.add_commit_scope(
+    commit_scope_name NAME,
+    origin_node_group NAME,
+    rule TEXT)
 ```
 
 ### Changing a commit scope rule
@@ -159,8 +178,10 @@ commit scope, the function `bdr.alter_commit_scope` may be used.
 #### Synopsis
 
 ```sql
-bdr.alter_commit_scope(commit_scope_name NAME, origin_node_group NAME,
-                       rule TEXT)
+bdr.alter_commit_scope(
+    commit_scope_name NAME,
+    origin_node_group NAME,
+    rule TEXT)
 ```
 
 ### Removing a commit scope rule
@@ -173,5 +194,7 @@ commit scope.
 #### Synopsis
 
 ```sql
-bdr.remove_commit_scope(commit_scope_name NAME, origin_node_group NAME)
+bdr.remove_commit_scope(
+    commit_scope_name NAME,
+    origin_node_group NAME)
 ```


### PR DESCRIPTION
## What Changed?

- Fixed typo in BDR4 group commit section
- Fix output in the code blocks to be viewed entirely in BDR4 group commit section

## Checklist

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
