### PR TITLE
Update pem_server_other_linux8_x86.mdx

### DIFF
--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
@@ -31,7 +31,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](https://www.enterprisedb.com/docs/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
@@ -31,7 +31,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](https://www.enterprisedb.com/docs/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 


### PR DESCRIPTION
The page doesn't exist and that we got a 404 out of it. The path was taken from the left bar, "Initial configuration on Linux" link, which I believe to be the intention.

## What Changed?

Changed the Initial configuration on Linux link

