### PR TITLE
chore: adding chapter formatting to the opening page for EDB Postgres for Kubernetes

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/index.mdx
@@ -3,11 +3,14 @@ title: "EDB Postgres for Kubernetes"
 navigation:
 - rel_notes
 - cloudnativepg
+- "#Getting Started"
 - installation_upgrade
 - quickstart
 - interactive_demo
+- "#Configuration"
 - operator_conf
 - logging
+- "#Enhanced"
 - cnp-plugin
 - openshift
 - evaluation


### PR DESCRIPTION
After discussing with @josh-heyer, we figured out why the tiles on the opening page were missing and how to add those.
This PR is to fix that.