### PR TITLE
Fix known issues for decoding worker and replications sets

### DIFF
--- a/product_docs/docs/pgd/5/known_issues.mdx
+++ b/product_docs/docs/pgd/5/known_issues.mdx
@@ -46,8 +46,6 @@ release.
     Installations using CAMO/Eager/Group Commit must keep `enable_wal_decoder`
     disabled.
 
--   Decoding Worker works only with the default replication sets.
-
 -   Lag control doesn't adjust commit delay in any way on a fully
     isolated node, that is, in case all other nodes are unreachable or not
     operational. As soon as at least one node is connected, replication


### PR DESCRIPTION
## What Changed?

- Non-default replications sets are supported now with bdr-1775 changes. So removed the known issues related to it. 

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ ] This PR changes existing content
- [X] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
