### PR TITLE
docs(UPM-9010): Remove the SSO note for superset

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
@@ -10,9 +10,6 @@ You can open Superset from the [BigAnimal](https://portal.biganimal.com/) portal
 
 Default permissions include the ability to view data and create dashboards. To add or modify data sources, you need additional permissions. For more information on permissions to access Superset, see [Managing Superset access](../administering_cluster/01a_superset_access).
 
-!!! Note
-    Apache Superset shares single sign-on with BigAnimal. Logging out of Superset logs you out of BigAnimal and vice-versa.
-
 
 ## Connecting Superset to your cluster
 


### PR DESCRIPTION
## What Changed?

Removing the SSO auth mechanism note between BigAnimal and Superset as it is no longer valid after the new PKCE flow implementation. 


## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [x] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
