### PR TITLE
Update epas_deb9_x86.mdx

### DIFF
--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_deb9_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_deb9_x86.mdx
@@ -21,6 +21,12 @@ The following steps walk you through using the EDB apt repository to install a d
     sh -c 'echo "deb https://USERNAME:PASSWORD@apt.enterprisedb.com/$(lsb_release -cs)-edb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/edb-$(lsb_release -cs).list'
     ```
 
+-   Add support to your system for GNU privacy guard. Needed for adding EDB signing key:
+
+    ```text
+    apt-get -y install gnupg2
+    ```
+    
 -   Add support to your system for secure APT repositories:
 
     ```text


### PR DESCRIPTION
Needed to install gnupg2 before I could successfully install the EDB signing key.  Updated docs to include the command for installing gnupg2.

## What Changed?

- Modified docs to include step for installing gnupg2 which is needed to successfully import the EDB signing key.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [x] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
