### PR TITLE
docs(UPM-8492): Removing table metrics from documentation

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
@@ -296,51 +296,6 @@ This group of metrics can have these labels:
 | --------- | -------------------- |
 | `datname` | Name of the database |
 
-#### Group `cnp_pg_stat_user_tables`
-
-Access and usage statistics maintained by postgres on nonsystem tables.
-
-Metrics in this section are reset when a postgres stats reset is issued
-on the db server.
-
-Derived from the `pg_stat_user_tables` view.
-
-See also `cnp_pg_statio_user_tables`.
-
-##### Metrics
-
-| Metric                                        | Usage   | Description                                                                 |
-| --------------------------------------------- | ------- | --------------------------------------------------------------------------- |
-| `cnp_pg_stat_user_tables_seq_scan`            | COUNTER | Number of sequential scans initiated on this table                          |
-| `cnp_pg_stat_user_tables_seq_tup_read`        | COUNTER | Number of live rows fetched by sequential scans                             |
-| `cnp_pg_stat_user_tables_idx_scan`            | COUNTER | Number of index scans initiated on this table                               |
-| `cnp_pg_stat_user_tables_idx_tup_fetch`       | COUNTER | Number of live rows fetched by index scans                                  |
-| `cnp_pg_stat_user_tables_n_tup_ins`           | COUNTER | Number of rows inserted                                                     |
-| `cnp_pg_stat_user_tables_n_tup_upd`           | COUNTER | Number of rows updated                                                      |
-| `cnp_pg_stat_user_tables_n_tup_del`           | COUNTER | Number of rows deleted                                                      |
-| `cnp_pg_stat_user_tables_n_tup_hot_upd`       | COUNTER | Number of rows HOT updated (i.e., with no separate index update required)   |
-| `cnp_pg_stat_user_tables_n_live_tup`          | GAUGE   | Estimated number of live rows                                               |
-| `cnp_pg_stat_user_tables_n_dead_tup`          | GAUGE   | Estimated number of dead rows                                               |
-| `cnp_pg_stat_user_tables_n_mod_since_analyze` | GAUGE   | Estimated number of rows changed since last analyze                         |
-| `cnp_pg_stat_user_tables_last_vacuum`         | GAUGE   | Last time when this table was manually vacuumed (not counting VACUUM FULL)  |
-| `cnp_pg_stat_user_tables_last_autovacuum`     | GAUGE   | Last time when this table was vacuumed by the autovacuum daemon             |
-| `cnp_pg_stat_user_tables_last_analyze`        | GAUGE   | Last time when this table was manually analyzed                             |
-| `cnp_pg_stat_user_tables_last_autoanalyze`    | GAUGE   | Last time when this table was analyzed by the autovacuum daemon             |
-| `cnp_pg_stat_user_tables_vacuum_count`        | COUNTER | Number of times this table was manually vacuumed (not counting VACUUM FULL) |
-| `cnp_pg_stat_user_tables_autovacuum_count`    | COUNTER | Number of times this table was vacuumed by the autovacuum daemon            |
-| `cnp_pg_stat_user_tables_analyze_count`       | COUNTER | Number of times this table was manually analyzed                            |
-| `cnp_pg_stat_user_tables_autoanalyze_count`   | COUNTER | Number of times this table was analyzed by the autovacuum daemon            |
-
-##### Labels
-
-This group of metrics can have these labels:
-
-| Label        | Description                              |
-| ------------ | ---------------------------------------- |
-| `datname`    | Name of current database                 |
-| `schemaname` | Name of the schema that this table is in |
-| `relname`    | Name of this table                       |
-
 #### Group `cnp_pg_stat_replication`
 
 Realtime information about replication connections to this postgres instance,
@@ -377,40 +332,6 @@ This group of metrics can have these labels:
 | `usename`          | Name of the replication user |
 | `application_name` | Name of the application      |
 | `client_addr`      | Client IP address            |
-
-#### Group `cnp_pg_statio_user_tables`
-
-I/O activity statistics maintained by postgres on nonsystem tables.
-
-Metrics in this section are reset when a postgres stats reset is issued
-on the db server.
-
-Derived from the `pg_statio_user_tables` view.
-
-See also `cnp_pg_stat_user_tables`.
-
-##### Metrics
-
-| Metric                                      | Usage   | Description                                                               |
-| ------------------------------------------- | ------- | ------------------------------------------------------------------------- |
-| `cnp_pg_statio_user_tables_heap_blks_read`  | COUNTER | Number of disk blocks read from this table                                |
-| `cnp_pg_statio_user_tables_heap_blks_hit`   | COUNTER | Number of buffer hits in this table                                       |
-| `cnp_pg_statio_user_tables_idx_blks_read`   | COUNTER | Number of disk blocks read from all indexes on this table                 |
-| `cnp_pg_statio_user_tables_idx_blks_hit`    | COUNTER | Number of buffer hits in all indexes on this table                        |
-| `cnp_pg_statio_user_tables_toast_blks_read` | COUNTER | Number of disk blocks read from this table's TOAST table (if any)         |
-| `cnp_pg_statio_user_tables_toast_blks_hit`  | COUNTER | Number of buffer hits in this table's TOAST table (if any)                |
-| `cnp_pg_statio_user_tables_tidx_blks_read`  | COUNTER | Number of disk blocks read from this table's TOAST table indexes (if any) |
-| `cnp_pg_statio_user_tables_tidx_blks_hit`   | COUNTER | Number of buffer hits in this table's TOAST table indexes (if any)        |
-
-##### Labels
-
-This group of metrics can have these labels:
-
-| Label        | Description                              |
-| ------------ | ---------------------------------------- |
-| `datname`    | Name of current database                 |
-| `schemaname` | Name of the schema that this table is in |
-| `relname`    | Name of this table                       |
 
 #### Group `cnp_pg_settings`
 


### PR DESCRIPTION
## What Changed?

Removed references to PG table metrics in product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx as this has now been removed as per UPM-8492.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [x] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
