### PR TITLE
Update 01_understanding_qotas_in_azure.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/01_understanding_qotas_in_azure.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/01_understanding_qotas_in_azure.mdx
@@ -31,13 +31,9 @@ To prevent failures while creating your clusters, ensure that each of the follow
 
 Every BigAnimal cluster with public network access is assigned a single public IP address, and this IP address counts against the quota for both basic and standard IP address types in a region. BigAnimal can't create more clusters if the IP address limit is reached.
 
-### Default Azure limit
-
-The default public IP addresses limits for basic and standard type are set to 10. See [Public IP address limits](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#publicip-address) for more information.
-
 ### Recommended limit
 
-This is decided by the number of the clusters you will create. 
+The default public IP addresses limits for basic and standard type are set to 10. See [Public IP address limits](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#publicip-address) for more information. If you need more than 10 clusters, increase the limit to the number of clusters you plan to deploy plus current usage.
 
 ## vCPU limits
 
@@ -51,7 +47,7 @@ The number of cores required by the database cluster depends on the instance typ
 
 BigAnimal requires an additional eight Dv4 virtual machine cores per region for management resources. 
 
-As the AKS cluster involves performing periodic upgrades to the proper Kubernetes version, an additional six Dv4 virtual machine cores per region are needed for AKS upgrade.
+BigAnimal requires an additional six Dv4 virtual machine cores per region for periodic maintenance upgrades.
 
 ### Recommended limits
 
@@ -59,4 +55,4 @@ BigAnimal recommends the following per region when requesting virtual machine re
 
 -   Total Regional vCPUs: minimum of 50 per designated region
 -   Standard Dv4 Family vCPUs: minimum of 14 per designated region
--   Other Family vCPUs: depending on the instance type, cluster type and number of clusters.
+-   Other Family vCPUs: depending on the instance type, cluster type, and number of clusters.

--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/01_understanding_qotas_in_azure.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/01_understanding_qotas_in_azure.mdx
@@ -27,10 +27,6 @@ To prevent failures while creating your clusters, ensure that each of the follow
 | Microsoft.OperationsManagement | Monitors workloads and provides container insight                                                      |
 | Microsoft.Portal               | Provides a dashboard to monitor the running status of the clusters (using aggregated logs and metrics) |
 
-## Virtual machine SKU restrictions
-
-When you deploy your clusters in high availability (HA) mode, BigAnimal uses multiple availability zones in the region where you plan to deploy the cluster. Ensure that all regions designated for the deployment of your clusters have no virtual machine SKU restrictions for the ESv3 and Dv4 VM size families in zone 1, 2, and 3.
-
 ## Public IP addresses limits
 
 Every BigAnimal cluster with public network access is assigned a single public IP address, and this IP address counts against the quota for both basic and standard IP address types in a region. BigAnimal can't create more clusters if the IP address limit is reached.
@@ -41,30 +37,26 @@ The default public IP addresses limits for basic and standard type are set to 10
 
 ### Recommended limit
 
-EDB recommends that you increase the public IP addresses limits for Basic and Standard type to 50. If you need more than 50 clusters, increase the limit to the number of clusters you plan to deploy.
+This is decided by the number of the clusters you will create. 
 
 ## vCPU limits
 
 Any time a new VM is deployed in Azure, the vCPUs for the VMs must not exceed the total vCPU limits for the region.
 
-Clusters deployed in the region use ESv3 virtual machine cores. The number of cores depends on the instance type and HA options of the clusters. You can calculate the number of ESv3 cores required for your cluster based on the following:
+The number of cores required by the database cluster depends on the instance type and cluster type of the clusters. For exampe, if you create cluster with ESv3 instance type, you can calculate the number of ESv3 cores required for your cluster based on the following:
 
 -   A virtual machine instance of type E{N}sv3 uses {N} cores. For example, an instance of type E64sv3 uses 64 ESv3 cores.
 -   A cluster running on an E{N}sv3 instance without HA enabled uses exactly {N} ESv3 cores.
--   A cluster running on an E{N}sv3 instance with HA enabled uses 3 \* {N} ESv3 cores.
+-   A cluster running on an E{N}sv3 instance with HA enabled and 2 replicas uses 3 \* {N} ESv3 cores.
 
-For example, if you provision the largest virtual machine E64sv3 with high availability enabled, it requires (3 \* 64) = 192 ESv3 cores per region.
+BigAnimal requires an additional eight Dv4 virtual machine cores per region for management resources. 
 
-BigAnimal requires an additional eight Dv4 virtual machine cores per region.
-
-### Default limit
-
-The default number of total vCPU (cores) per subscription per region is 20. For more information, see [Virtual Machines limits - Azure Resource Manager](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#virtual-machines-limits---azure-resource-manager).
+As the AKS cluster involves performing periodic upgrades to the proper Kubernetes version, an additional six Dv4 virtual machine cores per region are needed for AKS upgrade.
 
 ### Recommended limits
 
 BigAnimal recommends the following per region when requesting virtual machine resource limit increases:
 
--   Total Regional vCPUs: minimum of 60 per designated region
--   Standard ESv3 Family vCPUs: minimum of 50 per designated region
+-   Total Regional vCPUs: minimum of 50 per designated region
 -   Standard Dv4 Family vCPUs: minimum of 14 per designated region
+-   Other Family vCPUs: depending on the instance type, cluster type and number of clusters.


### PR DESCRIPTION
## What Changed?

- Correct the error of not all the clusters require ESv3 CPU cores, this is depending on instance and cluster type.
- BigAnimal has more cluster type, e.g. BDR, HA with 1 replica, HA with 2 replicas. So we need to be careful about the doc only covering single node and HA which is not true now.
- Highlight why we need 14 Dv4 cores, 6 of them are only required during AKS upgrade. 
- About the recommended IP quota, usually customer doesn't need to create 50 clusters, so there is no need to set the IP limit as 50.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [X] This PR adds new content
- [X] This PR changes existing content
- [X] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
