### PR TITLE
pglogical3: duplicate info issue

### DIFF
--- a/product_docs/docs/pgd/3.7/pglogical/subscriptions/index.mdx
+++ b/product_docs/docs/pgd/3.7/pglogical/subscriptions/index.mdx
@@ -212,7 +212,6 @@ alternately choose your own replication slot name instead of using
     that didn't originate on provider node (this is useful for two-way
     replication between the nodes), or "{all}" which means replicate all
     changes no matter what is their origin; default is "{all}"
--   `apply_delay` - how much to delay replication; default is 0 seconds
 -   `strip_origins` - determines whether to remove origin names from
     forwarded data, making it look like the data originate from local node,
     and allowing to forward the data to a subscription in the same instance


### PR DESCRIPTION
## What Changed?

Removed the second instance of the `apply_delay` parameter of the pglogical.create_subscription function