### PR TITLE
EPRS: alterDDL command limitation note

### DIFF
--- a/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
@@ -22,4 +22,6 @@ The following is the series of steps that occur during the DDL change replicatio
 -   The in-memory table metadata definition is refreshed to reflect the DDL change. The user is informed of successful completion of the operation.
 -   If an error occurs during the prior steps, any changes up to that point are rolled back so that the publication table, replication triggers, and shadow table are reverted back to their original state prior to the start of this operation. If one or more databases goes down before completion of the operation, the publication is marked as dirty to avoid further replication events.
 
-The following section describes how to initiate DDL change replication using the xDB Replication Console.
+!!! Note
+   When you execute the alterDDL command, non-MDN nodes usually don't have any CDC changes during the MMR setup. If there are any changes on the altered table in the non-MDN node, it can result in data loss and a break in replication. 
+!!!

--- a/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
@@ -23,5 +23,5 @@ The following is the series of steps that occur during the DDL change replicatio
 -   If an error occurs during the prior steps, any changes up to that point are rolled back so that the publication table, replication triggers, and shadow table are reverted back to their original state prior to the start of this operation. If one or more databases goes down before completion of the operation, the publication is marked as dirty to avoid further replication events.
 
 !!! Note
-   When you execute the alterDDL command, non-MDN nodes usually don't have any CDC changes during the MMR setup. If there are any changes on the altered table in the non-MDN node, it can result in data loss and a break in replication. 
+   When you execute the alterDDL command, non-MDN nodes shouldn't have any CDC changes during that window for MMR setup. If there are any CDC changes, it may result in data loss and a break in replication. 
 !!!

--- a/product_docs/docs/eprs/7/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
+++ b/product_docs/docs/eprs/7/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
@@ -23,5 +23,5 @@ The following is the series of steps that occur during the DDL change replicatio
 -   If an error occurs during these steps, any changes up to that point are rolled back so that the publication table, replication triggers, and shadow table revert to their original state prior to the start of this operation. If one or more databases goes down before the operation finishes, the publication is marked as dirty to avoid further replication events.
 
 !!! Note
-   When you execute the alterDDL command, non-MDN nodes usually don't have any CDC changes during the MMR setup. If there are any changes on the altered table in the non-MDN node, it can result in data loss and a break in replication. 
+   When you execute the alterDDL command, non-MDN nodes shouldn't have any CDC changes during that window for MMR setup. If there are any CDC changes, it may result in data loss and a break in replication. 
 !!!

--- a/product_docs/docs/eprs/7/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
+++ b/product_docs/docs/eprs/7/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
@@ -21,3 +21,7 @@ The following is the series of steps that occur during the DDL change replicatio
 -   These two actions are repeated on the target table for each database in the replication system.
 -   The in-memory table metadata definition is refreshed to reflect the DDL change. You're notified when the operation completes successfully.
 -   If an error occurs during these steps, any changes up to that point are rolled back so that the publication table, replication triggers, and shadow table revert to their original state prior to the start of this operation. If one or more databases goes down before the operation finishes, the publication is marked as dirty to avoid further replication events.
+
+!!! Note
+   When you execute the alterDDL command, non-MDN nodes usually don't have any CDC changes during the MMR setup. If there are any changes on the altered table in the non-MDN node, it can result in data loss and a break in replication. 
+!!!


### PR DESCRIPTION
## What Changed?

- added note as per [XDB-1595](https://enterprisedb.atlassian.net/browse/XDB-1595)
- removed sentence at the bottom of /6.2/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication/ that referred to a nonexistent section and referred to Replication Server as xDB
