### PR TITLE
BigAnimal: GUC formulas - terminology improvements

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/03_modifying_your_cluster/05_db_configuration_parameters.mdx
@@ -35,9 +35,9 @@ Formulas can calculate a value relative to the specifications you selected for t
 `*` and `/` are at the same operator precedence. `+` and `-` are at the same operator precedence. `*` and `/` are evaluated before `+` and `-`. Use parentheses to specify additional order of operations. 
 
 ### Units
-GUCs can either be a bare number, such as 8, or have a unit, such as GB. Units are categorized into classes such as size or duration.
+GUCs can either be a bare number, such as 8, or have a unit, such as GB. Units are categorized into kinds of units such as size or duration.
 
-The category of unit of the target GUC must match the category of unit used in the formula. For example, you can't use a formula that tries to multiply two seconds with three kilobytes (`2s * 3KB`), but you can use a formula that multiplies two sizes even if they have different scales (`2KB * 8GB`). 
+The kind of unit of the target GUC must match the kind of unit used in the formula. For example, you can't use a formula that tries to multiply two seconds with three kilobytes (`2s * 3KB`), but you can use a formula that multiplies two sizes even if they have different scales (`2KB * 8GB`). 
 
 The unit of the target GUC must match the unit used in the formula. For example, you can multiply two seconds by four days but you can't assign the result to a GUC of unit KB.
 


### PR DESCRIPTION
## What Changed?

Using "kind" instead of "category" when talking about classes of units