### PR TITLE
Add missing column in bdr.ddl_epoch

### DIFF
--- a/product_docs/docs/pgd/4/overview/bdr/catalogs.mdx
+++ b/product_docs/docs/pgd/4/overview/bdr/catalogs.mdx
@@ -24,7 +24,7 @@ For details, see [Logging conflicts to a table](conflicts).
 | ----------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
 | sub_id                  | oid                      | Which subscription produced this conflict; can be joined to `bdr.subscription` table                                     |
 | local_xid               | xid                      | Local transaction of the replication process at the time of conflict                                                     |
-| local_lsn               | pg_lsn                   | Local transaction of the replication process at the time of conflict                                                     |
+| local_lsn               | pg_lsn                   | Local LSN at the time of conflict                                                     |
 | local_time              | timestamp with time zone | Local time of the conflict                                                                                               |
 | remote_xid              | xid                      | Transaction that produced the conflicting change on the remote node (an origin)                                         |
 | remote_commit_lsn       | pg_lsn                   | Commit LSN of the transaction which produced the conflicting change on the remote node (an origin)                      |
@@ -1292,6 +1292,8 @@ An internal catalog table holding state per DDL epoch.
 | origin_node_id        | oid         | Internal node ID of the node that requested creation of this epoch       |
 | epoch_consume_timeout | timestamptz | Timeout of this epoch                                                    |
 | epoch_consumed        | boolean     | Switches to true as soon as the local node has fully processed the epoch |
+| epoch_consumed_lsn    | boolean     | LSN at which the local node has processed the epoch                      |
+
 
 ### `bdr.internal_node_pre_commit`
 


### PR DESCRIPTION

## What Changed?

-  Add missing column in `bdr.ddl_epoch`
-  Fixed a typo in the description of `bdr.conflict_history.local_lsn`.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [X] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
