### PR TITLE
Adjust dependencies of pgBackRest in RHEL 7

### DIFF
--- a/advocacy_docs/supported-open-source/pgbackrest/02-installation.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/02-installation.mdx
@@ -34,9 +34,9 @@ Once you configured the repositories, run the following command to install pgBac
 $ sudo yum install pgbackrest
 ```
 
-The following additional packages will be installed:
+The following additional packages may be installed to satisfy the dependencies:
 
-* `postgresql-libs`
+* `libpq5`
 * `libzstd`
 
 ### EDB Postgres Advanced Server


### PR DESCRIPTION
In a support ticket (83285), a customer followed these directions and installed `postgresql-libs` manually before pgbackrest. Later on, that package conflicted with other dependencies of other packages, in the typical collision on `/usr/lib64/libpq.so`.

In RHEL 7, `postgresql-libs` brings libpq 9.2 of Red Hat, which is not a supported version and is also not tested against any of our packages. In RHEL 8, that package does not exist; instead, RHEL 8 provides `libpq` in the appstream repository.

In both cases, the package provided by PGDG is called `libpq5`, which is the right expectation to set when installing `pgbackrest` also from PGDG.

Additionally, if other packages have been installed before and already pulled these dependencies, then maybe these libraries won't be pulled in when installing `pgbackrest`, so this also adjusts the wording slightly to reflect that.

## What Changed?

Please list, at a high level, what changed in your branch. If you changed content, include the product, section, and version as applicable. **Please remove the user instructions including the examples before merging the PR.**

**Examples**

- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
