### PR TITLE
BigAnimal: two-node cluster clarification

### DIFF
--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -45,7 +45,7 @@ Incoming client connections are always routed to the current primary. In case of
 
 By default, replication is synchronous to one standby replica and asynchronous to the other. That is, one standby replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. 
 
-In a cluster with one primary and one replica (a two-node high availability cluster), you run the risk of the cluster being unavailable for writes because it doesn't have the same level of reliability as three-node cluster. Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster to ensure write availability. You can also change from the default synchronous replication for a two-node cluster to asynchronous replication on a per-session/per-transaction basis.
+In a cluster with one primary and one replica (a two-node high availability cluster), you run the risk of the cluster being unavailable for writes because it doesn't have the same level of reliability as a three-node cluster. Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster to ensure write availability. You can also change from the default synchronous replication for a two-node cluster to asynchronous replication on a per-session/per-transaction basis.
 
 In PostgreSQL terms, `synchronous_commit` is set to `on` and `synchronous_standby_names` is set to `ANY 1 (replica-1, replica-2)`. You can modify this behavior on a per-transaction, per-session, per-user, or per-database basis with appropriate `SET` or `ALTER` commands. 
 

--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -43,9 +43,9 @@ Incoming client connections are always routed to the current primary. In case of
 
 ### Synchronous replication
 
-By default, replication is synchronous to one standby replica and asynchronous to the other. That is, one standby replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. You can change from the default synchronous replication for a two-node cluster to asynchronous replication on a per-session/per-transaction basis.
+By default, replication is synchronous to one standby replica and asynchronous to the other. That is, one standby replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. 
 
-In a cluster with one primary and one replica (a two-node high availability cluster), the entire system is unavailable for writes if either node goes down.  Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster to ensure write availability. 
+In a cluster with one primary and one replica (a two-node high availability cluster), you run the risk of the cluster being unavailable for writes because it doesn't have the same level of reliability as three-node cluster. Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster to ensure write availability. You can also change from the default synchronous replication for a two-node cluster to asynchronous replication on a per-session/per-transaction basis.
 
 In PostgreSQL terms, `synchronous_commit` is set to `on` and `synchronous_standby_names` is set to `ANY 1 (replica-1, replica-2)`. You can modify this behavior on a per-transaction, per-session, per-user, or per-database basis with appropriate `SET` or `ALTER` commands. 
 

--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -43,11 +43,11 @@ Incoming client connections are always routed to the current primary. In case of
 
 ### Synchronous replication
 
-By default, replication is synchronous to one standby replica and asynchronous to the other. That is, one standby replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. In a cluster with one primary and one replica, the entire system is unavailable for writes if either node goes down.
+By default, replication is synchronous to one standby replica and asynchronous to the other. That is, one standby replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. 
+
+In a cluster with one primary and one replica (a two-node high availability cluster), the entire system is unavailable for writes if either node goes down. You can change from the default synchronous replication for a two-node cluster to asynchronous replication on a per-session/per-transaction basis. Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster to ensure write availability. 
 
 In PostgreSQL terms, `synchronous_commit` is set to `on` and `synchronous_standby_names` is set to `ANY 1 (replica-1, replica-2)`. You can modify this behavior on a per-transaction, per-session, per-user, or per-database basis with appropriate `SET` or `ALTER` commands. 
-
-Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster (to ensure write availability).
 
 
 ## Extreme high availability (beta)

--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -43,9 +43,9 @@ Incoming client connections are always routed to the current primary. In case of
 
 ### Synchronous replication
 
-By default, replication is synchronous to one standby replica and asynchronous to the other. That is, one standby replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. 
+By default, replication is synchronous to one standby replica and asynchronous to the other. That is, one standby replica must confirm that a transaction record was written to disk before the client receives acknowledgment of a successful commit. You can change from the default synchronous replication for a two-node cluster to asynchronous replication on a per-session/per-transaction basis.
 
-In a cluster with one primary and one replica (a two-node high availability cluster), the entire system is unavailable for writes if either node goes down. You can change from the default synchronous replication for a two-node cluster to asynchronous replication on a per-session/per-transaction basis. Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster to ensure write availability. 
+In a cluster with one primary and one replica (a two-node high availability cluster), the entire system is unavailable for writes if either node goes down.  Note that BigAnimal automatically disables synchronous replication during maintenance operations of a two-node cluster to ensure write availability. 
 
 In PostgreSQL terms, `synchronous_commit` is set to `on` and `synchronous_standby_names` is set to `ANY 1 (replica-1, replica-2)`. You can modify this behavior on a per-transaction, per-session, per-user, or per-database basis with appropriate `SET` or `ALTER` commands. 
 


### PR DESCRIPTION
## What Changed?

Updated the description in the Synchronous replication section to mention that you can change the default behavior of 2-node clusters