### PR TITLE
Connectors: misc fixes 

### DIFF
--- a/install_template/deploy.mjs
+++ b/install_template/deploy.mjs
@@ -243,8 +243,6 @@ const moveDoc = async (product, platform, version) => {
       (ctx) => `epas/12/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_deb11_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "EDB Postgres Advanced Server", version: 12}, platform: {name: "Ubuntu 18.04"}}, 
       (ctx) => `epas/12/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_ubuntu18_${fmtArchFilename(ctx)}.mdx`),
-    when({product: {name: "EDB Postgres Advanced Server", version: 12}, platform: {name: "Ubuntu 20.04"}}, 
-      (ctx) => `epas/12/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_ubuntu20_${fmtArchFilename(ctx)}.mdx`),
 
     when({product: {name: "EDB Postgres Advanced Server", version: 11}, platform: {name: "CentOS 7"}}, 
       (ctx) => `epas/11/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_centos7_${fmtArchFilename(ctx)}.mdx`),
@@ -262,14 +260,10 @@ const moveDoc = async (product, platform, version) => {
       (ctx) => `epas/11/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_sles12_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "EDB Postgres Advanced Server", version: 11}, platform: {name: "SLES 15"}}, 
       (ctx) => `epas/11/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_sles15_${fmtArchFilename(ctx)}.mdx`),
