### PR TITLE
PGD: upgrades typo fix

### DIFF
--- a/product_docs/docs/pgd/4/upgrades/index.mdx
+++ b/product_docs/docs/pgd/4/upgrades/index.mdx
@@ -5,7 +5,7 @@ title: "Upgrading"
 Because EDB Postgres Distributed consists in multiple software components,
 the upgrade strategy depends partially on which components are being upgraded.
 
-In general it's possible to upgrade the cluster with almost zero upgrade, by
+In general it's possible to upgrade the cluster with almost zero downtime, by
 using an approach called Rolling Upgrade where nodes are upgraded one by one, and
 the application connections are switched over to already upgraded nodes.
 


### PR DESCRIPTION
Changed "upgrade" to "downtime" as per [DF-298](https://enterprisedb.atlassian.net/browse/DF-298)