### PR TITLE
integral deployment (deployment paths in frontmatter)

### DIFF
--- a/install_template/README.md
+++ b/install_template/README.md
@@ -49,7 +49,8 @@ After a template file is found, no rules are enforced on how that template shoul
 #### `/templates/platformBase/base.njk`
 
 - All templates ultimately should inherit from this file. This is a good place to write copy that needs to be shared by all docs, regardless of the product being installed
-- 3 blocks are currently available:
+- several blocks are currently defined in this base file, including:
+  - `frontmatter` — This is where additional frontmatter keys can be defined (the base template defines title and navTitle) - this is particularly useful for redirects and deployment rules, see below.
   - `prerequisites` — This is where information like adding EDB repos will go
   - `installCommand` — This is where the command to actually install the product will go
   - `postinstall` — This is where commands like starting the EPAS server will go
@@ -107,3 +108,33 @@ We also use global variables to trigger conditionals:
 For small template systems, this system works well enough. But as the number of templates increases, this becomes harder to understand. In this case, we need to search through the template files to find out where the variables are being used. Fortunately, they are used just once, but it's not hard to imagine multiple (and exclusive) conditionals that are hard to read, modify and debug.
 
 It's almost always better to use one of the other techniques than fall back on conditionals triggered by global variables.
+
+## Deployment rules
+
+The deployment script (`npm run install-docs:deploy`) can use two sources of information on where to deploy the final MDX files:
+
+1. A rule defined within the deployment script itself (`deploy.mjs`). 
+2. (RECOMMENDED) A frontmatter key (`deployPath`) written to the generated MDX file itself. Ex:
+
+   ```yaml
+   deployPath: mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_12.mdx
+   ```
+
+   This is best defined within the product template heirarchy, where context variables can be used:
+
+   ```
+   {% block frontmatter %}
+   deployPath: mongo_data_adapter/{{ product.version }}/installing/linux_{{platform.arch}}/mongo_{{deploy.map_platform[platform.name]}}.mdx
+   {% endblock frontmatter %}
+   ```
+
+The 2nd technique above lends itself well to writing redirect rules that prevent broken links when deployment paths change:
+
+```
+{% block frontmatter %}
+redirects:
+  - mongo_data_adapter/{{ product.version }}/04_installing_the_mongo_data_adapter/{{deploy.expand_arch[platform.arch]}}/mongo_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace("_64", "")}}.mdx
+{% endblock frontmatter %}
+```
+
+**Note:** the path generated from that pattern wouldn't normally be a valid redirect rule - it should start with `/` and *not* end with `.mdx`. For convenience, the deploy script will automatically rewrite redirects written in this form to the proper format, thus allowing you to just copy the old `deployPath` value to a redirect before modifying it. 

--- a/install_template/deploy.mjs
+++ b/install_template/deploy.mjs
@@ -72,6 +72,8 @@ const moveDoc = async (product, platform, version) => {
       context.platform.arch,
     ].join("_") + ".mdx";
 
+  const srcFilepath = path.resolve(__dirname, "renders", srcFilename);
+
   const prefix = {
     rhel_8_x86_64: "01",
     other_linux8_x86_64: "02",
@@ -145,8 +147,10 @@ const moveDoc = async (product, platform, version) => {
   const fmtArchPath = (ctx) => expand_arch[ctx.platform.arch];
   const fmtArchFilename = (ctx) => ctx.platform.arch.replace(/_?64/g, "");
 
+  const [srcContent, integralDeploymentPath] = await readSource(srcFilepath);
+
   // prettier-ignore
-  const destFilename = match(context, 
+  const destFilename = integralDeploymentPath || match(context, 
     when({product: {name: "EDB*Plus", version: 40}, platform: {name: "SLES 12"}}, 
       (ctx) => `edb_plus/40/03_installing_edb_plus/install_on_linux/${fmtArchPath(ctx)}/edbplus_sles12_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "EDB*Plus", version: 40}, platform: {name: "SLES 15"}}, 
@@ -168,7 +172,7 @@ const moveDoc = async (product, platform, version) => {
     when({product: {name: "EDB*Plus", version: 40}, platform: {name: "RHEL 8"}}, 
       (ctx) => `edb_plus/40/03_installing_edb_plus/install_on_linux/${fmtArchPath(ctx)}/edbplus_rhel8_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "EDB*Plus", version: 40}, platform: {name: "RHEL 8 or OL 8"}}, 
-      (ctx) => `edb_plus/40/03_installing_edb_plus/install_on_linux/${fmtArchPath(ctx)}/edbplus_RHEL8_${fmtArchFilename(ctx)}.mdx`),
+      (ctx) => `edb_plus/40/03_installing_edb_plus/install_on_linux/${fmtArchPath(ctx)}/edbplus_rhel8_${fmtArchFilename(ctx)}.mdx`),
   
   
     when({product: {name: "EDB Postgres Advanced Server", version: 14}, platform: {name: "CentOS 7"}}, 
@@ -295,29 +299,6 @@ const moveDoc = async (product, platform, version) => {
     when({product: {name: "Failover Manager", version: 4}, platform: {name: "Ubuntu 20.04"}}, 
       (ctx) => `efm/4/03_installing_efm/${fmtArchPath(ctx)}/efm4_ubuntu20_${fmtArchFilename(ctx)}.mdx`),      
 
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "SLES 12"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_sles_12.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "SLES 15"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_sles_15.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "Ubuntu 20.04"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_ubuntu_20.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "Ubuntu 18.04"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_ubuntu_18.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "Debian 11"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_debian_11.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "Debian 10"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_debian_10.mdx`),
-      when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "CentOS 7"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_centos_7.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "AlmaLinux 8 or Rocky Linux 8"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_other_linux_8.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "RHEL 7 or OL 7"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_rhel_7.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "RHEL 8 or OL 8"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_rhel_8.mdx`),
-    when({product: {name: "Hadoop Foreign Data Wrapper", version: 2}, platform: {name: "RHEL 8"}}, 
-      (ctx) => `hadoop_data_adapter/2/installing/linux_${ctx.platform.arch}/hadoop_rhel_8.mdx`),
-    
     when({product: {name: "EDB JDBC Connector"}, platform: {name: "CentOS 7"}}, 
       (ctx) => `jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/${fmtArchPath(ctx)}/jdbc42_centos7_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "EDB JDBC Connector"}, platform: {name: "AlmaLinux 8 or Rocky Linux 8"}}, 
@@ -363,52 +344,6 @@ const moveDoc = async (product, platform, version) => {
       (ctx) => `migration_toolkit/55/05_installing_mtk/install_on_linux/${fmtArchPath(ctx)}/mtk55_centos7_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "Migration Toolkit"}, platform: {name: "RHEL 8"}}, 
       (ctx) => `migration_toolkit/55/05_installing_mtk/install_on_linux/${fmtArchPath(ctx)}/mtk55_rhel8_${fmtArchFilename(ctx)}.mdx`),
