### PR TITLE
MySQL: updated MySQL prerequisite for Debian 11

### DIFF
--- a/install_template/templates/products/mysql-foreign-data-wrapper/centos-7.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/centos-7.njk
@@ -1,9 +1,9 @@
 {% extends "products/mysql-foreign-data-wrapper/base.njk" %}
 {% set platformBaseTemplate = "centos-7" %}
-{% block mysqlfdw %}# Download and install the MYSQL repo:
+{% block mysqlfdw %}# Download and install the MySQL repo:
   sudo yum -y install https://dev.mysql.com/get/mysql80-community-release-el7-3.noarch.rpm
 
-  # Enable the MYSQL repo:
+  # Enable the MySQL repo:
   # For MySQL 8:
   sudo yum -y install --enablerepo=mysql80-community --disablerepo=mysql57-community edb-as<xx>-mysql8_fdw
 

--- a/install_template/templates/products/mysql-foreign-data-wrapper/debian-10.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/debian-10.njk
@@ -3,14 +3,16 @@
 {% block mysqlfdw %}
 - Address other prerequisites
   ```shell
-  # If there is `libmysqlclient-dev` already installed on your system, 
-  # remove it by using the following command:
-  sudo apt-get remove  libmysqlclient-dev
+  # Download the GPG key to your APT keyring directly using the apt-key utility: 
+  sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
 
-  #Enable the MySQL repo:
+  # Install and configure the MySQL repo:
   For MySQL 8:
   sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   For MySQL 5:
   sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  
+  # Get the most up-to-date package information from the MySQL APT repository:
+  sudo apt-get update
   ```
 {% endblock mysqlfdw %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/debian-11.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/debian-11.njk
@@ -10,7 +10,5 @@
   #Enable the MySQL repo:
   For MySQL 8:
   sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
-  For MySQL 5:
-  sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
   ```
 {% endblock mysqlfdw %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/debian-11.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/debian-11.njk
@@ -9,8 +9,8 @@
 
   #Enable the MySQL repo:
   For MySQL 8:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   For MySQL 5:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
   ```
 {% endblock mysqlfdw %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/debian-11.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/debian-11.njk
@@ -3,12 +3,13 @@
 {% block mysqlfdw %}
 - Address other prerequisites
   ```shell
-  # If there is `libmysqlclient-dev` already installed on your system, 
-  # remove it by using the following command:
-  sudo apt-get remove  libmysqlclient-dev
+  # Download the GPG key to your APT keyring directly using the apt-key utility: 
+  sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
 
-  #Enable the MySQL repo:
-  For MySQL 8:
+  # Install and configure the MySQL repo:
   sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  
+  # Get the most up-to-date package information from the MySQL APT repository:
+  sudo apt-get update
   ```
 {% endblock mysqlfdw %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/ubuntu-18.04.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/ubuntu-18.04.njk
@@ -9,8 +9,8 @@
 
   # Enable the MySQL repo:
   # For MySQL 8:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   # For MySQL 5:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
   ```
 {% endblock mysqlfdw %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/ubuntu-18.04.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/ubuntu-18.04.njk
@@ -3,14 +3,16 @@
 {% block mysqlfdw %}
 - Address other prerequisites
   ```shell
-  # If there is `libmysqlclient-dev` already installed on your system, 
-  # remove it by using the following command:
-  sudo apt-get remove  libmysqlclient-dev
+  # Download the GPG key to your APT keyring directly using the apt-key utility: 
+  sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
 
-  # Enable the MySQL repo:
+  # Install and configure the MySQL repo:
   # For MySQL 8:
   sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   # For MySQL 5:
   sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  
+  # Get the most up-to-date package information from the MySQL APT repository:
+  sudo apt-get update
   ```
 {% endblock mysqlfdw %}

--- a/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
@@ -27,7 +27,7 @@ The MySQL Foreign Data Wrapper is supported for MySQL 8 on the following platfor
  -   SLES 15
  -   SLES 12
  -   Ubuntu 20.04/18.04 LTS
- -   Debian 10.x
+ -   Debian 11/10.x
 
 **Linux on IBM Power (ppc64le)**
 

--- a/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
@@ -8,6 +8,7 @@ This table lists the latest MySQL Foreign Data Wrapper versions and their suppor
 
 | MySQL Foreign Data Wrapper | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 | 
 | -------------------------- | ------- | ------- | ------- | ------- | ------- | 
+| 2.8.0                      | Y       | Y       | Y       | Y       | Y       |  
 | 2.7.0                      | Y       | Y       | Y       | Y       | Y       |  
 | 2.6.0                      | N       | Y       | Y       | Y       | Y       | 
 | 2.5.5                      | N       | Y       | N       | N       | N       | 

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_centos7_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_centos7_x86.mdx
@@ -23,10 +23,10 @@ Before you begin the installation process:
   ```shell
   # Install the EPEL repository:
   sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  # Download and install the MYSQL repo:
+  # Download and install the MySQL repo:
   sudo yum -y install https://dev.mysql.com/get/mysql80-community-release-el7-3.noarch.rpm
 
-  # Enable the MYSQL repo:
+  # Enable the MySQL repo:
   # For MySQL 8:
   sudo yum -y install --enablerepo=mysql80-community --disablerepo=mysql57-community edb-as<xx>-mysql8_fdw
 

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb10_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb10_x86.mdx
@@ -21,15 +21,17 @@ Before you begin the installation process:
 - Address other prerequisites
 
   ```shell
-  # If there is `libmysqlclient-dev` already installed on your system,
-  # remove it by using the following command:
-  sudo apt-get remove  libmysqlclient-dev
+  # Download the GPG key to your APT keyring directly using the apt-key utility:
+  sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
 
-  #Enable the MySQL repo:
+  # Install and configure the MySQL repo:
   For MySQL 8:
   sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   For MySQL 5:
   sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+
+  # Get the most up-to-date package information from the MySQL APT repository:
+  sudo apt-get update
   ```
 
 ## Install the package

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb11_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb11_x86.mdx
@@ -27,9 +27,9 @@ Before you begin the installation process:
 
   #Enable the MySQL repo:
   For MySQL 8:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   For MySQL 5:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
   ```
 
 ## Install the package

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb11_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb11_x86.mdx
@@ -28,8 +28,6 @@ Before you begin the installation process:
   #Enable the MySQL repo:
   For MySQL 8:
   sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
-  For MySQL 5:
-  sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
   ```
 
 ## Install the package

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb11_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb11_x86.mdx
@@ -21,13 +21,14 @@ Before you begin the installation process:
 - Address other prerequisites
 
   ```shell
-  # If there is `libmysqlclient-dev` already installed on your system,
-  # remove it by using the following command:
-  sudo apt-get remove  libmysqlclient-dev
+  # Download the GPG key to your APT keyring directly using the apt-key utility:
+  sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
 
-  #Enable the MySQL repo:
-  For MySQL 8:
+  # Install and configure the MySQL repo:
   sudo echo "deb http://repo.mysql.com/apt/debian/bullseye mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+
+  # Get the most up-to-date package information from the MySQL APT repository:
+  sudo apt-get update
   ```
 
 ## Install the package

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu18_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu18_x86.mdx
@@ -27,9 +27,9 @@ Before you begin the installation process:
 
   # Enable the MySQL repo:
   # For MySQL 8:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   # For MySQL 5:
-  sudo echo "deb http://repo.mysql.com/apt/debian/buster mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+  sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
   ```
 
 ## Install the package

--- a/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu18_x86.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu18_x86.mdx
@@ -21,15 +21,17 @@ Before you begin the installation process:
 - Address other prerequisites
 
   ```shell
-  # If there is `libmysqlclient-dev` already installed on your system,
-  # remove it by using the following command:
-  sudo apt-get remove  libmysqlclient-dev
+  # Download the GPG key to your APT keyring directly using the apt-key utility:
+  sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
 
-  # Enable the MySQL repo:
+  # Install and configure the MySQL repo:
   # For MySQL 8:
   sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-8.0" | sudo tee  /etc/apt/sources.list.d/mysql.list
   # For MySQL 5:
   sudo echo "deb http://repo.mysql.com/apt/debian/bionic mysql-5.7" | sudo tee  /etc/apt/sources.list.d/mysql.list
+
+  # Get the most up-to-date package information from the MySQL APT repository:
+  sudo apt-get update
   ```
 
 ## Install the package

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb11_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb11_x86.mdx
@@ -31,7 +31,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM Server on Linux](/pem/latest/installing_pem_server/installing_on_linux/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
 


### PR DESCRIPTION
buster > bullseye in url for Debian 11
buster > bionic for Ubuntu 18
removed MySQL 5 command