### PR TITLE
Typo fixes etc. for "product_docs/docs/pgd/4/choosing_server.mdx"

### DIFF
--- a/product_docs/docs/pgd/4/choosing_server.mdx
+++ b/product_docs/docs/pgd/4/choosing_server.mdx
@@ -2,7 +2,7 @@
 title: "Choosing a Postgres distribution"
 ---
 
-EDB Postgres Distributed can be deployed with three different Postgres distributions: PostgeSQL, EDB Postgres Extended Server, or EDB Postgres Advanced Server.  The EDB Postgres Distributed features available depend on which Postgres distribution is used. Therefore, it is essential to adopt the Postgres distribution best suited to your business needs. For example, if having the feature "Commit At Most Once (CAMO)" is mission critical to a your use case, you should not adopt open source PostgreSQL because it does not have the core capabilities required to handle CAMO. 
+EDB Postgres Distributed can be deployed with three different Postgres distributions: PostgreSQL, EDB Postgres Extended Server, or EDB Postgres Advanced Server.  The availability of particular EDB Postgres Distributed features depends on which Postgres distribution is used. Therefore, it is essential to adopt the Postgres distribution best suited to your business needs. For example, if having the feature "Commit At Most Once (CAMO)" is mission critical to your use case, you should not adopt open source PostgreSQL because it does not have the core capabilities required to handle CAMO.
 
 The following table lists features of EDB Postgres Distributed that are dependent on the Postgres distribution and version.
 

--- a/product_docs/docs/repmgr/5.3.2/index.mdx
+++ b/product_docs/docs/repmgr/5.3.2/index.mdx
@@ -1,0 +1,22 @@
+---
+navTitle: repmgr
+title: "Replication Manager (repmgr)"
+directoryDefaults:
+  description: "Replication Manager (repmgr) is among the most popular open-source tools for managing replication and failover of PostgreSQL clusters. It relies on PostgreSQL’s streaming replication and hot standby capabilities allowing DBAs to simplify the process of setting up and managing clusters having high availability as well as read scalability requirements. repmgr is distributed under GNU GPL 3 and maintained by EDB."
+---
+
+Replication Manager (repmgr) is among the most popular open-source tools for managing replication and failover of PostgreSQL clusters. It relies on PostgreSQL’s streaming replication and hot standby capabilities allowing DBAs to simplify the process of setting up and managing clusters having high availability as well as read scalability requirements. repmgr is distributed under GNU GPL 3 and maintained by EDB.
+
+repmgr is developed, tested and certified for PostgreSQL and EDB Postgres Extended Server. repmgr is not certified for EDB Postgres Advanced Server.
+
+!!! Note
+   Looking for repmgr documentation? Head over to [repmgr.org](https://repmgr.org/)
+!!!
+
+Key capabilities include:
+* Perform automatic failover by detecting failure of the primary and promoting the most suitable standby
+* Monitoring and recording replication performance
+* User defined scripts can be triggered by cluster events to perform tasks such as sending email alerts
+* Witness servers can improve repmgr failure assessment and resolution, especially in deployments involving multiple data centers
+* A "location" configuration option can restrict potential promotion candidates to a single location, e.g., when nodes are spread over multiple data centers
+* Supports multiple methods to determine node availability: PostgreSQL ping, query execution, or new connection


### PR DESCRIPTION
## What Changed?

- fixed typo "PostgeSQL"
- removed `a` in this section: `is mission critical to a your use case`
- changed `The EDB Postgres Distributed features available depend on which Postgres distribution is used` to `The availability of particular EDB Postgres Distributed features depends on which Postgres distribution is used.` as this seems clearer

## Checklist

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
