### PR TITLE
Fix case so JDBC install templates build on Linux

### DIFF
--- a/install_template/templates/products/edb-jdbc-connector/ubuntu-18.04.njk
+++ b/install_template/templates/products/edb-jdbc-connector/ubuntu-18.04.njk
@@ -1,2 +1,2 @@
 {% extends "products/edb-jdbc-connector/base.njk" %}
-{% set platformBaseTemplate = "Ubuntu-18.04" %}
+{% set platformBaseTemplate = "ubuntu-18.04" %}

--- a/install_template/templates/products/edb-jdbc-connector/ubuntu-20.04.njk
+++ b/install_template/templates/products/edb-jdbc-connector/ubuntu-20.04.njk
@@ -1,2 +1,2 @@
 {% extends "products/edb-jdbc-connector/base.njk" %}
-{% set platformBaseTemplate = "Ubuntu-20.04" %}
+{% set platformBaseTemplate = "ubuntu-20.04" %}


### PR DESCRIPTION
## What Changed?

This maybe doesn't affect Macs, but Linux systems do care if the case doesn't match the filename - JDBC install templates were failing to build as a result.