### PR TITLE
Add ticket number to EPAS 14.4.0 bug fix

### DIFF
--- a/product_docs/docs/epas/14/epas_rel_notes/epas14_4_0_rel_notes.mdx
+++ b/product_docs/docs/epas/14/epas_rel_notes/epas14_4_0_rel_notes.mdx
@@ -8,6 +8,6 @@ EDB Postgres Advanced Server 14.4.0 includes the following bug fixes:
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------| ------- | --------------------- |
 | Upstream merge | Merged with community PostgreSQL 14.4. See the community [Release Notes](https://www.postgresql.org/docs/release/14.4/) for details. |         |                       |
 | Bug fix        | Fix server crash while executing the function which returns TABLE and requires casting on attributes. [Support Ticket: #81924]       | DB-1778 |                       |
-| Bug fix        | Fix \dn command query.                                                                                                               | DB-1777 | psql                  |
+| Bug fix        | Fix \dn command query. [Support Ticket: #83263]                                                                                        | DB-1777 | psql                  |
 
 


### PR DESCRIPTION
Support ticket 83263 was depending on the fix of DB-1777, but was missing from the metadata

## What Changed?

This adds the support ticket number that is related to DB-1777

## Checklist

**Content**

- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
