### PR TITLE
docs(UPM-10326): Docs for PGD dashboard import in superset

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
@@ -54,16 +54,34 @@ You can use Superset dashboards to analyze data stored in your cluster. For a tu
 
 To view all available Superset dashboards, select **Analyze > Dashboards**.
 
-The superset allows you to import the dashboard template. The exported JSON includes the schema of the dashboard and individual charts. The data is expected to be uploaded from the Import dashboard option on the list of dashboards in the upper right corner.
-EDB provides a ready-to-import PGD dashboard JSON in Apache Superset, which helps to rename the database name of your target PGD cluster added in Superset in the exported JSON template file.
+To create a dashboard for monitoring EDB Postgres Distributed, you can use the template we provide. See [Configuring an EDB Postgres Distributed dashboard](#configuring-an-edb-postgres-distributed-dashboard) for more information.
 
-Perform the following steps:
+### Configuring an EDB Postgres Distributed dashboard
+We provide a template for an EDB Postgres Distributed dashboard in JSON format (`utils/superset/pgd_monitoring_template.json`) in the [cloud-utilities](https://github.com/EnterpriseDB/cloud-utilities) repository. The JSON file includes the schema of the dashboard and the individual charts.
 
-- Git clone the [cloud-utilities](https://github.com/EnterpriseDB/cloud-utilities) repository on your local system.
+To add the dashboard:
 
-- Follow the [README](https://github.com/EnterpriseDB/cloud-utilities/tree/main/utils/superset) and execute the commands on your terminal as mentioned.
+1. Clone the [cloud-utilities](https://github.com/EnterpriseDB/cloud-utilities) repository on your local system.
 
-- The output file should be good to be uploaded on the Superset dashboard and the PGD dashboard is ready for visualization.
+1. Using Python 3.4 or later, use the following syntax to create an output JSON file:
+
+   ```py
+   db_name_change.py <database_name> -i <input_file> -o <output_file>
+   ```
+   
+   For example:
+
+   ```py
+   python3 db_name_change.py edb -i utils/superset/pgd_monitoring_template.json  -o utils/superset/upload.json
+   ```
+
+   To get more information on the `db_name_change` script, run:
+
+   ```py
+   python3 db_name_change.py -h 
+   ```
+
+1. In Superset, import your output file by selecting **Analyze > Dashboards > Import dashboard**.
 
 ## Using Superset charts
 

--- a/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
@@ -54,6 +54,16 @@ You can use Superset dashboards to analyze data stored in your cluster. For a tu
 
 To view all available Superset dashboards, select **Analyze > Dashboards**.
 
+The superset allows you to import the dashboard template. The exported JSON includes the schema of the dashboard and individual charts. The data is expected to be uploaded from the Import dashboard option on the list of dashboards in the upper right corner.
+EDB provides a ready-to-import PGD dashboard JSON in Apache Superset, which helps to rename the database name of your target PGD cluster added in Superset in the exported JSON template file.
+
+Perform the following steps:
+
+- Git clone the [cloud-utilities](https://github.com/EnterpriseDB/cloud-utilities) repository on your local system.
+
+- Follow the [README](https://github.com/EnterpriseDB/cloud-utilities/tree/main/utils/superset) and execute the commands on your terminal as mentioned.
+
+- The output file should be good to be uploaded on the Superset dashboard and the PGD dashboard is ready for visualization.
 
 ## Using Superset charts
 


### PR DESCRIPTION
## What Changed?

Added the docs for import dashboard template in Apache Superset in `Using Superset dashboards` section.

**Examples**

- We have added a capability to export the ready-to-import PGD dashboard in any Superset instance. We need to specify the steps and  export the JSON file.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [x] This PR adds new content
- [ ] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
