### PR TITLE
Remove superfluous back button

### DIFF
--- a/src/components/left-nav.js
+++ b/src/components/left-nav.js
@@ -73,7 +73,6 @@ const LeftNav = ({
 }) => {
   return (
     <ul className="list-unstyled mt-0">
-      <BackButton />
       {versionArray ? (
         <SectionHeadingWithVersions
           navTree={navTree}


### PR DESCRIPTION
## What Changed?

Early in the development of EDB Docs 2.0, navigating deep into a set of nested topics might leave you with a limited set of options in the navigation sidebar with no way to get back "up" to the parent topic. A "<- Back" link was added to let folks navigate "up". 

Docs was changed a long time ago to show the full heirarchy in the sidebar. The "Back" button was also changed to always go back to the docs homepage. Which is also what clicking the "docs" part of "EDB / docs" does. 

This leaves the "<-- Back" link sorta redundant at best and confusing at worst. Let's get rid of it!

