### PR TITLE
Note re EDB repos 2.0 - prototype

### DIFF
--- a/install_template/templates/platformBase/base.njk
+++ b/install_template/templates/platformBase/base.njk
@@ -3,6 +3,17 @@ navTitle: {{ platform.name }}
 title: Installing {{ product.name }} on {{ platform.name }} {{ platform.arch }}
 ---
 {% block pemprereq %}
+!!!note
+   EDB provides two repositories:
+   - EDB's new and improved EDB Repos 2.0
+
+   - EDB's legacy EDB Repos 1.0
+
+   To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+   The following instructions are specific to EDB Repos 1.0. 
+!!!
+
 Before you begin the installation process, log in as superuser.
 ```shell
 # To log in as a superuser:

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles12_ppcle.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB*Plus on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles15_ppcle.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB*Plus on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_deb10_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing EDB*Plus on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles12_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB*Plus on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles15_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB*Plus on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu18_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB*Plus on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu20_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB*Plus on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_rhel8_ppcle.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_rhel8_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: RHEL 8
 title: Installing Failover Manager on RHEL 8 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles12_ppcle.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Failover Manager on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles15_ppcle.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Failover Manager on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_centos7_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_centos7_x86.mdx
@@ -3,6 +3,18 @@ navTitle: CentOS 7
 title: Installing Failover Manager on CentOS 7 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_deb10_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing Failover Manager on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_other_linux8_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_other_linux8_x86.mdx
@@ -3,6 +3,18 @@ navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing Failover Manager on AlmaLinux 8 or Rocky Linux 8 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel7_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel7_x86.mdx
@@ -3,6 +3,18 @@ navTitle: RHEL 7 or OL 7
 title: Installing Failover Manager on RHEL 7 or OL 7 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel_8_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel_8_x86.mdx
@@ -3,6 +3,18 @@ navTitle: RHEL 8 or OL 8
 title: Installing Failover Manager on RHEL 8 or OL 8 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles12_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Failover Manager on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles15_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Failover Manager on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu18_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing Failover Manager on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu20_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing Failover Manager on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/13/epas_inst_linux/index.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/index.mdx
@@ -16,6 +16,16 @@ The *EDB Postgres Advanced Server Installation Guide* is a comprehensive guide t
 
 -   Software prerequisites for performing an Advanced Server 13 installation on a Linux host.
 -   Using a package manager to install and update Advanced Server and its supporting components or utilities on a Linux host.
+    !!!note
+    EDB provides two repositories:
+    - EDB's new and improved EDB Repos 2.0
+
+    - EDB's legacy EDB Repos 1.0
+
+    To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+    Repo-specific information in this guide are specific to EDB Repos 1.0. 
+    !!!
 -   Managing an Advanced Server installation.
 -   Configuring an Advanced Server package installation.
 -   Uninstalling Advanced Server and its components.

--- a/product_docs/docs/epas/14/epas_inst_linux/index.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/index.mdx
@@ -14,7 +14,8 @@ EDB Postgres Advanced Server adds extended functionality to the open-source Post
 The `edb-as<version>-server` package installs the required software on Linux platforms.
 
 
--    To install EDB Postgres Advanced server using the EDB repository, see [Installing using the EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_edb_repository).
+-    To install EDB Postgres Advanced server using the EDB repository, see [Installing EDB Postgres Advanced
+Server using the EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_edb_repository).
 
      !!!note
      EDB provides two repositories:
@@ -24,7 +25,8 @@ The `edb-as<version>-server` package installs the required software on Linux pla
 
      To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
 
-     The instructions in [Installing using the EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_edb_repository) are specific to EDB Repos 1.0. 
+     The instructions in [Installing EDB Postgres Advanced
+Server using the EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_edb_repository) are specific to EDB Repos 1.0. 
      !!!
 
 -    To set up a local repository and install EDB Postgres Advanced server, see  [Installing using a local EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_local_repository).

--- a/product_docs/docs/epas/14/epas_inst_linux/index.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/index.mdx
@@ -16,6 +16,17 @@ The `edb-as<version>-server` package installs the required software on Linux pla
 
 -    To install EDB Postgres Advanced server using the EDB repository, see [Installing using the EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_edb_repository).
 
+     !!!note
+     EDB provides two repositories:
+     - EDB's new and improved EDB Repos 2.0
+
+     - EDB's legacy EDB Repos 1.0
+
+     To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+     The instructions in [Installing using the EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_edb_repository) are specific to EDB Repos 1.0. 
+     !!!
+
 -    To set up a local repository and install EDB Postgres Advanced server, see  [Installing using a local EDB repository](/epas/latest/epas_inst_linux/installing_epas_using_local_repository).
 
 -    For information about default component locations and available packages, see [Installation details](/epas/latest/epas_inst_linux/install_details).

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: RHEL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/index.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/index.mdx
@@ -11,6 +11,17 @@ navigation:
  - ibm_power_ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0. 
+!!!
+
 
 For platform-specific install instructions, including accessing the repo, see:
 

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
@@ -3,6 +3,18 @@ navTitle: CentOS 7
 title: Installing EDB Postgres Advanced Server on CentOS 7 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
@@ -24,6 +36,8 @@ sed -i "s@<username>:<password>@USERNAME:PASSWORD@" /etc/yum.repos.d/edb.repo
 
 #  Install the EPEL repository:
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+
 ```
 
 ## Install the package

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing EDB Postgres Advanced Server on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
@@ -3,6 +3,18 @@ navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB Postgres Advanced Server on AlmaLinux 8 or Rocky Linux 8 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
@@ -3,6 +3,18 @@ navTitle: RHEL 7 or OL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 or OL 7 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
@@ -3,6 +3,18 @@ navTitle: RHEL 8 or OL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 or OL 8 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles12_ppcle.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Replication Server on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles15_ppcle.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Replication Server on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles12_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Replication Server on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles15_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Replication Server on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles12_ppcle.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Hadoop Foreign Data Wrapper on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles15_ppcle.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Hadoop Foreign Data Wrapper on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_deb10_x86.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing Hadoop Foreign Data Wrapper on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_sles12_x86.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Hadoop Foreign Data Wrapper on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_sles15_x86.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Hadoop Foreign Data Wrapper on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_ubuntu18_x86.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing Hadoop Foreign Data Wrapper on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_ubuntu20_x86.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing Hadoop Foreign Data Wrapper on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle.mdx
+++ b/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB JDBC Connector on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle.mdx
+++ b/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB JDBC Connector on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB JDBC Connector on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB JDBC Connector on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu18_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB JDBC Connector on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.3.3.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB JDBC Connector on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles12_ppcle.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Migration Toolkit on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles15_ppcle.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Migration Toolkit on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb10_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing Migration Toolkit on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles12_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Migration Toolkit on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles15_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Migration Toolkit on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu18_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing Migration Toolkit on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu20_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing Migration Toolkit on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles12_ppcle.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing MongoDB Foreign Data Wrapper on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles15_ppcle.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing MongoDB Foreign Data Wrapper on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_deb10_x86.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing MongoDB Foreign Data Wrapper on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_sles12_x86.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing MongoDB Foreign Data Wrapper on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_sles15_x86.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing MongoDB Foreign Data Wrapper on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_ubuntu18_x86.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing MongoDB Foreign Data Wrapper on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_ubuntu20_x86.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing MongoDB Foreign Data Wrapper on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles12_ppcle.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing MySQL Foreign Data Wrapper on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles15_ppcle.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing MySQL Foreign Data Wrapper on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb10_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing MySQL Foreign Data Wrapper on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_sles12_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing MySQL Foreign Data Wrapper on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_sles15_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing MySQL Foreign Data Wrapper on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu18_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing MySQL Foreign Data Wrapper on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu20_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing MySQL Foreign Data Wrapper on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles12_ppcle.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB OCL Connector on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles15_ppcle.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB OCL Connector on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_deb10_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing EDB OCL Connector on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles12_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB OCL Connector on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles15_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB OCL Connector on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu18_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB OCL Connector on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu20_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB OCL Connector on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB ODBC Connector on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB ODBC Connector on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing EDB ODBC Connector on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB ODBC Connector on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB ODBC Connector on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB ODBC Connector on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB ODBC Connector on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles12_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Postgres Enterprise Manager agent on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
@@ -12,7 +24,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository
@@ -42,4 +54,4 @@ zypper refresh
 zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information, see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles15_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Postgres Enterprise Manager agent on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
