### PR TITLE
Feature/jon/copy install docs

### DIFF
--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -413,16 +413,16 @@ products:
   #       supported versions: [14]
     - name: SLES 12
       arch: x86_64
-      supported versions: [14]
+      supported versions: [2]
     - name: SLES 12
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [2]
     - name: SLES 15
       arch: x86_64
-      supported versions: [14]
+      supported versions: [2]
     - name: SLES 15
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [2]
   - name: MongoDB Foreign Data Wrapper
     platforms:
   #     - name: CentOS 7
@@ -451,16 +451,16 @@ products:
   #       supported versions: [11, 12, 13, 14]
     - name: SLES 12
       arch: x86_64
-      supported versions: [14]
+      supported versions: [5]
     - name: SLES 12
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [5]
     - name: SLES 15
       arch: x86_64
-      supported versions: [14]
+      supported versions: [5]
     - name: SLES 15
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [5]
   - name: MySQL Foreign Data Wrapper
     platforms:
   #     - name: CentOS 7
@@ -489,16 +489,16 @@ products:
   #       supported versions: [11, 12, 13, 14]
     - name: SLES 12
       arch: x86_64
-      supported versions: [14]
+      supported versions: [2]
     - name: SLES 12
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [2]
     - name: SLES 15
       arch: x86_64
-      supported versions: [14]
+      supported versions: [2]
     - name: SLES 15
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [2]
   - name: PostGIS
     platforms:
   #     - name: CentOS 7
@@ -527,16 +527,16 @@ products:
   #       supported versions: [11, 12, 13, 14]
     - name: SLES 12
       arch: x86_64
-      supported versions: [14]
+      supported versions: [3.1]
     - name: SLES 12
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [3.1]
     - name: SLES 15
       arch: x86_64
-      supported versions: [14]
+      supported versions: [3.1]
     - name: SLES 15
       arch: ppc64le
-      supported versions: [14]
+      supported versions: [3.1]
   # - name: Postgres Enterprise Manager
   #   platforms:
   #     - name: CentOS 7

