### PR TITLE
Fix capitalization of pglogical on homepage

### DIFF
--- a/scripts/source/pglogical2.js
+++ b/scripts/source/pglogical2.js
@@ -104,6 +104,7 @@ function pglogicalTransformer() {
             metadata: {
               title: title,
               product: "pglogical 2",
+              generatedBy: `${process.argv[1]} - re-run to regenerate from originalFilePath`,
             },
             data: {
               type: "root",
@@ -146,7 +147,10 @@ function pglogicalTransformer() {
       path.basename(f.path, ".mdx"),
     );
     files[0].metadata.indexCards = "simple";
-    files[0].metadata.directoryDefaults = { iconName: "EdbReplicate" };
+    files[0].metadata.directoryDefaults = {
+      iconName: "EdbReplicate",
+      editTarget: "originalFilePath",
+    };
     tree.children = files;
   };
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -216,7 +216,7 @@ const Page = () => (
             </IndexCardLink>
             <IndexCardLink to="/slony/latest">Slony (Deprecated)</IndexCardLink>
             <IndexCardLink to="/supported-open-source/pglogical2/">
-              pgLogical 2
+              pglogical 2
             </IndexCardLink>
           </IndexCard>
 


### PR DESCRIPTION
## What Changed?

Should be "pglogical" not "pgLogical" (or "PGlogical" or "PgLogical" or "pGlOgIcAl")

Also restored a few omissions to the import script

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
