### PR TITLE
changed dnf to zypper for SLES 15 topics for Replication Server

### DIFF
--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/11_eprs_sles15_ppcle.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/11_eprs_sles15_ppcle.mdx
@@ -50,13 +50,13 @@ You can install all Replication Server components with a single install command,
 To install all Replication Server components:
 
 ```shell
-dnf -y install edb-xdb
+zypper -y install edb-xdb
 ```
 
 To install an individual component:
 
 ```shell
-dnf install package_name
+zypper install package_name
 ```
 
 Where `package_name` is:

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/05_eprs_sles15_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/05_eprs_sles15_x86.mdx
@@ -50,13 +50,13 @@ You can install all Replication Server components with a single install command,
 To install all Replication Server components:
 
 ```shell
-dnf -y install edb-xdb
+zypper -y install edb-xdb
 ```
 
 To install an individual component:
 
 ```shell
-dnf install package_name
+zypper install package_name
 ```
 
 Where `package_name` is:


### PR DESCRIPTION
Two topics had the package manager command as dnf. I assume that's supposed to be zypper. 

If you approve, you can merge