### PR TITLE
Adjust the example layout

### DIFF
--- a/product_docs/docs/pgd/4/deployments/tpaexec/quick_start.mdx
+++ b/product_docs/docs/pgd/4/deployments/tpaexec/quick_start.mdx
@@ -10,7 +10,7 @@ architecture using Amazon EC2.
 1. Generate a configuration file:
    
    ```
-   $ tpaexec configure myedbdpcluster --architecture BDR-Always-ON --layout Silver --platform aws --bdr-version 4 --2q --2Q-repositories products/2ndqpostgres/release
+   $ tpaexec configure myedbdpcluster --architecture BDR-Always-ON --layout silver --platform aws --bdr-version 4 --2q --2Q-repositories products/2ndqpostgres/release
    ```
 
    This creates a subdirectory directory in current working directory called `myedbdpcluster` containing the `config.yml` configuration file TPAexec uses to create the cluster. Edit the `config.yml` as needed, for example to change the IP address range used for servers or adjust locations of nodes.


### PR DESCRIPTION
The --layout parameter is case sensitive, and only accepts lower case values. So the "Silver" in the example causes it to fail, issuing a message to the user. 

## What Changed?

This change does s/Silver/silver/, which allows the example to be used as is intended.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
