### PR TITLE
Add the SSL configuration requirement

### DIFF
--- a/product_docs/docs/pgd/4/overview/harp/04_configuration.mdx
+++ b/product_docs/docs/pgd/4/overview/harp/04_configuration.mdx
@@ -105,6 +105,8 @@ configuration file:
 
 - **`ssl_key_file`**: Client SSL key file.
 
+Note that when `ssl` is set to `on`, the etcd endpoint URLs must contain the `https` scheme, e.g. `https://host1:2379`.
+
 #### Example
 
 This example shows how to configure HARP to contact an etcd DCS


### PR DESCRIPTION
I've lost two days trying to understand why the SSL connections fail...

## What Changed?

Add the requirement to enforce the SSL connection on the endpoints when the SSL support is switched on.

## Checklist

**Content**

- [X] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
