### PR TITLE
Remove the vague hint for props value

### DIFF
--- a/product_docs/docs/bdr/4/configuration.mdx
+++ b/product_docs/docs/bdr/4/configuration.mdx
@@ -55,10 +55,6 @@ of parallel apply uses extra origin per writer.
 When the [decoding worker](nodes#decoding-worker) is enabled, this
 process requires one extra replication slot per BDR group.
 
-The general safe recommended value on a 4-node BDR group with a single database
-is to set `max_replication_slots` and `max_worker_processes` to something
-like `50` and `max_wal_senders` to at least `10`.
-
 Changing these parameters requires restarting the local node:
 `max_worker_processes`, `max_wal_senders`, `max_replication_slots`.
 


### PR DESCRIPTION
The hint for a 4 node BDR cluster mentions some vague values for `max_replication_slots` and `max_worker_processes`. These values don't seem to be rational and hence dropping the hint.

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ x] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
