### PR TITLE
Search current product by default

### DIFF
--- a/src/components/main-content.js
+++ b/src/components/main-content.js
@@ -1,10 +1,14 @@
 import React from "react";
 import SearchNavigation from "./search-navigation";
 
-const MainContent = ({ children, searchNavLogo = false }) => {
+const MainContent = ({
+  children,
+  searchNavLogo = false,
+  searchProduct = "",
+}) => {
   return (
     <div className="flex-grow-1 min-w-50">
-      <SearchNavigation logo={searchNavLogo} />
+      <SearchNavigation logo={searchNavLogo} searchProduct={searchProduct} />
       <main role="main" className="content-container mt-0 p-5">
         {children}
       </main>

--- a/src/components/search-navigation-links.js
+++ b/src/components/search-navigation-links.js
@@ -4,7 +4,7 @@ import { Link } from "./";
 const SearchNavigationLinks = () => (
   <>
     <Link to="/search" className="btn btn-link text-nowrap ml-2">
-      Search by Product
+      Advanced Search
     </Link>
   </>
 );

--- a/src/components/search-navigation.js
+++ b/src/components/search-navigation.js
@@ -20,7 +20,7 @@ const DocsLink = () => (
   </Link>
 );
 
-const SearchNavigation = ({ children, logo = false }) => {
+const SearchNavigation = ({ children, searchProduct, logo = false }) => {
   return (
     <Navbar variant="light" className="flex-md-nowrap p-3 border-bottom">
       {logo ? (
@@ -32,7 +32,7 @@ const SearchNavigation = ({ children, logo = false }) => {
       ) : (
         <></>
       )}
-      <SearchBar />
+      <SearchBar searchProduct={searchProduct} />
       <SearchNavigationLinks />
     </Navbar>
   );

--- a/src/components/search/formComps.js
+++ b/src/components/search/formComps.js
@@ -10,17 +10,29 @@ const Results = connectStateResults(
     res ? children : null,
 );
 
-const TryAdvancedSearch = connectStateResults(({ searchResults: res }) => (
-  <div className="search-prompt flex-grow-1 d-flex align-items-center justify-content-center p-4">
-    {res && res.nbHits > 0 ? "Not finding what you need?" : "No results found."}
-    <Link
-      to={`/search?query=${encodeURIComponent(res.query)}`}
-      className="ml-2"
-    >
-      Try Search by Product
-    </Link>
-  </div>
-));
+const TryAdvancedSearch = connectStateResults(
+  ({ searchResults: res, searchState: state }) => {
+    const productFilter = (state?.configure?.filters || "").replace(
+      /^product:/,
+      "",
+    );
+    return (
+      <div className="search-prompt flex-grow-1 d-flex align-items-center justify-content-center p-4">
+        {res && res.nbHits > 0
+          ? "Not finding what you need?"
+          : "No results found."}
+        <Link
+          to={`/search?query=${encodeURIComponent(res.query)}${
+            productFilter ? "&product=" + encodeURIComponent(productFilter) : ""
+          }`}
+          className="ml-2"
+        >
+          Try Advanced Search
+        </Link>
+      </div>
+    );
+  },
+);
 
 const Hits = ({ hits, arrowIndex }) => (
   <>
@@ -47,7 +59,7 @@ export const SearchPane = ({ arrowIndex }) => (
 export const AdvancedSearchTabLink = ({ query }) => (
   <div className="flex-grow-1 d-flex align-items-center justify-content-flex-end mr-4">
     <Link to={`/search?query=${encodeURIComponent(query)}`}>
-      Search by Product
+      Advanced Search
     </Link>
   </div>
 );

--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -14,6 +14,7 @@ import {
 import Icon, { iconNames } from "../icon/";
 import { SlashIndicator, ClearButton, SearchPane } from "./formComps";
 import useSiteMetadata from "../../hooks/use-sitemetadata";
+import { products } from "../../constants/products";
 
 const searchClient = algoliasearch(
   "HXNAF5X3I8",
@@ -34,12 +35,15 @@ const useClickOutside = (ref, handler, events) => {
   });
 };
 
-const SearchForm = ({ currentRefinement, refine, query }) => {
+const SearchForm = ({ currentRefinement, refine, query, searchProduct }) => {
   const searchBarRef = createRef();
   const [focus, setFocus] = useState(false);
   const inputRef = createRef();
   const searchContentRef = useRef(null);
   const [arrowIndex, setArrowIndex] = useState(0);
+  const context = searchProduct
+    ? " " + (products[searchProduct]?.name || searchProduct)
+    : "";
 
   const close = useCallback(() => {
     setFocus(false);
@@ -141,7 +145,7 @@ const SearchForm = ({ currentRefinement, refine, query }) => {
           className="form-control form-control-lg border-0 pl-3"
           type="text"
           aria-label="search"
-          placeholder="Search"
+          placeholder={"Search" + context}
           value={currentRefinement}
           onChange={(e) => refine(e.currentTarget.value)}
           onFocus={() => setFocus(true)}
@@ -173,11 +177,13 @@ const SearchForm = ({ currentRefinement, refine, query }) => {
 };
 const Search = connectSearchBox(SearchForm);
 
-const SearchBar = () => {
+const SearchBar = ({ searchProduct }) => {
   const ref = createRef();
   const [query, setQuery] = useState(``);
 
   const { algoliaIndex } = useSiteMetadata();
+  const searchConfig = { hitsPerPage: 30 };
+  if (searchProduct) searchConfig.filters = `product:${searchProduct}`;
 
   return (
     <div className="global-search w-100 position-relative" ref={ref}>
@@ -187,8 +193,8 @@ const SearchBar = () => {
         onSearchStateChange={({ query }) => setQuery(query)}
         className="dropdown"
       >
-        <Configure hitsPerPage={30} />
-        <Search query={query} />
+        <Configure {...searchConfig} />
+        <Search query={query} searchProduct={searchProduct} />
       </InstantSearch>
     </div>
   );

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -30,7 +30,7 @@ const Search = (data) => {
   });
 
   return (
-    <Layout background="white" pageMeta={{ title: "Search by Product" }}>
+    <Layout background="white" pageMeta={{ title: "Advanced Search" }}>
       <Container fluid className="p-0 d-flex bg-white">
         <InstantSearch
           searchClient={searchClient}

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -268,7 +268,7 @@ const DocTemplate = ({ data, pageContext }) => {
             hideVersion={frontmatter.hideVersion}
           />
         </SideNavigation>
-        <MainContent>
+        <MainContent searchProduct={product}>
           {showInteractiveBadge && (
             <div className="new-thing-header" aria-roledescription="badge">
               <span className="badge-text">Interactive Demo</span>

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -147,7 +147,7 @@ const LearnDocTemplate = ({ data, pageContext }) => {
             iconName={iconName}
           />
         </SideNavigation>
-        <MainContent>
+        <MainContent searchProduct={frontmatter.product}>
           {showInteractiveBadge && (
             <div className="new-thing-header" aria-roledescription="badge">
               <span className="badge-text">Interactive Demo</span>


### PR DESCRIPTION
## What Changed?

Fixes #1874, #2243

- When browsing a product's documentation, defaults to searching only that product via the instant search box at the top of the page
- Allows choosing a specific product to search (or all products) at any time via a drop-down to the left of the search box. 
- Indicates the current search context (all / specific product) via both placeholder text in the search field, and the state of the aforementioned dropdown

May require adding product metadata to pages / for products that do not currently have it.