### PR TITLE
OCL: updated platform support topic to link to web site

### DIFF
--- a/product_docs/docs/ocl_connector/14.1.0.1/02_supported_platforms.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/02_supported_platforms.mdx
@@ -5,18 +5,5 @@ title: "Supported platforms"
 
 <div id="supported_platforms" class="registered_link"></div>
 
-The EDB OCL Connector is certified with EDB Postgres Advanced Server version 10 and later. The EDB OCL Connector native packages are supported on the following 64-bit platforms:
-
--   RHEL 7.x and 8.x (x86_64) 
--   Rocky Linux/AlmaLinux 8.x (x86_64)
--   CentOS 7.x (x86_64)  
--   OL Linux 7.x and 8.x
--   RHEL 8.x (ppc64le)
--   SLES 12.x
--   Debian 10.x
--   Ubuntu 18.04 and 20.04 LTS
-
-The EDB OCL Connector graphical installers are supported on the following 64-bit Windows platforms:
-
--   Windows Server 2019
+The EDB OCL Connector is certified with EDB Postgres Advanced Server version 10 and later. The EDB Connector is supported on the same platforms as EDB Postgres Advanced Server. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 


### PR DESCRIPTION
## What Changed?

Using the approach we are using for most other products of linking to https://www.enterprisedb.com/resources/platform-compatibility instead of maintaining a list of supported platforms in the doc - using a single source of truth.

https://enterprisedb.atlassian.net/browse/EC-2315