### PR TITLE
Adding instructions for Openshift upgrade to 1.16.x

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
@@ -23,16 +23,34 @@ As a result, we are introducing the following head versions in the new OLM chann
 
 Prior to this release, the only channel that we were supporting was the `stable` channel. This channel is now obsolete. However, for back compatibility it is currently set as an alias of the `stable-v1.15` channel and it will be removed once version 1.15 goes End of Life.
 
-## Important information about upgrading from a 1.15.x operator version to a 1.16.x operator version on Openshift
-We have made a change to the way Conditions are represented in the status of the operator in version 1.16.0 of our operator and onward. This change could cause an operator upgrade to hang on Openshift if one of the old conditions are set during the upgrade process because of the way the Operator Lifecycle Manager checks new CRD's against existing CR's.
+## Important information about upgrading to a 1.16.x operator version on Openshift
 
-Prior to installing 1.16.x on Openshift, if you are upgrading from a 1.15.x version of the operator, we recommend uninstalling the existing 1.15.x version of the operator then deleting all of the old conditions out of the statuses of all existing EDB Postgres for Kubernetes clusters. This will have no effect on the operability of your existing EDB Postgres for Kubernetes clusters.
+We have made a change to the way Conditions are represented in the status of
+the operator in version 1.16.0 and onward. This change could cause an operator
+upgrade to hang on Openshift if one of the old conditions are set during the
+upgrade process, because of the way the Operator Lifecycle Manager checks new
+CRDs against existing CRs.
+
+Prior to installing 1.16.x on Openshift, if you are upgrading from a 1.15.x (or
+earlier) version of the operator, we recommend uninstalling the existing
+version of the operator, then deleting all of the old conditions out of the
+statuses of all existing EDB Postgres for Kubernetes clusters.
+This will have no effect on the operability of your existing EDB Postgres for
+Kubernetes clusters.
 
 To remove the existing conditions run:
 
 ```bash
-for CLUSTER in `oc get clusters -A -o custom-columns=:.metadata.name`; do kubectl patch --type='json' cluster $CLUSTER --subresource=status -p='[{"op": "remove", "path": "/status/conditions"}]'; done
+for CLUSTER in `oc get clusters -A -o custom-columns=:.metadata.name`; do
+  kubectl patch --type='json' cluster $CLUSTER --subresource=status -p='[{"op": "remove", "path": "/status/conditions"}]'
+done
 ```
- That command will remove all of the conditions from all of the EDB Postgres for Kubernetes clusters in your Openshift cluster. Upon the command completing you can safely install version 1.16.x.
 
- If you have already tried to upgrade to 1.16.x from 1.15.x and have the install of 1.16.x as "Pending" and 1.15.x as "Cannot update" you will need to uninstall both version of the operator and then run the command that removes the statuses.
+This command will remove all of the conditions from all of the EDB Postgres for
+Kubernetes clusters in your Openshift cluster.
+Upon the command completing you can safely install version 1.16.x.
+
+If you have already tried to upgrade to 1.16.x from 1.15.x (or earlier) and
+have the install of 1.16.x marked as "Pending", while the previous one as
+"Cannot update", you will need to uninstall both versions of the operator, and
+then run the command that removes the statuses.

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
@@ -21,14 +21,14 @@ As a result, we are introducing the following head versions in the new OLM chann
 * `stable-v1.16`: the latest available patch release of the 1.16 minor release
 * `stable-v1.15`: the latest available patch release of the 1.15 minor release
 
-Prior to this release, the only channel that we were supporting was the `stable` channel. This channel is now obsolete. However, for back compatibility it is currently set as an alias of the `stable-v1.15` channel and it will be removed once version 1.15 goes End of Life.
+Prior to this release, the only channel that we were supporting was the `stable` channel. This channel is now obsolete. However, for backward compatibility it is currently set as an alias of the `stable-v1.15` channel. It will be removed once version 1.15 reaches End of Life.
 
 ## Important information about upgrading to a 1.16.x operator version on Openshift
 
-We have made a change to the way Conditions are represented in the status of
+We have made a change to the way conditions are represented in the status of
 the operator in version 1.16.0 and onward. This change could cause an operator
 upgrade to hang on Openshift if one of the old conditions are set during the
