### PR TITLE
BA: removed extraneous "to" in Connecting topic

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/index.mdx
@@ -85,7 +85,7 @@ SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, co
 
 ## Connect your cluster to EDB's migration tools
 
-To connect to your cluster to EDB's migration tools, see [Migrating databases to BigAnimal](/biganimal/latest/migration/).
+To connect your cluster to EDB's migration tools, see [Migrating databases to BigAnimal](/biganimal/latest/migration/).
 
 
 ## Connect to your cluster using pgAdmin


### PR DESCRIPTION
## What Changed?

Removed extraneous "to" in the "Connecting your cluster to EDB's migration tools" section of the "Connecting your cluster" topic.