### PR TITLE
BigAnimal: HA section of Shared responsibilities

### DIFF
--- a/product_docs/docs/biganimal/release/overview/04_responsibility_model.mdx
+++ b/product_docs/docs/biganimal/release/overview/04_responsibility_model.mdx
@@ -8,7 +8,7 @@ The following responsibility model describes the distribution of specific respon
 
 ## High availability
 
--   EDB is responsible for deploying clusters with one primary and two standby replicas. In cloud regions with availability zones, clusters are deployed across multiple availability zones. 
+-   EDB is responsible for deploying clusters with one primary and one or two standby replicas. In cloud regions with availability zones, clusters are deployed across multiple availability zones. 
 -   You are responsible for choosing whether to enable high availability.
 -   You are responsible for ensuring your applications reconnect when network connectivity is interrupted.
 


### PR DESCRIPTION
## What Changed?

Sandeep Arora pointed out the following: 

The High Availability section mentions two standby replicas whereas we have now an option to have either one or two. Only the wording needs to be updated to ensure one does not think we only deploy two standby replicas.

This PR addresses the issue.