-upgrade process, because of the way the Operator Lifecycle Manager checks new
+upgrade process because of the way the Operator Lifecycle Manager checks new
 CRDs against existing CRs.
 
 Prior to installing 1.16.x on Openshift, if you are upgrading from a 1.15.x (or
@@ -46,11 +46,11 @@ for CLUSTER in `oc get clusters -A -o custom-columns=:.metadata.name`; do
 done
 ```
 
-This command will remove all of the conditions from all of the EDB Postgres for
+This command removes all of the conditions from all of the EDB Postgres for
 Kubernetes clusters in your Openshift cluster.
-Upon the command completing you can safely install version 1.16.x.
+Once the command completes, you can safely install version 1.16.x.
 
 If you have already tried to upgrade to 1.16.x from 1.15.x (or earlier) and
-have the install of 1.16.x marked as "Pending", while the previous one as
-"Cannot update", you will need to uninstall both versions of the operator, and
-then run the command that removes the statuses.
+the install of 1.16.x shows as "Pending" and the earlier version shows as
+"Cannot update", uninstall both versions of the operator and
+run the command that removes the statuses.

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
@@ -23,5 +23,16 @@ As a result, we are introducing the following head versions in the new OLM chann
 
 Prior to this release, the only channel that we were supporting was the `stable` channel. This channel is now obsolete. However, for back compatibility it is currently set as an alias of the `stable-v1.15` channel and it will be removed once version 1.15 goes End of Life.
 
+## Important information about upgrading from a 1.15.x operator version to a 1.16.x operator version on Openshift
+We have made a change to the way Conditions are represented in the status of the operator in version 1.16.0 of our operator and onward. This change could cause an operator upgrade to hang on Openshift if one of the old conditions are set during the upgrade process because of the way the Operator Lifecycle Manager checks new CRD's against existing CR's.
 
+Prior to installing 1.16.x on Openshift, if you are upgrading from a 1.15.x version of the operator, we recommend uninstalling the existing 1.15.x version of the operator then deleting all of the old conditions out of the statuses of all existing EDB Postgres for Kubernetes clusters. This will have no effect on the operability of your existing EDB Postgres for Kubernetes clusters.
 
+To remove the existing conditions run:
+
+```bash
+for CLUSTER in `oc get clusters -A -o custom-columns=:.metadata.name`; do kubectl patch --type='json' cluster $CLUSTER --subresource=status -p='[{"op": "remove", "path": "/status/conditions"}]'; done
+```
+ That command will remove all of the conditions from all of the EDB Postgres for Kubernetes clusters in your Openshift cluster. Upon the command completing you can safely install version 1.16.x.
+
+ If you have already tried to upgrade to 1.16.x from 1.15.x and have the install of 1.16.x as "Pending" and 1.15.x as "Cannot update" you will need to uninstall both version of the operator and then run the command that removes the statuses.

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_16_rel_notes.mdx
@@ -17,7 +17,7 @@ We are adopting a new policy to support the last two minor versions of the produ
 
 As a result, we are introducing the following head versions in the new OLM channels in OpenShift to manage the update streams for EDB Postgres for Kubernetes:
 
-* `fast`: the latest available patch release for the latest available minor release 
+* `fast`: the latest available patch release for the latest available minor release
 * `stable-v1.16`: the latest available patch release of the 1.16 minor release
 * `stable-v1.15`: the latest available patch release of the 1.15 minor release
 
@@ -41,12 +41,17 @@ Kubernetes clusters.
 To remove the existing conditions run:
 
 ```bash
-for CLUSTER in `oc get clusters -A -o custom-columns=:.metadata.name`; do
-  kubectl patch --type='json' cluster $CLUSTER --subresource=status -p='[{"op": "remove", "path": "/status/conditions"}]'
-done
+while IFS=' ' read  NS CLUSTER; do
+  kubectl -n ${NS} patch --type='json' ${CLUSTER} --subresource=status -p='[{"op": "remove", "path": "/status/conditions"}]';
+done < <(kubectl get cluster -A --no-headers=true -o jsonpath='{range .items[*]}{.metadata.namespace}{" cluster/"}{.metadata.name}{"\n"}{end}')
 ```
 
-This command removes all of the conditions from all of the EDB Postgres for
+!!! Important
+    The kubectl command must be version 1.24 or higher.
+    If you get the output `The request is invalid` it means that the traget cluster
+    didn't have any condition on it.
+
+This command will remove all of the conditions from all of the EDB Postgres for
 Kubernetes clusters in your Openshift cluster.
 Once the command completes, you can safely install version 1.16.x.
 


### PR DESCRIPTION
## What Changed?

Added instructions for how to upgrade to versions 1.16.x of EDB Postgres for Kubernetes on Openshift.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
