### PR TITLE
Separate shell commands from output listings in BigAnimal docs

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/index.mdx
@@ -126,7 +126,7 @@ To check if an Azure resource provider is registered, use the following command.
 
 ```shell
 az provider show -n Microsoft.ContainerService
-
+__OUTPUT__
 Namespace                   RegistrationPolicy    RegistrationState
 --------------------------  --------------------  -------------------
 Microsoft.ContainerService  RegistrationRequired  Registered
@@ -139,7 +139,7 @@ You can check SKU restrictions for the VM size using the Azure Cloud Shell. For 
 
 ```shell
 az vm list-skus -l eastus2 --zone --size Standard_E2s_v3
-
+__OUTPUT__
 ResourceType     Locations    Name              Zones    Restrictions
 ---------------  -----------  ---------------   -------  ------------
 virtualMachines  eastus2      Standard_E2s_v3   1,2,3    NotAvailableForSubscription, type: Zone, locations: eastus2, zones: 3,2
@@ -179,6 +179,7 @@ use the [register command](https://docs.microsoft.com/en-us/cli/azure/provider?v
 
 ```shell
 az provider register -n Microsoft.ContainerService
+__OUTPUT__
 Registering is still on-going. You can monitor using 'az provider show -n Microsoft.ContainerService
 ```
 

--- a/product_docs/docs/biganimal/release/reference/api.mdx
+++ b/product_docs/docs/biganimal/release/reference/api.mdx
@@ -27,13 +27,13 @@ This call returns the information that either:
 -   You need later if you're using `curl` to request the device code and tokens.
 -   The `get-token` script uses to generate the tokens for you.
 
-```
+```shell
 curl https://portal.biganimal.com/api/v2/auth/provider
 ```
 
 The response returns the `clientId`, `freetrialClientId`, `issuerUri`, `scope`, and `audience`. For example:
 
-```
+```json
 {
   "clientId": "5B79FAjzKF2Ig5dVFAOhc1acDSJYY2xh",
   "freetrialClientId": "m71bEVZrGsWiKtPqMI3hYCHCG3EYLPDk",
@@ -66,7 +66,7 @@ The following example calls use these environment variables.
 
 This call gets a device code:
 
-```
+```shell
 curl --request POST \
   --url "$ISSUER_URL/oauth/device/code" \
   --header "content-type: application/x-www-form-urlencoded" \
@@ -86,7 +86,7 @@ The response returns:
 
 For example:
 
-```
+```json
 {
   "device_code": "KEOY2_5YjuVsRuIrrR-aq5gs",
   "user_code": "HHHJ-MMSZ",
@@ -120,7 +120,7 @@ DEVICE_CODE=KEOY2_5YjuVsRuIrrR-aq5gs
 
 The `curl --request POST` call requests a token. For example:
 
-```
+```shell
 curl --request POST \
   --url "$ISSUER_URL/oauth/token" \
   --header "content-type: application/x-www-form-urlencoded" \
@@ -139,7 +139,7 @@ If successful, the call returns:
 
 For example:
 
-```
+```json
 {
   "access_token": "eyJhbGc.......1Qtkaw2fyho",
   "id_token": "eyJhbGci.......FBra7tA",
@@ -152,7 +152,7 @@ For example:
 
 Store the access token and refresh token in environment variables for future use. For example:
 
-```
+```ini
 RAW_ACCESS_TOKEN="eyJhbGc.......1Qtkaw2fyho"
 REFRESH_TOKEN="v2.MTvuZpu.......sbiionEhtTw"
 ```
@@ -179,7 +179,7 @@ If not successful, you receive one of the following errors:
 
 Use the raw token you obtained in the previous step [Request the raw token using `curl`](#request-the-raw-token-using-curl) to get the BigAnimal token:
 
-```
+```shell
 curl -s --request POST \
      --url "https://portal.biganimal.com/api/v2/auth/token" \
      --header "content-type: application/json" \
@@ -192,7 +192,7 @@ If successful, the call returns:
 
 For example:
 
-```
+```json
 {
   "token": "eyJhbGc.......0HFkr_19Vr7w"
 }
@@ -201,7 +201,7 @@ For example:
 This token, as opposed to the raw-access token, is recognized by the BigAnimal API.
 Store this token in environment variables for future use. For example:
 
-```
+```ini
 ACCESS_TOKEN="eyJhbGc.......0HFkr_19Vr7w"
 ```
 
@@ -213,7 +213,7 @@ Contact [Customer Support](../overview/support) if you have trouble obtaining a 
 
 To call the BigAnimal API, your application must pass the retrieved access token as a bearer token in the Authorization header of your HTTP request. For example:
 
-```
+```shell
 curl --request GET \
   --url "$AUDIENCE/v2/postgres-types" \
   --header "authorization: Bearer $ACCESS_TOKEN"  \
@@ -222,7 +222,7 @@ curl --request GET \
 
 Example response:
 
-```
+```json
 {
   "pgTypesList": [
     {
@@ -253,7 +253,7 @@ The `get-token` script has an option to execute this step. See [Refresh the toke
 
 If you aren't using the `get-token` script to refresh your token, make a POST request to the `/oauth/token` endpoint in the Authentication API, using `grant_type=refresh_token`. For example:
 
-```
+```shell
 curl --request POST \
   --url "$ISSUER_URL/oauth/token" \
   --header "content-type: application/x-www-form-urlencoded" \
@@ -268,7 +268,7 @@ The `client_id` is always the same one in the response when you [queried the aut
 
 The response of this API call includes the `access_token`. For example:
 
-```
+```json
 {
   "access_token": "eyJ...MoQ",
   "expires_in": 86400,
@@ -281,7 +281,7 @@ The response of this API call includes the `access_token`. For example:
 
 Store the access token and refresh token in environment variables for future use. For example:
 
-```
+```ini
 RAW_ACCESS_TOKEN="eyJhbGc.......1Qtkaw2fyho"
 REFRESH_TOKEN="v2.MTvuZpu.......sbiionEhtTw"
 ```
@@ -322,8 +322,9 @@ Reference: https://www.enterprisedb.com/docs/biganimal/latest/reference/api/
 
 To use the `get-token` script to get your tokens, use the script without the `--refresh` option. For example:
 
-```
+```shell
 ./get-token.sh -o plain
+__OUTPUT__
 Please login to
 https://biganimal.us.auth0.com/activate?user_code=ZMNX-VVJT
 with your BigAnimal account
@@ -343,8 +344,9 @@ xxxxxxxxxx
 
 To use the `get-token` script to refresh your token, use the script with the `--refresh  <refresh_token>` option. For example:
 
-```
+```shell
 ./get-token.sh -o json --refresh v2.MVZ9_xxxxxxxx_FRs
+__OUTPUT__
 {
   "access_token": "xxxxxxxxxx",
   "refresh_token": "xxxxxxxxxxxx",

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -45,7 +45,11 @@ The CLI is available for Linux, MacOS, and Windows operating systems.
 Before using the CLI to manage BigAnimal, you need to authenticate as a valid BigAnimal user. Use the `create-credential` command to authenticate through the BigAnimal website and assign a refresh token and an access token to a local credential. For example:
 
 ```shell
-$ biganimal create-credential --name ba-user1 --address portal.biganimal.com  --port 443
+biganimal create-credential \
+  --name ba-user1 \
+  --address portal.biganimal.com \
+  --port 443
+__OUTPUT__
 Querying Authentication Endpoint for 'portal.biganimal.com
 First, copy your one-time code:
          CWWG-SMXC
@@ -58,7 +62,8 @@ Credential "ba-user1" created!
 Refresh tokens expire after 30 days. To continue using the credential to access the CLI, use the `reset-credential` command to authenticate through the BigAnimal website and receive a new refresh token.
 
 ```shell
-$ biganimal reset-credential ba-user1 
+biganimal reset-credential ba-user1 
+__OUTPUT__
 Visit this URL to login: https://auth.biganimal.com/activate?user_code=****-****
 or press [Enter] to continue in the web browser 
 
@@ -68,8 +73,9 @@ Credential "ba-user1" reset operation succeeded
 
 You can create multiple credentials for different BigAnimal accounts and then set one as context of your current management session. Use `show-credentials` to list all available credentials and use `config set context_credential` to set a default credential for the current context. For example:
 
-```
-$ biganimal show-credentials
+```shell
+biganimal show-credentials
+__OUTPUT__
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Credentials                                                             ┃
 ┣━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┫
@@ -79,7 +85,10 @@ $ biganimal show-credentials
 ┃ ba-user2 ┃ portal.biganimal.com        ┃ 443  ┃                         ┃
 ┗━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━┛
 The credential ba-user1 has been set up
-$ biganimal config set context_credential ba-user1
+```
+
+```shell
+biganimal config set context_credential ba-user1
 ```
 
 !!! Note
@@ -91,7 +100,7 @@ The initial running of the CLI creates a hidden configuration folder in your use
 
 Don’t edit files in this directory directly. Instead, use the `config` subcommand to list and update the configuration settings of the CLI. Use the following command to get detailed usage and available configurations inforamtion:
 ```shell
-$ biganimal config
+biganimal config
 ```
 
 ### Available configuration settings
@@ -114,14 +123,14 @@ Use the `-h` or `--help` flags for more information on the CLI commands. You can
 You can enable command line auto completion for bash, fish, powershell, and zsh. To set up auto completion: 
 
 ```shell
-$ biganimal completion
+biganimal completion
 ```
 
 ### Interactive mode
 In interactive mode, the CLI prompts you for any missing mandatory flags and lists any available options for your current context. To enable interactive mode:
 
 ```shell
-$ biganimal config set interactive_mode on
+biganimal config set interactive_mode on
 ```
 
 ## Sample use cases
@@ -136,7 +145,8 @@ You can turn off prompting using the `biganimal config set interactive_mode off`
 !!!
 
 ```shell
-$ biganimal create-cluster
+biganimal create-cluster
+__OUTPUT__
 Cluster architecture: High Availability
 Number of standby replicas: 2 Replicas
 Provider: Azure
@@ -166,8 +176,9 @@ Volume properties?
 
 You are prompted to confirm you want to create the cluster. After the cluster creation process is completed, it generates a cluster ID.
 
-```
-$ biganimal create-cluster
+```shell
+biganimal create-cluster
+__OUTPUT__
 ........
 Are you sure you want to Create Cluster ? [y|n]: y
 Create Cluster operation is started
@@ -177,8 +188,9 @@ To check current state, run: biganimal show-clusters --id p-gxhkfww1fe
 
 Check your cluster was created successfully using the `show-clusters` command shown in the return message:
 
-```
-$ biganimal show-clusters --id p-gxhkfww1fe
+```shell
+biganimal show-clusters --id p-gxhkfww1fe
+__OUTPUT__
 ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │ Clusters                                                                                                                                    │
 ├──────────────┬──────────────────────┬────────────────────┬──────────┬──────────────┬──────────────┬──────────────────────────────┬─────────┤
@@ -223,7 +235,7 @@ Here is a sample configuration file in YAML format with Azure specified as the p
 
 !!! Note
 For backward compatibility, `allowIpRangeMap` and `pgConfigMap` properties also support embedded JSON format.
-  ```
+  ```json
   allowIpRangeMap: [["9.9.9.9/28", "Allow traffic from App A"],["10.10.10.10/27", "Allow traffic from App B"]]
   pgConfigMap: [["application_name","test_app"],["array_nulls","true"]] 
   ```
@@ -239,6 +251,7 @@ To query an enumeration of valid values for above BigAnimal and cloud service pr
 
 ```shell
 biganimal show-cluster-architecture
+__OUTPUT__
 ┌──────────────────────────────────────────────┐
 │ Architecture                                 │
 ├────────┬───────────────────────────┬─────────┤
@@ -263,8 +276,12 @@ You can turn off the confirmation step with the `biganimal disable-confirm` comm
 
 To use your BigAnimal cluster, you first need to get your cluster's connection information. To get your cluster's connection information, use the `show-cluster-connection` command:
 
-```
-$ biganimal show-cluster-connection --name my-biganimal-cluster --provider azure --region eastus
+```shell
+biganimal show-cluster-connection \
+  --name my-biganimal-cluster \
+  --provider azure \
+  --region eastus
+__OUTPUT__
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Connection String                                                                              ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
@@ -276,7 +293,11 @@ $ biganimal show-cluster-connection --name my-biganimal-cluster --provider azure
 You can query the complete connection information with other output formats, like JSON or YAML. For example:
 
 ```shell
-biganimal show-cluster-connection --name my-biganimal-cluster --provider azure --region eastus --ouput json
+biganimal show-cluster-connection \
+  --name my-biganimal-cluster \
+  --provider azure \
+  --region eastus \
+  --ouput json
 ```
 !!!
 
@@ -296,13 +317,19 @@ After the cluster is created, you can update attributes of the cluster including
 For example, to set the public allowed IP range list, use the `--cidr-blocks` flag:
 
 ```shell
-$ biganimal update-cluster --name my-biganimal-cluster --provider azure --region eastus --cidr-blocks --cidr-blocks "9.9.9.9/28=Traffic from App A"
+biganimal update-cluster --name my-biganimal-cluster --provider azure \
+  --region eastus \
+  --cidr-blocks "9.9.9.9/28=Traffic from App A"
 ```
 
 To check whether the setting took effect, use the `show-clusters` command and view the detailed cluster information output in JSON format. For example,
 
 ```shell
-$ biganimal show-clusters --name my-biganimal-cluster --provider azure --region eastus --output json | jq '.[0].allowIpRangeMap'
+biganimal show-clusters --name my-biganimal-cluster --provider azure \
+  --region eastus \
+  --output json \
+| jq '.[0].allowIpRangeMap'
+__OUTPUT__
 [
   [
     "9.9.9.9/28",
@@ -316,7 +343,9 @@ $ biganimal show-clusters --name my-biganimal-cluster --provider azure --region 
 To update the Postgres configuration of a BigAnimal cluster directly from the CLI:
 
 ```shell
-biganimal update-cluster --id p-gxhkfww1fe --pg-config "application_name=ba_test_app,array_nulls=false"
+biganimal update-cluster --id p-gxhkfww1fe \
+  --pg-config "application_name=ba_test_app,array_nulls=false"
+__OUTPUT__
 Update Cluster operation is started
 Cluster ID is "p-gxhkfww1fe"
 ```
@@ -331,7 +360,20 @@ You can update "Cluster Architecture" with the `--cluster-architecture` flag. Th
 Biganimal continuously backs up your PostgrSQL clusters. Using CLI you can restore a cluster from its backup to any point in time as long as the backups are retained in the backup storage. The restored cluster can be a in another region and with different configurations, you can specify new configurations in restore command. For example:
 
 ```shell
-biganimal restore-cluster --name "my-biganimal-cluster" --provider "azure" --region "eastus" --password "mypassword@123" --new-name "my-biganimal-cluster-restored" --new-region="eastus2" --cluster-architecture "single" --instance-type "azure:Standard_E2s_v3" --volume-type "azurepremiumstorage" --volume-property "P1" --networking "public" --cidr-blocks="10.10.10.10/27=Traffic from App B" --restore-point "2022-01-26T15:04:05+0800"
+biganimal restore-cluster \
+  --name "my-biganimal-cluster" \
+  --provider "azure" \
+  --region "eastus" \
+  --password "mypassword@123" \
+  --new-name "my-biganimal-cluster-restored" \
+  --new-region="eastus2" \
+  --cluster-architecture "single" \
+  --instance-type "azure:Standard_E2s_v3" \
+  --volume-type "azurepremiumstorage" \
+  --volume-property "P1" \
+  --networking "public" \
+  --cidr-blocks="10.10.10.10/27=Traffic from App B" \
+  --restore-point "2022-01-26T15:04:05+0800"
 ```
 
 The password for the restored cluster is a mandatory. The other parameters, if not specified, inherit the source database's settings. In interactive mode, the source database's settings appear as the default input, or appear as the first option in a selection list.
@@ -347,7 +389,10 @@ You can restore a cluster in a "Single" cluster to a "High Availability" cluster
 To delete a cluster you no longer need, use the `delete-cluster` command. For example:
 
 ```shell
-$ biganimal delete-cluster --name my-biganimal-cluster --provider azure --region eastus
+biganimal delete-cluster \
+  --name my-biganimal-cluster \
+  --provider azure \
+  --region eastus
 ```
 
 You can list all deleted clusters with the `show-deleted-clusters` command and restore them from their history backups as needed.

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/01_private_endpoint.mdx
@@ -30,7 +30,8 @@ To walk through an example in your own environment, you need:
 -   The IP address of your cluster. You can find the IP address of your cluster using the following command:
 
     ```shell
-    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    __OUTPUT__
     10.240.1.218
     ```
 -   A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
@@ -42,7 +43,7 @@ To walk through an example in your own environment, you need:
 1.  Get the resource group details from the Azure CLI or the Azure portal and note the resource group name. For example, if the cluster's virtual network is `vnet-japaneast`, use the following command: 
 
     ```shell
-      $ az network vnet list --query "[?name==\`vnet-japaneast\`].resourceGroup" -o json
+    az network vnet list --query "[?name==\`vnet-japaneast\`].resourceGroup" -o json
 
     ```
 
@@ -67,7 +68,8 @@ To walk through an example in your own environment, you need:
      You can get the IP address of your cluster with the following command:
 
     ```shell
-    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    __OUTPUT__
     10.240.1.218
     ```
 
@@ -84,8 +86,9 @@ To walk through an example in your own environment, you need:
 5.  After the private link service is created, note its alias. The alias is the unique ID for your private service, which you can share with the service consumers. Obtain the alias either from the Azure portal or by using the following CLI command:
 
     ```shell
-      $ az network private-link-service list --query "[?name=='p-c4j0jfcmp3af2ieok5eg-service-private-link'].alias" -o tsv
-      p-c4j0jfcmp3af2ieok5eg-service-private-link.48f26b42-45dc-4e80-8e3d-307d58d7d274.japaneast.azure.privatelinkservice
+    az network private-link-service list --query "[?name=='p-c4j0jfcmp3af2ieok5eg-service-private-link'].alias" -o tsv
+    __OUTPUT__
+    p-c4j0jfcmp3af2ieok5eg-service-private-link.48f26b42-45dc-4e80-8e3d-307d58d7d274.japaneast.azure.privatelinkservice
     ```
 
 6.  Select **Review + Create**.
@@ -135,16 +138,17 @@ To walk through an example in your own environment, you need:
 11. You have successfully built a tunnel between your client VM's virtual network and the cluster. You can now access the cluster from the private endpoint in your client VM. The private endpoint's private IP address is associated with an independent virtual network NIC. Get the private endpoint's private IP address using the following commands:
 
     ```shell
-     $ NICID=$(az network private-endpoint show -n vnet-client-private-pg-service -g rg-client --query "networkInterfaces[0].id" -o tsv)
-     $ az network nic show -n ${NICID##*/} -g rg-client --query "ipConfigurations[0].privateIpAddress" -o tsv
-     100.64.111.5
+    NICID=$(az network private-endpoint show -n vnet-client-private-pg-service -g rg-client --query "networkInterfaces[0].id" -o tsv)
+    az network nic show -n ${NICID##*/} -g rg-client --query "ipConfigurations[0].privateIpAddress" -o tsv
+    __OUTPUT__
+    100.64.111.5
     ```
 
 12. From the client VM `vm-client`, access the cluster by using the private IP address:
 
     ```shell
-    $ psql -h 100.64.111.5 -U edb_admin 
-
+    psql -h 100.64.111.5 -U edb_admin 
+    __OUTPUT__
     Password for user edb_admin : 
 
     psql (13.4 (Ubuntu 13.4-1.pgdg20.04+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
@@ -186,10 +190,10 @@ With a Private DNS Zone, you configure a DNS entry for your cluster's public hos
 7.  You can now access your cluster with this private domain name.
 
     ```shell
-    $ dig +short p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io 
+    dig +short p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io 
+    psql -h p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
+    __OUTPUT__
     10.240.1.123 
-          
-    $ psql -h p-c4iabjleig40jngmac40.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
     Password for user edb_admin: 
 
     psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
@@ -204,5 +208,5 @@ With a Private DNS Zone, you configure a DNS entry for your cluster's public hos
         You might need to flush your local DNS cache to resolve your domain name to the new private IP address after adding the private endpoint. For example, on Ubuntu, run the following command:
 
         ```shell
-        $ sudo systemd-resolve --flush-caches
+        sudo systemd-resolve --flush-caches
         ```

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/02_virtual_network_peering.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/02_virtual_network_peering.mdx
@@ -32,7 +32,8 @@ To walk through an example in your own environment, you need:
 -   The IP address of your cluster. You can find the IP address of your cluster using the following command:
 
     ```shell
-    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    __OUTPUT__
     10.240.1.218
     ```
 -   A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
@@ -63,10 +64,10 @@ You need to add two peering links, one from the client VM's VNet `vnet-client` a
 Access the cluster with its domain name from your cluster's connection string. It's accessible from `vnet-client` after peering.
 
 ```shell
-$ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
+__OUTPUT__
 10.240.1.123 
-      
-$ psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
 Password for user edb_admin: 
 
 psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/03_vnet_vnet.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/03_vnet_vnet.mdx
@@ -34,7 +34,8 @@ To walk through an example in your own environment, you need:
 -   The IP address of your cluster. You can find the IP address of your cluster using the following command:
 
     ```shell
-    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    __OUTPUT__
     10.240.1.218
     ```
 -   A Postgresql client, such as [psql](https://www.postgresql.org/download/), installed on your client VM.
@@ -68,21 +69,29 @@ Use the Azure CLI (or [PowerShell](https://docs.microsoft.com/en-us/azure/vpn-ga
     **From the BigAnimal subscription**:
 
     ```shell
-    $ az network vnet-gateway show -n vpng-biganimal -g brCxzr08qr7RBEi1-rg-japaneast-management --query "[id]" -otsv
+    az network vnet-gateway show -n vpng-biganimal -g brCxzr08qr7RBEi1-rg-japaneast-management --query "[id]" -otsv
+    __OUTPUT__
     subscriptions/.../vpng-biganimal
     ```
 
     **From the client VM's subscription**:
 
     ```shell
-    $ az network vnet-gateway show -n vpng-client -g rg-client --query "[id]" -o tsv
+    az network vnet-gateway show -n vpng-client -g rg-client --query "[id]" -o tsv
+    __OUTPUT__
     /subscriptions/.../vpng-client
     ```
 
 2.  From the BigAnimal subscription, create a connection from `vpng-biganimal` to `vpng-client`.
 
     ```shell
-    $ az network vpn-connection create -n vpnc-biganimal-client -g brCxzr08qr7RBEi1-rg-japaneast-management --vnet-gateway1 /subscriptions/.../vpng-biganimal -l japaneast --shared-key "a_very_long_and_complex_psk" \--vnet-gateway2 /subscriptions/.../vpng-client
+    az network vpn-connection create \
+        -n vpnc-biganimal-client \
+        -g brCxzr08qr7RBEi1-rg-japaneast-management \
+        --vnet-gateway1 /subscriptions/.../vpng-biganimal \
+        -l japaneast 
+        --shared-key "a_very_long_and_complex_psk" \
+        --vnet-gateway2 /subscriptions/.../vpng-client
 
     ```
 
@@ -91,7 +100,13 @@ Use the Azure CLI (or [PowerShell](https://docs.microsoft.com/en-us/azure/vpn-ga
 3.  From the client VM's subscription, create another connection from `vpng-client` to `vpng-ebdcloud`.
 
     ```shell
-    $ az network vpn-connection create -n vpnc-client-biganimal -g rg-client --vnet-gateway1 /subscriptions/.../vpng-client -l japaneast --shared-key "a_very_long_and_complex_psk!" --vnet-gateway2 /subscriptions/.../vpng-biganimal
+    az network vpn-connection create \
+        -n vpnc-client-biganimal \
+        -g rg-client \
+        --vnet-gateway1 /subscriptions/.../vpng-client \
+        -l japaneast \
+        --shared-key "a_very_long_and_complex_psk!" \
+        --vnet-gateway2 /subscriptions/.../vpng-biganimal
     ```
 
 #### Step 4: Verify the connection
@@ -99,17 +114,19 @@ Use the Azure CLI (or [PowerShell](https://docs.microsoft.com/en-us/azure/vpn-ga
 1.  After a few minutes, verify the gateway connection status from either virtual networks with the following command:
 
     ```shell
-    $ az network vpn-connection show --name vpnc-client-biganimal -g rg-client --query "[connectionStatus]" -o tsv
+    az network vpn-connection show --name vpnc-client-biganimal -g rg-client \
+        --query "[connectionStatus]" -o tsv
+    __OUTPUT__
     Connected
     ```
 
 2.  Verify the connectivity to the cluster:
 
     ```shell
-    $ dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    dig +short p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io 
+    psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
+    __OUTPUT__
     10.240.1.123 
-          
-    $ psql -h p-c4j0jfcmp3af2ieok5eg.brcxzr08qr7rbei1.biganimal.io -U edb_admin      
     Password for user edb_admin: 
 
     psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/01_vpc_endpoint.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/01_vpc_endpoint.mdx
@@ -99,7 +99,8 @@ Now that your endpoint service is created, you can connect it to the cluster VPC
  In your application's AWS account, select **VPC** and then select **Endpoints**. Select the endpoint you created previously and use the DNS name provided in the details section to access your cluster.
 
     ```shell     
-    $ psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin      
+    psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin      
+    __OUTPUT__
     Password for user edb_admin: 
 
     psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/02_vpc_peering.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/02_vpc_peering.mdx
@@ -91,16 +91,17 @@ You can create a VPC peering connection with a VPC in the same region or a diffe
 
 1. Access the cluster with its domain name from your cluster's connection string. It's accessible from `vpc-client` after peering.
 
-```shell    
-    $ psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin      
-    Password for user edb_admin: 
+   ```shell    
+   psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin      
+   __OUTPUT__
+   Password for user edb_admin: 
 
-    psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
-    WARNING : psql major version 13, server major version 13. Some psql features might not work. 
-    SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
+   psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
+   WARNING : psql major version 13, server major version 13. Some psql features might not work. 
+   SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
 
-    edb_admin=>
-```
+   edb_admin=>
+   ```
 
 ### Create a VPC peering connection with a VPC in a different region
 
@@ -132,13 +133,14 @@ You can create a VPC peering connection with a VPC in the same region or a diffe
  
 1. Access the cluster with its domain name from your cluster's connection string. It's accessible from `vpc-client` after peering.
 
-```shell 
-    $ psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin      
-    Password for user edb_admin: 
+   ```shell 
+   psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin      
+   __OUTPUT__
+   Password for user edb_admin: 
 
-    psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
-    WARNING : psql major version 13, server major version 13. Some psql features might not work. 
-    SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
+   psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10)) 
+   WARNING : psql major version 13, server major version 13. Some psql features might not work. 
+   SSL connection (protocol : TLSV1.3cipherTLS_AES_256_GCM_SHA384, bits : 256, compression : off) Type "help" for help. 
 
-    edb_admin=>
-```
+   edb_admin=>
+   ```

--- a/src/styles/_docs.scss
+++ b/src/styles/_docs.scss
@@ -129,6 +129,9 @@ label.link-label {
     background: #d1d1d1;
     color: #272822;
     text-shadow: none;
+    line-height: normal;
+    // Google doesn't serve some character ranges for Source Code Pro that we need for legible output, e.g. table listings - so use default
+    font-family: monospace !important;
   }
 }
 
@@ -172,7 +175,6 @@ html.katacoda-panel-active .katacoda-exec-button {
 }
 
 @media print {
-
   .topbar,
   .sidebar,
   nav {


### PR DESCRIPTION
## What Changed?

Addresses issue #3022 - inability to copy certain commands in shell listings due to the presence of output listings.

Three conventions should be used in these docs for shell code blocks:

1. Do not lead with a "prompt" (such as `$` or `#`) - if copy-pasted, these will lead to either "command not found" or a no-op, both which are confusing.

2. Separate command output from the command(s) themselves by a line containing only the text `__OUTPUT__`. When built, this will result in a separate (but visually-connected) listing that will not be copied.

3. Break long lines in a consistent and visually-appealing fashion to aid in reading long commands. 70 characters give or take is a good rule of thumb - if more than two lines, might as well go with one parameter per line.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
