### PR TITLE
BigAnimal: fixed --high-availability examples

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/index.mdx
@@ -60,7 +60,7 @@ Perform the following steps:
     setup-csp --provider 
           {--account-id | --subscription-id}
           --region
-          [--instance-type --high-availability --networking | --skip-preflight]
+          [--instance-type --cluster-architecture --networking | --skip-preflight]
           [--run]
     ```
  !!! Important
@@ -68,12 +68,12 @@ Perform the following steps:
  Here is an example of setting up an AWS account:
 
     ```shell
-   biganimal setup-csp --provider aws --account-id 123456789102  --region us-east-1 --instance-type aws:r5.large --high-availability --networking private --run
+   biganimal setup-csp --provider aws --account-id 123456789102  --region us-east-1 --instance-type aws:r5.large --cluster-architecture ha --networking private --run
    ```
 
  Here is an example if setting up an Azure account:
     ```shell
-   biganimal setup-csp --provider azure --subscription-id abc12345-1234-1234-abcd-12345678901 --region eastus --instance-type azure:Standard_E4s_v3 --high-availability --networking private --run
+   biganimal setup-csp --provider azure --subscription-id abc12345-1234-1234-abcd-12345678901 --region eastus --instance-type azure:Standard_E4s_v3 --cluster-architecture ha --networking private --run
    ```
   
    For more information on the command arguments, run the following command:


### PR DESCRIPTION
## What Changed?

Updated the examples in the CLI examples that used deprecated --high-availability option

https://enterprisedb.atlassian.net/browse/UPM-8984