### PR TITLE
Replacing references to BDR with EDB Postgres Distributed (EPD) - harp2.1.0_rel_notes page

### DIFF
--- a/product_docs/docs/harp/2/01_release_notes/harp2.1.0_rel_notes.mdx
+++ b/product_docs/docs/harp/2/01_release_notes/harp2.1.0_rel_notes.mdx
@@ -7,11 +7,11 @@ as fixes for issues identified in previous versions.
 
 | Type | Description |
 | ---- |------------ |
-| Feature | The BDR DCS now uses a push notification from the consensus rather than through polling nodes. <p>This change reduces the time for new leader selection and the load that HARP does on the BDR DCS since it doesn't need to poll in short intervals anymore.</p> |
+| Feature | The EDB Postgres Distributed (EPD) DCS now uses a push notification from the consensus rather than through polling nodes. <p>This change reduces the time for new leader selection and the load that HARP does on the EPD DCS since it doesn't need to poll in short intervals anymore.</p> |
 | Feature | TPA now restarts each HARP Proxy one by one and wait until they come back to reduce any downtime incurred by the application during software upgrades. |
 | Feature | The support for embedding PGBouncer directly into HARP Proxy is now deprecated and will be removed in the next major release of HARP. <p>It's now possible to configure TPA to put PGBouncer on the same node as HARP Proxy and point to that HARP Proxy. </p> |
 | Bug Fix | `harpctl promote <node_name>` would occasionally promote a different node than the one specified.  This has been fixed. (RT75406) |
-| Bug Fix | Fencing would sometimes fail when using BDR as the Distributed Consensus Service.  This has been corrected. |
+| Bug Fix | Fencing would sometimes fail when using EPD as the Distributed Consensus Service.  This has been corrected. |
 | Bug Fix | `harpctl apply` no longer turns off routing for leader after the cluster has been established. (RT80790) |
 | Bug Fix | Harp-manager no longer exits if it cannot start a failed database. Harp-manager will keep retrying with randomly increasing periods. (RT78516) |
 | Bug Fix | The internal pgbouncer proxy implementation had a memory leak.  This has been remediated. |


### PR DESCRIPTION
2.1 is the first version paired to EPD