-    when({product: {name: "EDB Postgres Advanced Server", version: 11}, platform: {name: "Debian 10"}}, 
-      (ctx) => `epas/11/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_deb10_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "EDB Postgres Advanced Server", version: 11}, platform: {name: "Debian 11"}}, 
       (ctx) => `epas/11/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_deb11_${fmtArchFilename(ctx)}.mdx`),
     when({product: {name: "EDB Postgres Advanced Server", version: 11}, platform: {name: "Ubuntu 18.04"}}, 
       (ctx) => `epas/11/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_ubuntu18_${fmtArchFilename(ctx)}.mdx`),
-    when({product: {name: "EDB Postgres Advanced Server", version: 11}, platform: {name: "Ubuntu 20.04"}}, 
-      (ctx) => `epas/11/epas_inst_linux/installing_epas_using_edb_repository/${fmtArchPath(ctx)}/epas_ubuntu20_${fmtArchFilename(ctx)}.mdx`),
 
 
     when({product: {name: "Failover Manager", version: 4}, platform: {name: "CentOS 7"}}, 

--- a/install_template/templates/products/edb-odbc-connector/base.njk
+++ b/install_template/templates/products/edb-odbc-connector/base.njk
@@ -3,3 +3,10 @@
 {% block prodprereq %}{% include "platformBase/_epasinstalldiffserver.njk" %}
 
 {% endblock prodprereq %}
+{% block installCommand %}{% block odbcconnector %}
+```shell
+sudo {{packageManager}} -y install {{ packageName }}
+sudo {{packageManager}} -y install {{ packageName }}-devel
+```
+{% endblock odbcconnector %}{% endblock installCommand %}
+

--- a/install_template/templates/products/edb-odbc-connector/debian.njk
+++ b/install_template/templates/products/edb-odbc-connector/debian.njk
@@ -1,7 +1,7 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% block odbcconnector %}
 ```shell
-sudo apt-get install {{ packageName }}
-sudo apt-get install {{ packageName }}-dev
+sudo {{packageManager}} -y install {{ packageName }}
+sudo {{packageManager}} -y install {{ packageName }}-dev
 ```
 {% endblock odbcconnector %}

--- a/install_template/templates/products/edb-odbc-connector/sles-12.njk
+++ b/install_template/templates/products/edb-odbc-connector/sles-12.njk
@@ -1,2 +1,8 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "sles-12" %}
+{% block odbcconnector %}
+```shell
+sudo {{packageManager}} -n install {{ packageName }}
+sudo {{packageManager}} -n install {{ packageName }}-devel
+```
+{% endblock odbcconnector %}

--- a/install_template/templates/products/edb-odbc-connector/sles-15.njk
+++ b/install_template/templates/products/edb-odbc-connector/sles-15.njk
@@ -1,2 +1,8 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "sles-15" %}
+{% block odbcconnector %}
+```shell
+sudo {{packageManager}} -n install {{ packageName }}
+sudo {{packageManager}} -n install {{ packageName }}-devel
+```
+{% endblock odbcconnector %}

--- a/install_template/templates/products/edb-odbc-connector/ubuntu.njk
+++ b/install_template/templates/products/edb-odbc-connector/ubuntu.njk
@@ -1,7 +1,7 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% block odbcconnector %}
 ```shell
-sudo apt-get install {{ packageName }}
-sudo apt-get install {{ packageName }}-dev
+sudo {{packageManager}} -y install {{ packageName }}
+sudo {{packageManager}} -y install {{ packageName }}-dev
 ```
 {% endblock odbcconnector %}

--- a/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_centos7_x86.mdx
+++ b/product_docs/docs/eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_centos7_x86.mdx
@@ -17,7 +17,7 @@ Before you begin the installation process:
   ```
 
   !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since, in this case, the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
+  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
 
   If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
   !!!

--- a/product_docs/docs/jdbc_connector/42.5.0.1/images/selecting_the_connectors_installer.png
+++ b/product_docs/docs/jdbc_connector/42.5.0.1/images/selecting_the_connectors_installer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06b88193e81437e2d6e58e2f2d78498df6148f39ed9af97e4014de0c8b5d78bc
-size 167172
+oid sha256:3061df99dd47ba278dc5446f802c245c4da6c19d2b58d8079ad2ec668092842a
+size 140782

--- a/product_docs/docs/ocl_connector/12.1.2.1/images/selecting_the_connectors_installer.png
+++ b/product_docs/docs/ocl_connector/12.1.2.1/images/selecting_the_connectors_installer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34c829e958aba00782875a1bf6587ba45c44efc2072033b0b63dbbd4cd87d49d
-size 160720
+oid sha256:96a9540c9fae476178701169ae25a7c1e7f05d63f4f28131b210e67a5e1a09ee
+size 135657

--- a/product_docs/docs/ocl_connector/13.1.4.2/images/selecting_the_connectors_installer.png
+++ b/product_docs/docs/ocl_connector/13.1.4.2/images/selecting_the_connectors_installer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34c829e958aba00782875a1bf6587ba45c44efc2072033b0b63dbbd4cd87d49d
-size 160720
+oid sha256:0dde0fd854aa15cf06d83dd36c7e059bc81118bdc5d9fd25e72904a79550026e
+size 135647

--- a/product_docs/docs/ocl_connector/14.1.0.1/images/selecting_the_connectors_installer.png
+++ b/product_docs/docs/ocl_connector/14.1.0.1/images/selecting_the_connectors_installer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34c829e958aba00782875a1bf6587ba45c44efc2072033b0b63dbbd4cd87d49d
-size 160720
+oid sha256:5d4dc68af55433c0c695eed059160505b3ee6c7d25c7d5426f4228109d84042a
+size 135650

--- a/product_docs/docs/odbc_connector/12/images/selecting_the_connectors_installer.png
+++ b/product_docs/docs/odbc_connector/12/images/selecting_the_connectors_installer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31f84a8f760ae6e7a2a41bc81b8537906939bc81efd03aca21eed29ae163d796
-size 172259
+oid sha256:ac83549b924c11324930a98efa25864b15c3d5c5e9922e56486b8711e2a09baa
+size 144119

--- a/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/index.mdx
+++ b/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/index.mdx
@@ -2,7 +2,7 @@
 title: "Release notes"
 ---
 
-The ODBC JDBC connector documentation describes version 13 of the ODBC JDBC connector. 
+The ODBC JDBC connector documentation describes the latest version of the ODBC JDBC connector. 
 
 Release notes describe what's new in a release. When a minor or patch release introduces new functionality, indicators in the content identify the version that introduced the new feature.
 

--- a/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/index.mdx
+++ b/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/index.mdx
@@ -2,7 +2,7 @@
 title: "Release notes"
 ---
 
-The ODBC JDBC connector documentation describes the latest version of the ODBC JDBC connector. 
+The ODBC JDBC connector documentation describes the latest version of the EDB JDBC connector. 
 
 Release notes describe what's new in a release. When a minor or patch release introduces new functionality, indicators in the content identify the version that introduced the new feature.
 

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel8_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel8_ppcle.mdx
@@ -37,4 +37,5 @@ Before you begin the installation process:
 
 ```shell
 sudo dnf -y install edb-odbc
+sudo dnf -y install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
@@ -32,5 +32,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -n install edb-odbc
+sudo zypper -y install edb-odbc
+sudo zypper -y install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
@@ -31,5 +31,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -n install edb-odbc
+sudo zypper -y install edb-odbc
+sudo zypper -y install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_centos7_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_centos7_x86.mdx
@@ -30,4 +30,5 @@ Before you begin the installation process:
 
 ```shell
 sudo yum -y install edb-odbc
+sudo yum -y install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86.mdx
@@ -21,6 +21,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get install edb-odbc
-sudo apt-get install edb-odbc-dev
+sudo apt-get -y install edb-odbc
+sudo apt-get -y install edb-odbc-dev
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb11_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb11_x86.mdx
@@ -21,6 +21,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get install edb-odbc
-sudo apt-get install edb-odbc-dev
+sudo apt-get -y install edb-odbc
+sudo apt-get -y install edb-odbc-dev
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux8_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux8_x86.mdx
@@ -32,4 +32,5 @@ Before you begin the installation process:
 
 ```shell
 sudo dnf -y install edb-odbc
+sudo dnf -y install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel7_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel7_x86.mdx
@@ -30,4 +30,5 @@ Before you begin the installation process:
 
 ```shell
 sudo yum -y install edb-odbc
+sudo yum -y install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel8_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel8_x86.mdx
@@ -35,4 +35,5 @@ Before you begin the installation process:
 
 ```shell
 sudo dnf -y install edb-odbc
+sudo dnf -y install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86.mdx
@@ -33,4 +33,5 @@ Before you begin the installation process:
 
 ```shell
 sudo zypper -n install edb-odbc
+sudo zypper -n install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86.mdx
@@ -32,4 +32,5 @@ Before you begin the installation process:
 
 ```shell
 sudo zypper -n install edb-odbc
+sudo zypper -n install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86.mdx
@@ -21,6 +21,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get install edb-odbc
-sudo apt-get install edb-odbc-dev
+sudo apt-get -y install edb-odbc
+sudo apt-get -y install edb-odbc-dev
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86.mdx
@@ -21,6 +21,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get install edb-odbc
-sudo apt-get install edb-odbc-dev
+sudo apt-get -y install edb-odbc
+sudo apt-get -y install edb-odbc-dev
 ```

--- a/product_docs/docs/odbc_connector/13/images/selecting_the_connectors_installer.png
+++ b/product_docs/docs/odbc_connector/13/images/selecting_the_connectors_installer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31f84a8f760ae6e7a2a41bc81b8537906939bc81efd03aca21eed29ae163d796
-size 172259
+oid sha256:4652dde7f0cb74b4f9430b223363d71b3a6677375351de912c9ab9185f949b42
+size 144147


### PR DESCRIPTION
## What Changed?

- Address  [EC-2395](https://enterprisedb.atlassian.net/browse/EC-2394) - ODBC Docs: Correct the description on Release Notes landing page
- Address [EC-2394](https://enterprisedb.atlassian.net/browse/EC-2395) - Update JDBC, OCI, ODBC docs to remove connector version numbers from Stackbuilder Plus screenshots
- Address [EC-2393](https://enterprisedb.atlassian.net/browse/EC-2393) - ODBC Docs: Add edb-odbc-devel install command to Rhel, CentOS, Rocky and SLES platforms installation pages