### PR TITLE
PGD organization scratchpad

### DIFF
--- a/product_docs/docs/pgd/4/deployments/index.mdx
+++ b/product_docs/docs/pgd/4/deployments/index.mdx
@@ -1,12 +1,14 @@
 ---
-title: "Deployment options"
+title: "Deploying EDB Postgres Distributed"
+navTitle: "Deploying"
 indexCards: simple
 
 ---
 
-You can deploy and install EDB Postgres Distributed products using the following methods:
+Current:
 
-- TPAexec is an orchestration tool that uses Ansible to build Postgres clusters as specified by TPA (Trusted Postgres Architecture), a set of reference architectures that document how to set up and operate Postgres in various scenarios. TPA represents the best practices followed by EDB, and its recommendations are as applicable to quick testbed setups as to production environments.
+- [Deploy PGD using TPAexec](tpaexec).
+  TPAexec is an orchestration tool that uses Ansible to build Postgres clusters as specified by TPA (Trusted Postgres Architecture), a set of reference architectures that document how to set up and operate Postgres in various scenarios. TPA represents the best practices followed by EDB, and its recommendations are as applicable to quick testbed setups as to production environments.
 
 Coming soon:
 

--- a/product_docs/docs/pgd/4/deployments/tpaexec/index.mdx
+++ b/product_docs/docs/pgd/4/deployments/tpaexec/index.mdx
@@ -1,19 +1,25 @@
 ---
-title: TPAexec
+title: "Deploying EDB Postgres Distributed with TPAexec"
+navTitle: "Deploying with TPAexec"
 navigation:
 - installing_tpaexec
-- using_tpaexec
 - quick_start
+- using_tpaexec
 ---
 
 The standard way of deploying EDB Postgres Distributed in a self managed setting,
 including physical and virtual machines, both self-hosted and in the cloud
 (EC2), is to use EDB's deployment tool called TPAexec.
 
-TPAexec is an orchestration tool that uses Ansible to build Postgres clusters as specified by Trusted Postgres Architecture (TPA), a set of reference architectures that documents how to set up and operate Postgres in various scenarios. TPA represents the best practices followed by EDB and its recommendations are as applicable to quick testbed setups as to production environments.
+TPAexec is an orchestration tool that uses Ansible to build Postgres clusters as specified by [Trusted Postgres Architecture (TPA)](../../architectures/), a set of reference architectures that documents how to set up and operate Postgres in various scenarios. TPA represents the best practices followed by EDB and its recommendations are as applicable to quick testbed setups as to production environments.
 
 TPAexec packages are only available to EDB customers with an active BDR subscription. Please contact your account manager to request access.
 
+## Getting started
+
+See these topics to install TPAexec and use it to deploy your first EDB Postgres Distributed cluster:
+- [Installing TPAexec](installing_tpaexec)
+- [Example: Deploying EDB Postgres Distributed](quick_start)
 
 ## Incremental changes
 TPAexec is carefully designed so that provisioning, deployment, and testing are idempotent. You can run through them, make a change to config.yml, and run through the process again to deploy the change. If nothing has changed in the configuration or on the instances, then rerunning the entire process does not change anything either.
@@ -29,12 +35,8 @@ Once your cluster is up and running, TPAexec provides convenient cluster managem
 ## It's just Postgres
 TPAexec can create complex clusters with many features configured, but the result is just Postgres. The installation follows some conventions designed to make life simpler, but there is no hidden magic or anything standing in the way between you and the database. You can do everything on a TPA cluster that you could do on any other Postgres installation.
 
