### PR TITLE
BDR-2351 - Add a note about clock skew estimation with current implementation

### DIFF
--- a/product_docs/docs/pgd/4/cli/command_ref/pgd_check-health.mdx
+++ b/product_docs/docs/pgd/4/cli/command_ref/pgd_check-health.mdx
@@ -9,9 +9,9 @@ Checks the health of the EDB Postgres Distributed cluster.
 Performs various checks such as if all nodes are accessible, all replication
 slots are working, and CAMO pairs are connected.
 
-Please note that the current implementation of clock skew may return inaccurate
-skew value if the cluster is under high load while running this command or has
-large number of nodes in it.
+Please note that the current implementation of clock skew may return an
+inaccurate skew value if the cluster is under high load while running this
+command or has large number of nodes in it.
 
 ```sh
 pgd check-health [flags]

--- a/product_docs/docs/pgd/4/cli/command_ref/pgd_check-health.mdx
+++ b/product_docs/docs/pgd/4/cli/command_ref/pgd_check-health.mdx
@@ -9,6 +9,10 @@ Checks the health of the EDB Postgres Distributed cluster.
 Performs various checks such as if all nodes are accessible, all replication
 slots are working, and CAMO pairs are connected.
 
+Please note that the current implementation of clock skew may return inaccurate
+skew value if the cluster is under high load while running this command or has
+large number of nodes in it.
+
 ```sh
 pgd check-health [flags]
 ```

--- a/product_docs/docs/pgd/4/cli/command_ref/pgd_show-clockskew.mdx
+++ b/product_docs/docs/pgd/4/cli/command_ref/pgd_show-clockskew.mdx
@@ -8,9 +8,9 @@ Shows the status of clock skew between each BDR node pair.
 
 Shows the status of clock skew between each BDR node pair in the cluster.
 
-Please note that the current implementation of clock skew may return inaccurate
-skew value if the cluster is under high load while running this command or has
-large number of nodes in it.
+Please note that the current implementation of clock skew may return an
+inaccurate skew value if the cluster is under high load while running this
+command or has large number of nodes in it.
 
     Symbol      Meaning
     -------     --------

--- a/product_docs/docs/pgd/4/cli/command_ref/pgd_show-clockskew.mdx
+++ b/product_docs/docs/pgd/4/cli/command_ref/pgd_show-clockskew.mdx
@@ -8,6 +8,10 @@ Shows the status of clock skew between each BDR node pair.
 
 Shows the status of clock skew between each BDR node pair in the cluster.
 
+Please note that the current implementation of clock skew may return inaccurate
+skew value if the cluster is under high load while running this command or has
+large number of nodes in it.
+
     Symbol      Meaning
     -------     --------
     *           ok


### PR DESCRIPTION


Added a note about inaccurate results for clock skew estimation with current implementation
when cluster is under high load or has large number of nodes in it.
We are working to improve the accuracy as part of [BDR-2157](https://enterprisedb.atlassian.net/browse/BDR-2157). 
This note would go away once the algorithm is updated.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
