### PR TITLE
Redirect from import path to internal path for release notes

### DIFF
--- a/advocacy_docs/supported-open-source/cloud_native_pg/index.mdx
+++ b/advocacy_docs/supported-open-source/cloud_native_pg/index.mdx
@@ -5,8 +5,6 @@ description: EDB supports CloudNativePG.
 directoryDefaults:
   iconName: logos/KubernetesMono
   product: CloudNativePG
-redirects:
-  - /postgres_for_kubernetes/latest/release_notes/
 
 ---
 

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: EDB Postgres for Kubernetes Release notes
 navTitle: "Release notes"
+redirects:
+- ../release_notes
 navigation:
 - 1_17_rel_notes
 - 1_16_2_rel_notes


### PR DESCRIPTION
## What Changed?

Redirect relative paths pointing at ./release_notes to ./rel_notes

Avoids unnecessary trip through stub page. The original path is release_notes, which we don't include (referring instead to the open source docs from our internal release notes which live at rel_notes). 

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
