### PR TITLE
Release: 2022-10-17

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/index.mdx
@@ -85,7 +85,7 @@ SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, co
 
 ## Connect your cluster to EDB's migration tools
 
-To connect to your cluster to EDB's migration tools, see [Migrating databases to BigAnimal](/biganimal/latest/migration/).
+To connect your cluster to EDB's migration tools, see [Migrating databases to BigAnimal](/biganimal/latest/migration/).
 
 
 ## Connect to your cluster using pgAdmin

--- a/product_docs/docs/efm/4/12_upgrading_existing_cluster.mdx
+++ b/product_docs/docs/efm/4/12_upgrading_existing_cluster.mdx
@@ -91,9 +91,9 @@ apt-get remove edb-efm44
 zypper remove edb-efm44
 ```
 
-## Performing a database update (minor version)
+## Performing a maintenance task
 
-You can perform a quick minor database version upgrade. You can upgrade from one minor version to another (for example, from 10.1.5 to version 10.2.7) or apply a patch release for a version.
+You can perform maintenance activities such as an OS patch or a minor database version upgrade. You can upgrade from one minor version to another (for example, from 10.1.5 to version 10.2.7) or apply a patch release for a version.
 
 First, update the database server on each standby node of the Failover Manager cluster. Then, perform a switchover, promoting a standby node to the role of primary in the Failover Manager cluster. Then, perform a database update on the old primary node.
 

--- a/product_docs/docs/epas/14/language_pack/02_installing_language_pack.mdx
+++ b/product_docs/docs/epas/14/language_pack/02_installing_language_pack.mdx
@@ -158,7 +158,7 @@ Follow these steps to add Python, Perl, and Tcl to your Language Pack:
 
     ```text
     C:\edb\languagepack\v2\Python-3.7\
-    C:\edb\languagepack\v1\Python-3.7\Scripts
+    C:\edb\languagepack\v2\Python-3.7\Scripts
     ```
 
    To add Perl and Tcl, enter the following:

--- a/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
@@ -25,3 +25,7 @@ The following is the series of steps that occur during the DDL change replicatio
 !!! Note
    When you execute the alterDDL command, non-MDN nodes shouldn't have any CDC changes during that window for MMR setup. If there are any CDC changes, it may result in data loss and a break in replication. 
 !!!
+
+!!! Note
+   The replicateDDL command performs an implicit synchronization operation that replicates any backlog changes before applying the DDL changes. When continuous data becomes available for replication, this operation may take a long time to complete. 
+!!!

--- a/product_docs/docs/eprs/7/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
+++ b/product_docs/docs/eprs/7/07_common_operations/08_replicating_ddl_changes/01_ddl_change_replication.mdx
@@ -25,3 +25,7 @@ The following is the series of steps that occur during the DDL change replicatio
 !!! Note
    When you execute the alterDDL command, non-MDN nodes shouldn't have any CDC changes during that window for MMR setup. If there are any CDC changes, it may result in data loss and a break in replication. 
 !!!
+
+!!! Note
+   The replicateDDL command performs an implicit synchronization operation that replicates any backlog changes before applying the DDL changes. When continuous data becomes available for replication, this operation may take a long time to complete. 
+!!!

--- a/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
+++ b/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
@@ -11,6 +11,8 @@ On Linux, the `toolkit.properties` file is located in `/usr/edb/migrationtoolkit
 
 On Windows, the file is located in `C:\Program Files\edb\mtk\etc`.
 
+On Mac OS, the file is located in `/Library/edb/mtk/etc`.
+
 The figure shows a sample `toolkit.properties` file:
 
 ![A typical toolkit.properties file.](./images/building_toolkit.properties.png)

--- a/product_docs/docs/pgd/4/deployments/tpaexec/quick_start.mdx
+++ b/product_docs/docs/pgd/4/deployments/tpaexec/quick_start.mdx
@@ -10,7 +10,7 @@ architecture using Amazon EC2.
 1. Generate a configuration file:
    
    ```
-   $ tpaexec configure myedbdpcluster --architecture BDR-Always-ON --layout Silver --platform aws --bdr-version 4 --2q --2Q-repositories products/2ndqpostgres/release
+   $ tpaexec configure myedbdpcluster --architecture BDR-Always-ON --layout silver --platform aws --bdr-version 4 --2q --2Q-repositories products/2ndqpostgres/release
    ```
 
    This creates a subdirectory directory in current working directory called `myedbdpcluster` containing the `config.yml` configuration file TPAexec uses to create the cluster. Edit the `config.yml` as needed, for example to change the IP address range used for servers or adjust locations of nodes.


### PR DESCRIPTION
## What Changed?

- EPAS: fixed version number in Language Pack doc
- MTK: added location for toolkit file in Mac OS
- EPRS: added DDL change replication process note
- EFM: clarified cluster upgrade process
- PGD: fixed case of Silver in TPAexec example
- BigAnimal: removed extraneous "to" in Connecting topic