-
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "SLES 12"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_sles_12.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "SLES 15"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_sles_15.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "Ubuntu 20.04"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_ubuntu_20.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "Ubuntu 18.04"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_ubuntu_18.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "Debian 11"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_debian_11.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "Debian 10"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_debian_10.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "CentOS 7"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_centos_7.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "AlmaLinux 8 or Rocky Linux 8"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_other_linux_8.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "RHEL 7 or OL 7"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_rhel_7.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "RHEL 8 or OL 8"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_rhel_8.mdx`),
-    when({product: {name: "MongoDB Foreign Data Wrapper", version: 5}, platform: {name: "RHEL 8"}}, 
-      (ctx) => `mongo_data_adapter/5/installing/linux_${ctx.platform.arch}/mongo_rhel_8.mdx`),
-
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "RHEL 8 or OL 8"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_rhel_8.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "AlmaLinux 8 or Rocky Linux 8"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_other_linux_8.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "RHEL 7 or OL 7"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_rhel_7.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "CentOS 7"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_centos_7.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "RHEL 8"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_rhel_8.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "SLES 12"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_sles_12.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "SLES 15"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_sles_15.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "Debian 10"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_debian_10.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "Debian 11"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_debian_11.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "Ubuntu 18.04"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_ubuntu_18.mdx`),
-    when({product: {name: "MySQL Foreign Data Wrapper", version: 2}, platform: {name: "Ubuntu 20.04"}}, 
-      (ctx) => `mysql_data_adapter/2/installing/linux_${ctx.platform.arch}/mysql_ubuntu_20.mdx`),
 
     when({product: {name: "EDB OCL Connector"}, platform: {name: "SLES 12"}}, 
       (ctx) => `ocl_connector/${ctx.product.version}/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/${fmtArchPath(ctx)}/ocl_connector14_sles12_${fmtArchFilename(ctx)}.mdx`),
@@ -635,18 +570,17 @@ const moveDoc = async (product, platform, version) => {
     return { note: `Skipping (no mapping): ${srcFilename}`, context };
   }
 
-  const src = path.resolve(__dirname, "renders", srcFilename);
-  const dest = path.resolve(__dirname, destPath, destFilename);
+  const destFilepath = path.resolve(__dirname, destPath, destFilename);
   try {
-    await fs.mkdir(path.dirname(dest), { recursive: true });
-    await fs.copyFile(src, dest);
-    return { success: `deployed ${src} to ${dest}` };
+    await fs.mkdir(path.dirname(destFilepath), { recursive: true });
+    await fs.writeFile(destFilepath, srcContent, "utf8");
+    return { success: `deployed ${srcFilepath} to ${destFilepath}` };
   } catch (err) {
     return {
       warn: err.toString(),
       context: {
-        src,
-        dest,
+        srcFilepath,
+        destFilepath,
       },
     };
   }
@@ -691,6 +625,57 @@ const generateContext = (product, platform, version) => {
       arch: platform.arch,
     },
   };
