### PR TITLE
Update 04_backup_and_restore.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/04_backup_and_restore.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/04_backup_and_restore.mdx
@@ -15,7 +15,7 @@ BigAnimal backs up the data in your PostgreSQL clusters. Depending on the cloud 
 !!! Note
     Backups in AWS do not currently support cross-regional replication.
 
-PostgreSQL clusters in BigAnimal are continuously backed up through a combination of base backups and transaction log (WAL) archiving. When a new cluster is created, an initial "base" backup is taken. After that, every time a WAL file is closed, which is, by default, every 5 minutes, it is automatically uploaded to the cloud object storage solution. Your organization is responsible for the charges associated with the cloud object storage solution.
+PostgreSQL clusters in BigAnimal are continuously backed up through a combination of base backups and transaction log (WAL) archiving. When a new cluster is created, an initial "base" backup is taken. After that, every time a WAL file is closed, which is, by default, up to every 5 minutes, it is automatically uploaded to the cloud object storage solution. Your organization is responsible for the charges associated with the cloud object storage solution.
 
 BigAnimal retains backups for 30 days by default.
 


### PR DESCRIPTION
## What Changed?

The correction: “every 5 minutes” -> “up to every 5 minutes”. As 5 minutes is the maximum time based value, when WAL files are filled, they are closed. So it is whatever comes first between 5 minutes and the actual file being filled up with transactional info

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
