### PR TITLE
Add description of `bdr.queue.message_type` values

### DIFF
--- a/product_docs/docs/bdr/4/catalogs.mdx
+++ b/product_docs/docs/bdr/4/catalogs.mdx
@@ -631,7 +631,7 @@ This table stores the historical record of replicated DDL statements.
 | queued_at        | timestamptz | When was the statement queued                                  |
 | role             | name        | Which role has executed the statement                          |
 | replication_sets | text\[]     | Which replication sets was the statement published to          |
-| message_type     | char        | Type of a message                                              |
+| message_type     | char        | Type of a message. Possible values:<br>A - Table sync<br>D - DDL<br>S - Sequence<br>T - Truncate<br>Q - SQL statement|
 | message          | json        | Payload of the message needed for replication of the statement |
 
 ### `bdr.replication_set`


### PR DESCRIPTION
## What Changed?

Added descriptions of possible values in the `message_type` column of `bdr.queue`, lifted from `pglogical_queue.h`.

## Checklist

**Content**

- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