+};
+
+/**
+ * Reads the source mdx file, parse out the deployment path and filename from the MDX frontmatter
+ * @param srcPath the path + name of the mdx file to read
+ * @returns [full contents, the relative deployment path], undefined on error
+ */
+const readSource = async (srcPath) => {
+  const frontmatterRE = /^(?<open>---\s*?\n)(?<yaml>.+?\n)(?<close>---\s*?\n)/s;
+
+  try {
+    let src = await fs.readFile(srcPath, "utf8");
+    const frontmatter = yaml.parseDocument(
+      src.match(frontmatterRE)?.groups?.yaml,
+    );
+
+    const deployPath = frontmatter.contents.get("deployPath");
+    const redirects = frontmatter.contents.get("redirects");
+
+    // delete deployPath but preserve any comments that might've been attached
+    if (deployPath) {
+      let deployComments = "";
+      for (let { key, value } of frontmatter.contents.items) {
+        if (
+          (key.value || key) === "deployPath" &&
+          (key.commentBefore || value.commentBefore)
+        ) {
+          deployComments =
+            (key.commentBefore || "") + (value.commentBefore || "");
+        }
+        if (key.value === "redirects")
+          key.commentBefore = deployComments + (key.commentBefore || "");
+      }
+      frontmatter.contents.delete("deployPath");
+    }
+
+    for (let i = 0; i < redirects?.items?.length; ++i) {
+      redirects.items[i].value = redirects.items[i].value
+        .replace(/^\/?/, "/")
+        .replace(/\.mdx$/, "");
+    }
+
+    src = src.replace(
+      frontmatterRE,
+      (_, open, fmYaml, close) => open + frontmatter.toString() + close,
+    );
+
+    return [src, deployPath];
+  } catch (e) {
+    console.log(srcPath, e);
+  }
 };
 
 run();

--- a/install_template/package-lock.json
+++ b/install_template/package-lock.json
@@ -12,7 +12,7 @@
         "lodash.ismatch": "^4.4.0",
         "nunjucks": "^3.2.3",
         "prettier": "^2.4.0",
-        "yaml": "^1.10.2"
+        "yaml": "^2.1.3"
       }
     },
     "node_modules/a-sync-waterfall": {
@@ -74,11 +74,11 @@
       }
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     }
   },
@@ -119,9 +119,9 @@
       "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg=="
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg=="
     }
   }
 }

--- a/install_template/package.json
+++ b/install_template/package.json
@@ -13,6 +13,6 @@
     "lodash.ismatch": "^4.4.0",
     "nunjucks": "^3.2.3",
     "prettier": "^2.4.0",
-    "yaml": "^1.10.2"
+    "yaml": "^2.1.3"
   }
 }

--- a/install_template/templates/platformBase/_deploymentConstants.njk
+++ b/install_template/templates/platformBase/_deploymentConstants.njk
@@ -1,0 +1,37 @@
+{% set expand_arch = {
+    ppcle: "ibm_power_ppc64le",
+    x86: "x86_amd64",
+    x86_64: "x86_amd64",
+    ppc64le: "ibm_power_ppc64le"
+  } 
+%}
+{% set map_platform_old = {
+    "Debian 10": "deb10",
+    "Debian 11": "deb11",
+    "Ubuntu 18.04": "ubuntu18",
+    "Ubuntu 20.04": "ubuntu20",
+    "Ubuntu 22.04": "ubuntu22",
+    "SLES 12": "sles12",
+    "SLES 15": "sles15",
+    "CentOS 7": "centos7",
+    "AlmaLinux 8 or Rocky Linux 8": "other_linux8",
+    "RHEL 7 or OL 7": "rhel7",
+    "RHEL 8 or OL 8": "rhel8",
+    "RHEL 8": "rhel8"
+  }
+%}
+{% set map_platform = {
+    "Debian 10": "debian_10",
+    "Debian 11": "debian_11",
+    "Ubuntu 18.04": "ubuntu_18",
+    "Ubuntu 20.04": "ubuntu_20",
+    "Ubuntu 22.04": "ubuntu_22",
+    "SLES 12": "sles_12",
+    "SLES 15": "sles_15",
+    "CentOS 7": "centos_7",
+    "AlmaLinux 8 or Rocky Linux 8": "other_linux_8",
+    "RHEL 7 or OL 7": "rhel_7",
+    "RHEL 8 or OL 8": "rhel_8",
+    "RHEL 8": "rhel_8"
+  }
+%}

--- a/install_template/templates/platformBase/base.njk
+++ b/install_template/templates/platformBase/base.njk
@@ -4,6 +4,7 @@ title: Installing {{ product.name }} on {{ platform.name }} {{ platform.arch }}
 # This topic is generated from templates. If you have feedback on it, instead of 
 # editing the page and creating a pull request, please enter a GitHub issue and 
 # the documentation team will update the templates accordingly.
+{% block frontmatter %}{% endblock frontmatter %}
 ---
 
   {% block pemslesnote %}{% endblock pemslesnote %}