--- a/install_template/deploy.mjs
+++ b/install_template/deploy.mjs
@@ -1,0 +1,172 @@
+import fs from "fs/promises";
+import { existsSync as fileExists } from "fs";
+import path from "path";
+import nunjucks from "nunjucks";
+import prettier from "prettier";
+import yaml from "yaml";
+
+nunjucks.configure("templates", { throwOnUndefined: true, autoescape: false });
+
+/**
+ * Loop through the config.yaml file and generate docs for every product/platform/supported version combination found.
+ * @returns void
+ */
+const run = async () => {
+  const config = yaml.parse(await fs.readFile("config.yaml", "utf8"));
+
+  config.products.forEach((product) => {
+    product.platforms.forEach((platform) => {
+      platform["supported versions"].forEach((version) => {
+        moveDoc(product, platform, version);
+      });
+    });
+  });
+    
+  return;
+};
+
+/**
+ * Composes the code needed to copy a document for a product/platform/version combination.
+ * @param product The product name we are generating a template for
+ * @param platform The platform and architecture we are generating docs for (e.g. { name: Centos 7, arch: x86_64 })
+ * @param version The version of the product to generate docs for
+ * @returns void
+ */
+const moveDoc = (product, platform, version) => {
+/*
+  console.log(
+    `Copying install guide for ${product.name} ${version} on ${platform.name} ${platform.arch}`,
+  );
+*/
+    
+  const context = generateContext(product, platform, version);
+
+  const filename =
+    [
+      formatStringForFile(context.product.name),
+      context.product.version,
+      formatStringForFile(context.platform.name),
+      context.platform.arch,
+    ].join("_") + ".mdx";
+
+  /*console.log(`  copying ${filename}`);*/
+
+  const prefix = {
+    rhel_8_x86_64: "01",
+    other_linux8_x86_64: "02",
+    rhel_7_x86_64: "03",
+    centos_7_x86_64: "04",
+    sles_15_x86_64: "05",
+    sles_12_x86_64: "06",
+    ubuntu_20_deb10_x86_64: "07",
+    ubuntu_18_deb9_x86_64: "08",
+    rhel_8_ppc64le: "09",
+    rhel_7_ppc64le: "10",
+    sles_15_ppc64le: "11",
+    sles_12_ppc64le: "12",
+  };
+
+  const abrev_product = {
+        "failover-manager": "efm",
+        "migration-toolkit": "mtk",
+        "hadoop-foreign-data-wrapper": "hadoop",
+        "mongodb-foreign-data-wrapper": "mongo",
+        "mysql-foreign-data-wrapper": "mysql",
+        "edb-pgpoolii": "pgpool",
+        "edb-pgpoolii-extensions": "pgpool_extensions",
+        "postgis": "postgis",
+        "edb-jdbc-connector": "jdbc_connector",
+        "edb-oci-connector": "oci_connector",
+        "edb-odbc-connector": "odbc_connector",
+      "edb-pgbouncer": "pgbouncer",
+      
+      
+  };
+
+
+  if (abrev_product[formatStringForFile(context.product.name)] == null){
+    console.error(
+        `[ERROR] product abbreviation missing\n` +
+            formatStringForFile(context.product.name));
+  }
+    
+  const expand_arch = {
+    ppcle: "ibm_power_ppc64le",
+      x86: "x86_amd64",
+      x86_64: "x86_amd64",
+      ppc64le: "ibm_power_pcc64le",
+  };
+
+  const plat = [
+    context.platform.name.toLowerCase().replace(/ /g, "_"),
+    context.platform.arch,
+  ].join("_");
+
+    const dirpath = [
+      "..",
+      "product_docs",
+      "docs",
+      abrev_product[formatStringForFile(context.product.name)],
+      context.product.version.toString().replace(/\..*/, ""),
+      [
+          "03_installing",
+          abrev_product[formatStringForFile(context.product.name)],
+      ].join("_"),
+      expand_arch[context.platform.arch],
+  ].join("/");
+
+    const file =
+    [
+      prefix[plat],
+      abrev_product[formatStringForFile(context.product.name)]+ context.product.version.toString().replace(/\..*/, ""),
+      context.platform.name.toLowerCase().replace(/ /g, ""),
+      context.platform.arch.replace(/_?64/g, ""),
+    ].join("_") + ".mdx";
+    
+    console.log(`renders/${filename} ${dirpath}/${file}`);
+};
+
+
+/**
+ * Format a string into the format expected when used in file or folder names.
+ * Converts a string to lowercase, and replaces all spaces with dashes
+ * @param string
+ * @returns a string formatted for file names
+ */
+const formatStringForFile = (string) => {
+  return string.toLowerCase().replace(/ /g, "-");
+};
+
+/**
+ * Creates a filename based on the filenameParts passed in, and appends to to a base path
+ * @param basePath A file path formatted string which will be used as a prefix to the generated filename. e.g "products/product-name/"
+ * @param filenameParts An array of strings to combine into a template name. e.g. ["first-part", "second", "last-part"]
+ * @returns A file path which refers to the expected location of a nunjucks template, with each filename part seperated by an underscore.
+ *          e.g. "products/product-name/first-part_second_last-part.njk"
+ */
+const constructTemplatePath = (basePath, filenameParts) => {
+  return path.join(basePath, filenameParts.join("_") + ".njk");
+};
+
+/**
+ * Creates the context object used by nunjucks templates
+ * @param product The product to render docs for, from the config.
+ * @param platform The platform to render docs for, from the config.
+ * @param version The version of the product to render docs for
+ * @returns a context object.
+ */
+const generateContext = (product, platform, version) => {
+  return {
+    product: {
+      name: product.name,
+      version: version,
+    },
+    platform: {
+      name: platform.name,
+      arch: platform.arch,
+    },
+  };
+};
+
+
+run();

