### PR TITLE
EPRS: 6.2 SSL default path note

### DIFF
--- a/product_docs/docs/eprs/6.2/07_common_operations/11_using_ssl_connections.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/11_using_ssl_connections.mdx
@@ -184,6 +184,11 @@ Before you begin, configure the client for SSL with trigger mode.
 
   The default location of these files is `{user.home}/.postgresql(e.g/var/lib/edb/.postgresql/)`. The file location can be overridden using SSL connection parameters or Postgres SSL environmental variables, see [Setting Non-default Paths using Environment Variables](#setting-non-default-paths-using-environment-variables) for more information.
 
+  !!!note
+     If you used the Linux interactive installer, and set the operating system username as:
+     - `postgres`, your `{user.home}` path is `/var/lib/pgsql/` 
+     - `enterprisedb`, your `{user.home}` path is `/var/lib/edb/`, which is the same path created from an RPM installation.
+
   Copy and rename the files:
   ```
   $ cd /var/lib/pgsql/.postgresql/


### PR DESCRIPTION
## What Changed?

Added note about default paths when using Linux interactive installer to 6.2 doc