--- a/install_template/templates/products/hadoop-foreign-data-wrapper/base.njk
+++ b/install_template/templates/products/hadoop-foreign-data-wrapper/base.njk
@@ -1,5 +1,18 @@
 {% extends "platformBase/" + platformBaseTemplate + '.njk' %}
 {% set packageName %}edb-as14-hdfs-fdw{% endset %}
+
+{% import "platformBase/_deploymentConstants.njk" as deploy %}
+{% block frontmatter %}
+{# 
+  If you modify deployment path here, please first copy the old expression
+  and add it to the list under "redirects:" below - this ensures we don't 
+  break any existing links.  
+#}
+deployPath: hadoop_data_adapter/{{ product.version }}/installing/linux_{{platform.arch}}/hadoop_{{deploy.map_platform[platform.name]}}.mdx
+redirects:
+  - hadoop_data_adapter/{{ product.version }}/05_installing_the_hadoop_data_adapter/{{deploy.expand_arch[platform.arch]}}/hadoop_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace("_64", "")}}.mdx
+{% endblock frontmatter %}
+
 {% block prodprereq %}{% include "platformBase/_epasinstallsameserver.njk" %}
 
 {% endblock prodprereq %}

--- a/install_template/templates/products/hadoop-foreign-data-wrapper/base.njk
+++ b/install_template/templates/products/hadoop-foreign-data-wrapper/base.njk
@@ -10,7 +10,7 @@
 #}
 deployPath: hadoop_data_adapter/{{ product.version }}/installing/linux_{{platform.arch}}/hadoop_{{deploy.map_platform[platform.name]}}.mdx
 redirects:
-  - hadoop_data_adapter/{{ product.version }}/05_installing_the_hadoop_data_adapter/{{deploy.expand_arch[platform.arch]}}/hadoop_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace("_64", "")}}.mdx
+  - hadoop_data_adapter/{{ product.version }}/05_installing_the_hadoop_data_adapter/{{deploy.expand_arch[platform.arch]}}/hadoop_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
 {% endblock frontmatter %}
 
 {% block prodprereq %}{% include "platformBase/_epasinstallsameserver.njk" %}

--- a/install_template/templates/products/hadoop-foreign-data-wrapper/ubuntu-22.04.njk
+++ b/install_template/templates/products/hadoop-foreign-data-wrapper/ubuntu-22.04.njk
@@ -1,2 +1,5 @@
 {% extends "products/hadoop-foreign-data-wrapper/debian-10.njk" %}
 {% set platformBaseTemplate = "ubuntu-22.04" %}
+{% block frontmatter %}
+{# remove this block when Ubuntu 22 is released #}
+{% endblock frontmatter %}

--- a/install_template/templates/products/mongodb-foreign-data-wrapper/base.njk
+++ b/install_template/templates/products/mongodb-foreign-data-wrapper/base.njk
@@ -10,7 +10,7 @@
 #}
 deployPath: mongo_data_adapter/{{ product.version }}/installing/linux_{{platform.arch}}/mongo_{{deploy.map_platform[platform.name]}}.mdx
 redirects:
-  - mongo_data_adapter/{{ product.version }}/04_installing_the_mongo_data_adapter/{{deploy.expand_arch[platform.arch]}}/mongo_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace("_64", "")}}.mdx
+  - mongo_data_adapter/{{ product.version }}/04_installing_the_mongo_data_adapter/{{deploy.expand_arch[platform.arch]}}/mongo_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
 {% endblock frontmatter %}
 
 {% block prodprereq %}{% include "platformBase/_epasinstallsameserver.njk" %}

--- a/install_template/templates/products/mongodb-foreign-data-wrapper/base.njk
+++ b/install_template/templates/products/mongodb-foreign-data-wrapper/base.njk
@@ -1,5 +1,18 @@
 {% extends "platformBase/" + platformBaseTemplate + '.njk' %}
 {% set packageName %}edb-as14-mongo-fdw{% endset %}
+
+{% import "platformBase/_deploymentConstants.njk" as deploy %}
+{% block frontmatter %}
+{# 
+  If you modify deployment path here, please first copy the old expression
+  and add it to the list under "redirects:" below - this ensures we don't 
+  break any existing links.  
+#}
+deployPath: mongo_data_adapter/{{ product.version }}/installing/linux_{{platform.arch}}/mongo_{{deploy.map_platform[platform.name]}}.mdx
+redirects:
+  - mongo_data_adapter/{{ product.version }}/04_installing_the_mongo_data_adapter/{{deploy.expand_arch[platform.arch]}}/mongo_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace("_64", "")}}.mdx
+{% endblock frontmatter %}
+
 {% block prodprereq %}{% include "platformBase/_epasinstallsameserver.njk" %}
 
 {% endblock prodprereq %}

--- a/install_template/templates/products/mongodb-foreign-data-wrapper/ubuntu-22.04.njk
+++ b/install_template/templates/products/mongodb-foreign-data-wrapper/ubuntu-22.04.njk
@@ -1,2 +1,6 @@
 {% extends "products/mongodb-foreign-data-wrapper/base.njk" %}
 {% set platformBaseTemplate = "ubuntu-22.04" %}
