### PR TITLE
EPAS: updated edb_audit_statement syntax as per DB-1689

### DIFF
--- a/product_docs/docs/epas/14/epas_guide/03_database_administration/05_edb_audit_logging/09_object_auditing.mdx
+++ b/product_docs/docs/epas/14/epas_guide/03_database_administration/05_edb_audit_logging/09_object_auditing.mdx
@@ -9,7 +9,7 @@ The object-level auditing allows selective auditing of objects for specific Data
 Use the following syntax to specify an `edb_audit_statement` parameter value for `SELECT`, `UPDATE`, `DELETE`, or `INSERT` statements:
 
 ```text
-{ select | update | delete | insert }@groupname
+{ select | update | delete | insert }{@ | -}groupname
 ```
 
 ## Example


### PR DESCRIPTION
## What Changed?

- updated syntax from { select | update | delete | insert }@groupname to { select | update | delete | insert }{@ | -}groupname in v14
