### PR TITLE
Clarify documentation for bdr.worker_errors

### DIFF
--- a/product_docs/docs/bdr/3.6/index.mdx
+++ b/product_docs/docs/bdr/3.6/index.mdx
@@ -29,7 +29,7 @@ BDR Enterprise requires EDB Postgres Extended v11 (formerly known as 2ndQuadrant
 !!!note
   The documentation for the latest stable 3.6 release is available here:
 
-  [BDR 3.6 Enterprise Edition](https://documentation.2ndquadrant.com/bdr3-enterprise/release/latest-3.6/)
+  [BDR 3.6 Enterprise Edition](https://documentation.enterprisedb.com/bdr3-enterprise/release/latest-3.6/)
 
   **This is a protected area of our website, if you need access please [contact us](https://www.enterprisedb.com/contact)**
 !!!
@@ -52,7 +52,7 @@ BDR Standard requires PostgreSQL v10 or v11.
 !!!note
   The documentation for the latest stable 3.6 release is available here:
 
-  [BDR 3.6 Standard Edition](https://documentation.2ndquadrant.com/bdr3/release/latest-3.6/)
+  [BDR 3.6 Standard Edition](https://documentation.enterprisedb.com/bdr3/release/latest-3.6/)
 
    **This is a protected area of our website, if you need access please [contact us](https://www.enterprisedb.com/contact)**
 !!!

--- a/product_docs/docs/bdr/3.7/backup.mdx
+++ b/product_docs/docs/bdr/3.7/backup.mdx
@@ -52,7 +52,7 @@ backup and recovery of BDR.
 
 Physical backups of a node in a BDR cluster can be taken using
 standard PostgreSQL software, such as
-[Barman](https://www.2ndquadrant.com/en/resources/barman/).
+[Barman](https://www.enterprisedb.com/docs/supported-open-source/barman/).
 
 A physical backup of a BDR node can be performed with the same
 procedure that applies to any PostgreSQL node: a BDR node is just a
@@ -86,7 +86,7 @@ entirely *consistent*; a physical backup of a given node will
 provide Point-In-Time Recovery capabilities limited to the states
 actually assumed by that node (see the [Example] below).
 
-The following example shows how two nodes in the same BDR cluster might not 
+The following example shows how two nodes in the same BDR cluster might not
 (and usually do not) go through the same sequence of states.
 
 Consider a cluster with two nodes `N1` and `N2`, which is initially in
@@ -106,7 +106,7 @@ node `N1` will go through the following states:
 
 That is: node `N1` will *never* assume state `S + W2`, and node `N2`
 likewise will never assume state `S + W1`, but both nodes will end up
-in the same state `S + W1 + W2`. Considering this situation might affect how 
+in the same state `S + W1 + W2`. Considering this situation might affect how
 you decide upon your backup strategy.
 
 ### Point-In-Time Recovery (PITR)
@@ -135,7 +135,7 @@ BDR allows for changes from multiple masters, all recorded within the
 WAL log for one node, separately identified using replication origin
 identifiers.
 
-BDR allows PITR of all or some replication origins to a specific point in time, 
+BDR allows PITR of all or some replication origins to a specific point in time,
 providing a fully consistent viewpoint across all subsets of nodes.
 
 Thus for multi-origins, we view the WAL stream as containing multiple
@@ -195,7 +195,7 @@ to the original PostgreSQL PITR behaviour that is designed around the assumption
 of changes arriving from a single master in COMMIT order.
 
 !!! Note
-    This is feature is only available on EDB Postgres Extended and 
+    This is feature is only available on EDB Postgres Extended and
     Barman does not currently automatically create a `multi_recovery.conf` file.
 
 ## Restore

--- a/product_docs/docs/bdr/3.7/camo.mdx
+++ b/product_docs/docs/bdr/3.7/camo.mdx
@@ -5,4 +5,4 @@ originalFilePath: camo.md
 
 ---
 
-<AuthenticatedContentPlaceholder target="https://documentation.2ndquadrant.com/bdr3-enterprise/release/latest/camo/" topic="Commit At Most Once" />
+<AuthenticatedContentPlaceholder target="https://documentation.enterprisedb.com/bdr3-enterprise/release/latest/camo/" topic="Commit At Most Once" />

--- a/product_docs/docs/bdr/3.7/camo_clients.mdx
+++ b/product_docs/docs/bdr/3.7/camo_clients.mdx
@@ -5,4 +5,4 @@ originalFilePath: camo_clients.md
 
 ---
 
-<AuthenticatedContentPlaceholder target="https://documentation.2ndquadrant.com/bdr3-enterprise/release/latest/camo_clients/" topic="Appendix C: CAMO Reference Client Implementations" />
+<AuthenticatedContentPlaceholder target="https://documentation.enterprisedb.com/bdr3-enterprise/release/latest/camo_clients/" topic="Appendix C: CAMO Reference Client Implementations" />

--- a/product_docs/docs/bdr/3.7/configuration.mdx
+++ b/product_docs/docs/bdr/3.7/configuration.mdx
@@ -86,17 +86,17 @@ become relevant with BDR in combination with CAMO.
 
 ## pglogical Settings for BDR
 
-BDR is also affected by some of the pglogical settings as it uses 
+BDR is also affected by some of the pglogical settings as it uses
 pglogical internally to implement the basic replication.
 
--   `pglogical.track_subscription_apply` - Track apply statistics for 
+-   `pglogical.track_subscription_apply` - Track apply statistics for
     each subscription.
--   `pglogical.track_relation_apply` - Track apply statistics for each 
+-   `pglogical.track_relation_apply` - Track apply statistics for each
     relation.
 -   `pglogical.track_apply_lock_timing` - Track lock timing when tracking
     statistics for relations.
 -   `pglogical.standby_slot_names` - When using physical Standby nodes
-    intended for failover purposes, should be set to the replication 
+    intended for failover purposes, should be set to the replication
     slot(s) for each intended Standby.
 -   `pglogical.writers_per_subscription` - Default number of writers per
     subscription (in BDR this can also be changed by
@@ -228,7 +228,7 @@ Unless noted otherwise, values may be set by any user at any time.
     this setting. It is normal for some statements to result in two `WARNING`s,
     one for skipping the DML lock and one for skipping the DDL lock.
 
--   `bdr.truncate_locking` - False by default, this configuration option sets the 
+-   `bdr.truncate_locking` - False by default, this configuration option sets the
     TRUNCATE command's locking behavior. Determines whether (when true) TRUNCATE
     obeys the bdr.ddl_locking setting.
 
@@ -401,7 +401,7 @@ Unless noted otherwise, values may be set by any user at any time.
 
 -   `bdr.trace_level` - Similar to the above, this defines the log level
     to use for BDR trace messages.  Enabling tracing on all nodes of a
-    BDR cluster may help 2ndQuadrant Support to diagnose issues.
+    BDR cluster may help EDB Support to diagnose issues.
     May only be set at Postgres server start.
 
 !!! Warning
@@ -432,7 +432,7 @@ Unless noted otherwise, values may be set by any user at any time.
 -   `bdr.raft_group_max_connections` - The maximum number of connections
      across all BDR groups for a Postgres server. These connections carry
      bdr consensus requests between the groups' nodes. Default value of this
-     parameter is 100 connections. May only be set at Postgres server start.  
+     parameter is 100 connections. May only be set at Postgres server start.
 -   `bdr.backwards_compatibility` - Specifies the version to be
     backwards-compatible to, in the same numerical format as used by
     `bdr.bdr_version_num`, e.g. `30618`.  Enables exact behavior of a

--- a/product_docs/docs/bdr/3.7/eager.mdx
+++ b/product_docs/docs/bdr/3.7/eager.mdx
@@ -4,4 +4,4 @@ originalFilePath: eager.md
 
 ---
 
-<AuthenticatedContentPlaceholder target="https://documentation.2ndquadrant.com/bdr3-enterprise/release/latest/eager/" topic="Eager Replication" />
+<AuthenticatedContentPlaceholder target="https://documentation.enterprisedb.com/bdr3-enterprise/release/latest/eager/" topic="Eager Replication" />

--- a/product_docs/docs/bdr/3.7/index.mdx
+++ b/product_docs/docs/bdr/3.7/index.mdx
@@ -44,7 +44,7 @@ provides a solution for building multi-master clusters with mesh topology.
 This means that you can write to any server and the changes will be
 sent row-by-row to all the other servers that are part of the same BDR group.
 
-BDR version 3 ("BDR3") is built on the [pglogical3](https://www.2ndquadrant.com/resources/pglogical/)
+BDR version 3 ("BDR3") is built on the [pglogical3](https://www.enterprisedb.com/docs/pglogical/latest/)
 extension. However, everything you need to
 know about BDR3 is included here and it is unnecessary, as well as potentially
 confusing, to refer to pglogical docs.

--- a/product_docs/docs/bdr/3.7/isolation_details.mdx
+++ b/product_docs/docs/bdr/3.7/isolation_details.mdx
@@ -5,4 +5,4 @@ originalFilePath: isolation/details.md
 
 ---
 
-<AuthenticatedContentPlaceholder target="https://documentation.2ndquadrant.com/bdr3-enterprise/release/latest/isolation/details/" topic="Appendix B: Conflict Details" />
+<AuthenticatedContentPlaceholder target="https://documentation.enterprisedb.com/bdr3-enterprise/release/latest/isolation/details/" topic="Appendix B: Conflict Details" />

--- a/product_docs/docs/bdr/3.7/monitoring.mdx
+++ b/product_docs/docs/bdr/3.7/monitoring.mdx
@@ -319,10 +319,16 @@ So this view offers these insights into the state of a BDR system:
 The `bdr.workers` view shows BDR worker specific details, that are not
 available from `bdr.stat_activity`.
 
-The view `bdr.worker_errors` shows errors (if any) reported by any worker
-which has a problem continuing the work. Only active errors are visible in this
-view, so if the worker was having transient problems but has recovered, the
-view will be empty.
+The view `bdr.worker_errors` shows errors (if any) reported by any worker.
+BDR 3.7 depended explicitly on pglogical 3.7 as a separate extension. While
+pglogical deletes older worker errors, BDR does not aim to, given the additional
+complexity of bi-directional replication. A side effect of this dependency is
+that in BDR 3.7 some worker errors are deleted over time, while others are retained
+indefinitely. Because of this it's important to note the time of the error
+and not just the existence of one.
+Starting from BDR 4, there is a single extension, and dependency on
+pglogical as a separate extension has been removed, meaning that all worker errors
+are now retained indefinitely.
 
 ## Monitoring Global Locks
 

--- a/product_docs/docs/bdr/3.7/overview.mdx
+++ b/product_docs/docs/bdr/3.7/overview.mdx
@@ -37,7 +37,7 @@ replicate either from the master or from another standby.
 You don't have to write to all the masters, all of the time; it's
 a frequent configuration to direct writes mostly to just one master.
 However, if you just want one-way replication, the use of
-[pglogical](https://2ndquadrant.com/pglogical) may be more appropriate.
+[pglogical](https://www.enterprisedb.com/docs/pglogical/latest/) may be more appropriate.
 
 ### Asynchronous, by default
 

--- a/product_docs/docs/harp/2/03_installation.mdx
+++ b/product_docs/docs/harp/2/03_installation.mdx
@@ -25,7 +25,7 @@ version as listed here.
 
 The easiest way to install and configure HARP is to use the EDB TPAexec utility
 for cluster deployment and management. For details on this software, see the
-[TPAexec product page](https://access.2ndquadrant.com/customer_portal/sw/tpa/).
+[TPAexec product page](https://www.enterprisedb.com/docs/pgd/latest/deployments/tpaexec/).
 
 !!! Note
     TPAExec is currently available only through an EULA specifically dedicated
@@ -65,13 +65,13 @@ considerations.
 
 Currently CentOS/RHEL packages are provided by the EDB packaging
 infrastructure. For details, see the [HARP product
-page](https://access.2ndquadrant.com/customer_portal/sw/harp/).
+page](https://www.enterprisedb.com/docs/harp/latest/).
 
 ### etcd packages
 
-Currently `etcd` packages for many popular Linux distributions aren't 
-available by their standard public repositories. EDB has therefore packaged 
-`etcd` for RHEL and CentOS versions 7 and 8, Debian, and variants such as 
+Currently `etcd` packages for many popular Linux distributions aren't
+available by their standard public repositories. EDB has therefore packaged
+`etcd` for RHEL and CentOS versions 7 and 8, Debian, and variants such as
 Ubuntu LTS. You need access to our HARP package repository to use
 these libraries.
 
@@ -99,20 +99,20 @@ dcs:
     - host3:2379
 ```
 
-When using TPAExec, all configured etcd endpoints are entered here 
+When using TPAExec, all configured etcd endpoints are entered here
 automatically.
 
 ### BDR
 
-The `bdr` native consensus layer is available from BDR 3.6.21 and 3.7.3. This 
-consensus layer model requires no supplementary software when managing routing 
+The `bdr` native consensus layer is available from BDR 3.6.21 and 3.7.3. This
+consensus layer model requires no supplementary software when managing routing
 for a BDR cluster.
 
 To ensure quorum is possible in the cluster, always
 use more than two nodes so that BDR's consensus layer remains responsive during node
 maintenance or outages.
 
-To set BDR as the consensus layer, include this in the `config.yml` 
+To set BDR as the consensus layer, include this in the `config.yml`
 configuration file:
 
 ```yaml

--- a/product_docs/docs/pgd/4/backup.mdx
+++ b/product_docs/docs/pgd/4/backup.mdx
@@ -52,7 +52,7 @@ backup and recovery of BDR.
 
 Physical backups of a node in a BDR cluster can be taken using
 standard PostgreSQL software, such as
-[Barman](https://www.2ndquadrant.com/en/resources/barman/).
+[Barman](https://www.enterprisedb.com/docs/supported-open-source/barman/).
 
 A physical backup of a BDR node can be performed with the same
 procedure that applies to any PostgreSQL node: a BDR node is just a
@@ -86,7 +86,7 @@ entirely *consistent*; a physical backup of a given node will
 provide Point-In-Time Recovery capabilities limited to the states
 actually assumed by that node (see the [Example] below).
 
-The following example shows how two nodes in the same BDR cluster might not 
+The following example shows how two nodes in the same BDR cluster might not
 (and usually do not) go through the same sequence of states.
 
 Consider a cluster with two nodes `N1` and `N2`, which is initially in
@@ -106,7 +106,7 @@ node `N1` will go through the following states:
 
 That is: node `N1` will *never* assume state `S + W2`, and node `N2`
 likewise will never assume state `S + W1`, but both nodes will end up
-in the same state `S + W1 + W2`. Considering this situation might affect how 
+in the same state `S + W1 + W2`. Considering this situation might affect how
 you decide upon your backup strategy.
 
 ### Point-In-Time Recovery (PITR)
@@ -135,7 +135,7 @@ BDR allows for changes from multiple masters, all recorded within the
 WAL log for one node, separately identified using replication origin
 identifiers.
 
-BDR allows PITR of all or some replication origins to a specific point in time, 
+BDR allows PITR of all or some replication origins to a specific point in time,
 providing a fully consistent viewpoint across all subsets of nodes.
 
 Thus for multi-origins, we view the WAL stream as containing multiple
@@ -195,7 +195,7 @@ to the original PostgreSQL PITR behaviour that is designed around the assumption
 of changes arriving from a single master in COMMIT order.
 
 !!! Note
-    This is feature is only available on EDB Postgres Extended and 
+    This is feature is only available on EDB Postgres Extended and
     Barman does not currently automatically create a `multi_recovery.conf` file.
 
 ## Restore

--- a/product_docs/docs/pgd/4/monitoring.mdx
+++ b/product_docs/docs/pgd/4/monitoring.mdx
@@ -319,10 +319,11 @@ So this view offers these insights into the state of a BDR system:
 The `bdr.workers` view shows BDR worker specific details, that are not
 available from `bdr.stat_activity`.
 
-The view `bdr.worker_errors` shows errors (if any) reported by any worker
-which has a problem continuing the work. Only active errors are visible in this
-view, so if the worker was having transient problems but has recovered, the
-view will be empty.
+The view `bdr.worker_errors` shows last error (if any) reported by any worker
+which has a problem continuing the work. This is persistent information, so
+it's important to note the time of the error not just the existence of one,
+because most errors are transient in their nature and BDR workers will retry
+the failed operation.
 
 ## Monitoring BDR Writers
 


### PR DESCRIPTION
## What Changed?

Documentation for BDR4 and BDR3.7 in the `Monitoring`  section

- Adjusted information related to `bdr.worker_errors` and the persistency of the data.
- Adjusted links and references to 2ndQuadrant -> EDB

## Checklist

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
