### PR TITLE
PEM: fixed broken link to init config topic in install topics

### DIFF
--- a/install_template/templates/products/postgres-enterprise-manager-server/base.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/base.njk
@@ -12,7 +12,7 @@
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
     

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_rhel8_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_rhel8_ppcle.mdx
@@ -31,7 +31,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle.mdx
@@ -42,7 +42,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles15_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles15_ppcle.mdx
@@ -41,7 +41,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_centos7_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_centos7_x86.mdx
@@ -31,7 +31,7 @@ sudo yum -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb10_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb10_x86.mdx
@@ -31,7 +31,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
@@ -31,7 +31,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel7_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel7_x86.mdx
@@ -31,7 +31,7 @@ sudo yum -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel8_x86.mdx
@@ -31,7 +31,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles12_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles12_x86.mdx
@@ -42,7 +42,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles15_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles15_x86.mdx
@@ -41,7 +41,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu18_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu18_x86.mdx
@@ -31,7 +31,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu20_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu20_x86.mdx
@@ -31,7 +31,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 


### PR DESCRIPTION
## What Changed?

Fixed broken link and the capitalization in the label in the install topics 
Updated the template files and regenerated and deployed install topics with corrections