### PR TITLE
repmgr: add stub for 5.3.2 release

### DIFF
--- a/product_docs/docs/repmgr/5.3.2/index.mdx
+++ b/product_docs/docs/repmgr/5.3.2/index.mdx
@@ -1,0 +1,22 @@
+---
+navTitle: repmgr
+title: "Replication Manager (repmgr)"
+directoryDefaults:
+  description: "Replication Manager (repmgr) is among the most popular open-source tools for managing replication and failover of PostgreSQL clusters. It relies on PostgreSQL’s streaming replication and hot standby capabilities allowing DBAs to simplify the process of setting up and managing clusters having high availability as well as read scalability requirements. repmgr is distributed under GNU GPL 3 and maintained by EDB."
+---
+
+Replication Manager (repmgr) is among the most popular open-source tools for managing replication and failover of PostgreSQL clusters. It relies on PostgreSQL’s streaming replication and hot standby capabilities allowing DBAs to simplify the process of setting up and managing clusters having high availability as well as read scalability requirements. repmgr is distributed under GNU GPL 3 and maintained by EDB.
+
+repmgr is developed, tested and certified for PostgreSQL and EDB Postgres Extended Server. repmgr is not certified for EDB Postgres Advanced Server.
+
+!!! Note
+   Looking for repmgr documentation? Head over to [repmgr.org](https://repmgr.org/)
+!!!
+
+Key capabilities include:
+* Perform automatic failover by detecting failure of the primary and promoting the most suitable standby
+* Monitoring and recording replication performance
+* User defined scripts can be triggered by cluster events to perform tasks such as sending email alerts
+* Witness servers can improve repmgr failure assessment and resolution, especially in deployments involving multiple data centers
+* A "location" configuration option can restrict potential promotion candidates to a single location, e.g., when nodes are spread over multiple data centers
+* Supports multiple methods to determine node availability: PostgreSQL ping, query execution, or new connection


### PR DESCRIPTION
Currently this page: https://www.enterprisedb.com/docs/repmgr/latest/ shows repmgr on version 5.2.1, which is outdated; I am guessing this is the correct way to update it?