### PR TITLE
chore(UPM-8458): Document update to reflect CLI 1.6.0 changes.

### DIFF
--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -188,7 +188,7 @@ Here is a sample configuration file in YAML format with Azure specified as the p
   # config_file.yaml
   ---
   clusterArchitecture: ha                                                         # <string:  cluster architecture, valid values ["single" | "ha" | "eha"]>
-  haStandbyReplicas: 2                                                            # <number:  Number of standby replicas. Field must be specified only if user has selected high-availability type cluster architecture. Default value considered is 2, valid values [1, 2]>
+  haStandbyReplicas: 2                                                            # <number:  Number of standby replicas. Field must be specified if user has selected high availability cluster type. Default value is 2, valid values [1, 2].>
   provider: azure                                                                 # <string:  cloud provider id>
   clusterName: my-biganimal-cluster                                               # <string:  cluster name>
   password: ************                                                          # <string:  cluster password (must be at least 12 characters)>

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -126,16 +126,16 @@ You can turn off prompting using the `biganimal config set interactive_mode off`
 
 ```shell
 $ biganimal create-cluster
-Cluster Name: my-biganimal-cluster
-Password: ************
 Cluster architecture: High Availability
+Number of standby replicas: 2 Replicas
+Provider: Azure
+Cluster Name: my-biganimal-cluster
+Password: ****************
 PostgreSQL type: Oracle Compatible
 PostgreSQL version: 14
-Provider: Azure
 Region: (US) East US
-Instance type: D4s v4(4vCPU, 16GB RAM)
+Instance type: D4s v3(4vCPU, 16GB RAM)
 Volume type: Azure Premium Storage
-Use the arrow keys to navigate: ↓ ↑
 Volume properties?
   ▸ P1 (4 Gi, 120 Provisioned IOPS, 25 Provisioned MB/s)
     P2 (8 Gi, 120 Provisioned IOPS, 25 Provisioned MB/s)
@@ -188,6 +188,7 @@ Here is a sample configuration file in YAML format with Azure specified as the p
   # config_file.yaml
   ---
   clusterArchitecture: ha                                                         # <string:  cluster architecture, valid values ["single" | "ha" | "eha"]>
+  haStandbyReplicas: 2                                                            # <number:  Number of standby replicas. Field must be specified only if user has selected high-availability type cluster architecture. Default value considered is 2, valid values [1, 2]>
   provider: azure                                                                 # <string:  cloud provider id>
   clusterName: my-biganimal-cluster                                               # <string:  cluster name>
   password: ************                                                          # <string:  cluster password (must be at least 12 characters)>


### PR DESCRIPTION
## What Changed?

- The `create-cluster` subcommand interactive mode sample. 
- The `create-cluster` configuration file sample.

**Examples**

- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