-## Getting started
-See these topics to install TPAexec and use it to deploy your first EDB Postgres Distributed cluster:
-- [Installing TPAexec](installing_tpaexec)
-- [Using TPAexec](using_tpaexec)
-- [Example: Deploying EDB Postgres Distributed](quick_start)
-
-For more information, see [TPAexec](https://documentation.enterprisedb.com/tpa/release/latest/).
+## More information
+- [TPAexec command reference](using_tpaexec)
+- [TPAexec documentation in the EDB Customer Portal](https://documentation.enterprisedb.com/tpa/release/latest/).
 
 

--- a/product_docs/docs/pgd/4/deployments/tpaexec/installing_tpaexec.mdx
+++ b/product_docs/docs/pgd/4/deployments/tpaexec/installing_tpaexec.mdx
@@ -4,6 +4,9 @@ title: "Installing TPAexec"
 
 The TPAexec install package in available from the EDB customer portal. You must have a subscription to access the repository and the TPAexec install package.
 
+!!! Note
+    The examples in this section assume you are using TPAexec v22.14 and installing Postgres 14.
+
 ## Prerequisites
 
 ### Access
@@ -15,24 +18,13 @@ Setting up the repository requires root user permissions. If you do not have dir
 sudo su -
 ```
 
-If you are behind an HTTPS proxy, see [How to install RPM/APT repositories through a HTTPS proxy](https://techsupport.enterprisedb.com/kb/a/how-to-install-rpm-apt-repositories-through-a-https-proxy/).
+## Repository
 
-
-### Token
-
-You need your token to complete the install process. It is available from the [EnterpriseDB customer portal](https://techsupport.enterprisedb.com/customer_portal/). From the left navigation pane, select **Company info > Company**. The account information for your company displays. Copy your token. 
-
-
-
-## Installing TPAexec
-
-The examples in this section assume you are using TPAexec v22.14 and installing Postgres 14.
-
-1. Install the EnterpriseDB repository for TPAexec. Replace `token` with your company token. Replace `pgVersion` with the version of Postgres you are installing.
+Configure the EnterpriseDB repository for TPAexec. Replace `token` with your company token. Replace `pgVersion` with the version of Postgres you are installing. Replace `<package manager>` with `rpm` for RedHat or `deb` for Debian/Ubuntu.
 
    Syntax:
    ```
-   curl https://techsupport.enterprisedb.com/api/repository/<token>/products/tpa/release/<pgVersion>/rpm | bash
+   curl https://techsupport.enterprisedb.com/api/repository/<token>/products/tpa/release/<pgVersion>/<package manager> | bash
    ```
 
    Example:
@@ -40,7 +32,19 @@ The examples in this section assume you are using TPAexec v22.14 and installing 
    curl https://techsupport.enterprisedb.com/api/repository/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/products/tpa/release/14/rpm | bash
    ```
 
-2. Install TPAexec:
+You can also find this command (with your token pre-filled) on the [EDB customer portal](https://techsupport.enterprisedb.com/customer_portal/): *Support -> Software -> Linux repositories*.
+
+If you are behind an HTTPS proxy, see [How to install RPM/APT repositories through a HTTPS proxy](https://techsupport.enterprisedb.com/kb/a/how-to-install-rpm-apt-repositories-through-a-https-proxy/).
+
+### Token
+
+You need your token to complete the install process. It is available from the [EDB customer portal](https://techsupport.enterprisedb.com/customer_portal/). From the left navigation pane, select **Company info > Company**. The account information for your company displays. Copy your token. 
+
+
+
+## Installing TPAexec using the package manager
+
+1. Install TPAexec:
 
    - On RedHat
 
@@ -56,6 +60,7 @@ The examples in this section assume you are using TPAexec v22.14 and installing 
    ```
    /opt/EDB/TPA/bin/tpaexec setup
    ```
+   
 4. Verify the installation:
    ```
    /opt/EDB/TPA/bin/tpaexec selftest

--- a/product_docs/docs/pgd/4/deployments/tpaexec/quick_start.mdx
+++ b/product_docs/docs/pgd/4/deployments/tpaexec/quick_start.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Example: Deploying EDB Postgres Distributed"
-navTitle: "Example: Deploying EDB Postgres Distributed"
+title: "Example: Deploying EDB Postgres Distributed on AWS"
+navTitle: "Example: Deploying PGD on AWS"
 ---
 
 
@@ -10,12 +10,12 @@ architecture using Amazon EC2.
 1. Generate a configuration file:
    
    ```
-   $ tpaexec configure myedbdpcluster --architecture BDR-Always-ON --layout Silver --platform aws --bdr-version 4 --2q --2Q-repositories products/2ndqpostgres/release
+   $ tpaexec configure myedbdpcluster --architecture BDR-Always-ON --layout silver --platform aws --bdr-version 4 --harp-consensus-protocol bdr --2q --2Q-repositories products/2ndqpostgres/release
    ```
 
    This creates a subdirectory directory in current working directory called `myedbdpcluster` containing the `config.yml` configuration file TPAexec uses to create the cluster. Edit the `config.yml` as needed, for example to change the IP address range used for servers or adjust locations of nodes.
 
-   We included options to specify using BDR 4 (the default version) and the 2ndQuadrant repositories to install EDB Postgres Extended Server. By default, TPAexec installs the 2ndQuadrant public repository and adds on any product repositories that the architecture requires. In this example, we specified `--2Q-repositories` so the complete list of 2ndQuadrant repositories is installed on each instance in addition to the 2ndQuadrant public repository. Since we did this, before the provisioning step, you must first export TPA_2Q_SUBSCRIPTION_TOKEN=xxx. You can get a subscription token from the [EnterpriseDB customer portal](https://techsupport.enterprisedb.com/customer_portal/) (**Support > Software subscriptions > Add**).
+   We included options to specify using BDR 4 (the default version) and the 2ndQuadrant repositories to install EDB Postgres Extended Server. By default, TPAexec installs the 2ndQuadrant public repository and adds on any product repositories that the architecture requires. In this example, we specified `--2Q-repositories` so the complete list of 2ndQuadrant repositories is installed on each instance in addition to the 2ndQuadrant public repository. Since we did this, before the provisioning step, you must first export TPA_2Q_SUBSCRIPTION_TOKEN=xxx. You can get a subscription token from the [EDB customer portal](https://techsupport.enterprisedb.com/customer_portal/) (**Support > Software subscriptions > Add**).
 
    ```
    cd ~/clusters/myedbdpcluster

--- a/product_docs/docs/pgd/4/deployments/tpaexec/using_tpaexec.mdx
+++ b/product_docs/docs/pgd/4/deployments/tpaexec/using_tpaexec.mdx
@@ -82,7 +82,7 @@ By default, TPAexec installs the 2ndQuadrant public repository and adds on any p
 
 Specify `--2Q-repositories source/name/release … ` to specify the complete list of 2ndQuadrant repositories to install on each instance in addition to the 2ndQuadrant public repository.
 
-If you do this, you must first export TPA_2Q_SUBSCRIPTION_TOKEN=xxx before you run tpaexec. You can get a subscription token from the [EnterpriseDB customer portal](https://techsupport.enterprisedb.com/customer_portal/) (**Support > Software subscriptions > Add**).
+If you do this, you must first export TPA_2Q_SUBSCRIPTION_TOKEN=xxx before you run tpaexec. You can get a subscription token from the [EDB customer portal](https://techsupport.enterprisedb.com/customer_portal/) (**Support > Software subscriptions > Add**).
 
 ### Software versions
 By default TPAexec uses the latest major version of Postgres. Specify `--postgres-version` to install an earlier supported major version. 


### PR DESCRIPTION
## Introduction

PGD is a recent creation, an attempt to create an overarching product that exists on top of / as a superset of the existing components BDR, TPA, Harp, LiveCompare

As such, the PGD documentation should be considered the entrypoint for folks looking to learn about EDB's ecosystem of HA products and designs, identify their collective requirements and limitations, prepare for evaluation or plan a strategy for deployment. Individual product docs should be focused on reference material for their individual components or services, e.g. documenting BDR built-in roles, harpctl commands, LiveCompare configuration, etc.
   
Current docs are split in roughly this manner, but some artifacts remain (for historical reasons or through oversight). A few representative examples: 
   
- HARP 2.0 docs contain an installation topic that partially duplicates information found under PGD, largely for the benefit of those using versions of PGD/BDR prior to v4. 
- The PGD "Other considerations" topic and the BDR "Architectural Overview" topic both contain roughly the same note on clocks and timezones
- The PGD section on Durability largely defers to the BDR topic "Durability and performance options", presenting little more than a link and a bullet list (that does not readily map to the linked topic).
- The BDR "Application use" topic should probably be introduced as part of PGD, as it is less specific to the mechanics of the BDR extension than with the application changes and testing that may be needed in order for PGD to be used.
- etc.

This PR is currently sort of a scratchpad for investigating possible remediation for issues such as these. 
   
## Research (ongoing)

I've [started a list of PGD/BDR/HARP/LiveCompare topics currently in docs](https://docs.google.com/spreadsheets/d/15mX3glnCjMTai7HEX67GgdTkRNssqLKxnbxmYnIM5qM/edit#gid=0), with notes on what I observed while reading them:

- **type** is how the topic appears to present itself (in format, title, etc.). E.g. "interface doc" appers to describe a CLI or API, "reference" covers complete set (or subset) of commands, configuration options, etc., "procedure detail" describes the steps necessary to accomplish some task (or tasks), etc.

- **Purpose** is my impression of the topic's reason for existing (which is... not necessarily how it was intended or how the information *should be* presented, but gotta start somewhere)

- **Categories** are a collection of keywords or phrases that pertain to the topic (think: tags.) I'm mostly just using this to quickly find stuff again.

I've also perused the knowledge base articles pertaining to BDR, HARP and LiveCompare. This is mostly for gaining background info on the evolution of these products; still have a lot more reading to do there.

## Current recommendations reflected by this PR

Deployment options:

   - Rename to "Deploying" - make this into an action for symmetry with "Upgrading" 
   - Link to TPAexec immediately (remove sentance implying multiple options as only one is currently available)

TPAexec:
   
   - Rename to "Deploying PGD with TPAexec" (nav: "Deploying with TPAexec")
   - Link to "Choosing your architecture" topic from the text "Trusted Postgres Architecture (TPA)" - TODO: are we still using this terminology going forward? Would be beneficial to define it somewhere
   - Link to "Installing TPAexec" topic immediately - leave explanatory sections for later by moving entire "Getting started" section to top of topic after intro

Installing TPAexec: 
   
   - Move the repo configuration from "Installing TPAexec" section to "Prerequesites" - it is a prerequesite, and a good introduction to how these repos are configured
   - Include note for Debian/Ubuntu repository
   - Describe how to find this script (with already-embedded token) via the customer portal
   - Rename subsection "Installing TPAexec" to "Installing TPAexec using a package manager"
      
Using TPAexec:
   
   - Move to last in the section
   
   (This is a reference topic)
   
Example: Deploying EDB Postgres Distributed
   
   - Add `--harp-consensus-protocol bdr` option to the configure call, and make "Silver" lowercase for layout
   - TODO: consider switching to docker for the example 
   - TODO: include detailed instructions / example for connecting via psql vs just "You can"
   
TODO: CLI install - rename, put last, crosslink with TPA
   
TODO: HARP install - immediately link to TPA, remove "can't access" note, make clear that rest of instructions are for legacy / unusual situations
   
TODO: software requirements need to be pushed up