### PR TITLE
change to efm standby priority description

### DIFF
--- a/product_docs/docs/efm/4/05_using_efm.mdx
+++ b/product_docs/docs/efm/4/05_using_efm.mdx
@@ -105,7 +105,7 @@ In the event of a failover, Failover Manager first retrieves information from Po
 
     The promotion priority for nodes changes when a new primary is promoted.
 
-    If the `efm set-priority` command was used to change whether a standby is promotable, you can reset this to the value in the standby's properties file through promotion or cluster splits and rejoins.
+    If the `efm set-priority` command was used to change whether a standby is promotable, it may be reset to the value in the standby's properties file through promotion or cluster splits and rejoins.
 
 ### Promoting a Failover Manager node
 


### PR DESCRIPTION
The original text here says that the user may reset the value, which isn't something we should direct the user to do (or even explain how they *could* do it). The text is supposed to say that it's something that can happen. The original text in the workspace didn't say that the user could do it, so this was messed up somewhere later.


## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