--- a/install_template/deploy.mjs
+++ b/install_template/deploy.mjs
@@ -41,9 +41,11 @@ const moveDoc = (product, platform, version) => {
     
   const context = generateContext(product, platform, version);
 
+  const product_stub = formatStringForFile(context.product.name)
+    
   const filename =
     [
-      formatStringForFile(context.product.name),
+      product_stub,
       context.product.version,
       formatStringForFile(context.platform.name),
       context.platform.arch,
@@ -76,7 +78,7 @@ const moveDoc = (product, platform, version) => {
         "edb-pgpoolii-extensions": "pgpool_extensions",
         "postgis": "postgis",
         "edb-jdbc-connector": "jdbc_connector",
-        "edb-oci-connector": "oci_connector",
+        "edb-oci-connector": "ocl_connector",
         "edb-odbc-connector": "odbc_connector",
       "edb-pgbouncer": "pgbouncer",
       
@@ -84,17 +86,17 @@ const moveDoc = (product, platform, version) => {
   };
 
 
-  if (abrev_product[formatStringForFile(context.product.name)] == null){
+  if (abrev_product[product_stub] == null){
     console.error(
         `[ERROR] product abbreviation missing\n` +
-            formatStringForFile(context.product.name));
+            product_stub);
   }
     
   const expand_arch = {
     ppcle: "ibm_power_ppc64le",
       x86: "x86_amd64",
       x86_64: "x86_amd64",
-      ppc64le: "ibm_power_pcc64le",
+      ppc64le: "ibm_power_ppc64le",
   };
 
   const plat = [
@@ -102,28 +104,190 @@ const moveDoc = (product, platform, version) => {
     context.platform.arch,
   ].join("_");
 
-    const dirpath = [
-      "..",
-      "product_docs",
-      "docs",
-      abrev_product[formatStringForFile(context.product.name)],
-      context.product.version.toString().replace(/\..*/, ""),
-      [
-          "03_installing",
-          abrev_product[formatStringForFile(context.product.name)],
-      ].join("_"),
-      expand_arch[context.platform.arch],
-  ].join("/");
+    const product_prefix = {
+        "failover-manager": "03",
+        "migration-toolkit": "05",
+        "hadoop-foreign-data-wrapper": "05",
+        "mongodb-foreign-data-wrapper": "04",
+        "mysql-foreign-data-wrapper": "04",
+        "edb-pgpoolii": "01",
+        "edb-pgpoolii-extensions": "pgpool_extensions",
+        "postgis": "01a",
+        "edb-jdbc-connector": "04",
+        "edb-oci-connector": "ocl_connector",
+        "edb-odbc-connector": "03",
+      "edb-pgbouncer": "01",
+      
+      
+    };
 
-    const file =
-    [
-      prefix[plat],
-      abrev_product[formatStringForFile(context.product.name)]+ context.product.version.toString().replace(/\..*/, ""),
-      context.platform.name.toLowerCase().replace(/ /g, ""),
-      context.platform.arch.replace(/_?64/g, ""),
-    ].join("_") + ".mdx";
+    var dirpath;
+    var file;
+
+
+    switch (product_stub) {
+        /* Products that don't have an install_on_linux layer */
+    case "failover-manager":
+        dirpath = [
+            "..",
+            "product_docs",
+            "docs",
+            abrev_product[product_stub],
+            context.product.version.toString().replace(/\..*/, ""),
+            [
+                product_prefix[product_stub],
+                "installing",
+                    abrev_product[product_stub],
+            ].join("_"),
+            expand_arch[context.platform.arch],
+        ].join("/");
+        
+        file =
+            [
+                prefix[plat],
+                abrev_product[product_stub]+ context.product.version.toString().replace(/\..*/, ""),
+                context.platform.name.toLowerCase().replace(/ /g, ""),
+                context.platform.arch.replace(/_?64/g, ""),
+            ].join("_") + ".mdx";
+        break;
+        
+        /* Products that don't abreviate in the directory */ 
+    case "migration-toolkit":
+        dirpath = [
+            "..",
+            "product_docs",
+            "docs",
+            context.product.name.toLowerCase().replace(/ /g, '_'),
+            context.product.version.toString().replace(/\..*/, ""),
+            [
+                product_prefix[product_stub],
+                "installing",
+                abrev_product[product_stub],
+            ].join("_"),
+            "install_on_linux",
+            expand_arch[context.platform.arch],
+        ].join("/");
+        
+            file =
+            [
+                prefix[plat],
+                abrev_product[product_stub]+ context.product.version.toString().replace(/\..*/, ""),
+                context.platform.name.toLowerCase().replace(/ /g, ""),
+                context.platform.arch.replace(/_?64/g, ""),
+            ].join("_") + ".mdx";
+        break;
+
+        /* Data wrappers */
+    case "hadoop-foreign-data-wrapper":
+    case "mongodb-foreign-data-wrapper":
+    case "mysql-foreign-data-wrapper":
+        prefix["sles_12_x86"]="07";
+        prefix["sles_12_x86_64"]="07";
+        prefix["rhel_8_ppc64le"]="13";
+        prefix["rhel_7_ppc64le"]="15";
+        prefix["sles_12_ppc64le"]="19";
+        prefix["sles_15_ppc64le"]="17";
+
+        dirpath = [
+            "..",
+            "product_docs",
+            "docs",        
+            abrev_product[product_stub] + "_data_adapter",
+            context.product.version.toString().replace(/\..*/, ""),
+            [
+                product_prefix[product_stub],
+                "installing_the",
+                abrev_product[product_stub],
+                "data_adapter"
+            ].join("_"),
+            expand_arch[context.platform.arch],
+        ].join("/");
+        
+        file =
+            [
+                prefix[plat],
+                abrev_product[product_stub],
+                context.platform.name.toLowerCase().replace(/ /g, ""),
+                context.platform.arch.replace(/_?64/g, ""),
+            ].join("_") + ".mdx";
+        break;
+        
+    case "edb-pgpoolii":
+        dirpath = [
+            "..",
+            "product_docs",
+            "docs",
+            abrev_product[product_stub],
+            context.product.version,
+            [
+                product_prefix[product_stub],
+                "installing_and_configuring_the",
+                abrev_product[product_stub]+"-II",
+            ].join("_"),
+            expand_arch[context.platform.arch],
+        ].join("/");
+        
+            file =
+            [
+                prefix[plat],
+                abrev_product[product_stub],
+                context.platform.name.toLowerCase().replace(/ /g, ""),
+                context.platform.arch.replace(/_?64/g, ""),
+            ].join("_") + ".mdx";
+        break;
+
+    case "postgis":
+        dirpath = [
+            "..",
+            "product_docs",
+            "docs",
+            abrev_product[product_stub],
+            context.product.version,
+            [
+                product_prefix[product_stub],
+                "installing",
+                abrev_product[product_stub],
+            ].join("_"),
+            "installing_on_linux",
+            expand_arch[context.platform.arch],
+        ].join("/");
+        
+            file =
+            [
+                prefix[plat],
+                abrev_product[product_stub],
+                context.platform.name.toLowerCase().replace(/ /g, ""),
+                context.platform.arch.replace(/_?64/g, ""),
+            ].join("_") + ".mdx";
+        break;
+
+    default:
+        dirpath = [
+            "..",
+            "product_docs",
+            "docs",
+            abrev_product[product_stub],
+            context.product.version.toString().replace(/\..*/, ""),
+            [
+                product_prefix[product_stub],
+                "installing",
+                abrev_product[product_stub],
+            ].join("_"),
+            "install_on_linux",
+            expand_arch[context.platform.arch],
+        ].join("/");
+        
+            file =
+            [
+                prefix[plat],
+                abrev_product[product_stub]+ context.product.version.toString().replace(/\..*/, ""),
+                context.platform.name.toLowerCase().replace(/ /g, ""),
+                context.platform.arch.replace(/_?64/g, ""),
+            ].join("_") + ".mdx";
+        break;
+    }
     
-    console.log(`renders/${filename} ${dirpath}/${file}`);
+        console.log(`renders/${filename} ${dirpath}/${file}`);
 };
 
 


### PR DESCRIPTION
## What Changed?

Create a mapping from the template output to the final location of the rendered install guide. Run with:

```
cd install_template
npm i && node deploy.mjs | xargs ls
```

This will show any errors that mean there is something wrong with the mapping. When all the products are correctly mapped, we can use `rsync` rather than just printing the two names.
