### PR TITLE
Update quickstart.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/free_trial/quickstart.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/quickstart.mdx
@@ -14,7 +14,9 @@ This topic provides a quick walk-through of the steps needed to configure a Post
 
 If you haven't done so already, you'll need to [create your EDB account](detail/create_an_account). 
 
-Then, use your account to access the [BigAnimal portal](https://freetrial.biganimal.com/).
+Then, use your newly created account to access [BigAnimal free trial portal](https://freetrial.biganimal.com/).
+!!! Note "Please continue to use this portal in order to access BigAnimal for the duration of your free trial."
+
 
 ## Step 2: Create an AWS cluster 
 

--- a/product_docs/docs/biganimal/release/free_trial/quickstart.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/quickstart.mdx
@@ -14,9 +14,10 @@ This topic provides a quick walk-through of the steps needed to configure a Post
 
 If you haven't done so already, you'll need to [create your EDB account](detail/create_an_account). 
 
-Then, use your newly created account to access [BigAnimal free trial portal](https://freetrial.biganimal.com/).
-!!! Note "Please continue to use this portal in order to access BigAnimal for the duration of your free trial."
+Then, use your newly created account to access the [BigAnimal free trial portal](https://freetrial.biganimal.com/).
 
+!!! Note
+    Continue to use the portal at [freetrial.biganimal.com](https://freetrial.biganimal.com/) to access BigAnimal  for the duration of your free trial.
 
 ## Step 2: Create an AWS cluster 
 


### PR DESCRIPTION
BigAnimal free trial users keep going around in circles attempting to log in to BigAnimal portal.
This PR tends to clear that confusion and point the free trial users to the correct sute when attempting to login into the portal.

Grammatical updates are left to the discretion of the documentation folks.


**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
