### PR TITLE
Update host to point to demo BA instance, fix path in restore

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
@@ -34,7 +34,7 @@ __OUTPUT__
 The connection string for this demo's Advanced Server cluster looks like this:
 
 ```
-postgres://demo:password@p-xj6qj8i1hx.qsbilba3hlgp1vqr.biganimal.io:5432/chinook?sslmode=require
+postgres://demo:password@p-vmpc7c40fm.pg.biganimal.io:5432/chinook?sslmode=require
 ```
 
 In case you're unfamiliar with [PostgreSQL connection URIs](https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6), let's break that down:
@@ -47,7 +47,7 @@ In case you're unfamiliar with [PostgreSQL connection URIs](https://www.postgres
     Avoid this practice for admin, superuser, or other roles used interactively - psql will prompt for a password
     if none is supplied.
     !!!
--   `p-xj6qj8i1hx.qsbilba3hlgp1vqr.biganimal.io` is the host name for the Advanced Server cluster on BigAnimal that I'm connecting to.
+-   `p-vmpc7c40fm.pg.biganimal.io` is the host name for the Advanced Server cluster on BigAnimal that I'm connecting to.
 -   `5432` is the usual PostgreSQL port number.
 -   `chinook` is the name of the database.
 -   `sslmode=require` ensures that we establish a secure connection.
@@ -55,7 +55,7 @@ In case you're unfamiliar with [PostgreSQL connection URIs](https://www.postgres
 With that in hand, we can launch psql:
 
 ```shell
-psql postgres://demo:password@p-xj6qj8i1hx.qsbilba3hlgp1vqr.biganimal.io:5432/chinook?sslmode=require
+psql postgres://demo:password@p-vmpc7c40fm.pg.biganimal.io:5432/chinook?sslmode=require
 __OUTPUT__
 psql (14.2.1, server 13.6.10 (Debian 13.6.10-1+deb10))
 SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
@@ -284,8 +284,8 @@ If you'd like to try these examples on your own BigAnimal cluster, follow these 
 
     ```shell
     pg_dump --format custom \
-        "postgres://demo:password@p-xj6qj8i1hx.qsbilba3hlgp1vqr.biganimal.io:5432/chinook?sslmode=require" \
-        > chinook.dump
+        "postgres://demo:password@p-vmpc7c40fm.pg.biganimal.io:5432/chinook?sslmode=require" \
+        > /tmp/chinook.dump
     ```
 
 7. Now grab the host name of your cluster from the Connect tab on the BigAnimal portal and use it in place of `<YOUR CLUSTER HOSTNAME>` to invoke pg_restore:
@@ -293,7 +293,7 @@ If you'd like to try these examples on your own BigAnimal cluster, follow these 
     ```shell
     pg_restore --no-owner \
         -d "postgres://edb_admin@<YOUR CLUSTER HOSTNAME>:5432/chinook?sslmode=require" \
-        /tmp/dump/chinook.dump
+        /tmp/chinook.dump
     ```
 
     !!! Note 


### PR DESCRIPTION
## What Changed?

Old BA cluster is being shut down, so need a new one - using a (long-lived) demo instance for convenience.

(also fixed paths in backup/restore section so they actually work)

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
