### PR TITLE
Update edb-psql description for accuracy (EDB modified not community) 

### DIFF
--- a/product_docs/docs/epas/13/epas_inst_linux/05_managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/05_managing_an_advanced_server_installation.mdx
@@ -136,7 +136,7 @@ Where:
 
 `-U` specifies the identity of the database user that will be used for the session.
 
-`edb-psql` is a symbolic link to PostgreSQL community `psql`. For more information about using the command line client, see the PostgreSQL Core Documentation at:
+`edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. . For more information about using the command line client, see the PostgreSQL Core Documentation at:
 
 <https://www.postgresql.org/docs/current/static/app-psql.html>
 

--- a/product_docs/docs/epas/13/epas_inst_windows/06_configuring_advanced_server/02_connecting_to_advanced_server_with_psql.mdx
+++ b/product_docs/docs/epas/13/epas_inst_windows/06_configuring_advanced_server/02_connecting_to_advanced_server_with_psql.mdx
@@ -29,6 +29,6 @@ Where:
 
 If you have performed an installation with the interactive installer, you can access the `edb-psql` client by selecting `EDB-PSQL` from the `EDB Postgres` menu. When the client opens, provide connection information for your session.
 
-`edb-psql` is a symbolic link to PostgreSQL community `psql`. For more information about using the command line client, see the PostgreSQL Core Documentation at:
+`edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. For more information about using the command line client, see the PostgreSQL Core Documentation at:
 
 <https://www.postgresql.org/docs/current/static/app-psql.html>

--- a/product_docs/docs/epas/14/epas_inst_linux/managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/managing_an_advanced_server_installation.mdx
@@ -135,7 +135,7 @@ Where:
 
 `-U` specifies the identity of the database user to use for the session.
 
-`edb-psql` is a symbolic link to PostgreSQL community `psql`. For more information about using the command line client, see the PostgreSQL Core Documentation at:
+`edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. For more information about using the command line client, see the PostgreSQL Core Documentation at:
 
 <https://www.postgresql.org/docs/current/static/app-psql.html>
 

--- a/product_docs/docs/epas/14/epas_inst_windows/managing_an_advanced_server_installation/configuring_epas.mdx
+++ b/product_docs/docs/epas/14/epas_inst_windows/managing_an_advanced_server_installation/configuring_epas.mdx
@@ -83,7 +83,7 @@ Where:
 
 If you have performed an installation with the interactive installer, you can access the `edb-psql` client by selecting `EDB-PSQL` from the `EDB Postgres` menu. When the client opens, provide connection information for your session.
 
-`edb-psql` is a symbolic link to PostgreSQL community `psql`. For more information about using the command line client, see the PostgreSQL Core Documentation at:
+`edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. For more information about using the command line client, see the PostgreSQL Core Documentation at:
 
 <https://www.postgresql.org/docs/current/static/app-psql.html>
 


### PR DESCRIPTION
## What Changed?

Changed the following language

Before: 
`edb-psql is a symbolic link to PostgreSQL community psql. For more information about using the command line client, see the PostgreSQL Core Documentation at:
`

After: 

`edb-psql is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. For more information about using the command line client, see the PostgreSQL Core Documentation at:`

**Reasoning**

it’s true the edb-psql is a symlink to a binary called psql, but it’s an EDB-modified version of psql, not the community version

**Content**

- [X ] This PR changes existing content


