### PR TITLE
small-mispelling-update-natalia

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -2,7 +2,7 @@
 title: "Managing Postgres access"
 ---
 
-Don't use the `edb_admin` database role and `edb_admin` database created when creating your cluster in your application. Instead, create a new database role and a new database, which provides a high level of isolation in Postgres. If multiple applications are using the same cluster, each database can also contain multiple schemas, essentially a namespace in the database. If strict isolation is needed, use a dedicated cluster or dedicated database. If that strict isolation level isn't required, a you can deploy a single database with multiple schemas. Refer to [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) in the PostgreSQL documentation to further customize ownership and roles to your requirements.
+Don't use the `edb_admin` database role and `edb_admin` database created when creating your cluster in your application. Instead, create a new database role and a new database, which provides a high level of isolation in Postgres. If multiple applications are using the same cluster, each database can also contain multiple schemas, essentially a namespace in the database. If strict isolation is needed, use a dedicated cluster or dedicated database. If that strict isolation level isn't required, you can deploy a single database with multiple schemas. Refer to [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) in the PostgreSQL documentation to further customize ownership and roles to your requirements.
 
 To create a new role and database, first connect using `psql`:
 
@@ -12,7 +12,7 @@ psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmod
 
 ## Notes on the edb_admin role
 
-- The `edb_admin` role does not have superuser priviledges by default. Contact [Support](../overview/support) to request superuser priviledges for `edb_admin`. If you request superuser privileges, you **must** take care to limit the number of connections used by superusers to avoid degraded service and/or compromising availability.
+- The `edb_admin` role does not have superuser privileges by default. Contact [Support](../overview/support) to request superuser priviledges for `edb_admin`. If you request superuser privileges, you **must** take care to limit the number of connections used by superusers to avoid degraded service and/or compromising availability.
 
 - Changes to system configuration (GUCs) made by edb_admin or other Postgres users are not persisted though a reboot or maintenance. Use the BigAnimal portal to modify system configuration.
 


### PR DESCRIPTION
removed extra 'a' and misspelling of 'privileges' as 'priviledges'

## What Changed?

Please list, at a high level, what changed in your branch. If you changed content, include the product, section, and version as applicable. **Please remove the user instructions including the examples before merging the PR.**

**Examples**

- Fixed typo in EPAS 13 epas_inst_linux guide
- Added more detail to ARK 3.5 getting started guide introduction
- Fixed broken link on `/supported-open-source/pgbackrest/05-retention_policy/` page

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
