### PR TITLE
BigAnimal: fixed nav order in Getting started

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/index.mdx
@@ -6,6 +6,7 @@ navigation:
  - identity_provider
  - 02_azure_market_setup
  - preparing_cloud_account
+ - 02_connecting_your_cloud
  - activating_regions
  - creating_a_cluster
 ---


### PR DESCRIPTION
## What Changed?

Added the Connecting your cluster back in to the nav order. Removed it erroneously.