@@ -12,7 +24,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository
@@ -41,4 +53,4 @@ zypper refresh
 zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information, see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_deb10_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing Postgres Enterprise Manager agent on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
@@ -12,7 +24,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 #  Set up the EDB repository
@@ -39,4 +51,4 @@ apt-get update
 apt-get install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information, see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles12_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing Postgres Enterprise Manager agent on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
@@ -12,7 +24,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository
@@ -42,4 +54,4 @@ zypper refresh
 zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, register the PEM agent. For detailed information, see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles15_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing Postgres Enterprise Manager agent on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
@@ -12,7 +24,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository
@@ -41,4 +53,4 @@ zypper refresh
 zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, register the PEM agent. For detailed information, see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu18_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu18_x86.mdx
@@ -3,15 +3,28 @@ navTitle: Ubuntu 18.04
 title: Installing Postgres Enterprise Manager agent on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
+# To log in as a superuser:
 sudo su -
 ```
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 #  Set up the EDB repository
@@ -38,4 +51,4 @@ apt-get update
 apt-get install edb-pem-agent
 ```
 
-After installing PEM agent, register the PEM agent. For detailed information, see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu20_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu20_x86.mdx
@@ -3,15 +3,28 @@ navTitle: Ubuntu 20.04
 title: Installing Postgres Enterprise Manager agent on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell
+# To log in as a superuser:
 sudo su -
 ```
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 #  Set up the EDB repository
@@ -38,4 +51,4 @@ apt-get update
 apt-get install edb-pem-agent
 ```
 
-After installing PEM agent, register the PEM agent. For detailed information, see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle.mdx
@@ -15,7 +15,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository
@@ -52,4 +52,4 @@ zypper -n install edb-pem
 /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles15_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles15_ppcle.mdx
@@ -15,7 +15,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb10_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb10_x86.mdx
@@ -15,7 +15,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 #  Set up the EDB repository
@@ -49,4 +49,4 @@ apt-get install edb-pem
 /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles12_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles12_x86.mdx
@@ -15,7 +15,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository
@@ -52,4 +52,4 @@ zypper -n install edb-pem
 /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles15_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles15_x86.mdx
@@ -15,7 +15,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 # Install the repository configuration and enter your EDB repository
@@ -51,4 +51,4 @@ zypper -n install edb-pem
 /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu18_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu18_x86.mdx
@@ -15,7 +15,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 #  Set up the EDB repository
@@ -49,4 +49,4 @@ apt-get install edb-pem
 /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu20_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu20_x86.mdx
@@ -15,7 +15,7 @@ sudo su -
 
 ## Set up the repository
 
-Setting up the repository is a one-time task. If you already set up your repository, you don't need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
+Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step. If you do need to set up the repository, you must register with EDB. To receive credentials for the EDB repository, visit: [Repository Access Request](https://www.enterprisedb.com/repository-access-request).
 
 ```shell
 #  Set up the EDB repository
@@ -49,4 +49,4 @@ apt-get install edb-pem
 /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).

--- a/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles12_ppcle.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB pgBouncer on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles15_ppcle.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB pgBouncer on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_deb10_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing EDB pgBouncer on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_sles12_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB pgBouncer on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_sles15_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB pgBouncer on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu18_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB pgBouncer on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu20_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.16/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB pgBouncer on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles12_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB Pgpool-II on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles15_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB Pgpool-II on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb10_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing EDB Pgpool-II on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles12_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB Pgpool-II on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles15_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB Pgpool-II on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu18_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB Pgpool-II on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu20_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB Pgpool-II on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles12_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB Pgpool-II Extensions on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles15_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB Pgpool-II Extensions on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb10_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing EDB Pgpool-II Extensions on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles12_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing EDB Pgpool-II Extensions on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles15_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing EDB Pgpool-II Extensions on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu18_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing EDB Pgpool-II Extensions on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu20_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu20_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 20.04
 title: Installing EDB Pgpool-II Extensions on Ubuntu 20.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles12_ppcle.mdx
+++ b/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles12_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing PostGIS on SLES 12 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles15_ppcle.mdx
+++ b/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles15_ppcle.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing PostGIS on SLES 15 ppc64le
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_deb10_x86.mdx
+++ b/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_deb10_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Debian 10
 title: Installing PostGIS on Debian 10 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles12_x86.mdx
+++ b/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles12_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 12
 title: Installing PostGIS on SLES 12 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles15_x86.mdx
+++ b/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles15_x86.mdx
@@ -3,6 +3,18 @@ navTitle: SLES 15
 title: Installing PostGIS on SLES 15 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell

--- a/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_ubuntu18_x86.mdx
+++ b/product_docs/docs/postgis/3.1/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_ubuntu18_x86.mdx
@@ -3,6 +3,18 @@ navTitle: Ubuntu 18.04
 title: Installing PostGIS on Ubuntu 18.04 x86_64
 ---
 
+!!!note
+EDB provides two repositories:
+
+- EDB's new and improved EDB Repos 2.0
+
+- EDB's legacy EDB Repos 1.0
+
+To access either repository you need an EDB account and credentials. To request credentials, see EDB Repository Access instructions and select **Getting Started**.
+
+The following instructions are specific to EDB Repos 1.0.
+!!!
+
 Before you begin the installation process, log in as superuser.
 
 ```shell


### PR DESCRIPTION
## What Changed?

The install content for the latest versions of the heritage EDB product documentation have install topics for each OS/arch combination. The topics have instructions for EDB repos 1.0. All the products follow a similar model for the Installing section. This prototype includes a note to try to minimize confusion around the two repos that we can use in the OS/arch specific install topics as well as other applicable landing pages. For examples, see:

- [Main Linux topic for EPAS](https://deploy-preview-2997--edb-docs-staging.netlify.app/docs/epas/latest/epas_inst_linux/) (note is manually placed)
- [Repo topic for EPAS](https://deploy-preview-2997--edb-docs-staging.netlify.app/docs/epas/latest/epas_inst_linux/installing_epas_using_edb_repository/)  (note is manually placed)
-[ x86 landing page](https://deploy-preview-2997--edb-docs-staging.netlify.app/docs/epas/latest/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/) (note would be manually placed if we decide to add it here)
- [Power landing page](https://deploy-preview-2997--edb-docs-staging.netlify.app/docs/epas/latest/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/) (note would be manually placed if we decide to add it here)
- [Install topics for Linux](https://deploy-preview-2997--edb-docs-staging.netlify.app/docs/epas/latest/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86/) (note is added to the base template file and automatically generated for all generated install topics - work on RHEL topics ongoing)

Earlier versions of the product documentation (most relevant being EPAS 10-13) do not have the new structure nor individual OS/arch topics. Here are examples of how we could handle the note for older versions:

- [Linux Guide landing page](https://deploy-preview-2997--edb-docs-staging.netlify.app/docs/epas/13/epas_inst_linux/) (note is manually placed)
- [Package Manager topic](https://deploy-preview-2997--edb-docs-staging.netlify.app/docs/epas/13/epas_inst_linux/03_using_a_package_manager_to_install_advanced_server/) (note would be manually placed if we decide to add it here)

Discussion points:

- Any suggestions for what the note says?
- In what topics do we want to add a note for EPAS? to all topics listed above or a subset?
- Do we want to add the notes to the corresponding topics for the latest versions of all the other products? 
