### PR TITLE
MTK: updates to sections that had referred to third-party drivers

### DIFF
--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/index.mdx
@@ -15,6 +15,6 @@ For operating system-specific install instructions, see:
   - [SLES 15](mtk55_sles15_ppcle)
   - [SLES 12](mtk55_sles12_ppcle)
 
-After installing Migration Toolkit, you must install the appropriate source-specific drivers before performing a migration. See [Installing source-specific drivers](../../#installing_drivers) for more information.
+
 
 

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/index.mdx
@@ -29,4 +29,3 @@ For operating system-specific install instructions, see:
   - [Debian 11](mtk55_deb11_x86)
   - [Debian 10](mtk55_deb10_x86)
   
-After installing Migration Toolkit, you must install the appropriate source-specific drivers before performing a migration. See [Installing source-specific drivers](../../#installing_drivers) for more information.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb11_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb11_x86.mdx
@@ -24,6 +24,4 @@ sudo apt-get -y install edb-migrationtoolkit
 
 ## Initial configuration
 
-Before invoking Migration Toolkit, you must download and install a freely available source-specific driver. To download a driver, or for a link to a vendor download site, see the [Third Party JDBC Drivers](https://www.enterprisedb.com/software-downloads-postgres#third-party-jdbc-drivers) on the Downloads page.
-
-After downloading the source-specific driver, move the driver file into the `<mtk_install_dir>/lib` directory.
+Before invoking Migration Toolkit, you must download and install JDBC drivers for connecting to the source and target databases. See [Installing a JDBC driver](/migration_toolkit/latest/05_installing_mtk/installing_jdbc_driver/) for details.


### PR DESCRIPTION
## What Changed?

Missed updating the link and label on these blurbs in the sub-landing pages for install. Decided to remove them as those instructions are provided on the parent topic and all the child install topics and are deemed unnecessary

Fixed same info on Debian 11 topic