### PR TITLE
EPAS: cleaning up references

### DIFF
--- a/product_docs/docs/epas/11/epas_compat_bip_guide/index.mdx
+++ b/product_docs/docs/epas/11/epas_compat_bip_guide/index.mdx
@@ -8,7 +8,3 @@ legacyRedirectsGenerated:
 ---
 
 Database Compatibility for Oracle means that an application runs in an Oracle environment as well as in the EDB Postgres Advanced Server (Advanced Server) environment with minimal or no changes to the application code. This guide focuses solely on the features that are related to the package support provided by Advanced Server.
-
-For more information about using other compatibility features offered by Advanced Server, please see the complete set of Advanced Server guides, available at:
-
-[https://www.enterprisedb.com/docs/](/epas/11/)

--- a/product_docs/docs/epas/11/epas_compat_ora_dev_guide/07_open_client_library.mdx
+++ b/product_docs/docs/epas/11/epas_compat_ora_dev_guide/07_open_client_library.mdx
@@ -14,9 +14,7 @@ The following diagram compares the Open Client Library and Oracle Call Interface
 
 ![Open Client Library](images/open_client_library.png)
 
-For detailed usage information about the Open Client Library and the supported functions, see the *EDB Postgres Advanced Server OCL Connector Guide*:
-
-<https://www.enterprisedb.com/docs>
+For detailed usage information about the Open Client Library and the supported functions, see [EDB OCL Connector](/ocl_connector/latest/).
 
 !!! Note
     EnterpriseDB does not support use of the Open Client Library with Oracle Real Application Clusters (RAC) and Oracle Exadata; the aforementioned Oracle products have not been evaluated nor certified with this EnterpriseDB product.

--- a/product_docs/docs/epas/11/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
+++ b/product_docs/docs/epas/11/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
@@ -15,6 +15,5 @@ Compatible tools and utility programs can allow a developer to work with Advance
 -   EDB\*Wrap
 -   The Dynamic Runtime Instrumentation Tools Architecture (DRITA)
 
-For detailed information about the functionality supported by Advanced Server, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide*, available at:
-
-<https://www.enterprisedb.com/docs>
+For detailed information about the functionality supported by EDB Postgres Advanced Server, see [Database Compatibility for Oracle
+Developers Tools and Utilities](/epas/latest/epas_compat_tools_guide/).

--- a/product_docs/docs/epas/11/epas_compat_ora_dev_guide/index.mdx
+++ b/product_docs/docs/epas/11/epas_compat_ora_dev_guide/index.mdx
@@ -17,22 +17,10 @@ Database Compatibility for Oracle means that an application runs in an Oracle en
 -   SQL statements that are compatible with Oracle SQL
 -   System catalog views that are compatible with Oracle’s data dictionary
 
-For detailed information about the compatible SQL syntax, data types, and views, see the *Database Compatibility for Oracle Developers SQL Guide*.
+For detailed information about the compatible SQL syntax, data types, and views, see the [Database Compatibility for Oracle Developers SQL Guide](/epas/latest/epas_compat_sql/).
 
-The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in the *Database Compatibility for Oracle Developers Built-in Package Guide*.
+The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in [Database Compatibility for Oracle Developers Built-in Packages](/epas/latest/epas_compat_bip_guide/).
 
-For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an Advanced Server installation, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide*.
+For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an EDB Postgres Advanced Server installation, see [Tools and utilities](/epas/latest/epas_compat_ora_dev_guide/09_tools_and_utilities/).
 
-For applications written using the Oracle Call Interface (OCI), EnterpriseDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see the *EDB Postgres Advanced Server OCL Connector Guide*.
-
-Advanced Server contains a rich set of features that enables development of database applications for either PostgreSQL or Oracle. For more information about all of the features of Advanced Server, see the user documentation available at the EnterpriseDB website.
-
-Advanced Server documentation is available at:
-
-<https://www.enterprisedb.com/docs>
-
-<div class="toctree" maxdepth="3">
-
-configuration_parameters_compatible_with_oracle_databases about_the_examples_used_in_this_guide
-
-</div>
+For applications written using the Oracle Call Interface (OCI), EDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see [EDB OCL Connector](/ocl_connector/latest/).

--- a/product_docs/docs/epas/11/epas_compat_reference/index.mdx
+++ b/product_docs/docs/epas/11/epas_compat_reference/index.mdx
@@ -23,7 +23,3 @@ Developing an application that is compatible with Oracle databases in the Advanc
 -   System and built-in functions for use in SQL statements and procedural logic that are compatible with Oracle databases
 -   Stored Procedure Language (SPL) to create database server-side application logic for stored procedures, functions, triggers, and packages
 -   System catalog views that are compatible with Oracle’s data dictionary
-
-For detailed information about Advanced Server's compatibility features and extended functionality, see the complete library of Advanced Server documentation, available at:
-
-<https://www.enterprisedb.com/docs>

--- a/product_docs/docs/epas/11/epas_compat_spl/index.mdx
+++ b/product_docs/docs/epas/11/epas_compat_spl/index.mdx
@@ -13,9 +13,3 @@ Advanced Server's stored procedural language (SPL) is a highly productive, proce
 -   ease of use
 
 This guide describes the basic elements of an SPL program, before providing an overview of the organization of an SPL program and how it is used to create a procedure or a function. Guides about the other compatibility features (such as triggers or built-in functions) that might be used in conjunction with the SPL language are available at the [EDB website](/epas/11/).
-
-<div class="toctree" maxdepth="4">
-
-basic_spl_elements spl_programs variable_declarations basic_statements control_structures transaction_control dynamic_sql static_cursors ref_cursors_and_cursor_variables collections collection_methods working_with_collections triggers packages object_types_and_objects errors_and_messages conclusion
-
-</div>

--- a/product_docs/docs/epas/11/epas_compat_table_partitioning/index.mdx
+++ b/product_docs/docs/epas/11/epas_compat_table_partitioning/index.mdx
@@ -19,9 +19,3 @@ This document discusses the aspects of table partitioning compatible with Oracle
     This document and particularly the partitioning presented in this chapter do not describe the *declarative partitioning* feature, which has been introduced with PostgreSQL version 10. Note that PostgreSQL declarative partitioning is supported in Advanced Server 10 in addition to the table partitioning compatible with Oracle databases as described in this chapter. For information about declarative partitioning, see the PostgreSQL core documentation available at: <https://www.postgresql.org/docs/11/static/ddl-partitioning.html>
 
 The PostgreSQL 9.6 `INSERT... ON CONFLICT DO NOTHING/UPDATE` clause (commonly known as `UPSERT`) is not supported on Oracle-styled partitioned tables. If you include the `ON CONFLICT DO NOTHING/UPDATE` clause when invoking the INSERT command to add data to a partitioned table, the server will return an error.
-
-<div class="toctree" maxdepth="6">
-
-introduction selecting_a_partition_type using_partition_pruning partitioning_commands_compatible_with_oracle_databases handling_stray_values_in_a_list_or_range_partitioned_table specifying_multiple_partitioning_keys_in_a_range_partitioned_table retrieving_information_about_a_partitioned_table conclusion
-
-</div>

--- a/product_docs/docs/epas/11/epas_compat_tools_guide/index.mdx
+++ b/product_docs/docs/epas/11/epas_compat_tools_guide/index.mdx
@@ -26,10 +26,4 @@ The EDB\*Plus command line client provides a user interface to Advanced Server t
 -   Execute OS commands
 -   Record output
 
-For detailed installation and usage information about EDB\*Plus, see the *EDB\*Plus User's Guide*, available from the EnterpriseDB website at:
-
-[https://www.enterprisedb.com/docs](/epas/11/)
-
-For detailed information about the features supported by Advanced Server, consult the complete library of Advanced Server guides available at:
-
-[https://www.enterprisedb.com/docs](/epas/11/)
+For detailed installation and usage information about EDB\*Plus, see the [EDB\*Plus](/edb_plus/latest/).

--- a/product_docs/docs/epas/11/epas_guide/index.mdx
+++ b/product_docs/docs/epas/11/epas_guide/index.mdx
@@ -28,18 +28,4 @@ Advanced Server adds extended functionality to the open-source PostgreSQL databa
 -   **System Catalog Tables.** This section contains additional *system catalog tables* added for Advanced Server specific database objects.
 -   **Advanced Server Keywords.** This section contains information about the words that Advanced Server recognizes as keywords.
 
-For information about the features that are shared by Advanced Server and PostgreSQL, see the PostgreSQL core documentation, available at:
-
-<https://www.postgresql.org/docs/11/index.html>
-
-<div class="toctree" maxdepth="5">
-
-whats_new conventions examples_used
-
-</div>
-
-<div class="toctree" maxdepth="6">
-
-introduction enhanced_compatibility_features database_administration index_advisor sql_profiler pgsnmpd edb_audit_logging unicode_collation_algorithm edb_resource_manager libpq_c_library debugger performance_analysis_and_tuning edb_clone_schema pl_java enhanced_sql_and_other_misc_features system_catalog_tables advanced_server_keywords conclusion
-
-</div>
+For information about the features that are shared by EDB Postgres Advanced Server and PostgreSQL, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/index.html).

--- a/product_docs/docs/epas/11/epas_security_guide/index.mdx
+++ b/product_docs/docs/epas/11/epas_security_guide/index.mdx
@@ -10,12 +10,4 @@ This guide describes features that provide added security to EDB Postgres Advanc
 -   [sslutils](04_sslutils/#sslutils) is a Postgres extension that allows you to generate SSL certificates.
 -   [Data redaction](05_data_redaction/#data_redaction) functionality allows you to dynamically mask portions of data.
 
-For information about Postgres authentication and security features, consult the PostgreSQL core documentation, available at:
-
-<https://www.postgresql.org/docs/>
-
-<div class="toctree" maxdepth="4">
-
-introduction protecting_against_sql_injection_attacks virtual_private_database sslutils data_redaction conclusion
-
-</div>
+For information about Postgres authentication and security features, consult the [PostgreSQL core documentation](https://www.postgresql.org/docs/).

--- a/product_docs/docs/epas/11/language_pack/index.mdx
+++ b/product_docs/docs/epas/11/language_pack/index.mdx
@@ -24,9 +24,3 @@ In previous Postgres releases, `plpython` was statically linked with ActiveState
 **Convention Used in this Guide**
 
 The term *Postgres* refers to either PostgreSQL or EDB Postgres Advanced Server.
-
-<div class="toctree" maxdepth="3">
-
-supported_database_server_versions installing_language_pack using_the_procedural_languages uninstalling_language_pack conclusion
-
-</div>

--- a/product_docs/docs/epas/12/epas_compat_bip_guide/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_bip_guide/index.mdx
@@ -8,7 +8,3 @@ legacyRedirectsGenerated:
 ---
 
 Database Compatibility for Oracle means that an application runs in an Oracle environment as well as in the EDB Postgres Advanced Server (Advanced Server) environment with minimal or no changes to the application code. This guide focuses solely on the features that are related to the package support provided by Advanced Server.
-
-For more information about using other compatibility features offered by Advanced Server, please see the complete set of Advanced Server guides, available at:
-
-[https://www.enterprisedb.com/docs/](/epas/latest/)

--- a/product_docs/docs/epas/12/epas_compat_ora_dev_guide/07_open_client_library.mdx
+++ b/product_docs/docs/epas/12/epas_compat_ora_dev_guide/07_open_client_library.mdx
@@ -14,9 +14,7 @@ The following diagram compares the Open Client Library and Oracle Call Interface
 
 ![Open Client Library](images/open_client_library.png)
 
-For detailed usage information about the Open Client Library and the supported functions, see the *EDB Postgres Advanced Server OCL Connector Guide*:
-
-<https://www.enterprisedb.com/docs/ocl_connector/latest/>
+For detailed usage information about the Open Client Library and the supported functions, see [EDB OCL Connector](/ocl_connector/latest/).
 
 !!! Note
     EnterpriseDB does not support use of the Open Client Library with Oracle Real Application Clusters (RAC) and Oracle Exadata; the aforementioned Oracle products have not been evaluated nor certified with this EnterpriseDB product.

--- a/product_docs/docs/epas/12/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
+++ b/product_docs/docs/epas/12/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
@@ -15,6 +15,5 @@ Compatible tools and utility programs can allow a developer to work with Advance
 -   EDB\*Wrap
 -   The Dynamic Runtime Instrumentation Tools Architecture (DRITA)
 
-For detailed information about the functionality supported by Advanced Server, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide*, available at:
-
-<https://www.enterprisedb.com/docs/epas/latest/epas_compat_tools_guide/>
+For detailed information about the functionality supported by EDB Postgres Advanced Server, see [Database Compatibility for Oracle
+Developers Tools and Utilities](/epas/latest/epas_compat_tools_guide/).

--- a/product_docs/docs/epas/12/epas_compat_ora_dev_guide/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_ora_dev_guide/index.mdx
@@ -17,22 +17,10 @@ Database Compatibility for Oracle means that an application runs in an Oracle en
 -   SQL statements that are compatible with Oracle SQL
 -   System catalog views that are compatible with Oracle’s data dictionary
 
-For detailed information about the compatible SQL syntax, data types, and views, see the *Database Compatibility for Oracle Developers SQL Guide*.
+For detailed information about the compatible SQL syntax, data types, and views, see the [Database Compatibility for Oracle Developers SQL Guide](/epas/latest/epas_compat_sql/).
 
-The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in the *Database Compatibility for Oracle Developers Built-in Package Guide.*
+The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in [Database Compatibility for Oracle Developers Built-in Packages](/epas/latest/epas_compat_bip_guide/).
 
-For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an Advanced Server installation, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide.*
+For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an EDB Postgres Advanced Server installation, see [Tools and utilities](/epas/latest/epas_compat_ora_dev_guide/09_tools_and_utilities/).
 
-For applications written using the Oracle Call Interface (OCI), EnterpriseDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see the *EDB Postgres Advanced Server OCL Connector Guide*.
-
-Advanced Server contains a rich set of features that enables development of database applications for either PostgreSQL or Oracle. For more information about all of the features of Advanced Server, see the user documentation available at the EnterpriseDB website.
-
-Advanced Server documentation is available at:
-
-<https://www.enterprisedb.com/docs/epas/latest/>
-
-<div class="toctree" maxdepth="3">
-
-configuration_parameters_compatible_with_oracle_databases about_the_examples_used_in_this_guide
-
-</div>
+For applications written using the Oracle Call Interface (OCI), EDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see the *EDB Postgres Advanced Server OCL Connector Guide*.

--- a/product_docs/docs/epas/12/epas_compat_reference/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_reference/index.mdx
@@ -23,7 +23,3 @@ Developing an application that is compatible with Oracle databases in the Advanc
 -   System and built-in functions for use in SQL statements and procedural logic that are compatible with Oracle databases
 -   Stored Procedure Language (SPL) to create database server-side application logic for stored procedures, functions, triggers, and packages
 -   System catalog views that are compatible with Oracle’s data dictionary
-
-For detailed information about Advanced Server's compatibility features and extended functionality, see the complete library of Advanced Server documentation, available at:
-
-[https://www.enterprisedb.com/docs](/epas/latest/)

--- a/product_docs/docs/epas/12/epas_compat_spl/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_spl/index.mdx
@@ -13,9 +13,3 @@ Advanced Server's stored procedural language (SPL) is a highly productive, proce
 -   ease of use
 
 This guide describes the basic elements of an SPL program, before providing an overview of the organization of an SPL program and how it is used to create a procedure or a function. Guides about the other compatibility features (such as triggers or built-in functions) that might be used in conjunction with the SPL language are available at the [EDB website](/epas/latest/).
-
-<div class="toctree" maxdepth="4">
-
-basic_spl_elements spl_programs variable_declarations basic_statements control_structures transaction_control dynamic_sql static_cursors ref_cursors_and_cursor_variables collections collection_methods working_with_collections triggers packages object_types_and_objects errors_and_messages conclusion
-
-</div>

--- a/product_docs/docs/epas/12/epas_compat_table_partitioning/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_table_partitioning/index.mdx
@@ -19,9 +19,3 @@ This document discusses the aspects of table partitioning compatible with Oracle
     This document and particularly the partitioning presented in this chapter do not describe the *declarative partitioning* feature, which has been introduced with PostgreSQL version 10. Note that PostgreSQL declarative partitioning is supported in Advanced Server 10 in addition to the table partitioning compatible with Oracle databases as described in this chapter. For information about declarative partitioning, see the PostgreSQL core documentation available at: <https://www.postgresql.org/docs/12/static/ddl-partitioning.html>
 
 The PostgreSQL 9.6 `INSERT... ON CONFLICT DO NOTHING/UPDATE` clause (commonly known as `UPSERT`) is not supported on Oracle-styled partitioned tables. If you include the `ON CONFLICT DO NOTHING/UPDATE` clause when invoking the INSERT command to add data to a partitioned table, the server will return an error.
-
-<div class="toctree" maxdepth="6">
-
-introduction selecting_a_partition_type using_partition_pruning partitioning_commands_compatible_with_oracle_databases handling_stray_values_in_a_list_or_range_partitioned_table specifying_multiple_partitioning_keys_in_a_range_partitioned_table retrieving_information_about_a_partitioned_table conclusion
-
-</div>

--- a/product_docs/docs/epas/12/epas_compat_tools_guide/index.mdx
+++ b/product_docs/docs/epas/12/epas_compat_tools_guide/index.mdx
@@ -27,8 +27,4 @@ The EDB\*Plus command line client provides a user interface to Advanced Server t
 -   Execute OS commands
 -   Record output
 
-For detailed installation and usage information about EDB\*Plus, see the [EDB\*Plus User's Guide](https://www.enterprisedb.com/docs/epas/12/edb_plus/) available from EnterpriseDB website.
-
-For detailed information about the features supported by Advanced Server, consult the complete library of Advanced Server guides available at:
-
-[https://www.enterprisedb.com/docs](/epas/12/)
+For detailed installation and usage information about EDB\*Plus, see the [EDB\*Plus](/edb_plus/latest/).

--- a/product_docs/docs/epas/12/epas_guide/index.mdx
+++ b/product_docs/docs/epas/12/epas_guide/index.mdx
@@ -27,18 +27,4 @@ Advanced Server adds extended functionality to the open-source PostgreSQL databa
 -   **System Catalog Tables.** This section contains additional *system catalog tables* added for Advanced Server specific database objects.
 -   **Advanced Server Keywords.** This section contains information about the words that Advanced Server recognizes as keywords.
 
-For information about the features that are shared by Advanced Server and PostgreSQL, see the PostgreSQL core documentation, available at:
-
-<https://www.postgresql.org/docs/12/index.html>
-
-<div class="toctree" maxdepth="5">
-
-whats_new conventions examples_used
-
-</div>
-
-<div class="toctree" maxdepth="6">
-
-introduction enhanced_compatibility_features database_administration index_advisor sql_profiler pgsnmpd edb_audit_logging unicode_collation_algorithm edb_resource_manager libpq_c_library debugger performance_analysis_and_tuning edb_clone_schema enhanced_sql_and_other_misc_features system_catalog_tables advanced_server_keywords conclusion
-
-</div>
+For information about the features that are shared by EDB Postgres Advanced Server and PostgreSQL, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/index.html).

--- a/product_docs/docs/epas/12/epas_security_guide/index.mdx
+++ b/product_docs/docs/epas/12/epas_security_guide/index.mdx
@@ -10,12 +10,4 @@ This guide describes features that provide added security to EDB Postgres Advanc
 -   [sslutils](04_sslutils/#sslutils) is a Postgres extension that allows you to generate SSL certificates.
 -   [Data redaction](05_data_redaction/#data_redaction) functionality allows you to dynamically mask portions of data.
 
-For information about Postgres authentication and security features, consult the PostgreSQL core documentation, available at:
-
-<https://www.postgresql.org/docs/>
-
-<div class="toctree" maxdepth="4">
-
-introduction protecting_against_sql_injection_attacks virtual_private_database sslutils data_redaction conclusion
-
-</div>
+For information about Postgres authentication and security features, consult the [PostgreSQL core documentation](https://www.postgresql.org/docs/).

--- a/product_docs/docs/epas/12/language_pack/index.mdx
+++ b/product_docs/docs/epas/12/language_pack/index.mdx
@@ -24,9 +24,3 @@ In previous Postgres releases, `plpython` was statically linked with ActiveState
 **Convention Used in this Guide**
 
 The term *Postgres* refers to either PostgreSQL or EDB Postgres Advanced Server.
-
-<div class="toctree" maxdepth="3">
-
-supported_database_server_versions installing_language_pack using_the_procedural_languages uninstalling_language_pack conclusion
-
-</div>

--- a/product_docs/docs/epas/13/epas_compat_bip_guide/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_bip_guide/index.mdx
@@ -10,7 +10,3 @@ legacyRedirectsGenerated:
 ---
 
 Database Compatibility for Oracle means that an application runs in an Oracle environment as well as in the EDB Postgres Advanced Server (Advanced Server) environment with minimal or no changes to the application code. This guide focuses solely on the features that are related to the package support provided by Advanced Server.
-
-For more information about using other compatibility features offered by Advanced Server, please see the complete set of Advanced Server guides, available at:
-
-[https://www.enterprisedb.com/docs/](/epas/latest/)

--- a/product_docs/docs/epas/13/epas_compat_ora_dev_guide/07_open_client_library.mdx
+++ b/product_docs/docs/epas/13/epas_compat_ora_dev_guide/07_open_client_library.mdx
@@ -14,9 +14,7 @@ The following diagram compares the Open Client Library and Oracle Call Interface
 
 ![Open Client Library](images/open_client_library.png)
 
-For detailed usage information about the Open Client Library and the supported functions, see the *EDB Postgres Advanced Server OCL Connector Guide*:
-
-<https://www.enterprisedb.com/docs/ocl_connector/latest/>
+For detailed usage information about the Open Client Library and the supported functions, see [EDB OCL Connector](/ocl_connector/latest/).
 
 !!! Note
     EDB does not support use of the Open Client Library with Oracle Real Application Clusters (RAC) and Oracle Exadata; the aforementioned Oracle products have not been evaluated nor certified with this EDB product.

--- a/product_docs/docs/epas/13/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
+++ b/product_docs/docs/epas/13/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
@@ -15,6 +15,5 @@ Compatible tools and utility programs can allow a developer to work with Advance
 -   EDB\*Wrap
 -   The Dynamic Runtime Instrumentation Tools Architecture (DRITA)
 
-For detailed information about the functionality supported by Advanced Server, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide*, available at:
-
-<https://www.enterprisedb.com/docs/epas/latest/epas_compat_tools_guide/>
+For detailed information about the functionality supported by EDB Postgres Advanced Server, see [Database Compatibility for Oracle
+Developers Tools and Utilities](/epas/latest/epas_compat_tools_guide/).

--- a/product_docs/docs/epas/13/epas_compat_ora_dev_guide/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_ora_dev_guide/index.mdx
@@ -19,22 +19,10 @@ Database Compatibility for Oracle means that an application runs in an Oracle en
 -   SQL statements that are compatible with Oracle SQL
 -   System catalog views that are compatible with Oracle’s data dictionary
 
-For detailed information about the compatible SQL syntax, data types, and views, see the *Database Compatibility for Oracle Developers SQL Guide*.
+For detailed information about the compatible SQL syntax, data types, and views, see the [Database Compatibility for Oracle Developers SQL Guide](/epas/latest/epas_compat_sql/).
 
-The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in the *Database Compatibility for Oracle Developers Built-in Package Guide*.
+The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in [Database Compatibility for Oracle Developers Built-in Packages](/epas/latest/epas_compat_bip_guide/).
 
-For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an Advanced Server installation, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide*.
+For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an EDB Postgres Advanced Server installation, see [Tools and utilities](/epas/latest/epas_compat_ora_dev_guide/09_tools_and_utilities/).
 
-For applications written using the Oracle Call Interface (OCI), EDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see the *EDB Postgres Advanced Server OCL Connector Guide*.
-
-Advanced Server contains a rich set of features that enables development of database applications for either PostgreSQL or Oracle. For more information about all of the features of Advanced Server, see the user documentation available at the EDB website.
-
-Advanced Server documentation is available at:
-
-<https://www.enterprisedb.com/docs/epas/latest/>
-
-<div class="toctree" maxdepth="3">
-
-configuration_parameters_compatible_with_oracle_databases about_the_examples_used_in_this_guide
-
-</div>
+For applications written using the Oracle Call Interface (OCI), EDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see [EDB OCL Connector](/ocl_connector/latest/).

--- a/product_docs/docs/epas/13/epas_compat_reference/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_reference/index.mdx
@@ -25,7 +25,3 @@ Developing an application that is compatible with Oracle databases in the Advanc
 -   System and built-in functions for use in SQL statements and procedural logic that are compatible with Oracle databases
 -   Stored Procedure Language (SPL) to create database server-side application logic for stored procedures, functions, triggers, and packages
 -   System catalog views that are compatible with Oracle’s data dictionary
-
-For detailed information about Advanced Server's compatibility features and extended functionality, see the complete library of Advanced Server documentation, available at:
-
-[https://www.enterprisedb.com/docs](/epas/latest/)

--- a/product_docs/docs/epas/13/epas_compat_spl/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_spl/index.mdx
@@ -18,9 +18,3 @@ Advanced Server's stored procedural language (SPL) is a highly productive, proce
 -   ease of use
 
 This guide describes the basic elements of an SPL program, before providing an overview of the organization of an SPL program and how it is used to create a procedure or a function. Guides about the other compatibility features (such as triggers or built-in functions) that might be used in conjunction with the SPL language are available at the [EDB website](/epas/latest/).
-
-<div class="toctree" maxdepth="4">
-
-basic_spl_elements spl_programs variable_declarations basic_statements control_structures transaction_control dynamic_sql static_cursors ref_cursors_and_cursor_variables collections collection_methods working_with_collections triggers packages object_types_and_objects errors_and_messages conclusion
-
-</div>

--- a/product_docs/docs/epas/13/epas_compat_table_partitioning/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_table_partitioning/index.mdx
@@ -25,9 +25,3 @@ This document discusses the aspects of table partitioning compatible with Oracle
     This document and particularly the partitioning presented in this chapter do not describe the *declarative partitioning* feature, which has been introduced with PostgreSQL version 10. Note that PostgreSQL declarative partitioning is supported in Advanced Server 10 in addition to the table partitioning compatible with Oracle databases as described in this chapter. For information about declarative partitioning, see the PostgreSQL core documentation available at: <https://www.postgresql.org/docs/current/static/ddl-partitioning.html>
 
 The PostgreSQL 9.6 `INSERT... ON CONFLICT DO NOTHING/UPDATE` clause (commonly known as `UPSERT`) is not supported on Oracle-styled partitioned tables. If you include the `ON CONFLICT DO NOTHING/UPDATE` clause when invoking the INSERT command to add data to a partitioned table, the server will return an error.
-
-<div class="toctree" maxdepth="6">
-
-introduction selecting_a_partition_type using_partition_pruning partitioning_commands_compatible_with_oracle_databases handling_stray_values_in_a_list_or_range_partitioned_table specifying_multiple_partitioning_keys_in_a_range_partitioned_table retrieving_information_about_a_partitioned_table conclusion
-
-</div>

--- a/product_docs/docs/epas/13/epas_compat_tools_guide/index.mdx
+++ b/product_docs/docs/epas/13/epas_compat_tools_guide/index.mdx
@@ -28,8 +28,4 @@ The EDB\*Plus command line client provides a user interface to Advanced Server t
 -   Execute OS commands
 -   Record output
 
-For detailed installation and usage information about EDB\*Plus, see the [EDB\*Plus User's Guide](https://www.enterprisedb.com/docs/epas/latest/edb_plus/) available from EDB website.
-
-For detailed information about the features supported by Advanced Server, consult the complete library of Advanced Server guides available at:
-
-[https://www.enterprisedb.com/docs](/epas/latest/)
+For detailed installation and usage information about EDB\*Plus, see the [EDB\*Plus](/edb_plus/latest/).

--- a/product_docs/docs/epas/13/epas_guide/index.mdx
+++ b/product_docs/docs/epas/13/epas_guide/index.mdx
@@ -31,18 +31,4 @@ Advanced Server adds extended functionality to the open-source PostgreSQL databa
 -   **Advanced Server Exceptions.** This section contains information about the pre-defined exceptions, the SQLstate values, associated redwood error code, and description of the exceptions.
 -   **Advanced Server Keywords.** This section contains information about the words that Advanced Server recognizes as keywords.
 
-For information about the features that are shared by Advanced Server and PostgreSQL, see the PostgreSQL core documentation, available at:
-
-<https://www.postgresql.org/docs/current/index.html>
-
-<div class="toctree" maxdepth="5">
-
-whats_new conventions examples_used
-
-</div>
-
-<div class="toctree" maxdepth="6">
-
-introduction enhanced_compatibility_features database_administration index_advisor sql_profiler pgsnmpd edb_audit_logging unicode_collation_algorithm edb_resource_manager libpq_c_library debugger performance_analysis_and_tuning edb_clone_schema enhanced_sql_and_other_misc_features system_catalog_tables advanced_server_keywords conclusion
-
-</div>
+For information about the features that are shared by EDB Postgres Advanced Server and PostgreSQL, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/index.html).

--- a/product_docs/docs/epas/13/epas_security_guide/index.mdx
+++ b/product_docs/docs/epas/13/epas_security_guide/index.mdx
@@ -16,12 +16,4 @@ This guide describes features that provide added security to EDB Postgres Advanc
 -   [sslutils](04_sslutils/#sslutils) is a Postgres extension that allows you to generate SSL certificates.
 -   [Data redaction](05_data_redaction/#data_redaction) functionality allows you to dynamically mask portions of data.
 
-For information about Postgres authentication and security features, consult the PostgreSQL core documentation, available at:
-
-<https://www.postgresql.org/docs/>
-
-<div class="toctree" maxdepth="4">
-
-introduction protecting_against_sql_injection_attacks virtual_private_database sslutils data_redaction conclusion
-
-</div>
+For information about Postgres authentication and security features, consult the [PostgreSQL core documentation](https://www.postgresql.org/docs/).

--- a/product_docs/docs/epas/13/language_pack/index.mdx
+++ b/product_docs/docs/epas/13/language_pack/index.mdx
@@ -30,9 +30,3 @@ In previous Postgres releases, `plpython` was statically linked with ActiveState
 **Convention Used in this Guide**
 
 The term *Postgres* refers to either PostgreSQL or EDB Postgres Advanced Server.
-
-<div class="toctree" maxdepth="3">
-
-supported_database_server_versions installing_language_pack using_the_procedural_languages uninstalling_language_pack conclusion
-
-</div>

--- a/product_docs/docs/epas/14/epas_compat_bip_guide/index.mdx
+++ b/product_docs/docs/epas/14/epas_compat_bip_guide/index.mdx
@@ -9,6 +9,3 @@ legacyRedirectsGenerated:
 
 Database compatibility for Oracle means that an application runs in an Oracle environment as well as in the EDB Postgres Advanced Server (EDB Postgres Advanced Server) environment with minimal or no changes to the application code. This guide focuses solely on the features that are related to the package support provided by EDB Postgres Advanced Server.
 
-For more information about using other compatibility features offered by EDB Postgres Advanced Server, see the complete set of EDB Postgres Advanced Server guides, available at:
-
-[https://www.enterprisedb.com/docs/](/epas/latest/)

--- a/product_docs/docs/epas/14/epas_compat_ora_dev_guide/07_open_client_library.mdx
+++ b/product_docs/docs/epas/14/epas_compat_ora_dev_guide/07_open_client_library.mdx
@@ -14,9 +14,7 @@ The following diagram compares the Open Client Library and Oracle Call Interface
 
 ![Open Client Library](images/open_client_library.png)
 
-For detailed usage information about the Open Client Library and the supported functions, see the *EDB Postgres Advanced Server OCL Connector Guide*:
-
-<https://www.enterprisedb.com/docs/ocl_connector/latest/>
+For detailed usage information about the Open Client Library and the supported functions, see [EDB OCL Connector](/ocl_connector/latest/).
 
 !!! Note
     EDB does not support use of the Open Client Library with Oracle Real Application Clusters (RAC) and Oracle Exadata; the aforementioned Oracle products have not been evaluated nor certified with this EDB product.

--- a/product_docs/docs/epas/14/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
+++ b/product_docs/docs/epas/14/epas_compat_ora_dev_guide/09_tools_and_utilities.mdx
@@ -14,7 +14,6 @@ Compatible tools and utility programs can allow a developer to work with EDB Pos
 -   EDB\*Wrap
 -   The Dynamic Runtime Instrumentation Tools Architecture (DRITA)
 
-For detailed information about the functionality supported by EDB Postgres Advanced Server, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide,* available at:
-
-[https://www.enterprisedb.com/docs](/epas/latest/)
+For detailed information about the functionality supported by EDB Postgres Advanced Server, see [Database Compatibility for Oracle
+Developers Tools and Utilities](/epas/latest/epas_compat_tools_guide/).
 

--- a/product_docs/docs/epas/14/epas_compat_ora_dev_guide/index.mdx
+++ b/product_docs/docs/epas/14/epas_compat_ora_dev_guide/index.mdx
@@ -18,22 +18,16 @@ Database compatibility for Oracle means that an application runs in an Oracle en
 -   SQL statements that are compatible with Oracle SQL
 -   System catalog views that are compatible with Oracle’s data dictionary
 
-For detailed information about the compatible SQL syntax, data types, and views, see the *Database Compatibility for Oracle Developers SQL Guide*.
+For detailed information about the compatible SQL syntax, data types, and views, see the [Database Compatibility for Oracle Developers SQL Guide](/epas/latest/epas_compat_sql/).
 
-The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in the *Database Compatibility for Oracle Developers Built-in Package Guide*.
+The compatibility offered by the procedures and functions that are part of the Built-in packages is documented in [Database Compatibility for Oracle Developers Built-in Packages](/epas/latest/epas_compat_bip_guide/).
 
-For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an EDB Postgres Advanced Server installation, see the *Database Compatibility for Oracle Developers Tools and Utilities Guide*.
+For information about using the compatible tools and utilities (EDB\*Plus, EDB\*Loader, DRITA, and EDB\*Wrap) that are included with an EDB Postgres Advanced Server installation, see [Tools and utilities](/epas/latest/epas_compat_ora_dev_guide/09_tools_and_utilities/).
 
-For applications written using the Oracle Call Interface (OCI), EDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see the *EDB Postgres Advanced Server OCL Connector Guide*.
+For applications written using the Oracle Call Interface (OCI), EDB’s Open Client Library (OCL) provides interoperability with these applications. For detailed information about using the Open Client Library, see [EDB OCL Connector](/ocl_connector/latest/).
 
-EDB Postgres Advanced Server contains a rich set of features that enables development of database applications for either PostgreSQL or Oracle. For more information about all of the features of EDB Postgres Advanced Server, see the user documentation available at the EDB website.
 
-EDB Postgres Advanced Server documentation is available at:
 
-[https://www.enterprisedb.com/docs](/epas/latest/)
 
-<div class="toctree" maxdepth="3">
 
-configuration_parameters_compatible_with_oracle_databases about_the_examples_used_in_this_guide
 
-</div>

--- a/product_docs/docs/epas/14/epas_compat_reference/index.mdx
+++ b/product_docs/docs/epas/14/epas_compat_reference/index.mdx
@@ -24,6 +24,3 @@ Developing an application that is compatible with Oracle databases in the EDB Po
 -   Stored Procedure Language (SPL) to create database server-side application logic for stored procedures, functions, triggers, and packages
 -   System catalog views that are compatible with Oracle’s data dictionary
 
-For detailed information about EDB Postgres Advanced Server's compatibility features and extended functionality, see the complete library of EDB Postgres Advanced Server documentation, available at:
-
-[https://www.enterprisedb.com/docs](/epas/latest/)

--- a/product_docs/docs/epas/14/epas_compat_spl/index.mdx
+++ b/product_docs/docs/epas/14/epas_compat_spl/index.mdx
@@ -13,8 +13,4 @@ EDB Postgres Advanced Server's stored procedural language (SPL) is a highly prod
 
 This guide describes the basic elements of an SPL program, before providing an overview of the organization of an SPL program and how it is used to create a procedure or a function. Guides about the other compatibility features (such as triggers or built-in functions) that might be used in conjunction with the SPL language are available at the [EDB website](/epas/latest/).
 
-<div class="toctree" maxdepth="4">
 
-basic_spl_elements spl_programs variable_declarations basic_statements control_structures transaction_control dynamic_sql static_cursors ref_cursors_and_cursor_variables collections collection_methods working_with_collections triggers packages object_types_and_objects errors_and_messages conclusion
-
-</div>

--- a/product_docs/docs/epas/14/epas_compat_table_partitioning/index.mdx
+++ b/product_docs/docs/epas/14/epas_compat_table_partitioning/index.mdx
@@ -22,8 +22,3 @@ The PostgreSQL 9.6 `INSERT... ON CONFLICT DO NOTHING/UPDATE` clause (commonly kn
 !!! Note
     EDB Postgres Advanced Server does not support global indexes, so the index is not inherited when a primary key that does not include partition key columns is defined on the partitioned table. However, all partitions defined within the `CREATE TABLE` have an independent primary index on the column. You can recreate the primary key on all newly added partitions by using `ALTER TABLE ... ADD CONSTRAINT`. This primary index enforces uniqueness only within each partition and not across the entire partition hierarchy (basically, you can have the same value repeated for the primary index column in two or more partitions).
 
-<div class="toctree" maxdepth="6">
-
-introduction selecting_a_partition_type using_partition_pruning partitioning_commands_compatible_with_oracle_databases handling_stray_values_in_a_list_or_range_partitioned_table specifying_multiple_partitioning_keys_in_a_range_partitioned_table retrieving_information_about_a_partitioned_table conclusion
-
-</div>

--- a/product_docs/docs/epas/14/epas_compat_tools_guide/index.mdx
+++ b/product_docs/docs/epas/14/epas_compat_tools_guide/index.mdx
@@ -26,10 +26,5 @@ The EDB\*Plus command line client provides a user interface to EDB Postgres Adva
 -   Execute OS commands
 -   Record output
 
-For detailed installation and usage information about EDB\*Plus, see the *EDB\*Plus User's Guide*, available from the EDB website at:
+For detailed installation and usage information about EDB\*Plus, see the [EDB\*Plus](/edb_plus/latest/).
 
-[https://www.enterprisedb.com/docs](/epas/latest/)
-
-For detailed information about the features supported by EDB Postgres Advanced Server, consult the complete library of EDB Postgres Advanced Server guides available at:
-
-[https://www.enterprisedb.com/docs](/epas/latest/)

--- a/product_docs/docs/epas/14/epas_guide/index.mdx
+++ b/product_docs/docs/epas/14/epas_guide/index.mdx
@@ -29,18 +29,7 @@ EDB Postgres Advanced Server adds extended functionality to the open-source Post
 -   EDB Postgres Advanced Server exceptions. This section contains information about the predefined exceptions, the SQLstate values, associated redwood error code, and description of the exceptions.
 -   EDB Postgres Advanced Server keywords. This section contains information about the words that EDB Postgres Advanced Server recognizes as keywords.
 
-For information about the features that are shared by EDB Postgres Advanced Server and PostgreSQL, see the PostgreSQL core documentation available at:
+For information about the features that are shared by EDB Postgres Advanced Server and PostgreSQL, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/index.html).
 
-<https://www.postgresql.org/docs/current/index.html>
 
-<div class="toctree" maxdepth="5">
 
-whats_new conventions examples_used
-
-</div>
-
-<div class="toctree" maxdepth="6">
-
-introduction enhanced_compatibility_features database_administration index_advisor sql_profiler pgsnmpd edb_audit_logging unicode_collation_algorithm edb_resource_manager libpq_c_library debugger performance_analysis_and_tuning edb_clone_schema enhanced_sql_and_other_misc_features system_catalog_tables advanced_server_keywords conclusion
-
-</div>

--- a/product_docs/docs/epas/14/epas_security_guide/index.mdx
+++ b/product_docs/docs/epas/14/epas_security_guide/index.mdx
@@ -10,12 +10,5 @@ This guide describes features that provide added security to EDB Postgres Advanc
 -   [sslutils](04_sslutils/#sslutils) is a Postgres extension that allows you to generate SSL certificates.
 -   [Data redaction](05_data_redaction/#data_redaction) functionality allows you to dynamically mask portions of data.
 
-For information about Postgres authentication and security features, consult the PostgreSQL core documentation, available at:
+For information about Postgres authentication and security features, consult the [PostgreSQL core documentation](https://www.postgresql.org/docs/).
 
-<https://www.postgresql.org/docs/>
-
-<div class="toctree" maxdepth="4">
-
-introduction protecting_against_sql_injection_attacks virtual_private_database sslutils data_redaction conclusion
-
-</div>

--- a/product_docs/docs/epas/14/language_pack/index.mdx
+++ b/product_docs/docs/epas/14/language_pack/index.mdx
@@ -21,8 +21,4 @@ In previous Postgres releases, `plpython` was statically linked with ActiveState
 
 The term *Postgres* refers to either PostgreSQL or EDB Postgres Advanced Server.
 
-<div class="toctree" maxdepth="3">
 
-supported_database_server_versions installing_language_pack using_the_procedural_languages uninstalling_language_pack conclusion
-
-</div>


### PR DESCRIPTION
## What Changed?

Changed references to "guides" to links to their landing pages