### PR TITLE
two efm timeout descriptions

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
@@ -481,7 +481,10 @@ If necessary, modify these values to suit your business model.
 
 <div id="remote_timeout" class="registered_link"></div>
 
-The `remote.timeout` property value specifies a timeout value for agent-to-agent communication. For example, if a node appears to have failed, an agent in the cluster will ask the other agents if they can reach the node's database. It will wait up to `remote.timeout` seconds for their responses and its own attempt to reach the database. Other timeout properties in the cluster properties file specify values for agent-to-database communication.
+Use the `remote.timeout` property to limit how many seconds an agent waits for a response from a remote agent or database. Agents only send messages to each other during cluster events. Examples include:
+-   Attempting to connect to a remote database that may have failed and asking other agents if they can connect.
+-   A primary agent requesting recovery settings from a standby agent as part of a switchover.
+-   Telling nodes to prepare to shut down when stopping the Failover Manager cluster.
 
 ```ini
 # Timeout for a call to check if a remote database is responsive.
@@ -502,6 +505,11 @@ Use the `node.timeout` property to specify the number of seconds for an agent to
 # The value of this property must be the same across all agents.
 node.timeout=50
 ```
+
+!!! Summary/comparison of timeout properties
+    - The `local.*` properties are for failure detection of an agent's local database.
+    - The `node.timeout` property is for failure detection of other nodes.
+    - The `remote.timeout` property limits how long agents wait for responses from other agents.
 
 <div id="encrypt_agent_messages" class="registered_link"></div>
 

--- a/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
@@ -481,7 +481,7 @@ If necessary, modify these values to suit your business model.
 
 <div id="remote_timeout" class="registered_link"></div>
 
-Use the `remote.timeout` property to specify how many seconds an agent waits for a response from a remote database server (that is, how long a standby agent waits to verify that the primary database is down before performing failover). The `remote.timeout` property value specifies a timeout value for agent-to-agent communication. Other timeout properties in the cluster properties file specify values for agent-to-database communication.
+The `remote.timeout` property value specifies a timeout value for agent-to-agent communication. For example, if a node appears to have failed, an agent in the cluster will ask the other agents if they can reach the node's database. It will wait up to `remote.timeout` seconds for their responses and its own attempt to reach the database. Other timeout properties in the cluster properties file specify values for agent-to-database communication.
 
 ```ini
 # Timeout for a call to check if a remote database is responsive.
@@ -493,7 +493,7 @@ remote.timeout=10
 
 <div id="node_timeout" class="registered_link"></div>
 
-Use the `node.timeout` property to specify the number of seconds for an agent to wait for a response from a node when determining if a node has failed.
+Use the `node.timeout` property to specify the number of seconds for an agent to wait for a heartbeat from another node when determining if a node has failed.
 
 ```ini
 # The total amount of time in seconds to wait before determining


### PR DESCRIPTION
The description for remote.timeout was misleading in that someone could infer that agents generally monitor remote databases. Agents only do this (communicate in general, that is) when there's some reason to, e.g. during a potential failover. They also send messages like "shutdown for switchover" to the primary, "reconfigure to follow the new primary" to standbys, "prepare to shutdown," etc. We could put in more examples if anyone thinks that would be more helpful in this section.

I'm suggesting we change the node.timeout one because an agent waiting "for a response" implies the agent sent a request to another. While "response" isn't technically NOT true, the real thing an agent is waiting on is a heartbeat message or any kind of communication from another agent before deciding "ok, it's gone."


