### PR TITLE
we don't recommend the user to store data in postgres database

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -2,7 +2,6 @@
 title: "Managing Postgres access"
 ---
 
-Avoid storing data in the `postgres` database, which is used as an access point to configure the cluster.
 
 Don't use the `edb_admin` database role and `edb_admin` database created when creating your cluster in your application. Instead, create a new database role and a new database, which provides a high level of isolation in Postgres. If multiple applications are using the same cluster, each database can also contain multiple schemas, essentially a namespace in the database. If strict isolation is needed, use a dedicated cluster or dedicated database. If that strict isolation level isn't required, you can deploy a single database with multiple schemas. Refer to [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) in the PostgreSQL documentation to further customize ownership and roles to your requirements.
 
@@ -11,6 +10,7 @@ To create a new role and database, first connect using `psql`:
 ```shell
 psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmode=require"
 ```
+Avoid storing data in the new database, which is used as an access point to configure the cluster.
 
 ## Notes on the edb_admin role
 

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -2,6 +2,8 @@
 title: "Managing Postgres access"
 ---
 
+Avoid storing data in the `postgres` database, which is used as an access point to configure the cluster.
+
 Don't use the `edb_admin` database role and `edb_admin` database created when creating your cluster in your application. Instead, create a new database role and a new database, which provides a high level of isolation in Postgres. If multiple applications are using the same cluster, each database can also contain multiple schemas, essentially a namespace in the database. If strict isolation is needed, use a dedicated cluster or dedicated database. If that strict isolation level isn't required, you can deploy a single database with multiple schemas. Refer to [Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) in the PostgreSQL documentation to further customize ownership and roles to your requirements.
 
 To create a new role and database, first connect using `psql`:

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -12,6 +12,7 @@ psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmod
 ```
 !!!Note
 Avoid storing data in the `postgres` system database.
+!!!
 
 ## Notes on the edb_admin role
 

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -10,9 +10,8 @@ To create a new role and database, first connect using `psql`:
 ```shell
 psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmode=require"
 ```
-!!!Note
+!!! Note
 Avoid storing data in the `postgres` system database.
-!!!
 
 ## Notes on the edb_admin role
 

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -11,7 +11,7 @@ To create a new role and database, first connect using `psql`:
 psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmode=require"
 ```
 !!! Note
-Avoid storing data in the `postgres` system database.
+    Avoid storing data in the `postgres` system database.
 
 ## Notes on the edb_admin role
 

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -10,7 +10,8 @@ To create a new role and database, first connect using `psql`:
 ```shell
 psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmode=require"
 ```
-Avoid storing data in the new database, which is used as an access point to configure the cluster.
+!!!Note
+Avoid storing data in the `postgres` system database.
 
 ## Notes on the edb_admin role
 


### PR DESCRIPTION
## What Changed?

Add the statement about not storing data in postgres database
Avoid storing data in the `postgres` database, which is used as an access point to configure the cluster.

## Checklist

Please check all boxes that apply (`[ ]` is unchecked, `[x]` is checked)

**Content**

- [ ] This PR adds new content
- [ x] This PR changes existing content
- [ ] This PR removes existing content
- [ ] This PR is for a release, please add this tag: 
