### PR TITLE
BigAnimal: fixing pricing calculater links and links to cluster types

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -31,13 +31,13 @@ Prior to creating your cluster, make sure you have enough resources. Without eno
 
 1. Select which type of cluster to deploy. 
 
-     - [Single node](bigamimal/release/03_security/#single-node) creates a cluster with one primary and no standby replicas. Suited for test environments where high availability might not be required. You can create single node clusters running EDB Postgres Advanced Server or PostgreSQL. 
+     - [Single node](/biganimal/latest/overview/02_high_availability/#single-node) creates a cluster with one primary and no standby replicas. Suited for test environments where high availability might not be required. You can create single node clusters running EDB Postgres Advanced Server or PostgreSQL. 
 
-    -  [High availability](bigamimal/release/03_security/#high-availability) creates a cluster with one primary and two standby replicas in different availability zones. You can create high availability clusters running EDB Postgres Advanced Server or PostgreSQL. 
+    -  [High availability](/biganimal/latest/overview/02_high_availability/#high-availability) creates a cluster with one primary and two standby replicas in different availability zones. You can create high availability clusters running EDB Postgres Advanced Server or PostgreSQL. 
 
-    -  [Extreme high availability (beta)](bigamimal/release/03_security/#extreme-high-availability-beta) creates a cluster configured with a leader node, three shadow nodes, and one witness node. This cluster uses EDB Postgres Distributed to deliver higher performance and faster recovery. You can create extreme high availability clusters with either PostgreSQL or Oracle compatibility. 
+    -  [Extreme high availability (beta)](/biganimal/latest/overview/02_high_availability/#extreme-high-availability-beta) creates a cluster configured with a leader node, three shadow nodes, and one witness node. This cluster uses EDB Postgres Distributed to deliver higher performance and faster recovery. You can create extreme high availability clusters with either PostgreSQL or Oracle compatibility. 
     
-    See [Supported cluster types](/biganimal/release/overview/03_security) for more information about the different cluster types.
+    See [Supported cluster types](/biganimal/latest/overview/02_high_availability/) for more information about the different cluster types.
 
     !!! Note
        You can't switch from a single node or high availability cluster to an extreme high availability cluster or vice versa. 

--- a/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
+++ b/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
@@ -45,7 +45,7 @@ The table shows a breakdown of management costs for Microsoft Azure.
 
 At list price, estimated overall monthly management costs are $400&ndash;$700 for a single cluster. Check with your Microsoft Azure account manager for specifics that apply to your account. 
 
-To get a better sense of your Microsoft Azure costs, check out the Microsoft Azure pricing [calculator](https://calculator.aws/#/) and reach out to [BigAnimal Support](../overview/support). 
+To get a better sense of your Microsoft Azure costs, check out the Microsoft Azure pricing [calculator](https://azure.microsoft.com/en-us/pricing/calculator/) and reach out to [BigAnimal Support](../overview/support). 
 
 ### AWS management costs
 
@@ -60,7 +60,7 @@ The table shows a breakdown of management costs for AWS.
 
 At list price, estimated overall monthly management costs are $400&ndash;$600 for a single cluster. Check with your AWS account manager for specifics that apply to your account.
 
-To get a better sense of your AWS costs, check out the AWS pricing [calculator](https://azure.microsoft.com/en-us/pricing/calculator/) and reach out to [BigAnimal Support](../overview/support).  
+To get a better sense of your AWS costs, check out the AWS pricing [calculator](https://calculator.aws/#/) and reach out to [BigAnimal Support](../overview/support).  
 
 ## Billing
 


### PR DESCRIPTION
## What Changed?

AWS and Azure calculator links were switched
Links to cluster types from creating a cluster were broken