+{% set osFilenamePart="ubuntu_22" %}
+{% block frontmatter %}
+{# remove this block when Ubuntu 22 is released #}
+{% endblock frontmatter %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/base.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/base.njk
@@ -1,5 +1,18 @@
 {% extends "platformBase/" + platformBaseTemplate + '.njk' %}
 {% set packageName %}edb-as<xx>-mysql<y>-fdw{% endset %}
+
+{% import "platformBase/_deploymentConstants.njk" as deploy %}
+{% block frontmatter %}
+{# 
+  If you modify deployment path here, please first copy the old expression
+  and add it to the list under "redirects:" below - this ensures we don't 
+  break any existing links.  
+#}
+deployPath: mysql_data_adapter/{{ product.version }}/installing/linux_{{platform.arch}}/mysql_{{deploy.map_platform[platform.name]}}.mdx
+redirects:
+  - mysql_data_adapter/{{ product.version }}/04_installing_the_mysql_data_adapter/{{deploy.expand_arch[platform.arch]}}/mysql_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace("_64", "")}}.mdx
+{% endblock frontmatter %}
+
 {% block prodprereq %}{% include "platformBase/_epasinstallsameserver.njk" %}
 
 {% endblock prodprereq %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/base.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/base.njk
@@ -10,7 +10,7 @@
 #}
 deployPath: mysql_data_adapter/{{ product.version }}/installing/linux_{{platform.arch}}/mysql_{{deploy.map_platform[platform.name]}}.mdx
 redirects:
-  - mysql_data_adapter/{{ product.version }}/04_installing_the_mysql_data_adapter/{{deploy.expand_arch[platform.arch]}}/mysql_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace("_64", "")}}.mdx
+  - mysql_data_adapter/{{ product.version }}/04_installing_the_mysql_data_adapter/{{deploy.expand_arch[platform.arch]}}/mysql_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
 {% endblock frontmatter %}
 
 {% block prodprereq %}{% include "platformBase/_epasinstallsameserver.njk" %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/ubuntu-22.04.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/ubuntu-22.04.njk
@@ -1,2 +1,6 @@
 {% extends "products/mysql-foreign-data-wrapper/base.njk" %}
 {% set platformBaseTemplate = "ubuntu-22.04" %}
+
+{% block frontmatter %}
+{# remove this block when Ubuntu 22 is released #}
+{% endblock frontmatter %}

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_rhel8_ppcle.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB*Plus on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles12_ppcle.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB*Plus on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles15_ppcle.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB*Plus on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_centos7_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB*Plus on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_deb10_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB*Plus on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_deb11_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB*Plus on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_other_linux8_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB*Plus on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_rhel7_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB*Plus on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_rhel8_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB*Plus on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles12_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB*Plus on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles15_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB*Plus on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu18_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB*Plus on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu20_x86.mdx
+++ b/product_docs/docs/edb_plus/40/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB*Plus on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_rhel8_ppcle.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing Failover Manager on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles12_ppcle.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Failover Manager on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles15_ppcle.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/ibm_power_ppc64le/efm4_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Failover Manager on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_centos7_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing Failover Manager on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_deb10_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing Failover Manager on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_deb11_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing Failover Manager on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_other_linux8_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing Failover Manager on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel7_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing Failover Manager on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel_8_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_rhel_8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing Failover Manager on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles12_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Failover Manager on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles15_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Failover Manager on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu18_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing Failover Manager on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu20_x86.mdx
+++ b/product_docs/docs/efm/4/03_installing_efm/x86_amd64/efm4_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing Failover Manager on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB Postgres Advanced Server on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
@@ -1,0 +1,73 @@
+---
+navTitle: Debian 10
+title: Installing EDB Postgres Advanced Server on Debian 10 x86_64
+
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the repository
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
+
+  To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
+
+## Install the package
+
+```shell
+sudo apt-get -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 11, the package name would be `edb-as11-server`.
+
+To install an individual component:
+
+```shell
+sudo apt-get -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/11/epas_inst_linux/install_details/rpm_packages/).
+
+## Initial configuration
+
+This section steps you through getting started with your cluster including logging in, ensuring the installation was successful, connecting to your cluster, and creating the user password.
+
+```shell
+
+# To work in your cluster, login as the enterprisedb user
+su - enterprisedb
+
+# Connect to the database server using the psql command line client
+psql edb
+
+# Assign a password to the database superuser the enterprisedb
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+
+# Create a database (named hr)
+CREATE DATABASE hr;
+
+# Connect to the new database and create a table (named dept)
+\c hr
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+
+# Add data to the table
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+
+# You can use simple SQL commands to query the database and retrieve
+# information about the data you have added to the table
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB Postgres Advanced Server on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB Postgres Advanced Server on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
+++ b/product_docs/docs/epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
@@ -1,0 +1,73 @@
+---
+navTitle: Ubuntu 20.04
+title: Installing EDB Postgres Advanced Server on Ubuntu 20.04 x86_64
+
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the repository
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
+
+  To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
+
+## Install the package
+
+```shell
+sudo apt-get -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 11, the package name would be `edb-as11-server`.
+
+To install an individual component:
+
+```shell
+sudo apt-get -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/11/epas_inst_linux/install_details/rpm_packages/).
+
+## Initial configuration
+
+This section steps you through getting started with your cluster including logging in, ensuring the installation was successful, connecting to your cluster, and creating the user password.
+
+```shell
+
+# To work in your cluster, login as the enterprisedb user
+su - enterprisedb
+
+# Connect to the database server using the psql command line client
+psql edb
+
+# Assign a password to the database superuser the enterprisedb
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+
+# Create a database (named hr)
+CREATE DATABASE hr;
+
+# Connect to the new database and create a table (named dept)
+\c hr
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+
+# Add data to the table
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+
+# You can use simple SQL commands to query the database and retrieve
+# information about the data you have added to the table
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB Postgres Advanced Server on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB Postgres Advanced Server on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB Postgres Advanced Server on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB Postgres Advanced Server on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
+++ b/product_docs/docs/epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
@@ -1,0 +1,73 @@
+---
+navTitle: Ubuntu 20.04
+title: Installing EDB Postgres Advanced Server on Ubuntu 20.04 x86_64
+
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the repository
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
+
+  To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
+
+## Install the package
+
+```shell
+sudo apt-get -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 12, the package name would be `edb-as12-server`.
+
+To install an individual component:
+
+```shell
+sudo apt-get -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/12/epas_inst_linux/install_details/rpm_packages/).
+
+## Initial configuration
+
+This section steps you through getting started with your cluster including logging in, ensuring the installation was successful, connecting to your cluster, and creating the user password.
+
+```shell
+
+# To work in your cluster, login as the enterprisedb user
+su - enterprisedb
+
+# Connect to the database server using the psql command line client
+psql edb
+
+# Assign a password to the database superuser the enterprisedb
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+
+# Create a database (named hr)
+CREATE DATABASE hr;
+
+# Connect to the new database and create a table (named dept)
+\c hr
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+
+# Add data to the table
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+
+# You can use simple SQL commands to query the database and retrieve
+# information about the data you have added to the table
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB Postgres Advanced Server on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB Postgres Advanced Server on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB Postgres Advanced Server on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB Postgres Advanced Server on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
+++ b/product_docs/docs/epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel7_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB Postgres Advanced Server on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB Postgres Advanced Server on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB Postgres Advanced Server on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB Postgres Advanced Server on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB Postgres Advanced Server on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB Postgres Advanced Server on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Postgres Advanced Server on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
+++ b/product_docs/docs/epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB Postgres Advanced Server on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_rhel8_ppcle.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing Replication Server on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles12_ppcle.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Replication Server on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles15_ppcle.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Replication Server on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_centos7_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing Replication Server on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_deb10_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing Replication Server on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_deb11_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing Replication Server on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_other_linux8_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing Replication Server on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_rhel7_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing Replication Server on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_rhel8_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing Replication Server on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles12_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Replication Server on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles15_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Replication Server on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_ubuntu18_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing Replication Server on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_ubuntu20_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing Replication Server on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_rhel_8.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_rhel_8.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on RHEL 8 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_rhel8_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_rhel_8.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing Hadoop Foreign Data Wrapper on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_rhel8_ppc64le
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_12.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_12.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on SLES 12 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles12_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_12.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing Hadoop Foreign Data Wrapper on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles12_ppc64le
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_15.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_15.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on SLES 15 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles15_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_15.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing Hadoop Foreign Data Wrapper on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles15_ppc64le
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_centos_7.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_centos_7.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on CentOS 7 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_debian_10.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_debian_10.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on Debian 10 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_debian_11.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_debian_11.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on Debian 11 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_other_linux_8.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_other_linux_8.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on AlmaLinux 8 or Rocky Linux 8 x8
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_rhel_7.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_rhel_7.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on RHEL 7 or OL 7 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_rhel_8.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_rhel_8.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on RHEL 8 or OL 8 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_sles_12.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_sles_12.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on SLES 12 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_sles_15.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_sles_15.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on SLES 15 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_ubuntu_18.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_ubuntu_18.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on Ubuntu 18.04 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_ubuntu_20.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_ubuntu_20.mdx
@@ -4,6 +4,9 @@ title: Installing Hadoop Foreign Data Wrapper on Ubuntu 20.04 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel8_ppcle.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB JDBC Connector on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB JDBC Connector on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB JDBC Connector on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_centos7_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB JDBC Connector on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb10_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB JDBC Connector on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb11_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB JDBC Connector on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux8_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB JDBC Connector on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel7_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB JDBC Connector on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel8_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB JDBC Connector on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB JDBC Connector on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB JDBC Connector on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu18_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB JDBC Connector on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB JDBC Connector on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_rhel8_ppcle.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing Migration Toolkit on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles12_ppcle.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Migration Toolkit on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles15_ppcle.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Migration Toolkit on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_centos7_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing Migration Toolkit on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb10_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing Migration Toolkit on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb11_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing Migration Toolkit on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_other_linux8_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing Migration Toolkit on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_rhel7_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing Migration Toolkit on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_rhel8_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing Migration Toolkit on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles12_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Migration Toolkit on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles15_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Migration Toolkit on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu18_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing Migration Toolkit on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu20_x86.mdx
+++ b/product_docs/docs/migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing Migration Toolkit on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_rhel_8.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_rhel_8.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on RHEL 8 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_rhel8_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_rhel_8.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing MongoDB Foreign Data Wrapper on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_rhel8_ppc64le
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_12.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing MongoDB Foreign Data Wrapper on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles12_ppc64le
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_12.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_12.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on SLES 12 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles12_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_15.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing MongoDB Foreign Data Wrapper on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles15_ppc64le
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_15.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_15.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on SLES 15 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles15_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_centos_7.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_centos_7.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on CentOS 7 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_debian_10.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_debian_10.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on Debian 10 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_debian_11.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_debian_11.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on Debian 11 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_other_linux_8.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_other_linux_8.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on AlmaLinux 8 or Rocky Linux 8 x
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_rhel_7.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_rhel_7.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on RHEL 7 or OL 7 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_rhel_8.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_rhel_8.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on RHEL 8 or OL 8 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_sles_12.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_sles_12.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on SLES 12 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_sles_15.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_sles_15.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on SLES 15 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_ubuntu_18.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_ubuntu_18.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on Ubuntu 18.04 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_ubuntu_20.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_ubuntu_20.mdx
@@ -4,6 +4,9 @@ title: Installing MongoDB Foreign Data Wrapper on Ubuntu 20.04 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_rhel_8.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing MySQL Foreign Data Wrapper on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_rhel8_ppc64le
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_rhel_8.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_rhel_8.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on RHEL 8 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_rhel8_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_12.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing MySQL Foreign Data Wrapper on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles12_ppc64le
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_12.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_12.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on SLES 12 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles12_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_15.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_15.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on SLES 15 ppc64le
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles15_ppc64le
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_15.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing MySQL Foreign Data Wrapper on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles15_ppc64le
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_centos_7.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_centos_7.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on CentOS 7 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_debian_10.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_debian_10.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on Debian 10 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_debian_11.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_debian_11.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on Debian 11 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_other_linux_8.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_other_linux_8.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on AlmaLinux 8 or Rocky Linux 8 x86
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_rhel_7.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_rhel_7.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on RHEL 7 or OL 7 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_rhel_8.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_rhel_8.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on RHEL 8 or OL 8 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_sles_12.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_sles_12.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on SLES 12 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_sles_15.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_sles_15.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on SLES 15 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_ubuntu_18.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_ubuntu_18.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on Ubuntu 18.04 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_ubuntu_20.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_ubuntu_20.mdx
@@ -4,6 +4,9 @@ title: Installing MySQL Foreign Data Wrapper on Ubuntu 20.04 x86_64
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_rhel8_ppcle.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB OCL Connector on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles12_ppcle.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB OCL Connector on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles15_ppcle.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_connector14_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB OCL Connector on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_centos7_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB OCL Connector on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_deb10_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB OCL Connector on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_deb11_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB OCL Connector on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_other_linux8_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB OCL Connector on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_rhel7_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB OCL Connector on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_rhel8_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB OCL Connector on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles12_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB OCL Connector on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles15_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB OCL Connector on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu18_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB OCL Connector on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu20_x86.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_connector14_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB OCL Connector on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel8_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB ODBC Connector on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB ODBC Connector on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB ODBC Connector on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_centos7_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB ODBC Connector on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB ODBC Connector on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb11_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB ODBC Connector on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux8_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB ODBC Connector on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel7_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB ODBC Connector on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel8_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB ODBC Connector on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB ODBC Connector on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB ODBC Connector on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB ODBC Connector on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB ODBC Connector on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_rhel8_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing Postgres Enterprise Manager agent on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles12_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Postgres Enterprise Manager agent on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles15_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Postgres Enterprise Manager agent on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_centos7_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing Postgres Enterprise Manager agent on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_deb10_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing Postgres Enterprise Manager agent on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_deb11_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing Postgres Enterprise Manager agent on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_other_linux8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_other_linux8_x86.mdx
@@ -1,6 +1,8 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
-title: Installing Postgres Enterprise Manager agent on AlmaLinux 8 or Rocky Linux 8 x86_64
+title: Installing Postgres Enterprise Manager agent on AlmaLinux 8 or Rocky
+  Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_rhel7_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing Postgres Enterprise Manager agent on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_rhel8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing Postgres Enterprise Manager agent on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles12_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Postgres Enterprise Manager agent on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles15_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Postgres Enterprise Manager agent on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu18_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing Postgres Enterprise Manager agent on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu20_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing Postgres Enterprise Manager agent on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_rhel8_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing Postgres Enterprise Manager server on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Postgres Enterprise Manager server on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles15_ppcle.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Postgres Enterprise Manager server on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_centos7_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing Postgres Enterprise Manager server on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb10_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing Postgres Enterprise Manager server on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb11_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing Postgres Enterprise Manager server on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_other_linux8_x86.mdx
@@ -1,6 +1,8 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
-title: Installing Postgres Enterprise Manager server on AlmaLinux 8 or Rocky Linux 8 x86_64
+title: Installing Postgres Enterprise Manager server on AlmaLinux 8 or Rocky
+  Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel7_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing Postgres Enterprise Manager server on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel8_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing Postgres Enterprise Manager server on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles12_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing Postgres Enterprise Manager server on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles15_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing Postgres Enterprise Manager server on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu18_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing Postgres Enterprise Manager server on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu20_x86.mdx
+++ b/product_docs/docs/pem/8/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing Postgres Enterprise Manager server on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_rhel8_ppcle.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB pgBouncer on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles12_ppcle.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB pgBouncer on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles15_ppcle.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB pgBouncer on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_centos7_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB pgBouncer on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_deb10_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB pgBouncer on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_deb11_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB pgBouncer on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_other_linux8_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB pgBouncer on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel7_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB pgBouncer on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel8_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB pgBouncer on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_sles12_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB pgBouncer on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_sles15_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB pgBouncer on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu18_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB pgBouncer on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu20_x86.mdx
+++ b/product_docs/docs/pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB pgBouncer on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_rhel8_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB Pgpool-II on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles12_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Pgpool-II on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles15_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Pgpool-II on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_centos7_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB Pgpool-II on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb10_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB Pgpool-II on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb11_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB Pgpool-II on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_other_linux8_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB Pgpool-II on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel7_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB Pgpool-II on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel8_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB Pgpool-II on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles12_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Pgpool-II on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles15_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Pgpool-II on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu18_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB Pgpool-II on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu20_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB Pgpool-II on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_rhel8_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing EDB Pgpool-II Extensions on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles12_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Pgpool-II Extensions on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles15_ppcle.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Pgpool-II Extensions on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_centos7_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing EDB Pgpool-II Extensions on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb10_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing EDB Pgpool-II Extensions on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb11_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing EDB Pgpool-II Extensions on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_other_linux8_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing EDB Pgpool-II Extensions on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_rhel7_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing EDB Pgpool-II Extensions on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_rhel8_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_rhel8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing EDB Pgpool-II Extensions on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles12_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing EDB Pgpool-II Extensions on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles15_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing EDB Pgpool-II Extensions on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu18_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing EDB Pgpool-II Extensions on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu20_x86.mdx
+++ b/product_docs/docs/pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing EDB Pgpool-II Extensions on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_rhel8_ppcle.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_rhel8_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8
 title: Installing PostGIS on RHEL 8 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles12_ppcle.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles12_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing PostGIS on SLES 12 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles15_ppcle.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles15_ppcle.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing PostGIS on SLES 15 ppc64le
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_centos7_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_centos7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: CentOS 7
 title: Installing PostGIS on CentOS 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_deb10_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_deb10_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 10
 title: Installing PostGIS on Debian 10 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_deb11_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_deb11_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Debian 11
 title: Installing PostGIS on Debian 11 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_other_linux8_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_other_linux8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: AlmaLinux 8 or Rocky Linux 8
 title: Installing PostGIS on AlmaLinux 8 or Rocky Linux 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_rhel7_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_rhel7_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 7 or OL 7
 title: Installing PostGIS on RHEL 7 or OL 7 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_rhel_8_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_rhel_8_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: RHEL 8 or OL 8
 title: Installing PostGIS on RHEL 8 or OL 8 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles12_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles12_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 12
 title: Installing PostGIS on SLES 12 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles15_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles15_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: SLES 15
 title: Installing PostGIS on SLES 15 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_ubuntu18_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_ubuntu18_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 18.04
 title: Installing PostGIS on Ubuntu 18.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.

--- a/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_ubuntu20_x86.mdx
+++ b/product_docs/docs/postgis/3.2/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_ubuntu20_x86.mdx
@@ -1,6 +1,7 @@
 ---
 navTitle: Ubuntu 20.04
 title: Installing PostGIS on Ubuntu 20.04 x86_64
+
 # This topic is generated from templates. If you have feedback on it, instead of
 # editing the page and creating a pull request, please enter a GitHub issue and
 # the documentation team will update the templates accordingly.


### PR DESCRIPTION
Adds a new way to specify deployment paths via the templates themselves. This should reduce the amount of editing we have to be doing to deploy.mjs, but more importantly provides us with a clear path to migrating products to a consistent path layout while also adding redirects. 

See examples for hadoop, mysql, mongodb and documentation in README.md