### PR TITLE
Install templates / ODBC: factor out the no-confirm / non-interactive package manager option

### DIFF
--- a/install_template/templates/platformBase/almalinux-8-or-rocky-linux-8.njk
+++ b/install_template/templates/platformBase/almalinux-8-or-rocky-linux-8.njk
@@ -1,5 +1,6 @@
 {% extends "platformBase/redhat-family.njk" %}
 {% set packageManager = "dnf" %}
+{% set packageManagerNoninteractive = "-y" %}
 {% set epelRepo = "epel-release" %}
 {% block redhatConfig %}#  Enable additional repositories to resolve dependencies:
 sudo dnf config-manager --set-enabled PowerTools{% block mysqlfdw %}

--- a/install_template/templates/platformBase/base.njk
+++ b/install_template/templates/platformBase/base.njk
@@ -25,7 +25,7 @@ Before you begin the installation process:
 
 {% block installCommand %}
 ```shell
-sudo {{packageManager}} -y install {{ packageName }}
+sudo {{packageManager}} {{packageManagerNoninteractive}} install {{ packageName }}
 ```
 {% endblock installCommand %}
 

--- a/install_template/templates/platformBase/centos-7.njk
+++ b/install_template/templates/platformBase/centos-7.njk
@@ -1,4 +1,5 @@
 {% extends "platformBase/redhat-family.njk" %}
 {% set packageManager = "yum" %}
+{% set packageManagerNoninteractive = "-y" %}
 {% set epelRepo = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm" %}
 {% block redhatConfig %}{% block mysqlfdw %}{% endblock mysqlfdw %}{% endblock redhatConfig %}

--- a/install_template/templates/platformBase/debian.njk
+++ b/install_template/templates/platformBase/debian.njk
@@ -1,8 +1,9 @@
 {% extends "platformBase/base.njk" %}
 {% set packageManager = "apt-get" %}
+{% set packageManagerNoninteractive = "-y" %}
 {% block prerequisites %}{% block mysqlfdw %}{% endblock mysqlfdw %}{% endblock prerequisites %}
 {% block installCommand %}{% block odbcconnector %}
 ```shell
-sudo apt-get -y install {{ packageName }}
+sudo {{ packageManager }} {{ packageManagerNoninteractive }} install {{ packageName }}
 ```
 {% endblock odbcconnector %}{% endblock installCommand %}

--- a/install_template/templates/platformBase/redhat-family.njk
+++ b/install_template/templates/platformBase/redhat-family.njk
@@ -3,7 +3,7 @@
 - Address other prerequisites
   ```shell
   # Install the EPEL repository:
-  sudo {{ packageManager }} -y install {{ epelRepo }}
+  sudo {{ packageManager }} {{ packageManagerNoninteractive }} install {{ epelRepo }}
   {% if includePPC %}
   # Refresh the cache:
   sudo dnf makecache{% endif %}{% block redhatConfig %}{% endblock redhatConfig %}

--- a/install_template/templates/platformBase/rhel-7-or-ol-7.njk
+++ b/install_template/templates/platformBase/rhel-7-or-ol-7.njk
@@ -1,5 +1,6 @@
 {% extends "platformBase/redhat-family.njk" %}
 {% set packageManager = "yum" %}
+{% set packageManagerNoninteractive = "-y" %}
 {% set epelRepo = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm" %}
 {% block redhatConfig %}# Enable additional repositories to resolve dependencies:
 subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extras-rpms"  --enable "rhel-ha-for-rhel-*-server-rpms"{% block mysqlfdw %}{% endblock mysqlfdw %}{% endblock redhatConfig %}

--- a/install_template/templates/platformBase/rhel-8-or-ol-8.njk
+++ b/install_template/templates/platformBase/rhel-8-or-ol-8.njk
@@ -1,5 +1,6 @@
 {% extends "platformBase/redhat-family.njk" %}
 {% set packageManager = "dnf" %}
+{% set packageManagerNoninteractive = "-y" %}
 {% set epelRepo = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm" %}
 {% block redhatConfig %}
   # Enable additional repositories to resolve dependencies:

--- a/install_template/templates/platformBase/sles-12.njk
+++ b/install_template/templates/platformBase/sles-12.njk
@@ -1,5 +1,6 @@
 {% extends "platformBase/base.njk" %}
 {% set packageManager = "zypper" %}
+{% set packageManagerNoninteractive = "-n" %}
 {% block prerequisites %}
 - Address other prerequisites
   ```shell{% block mysqlfdw %}{% endblock mysqlfdw %}
@@ -13,6 +14,6 @@
 {% endblock prerequisites %}
 {% block installCommand %}
 ```shell
-sudo zypper -n install {{ packageName }}
+sudo {{packageManager}} {{packageManagerNoninteractive}} install {{ packageName }}
 ```
 {% endblock installCommand %}

--- a/install_template/templates/platformBase/ubuntu.njk
+++ b/install_template/templates/platformBase/ubuntu.njk
@@ -1,8 +1,9 @@
 {% extends "platformBase/base.njk" %}
 {% set packageManager = "apt-get" %}
+{% set packageManagerNoninteractive = "-y" %}
 {% block prerequisites %}{% block mysqlfdw %}{% endblock mysqlfdw %}{% endblock prerequisites %}
 {% block installCommand %}{% block odbcconnector %}
 ```shell
-sudo apt-get -y install {{ packageName }}
+sudo {{ packageManager }} {{ packageManagerNoninteractive }} install {{ packageName }}
 ```
 {% endblock odbcconnector %}{% endblock installCommand %}

--- a/install_template/templates/products/edb-odbc-connector/almalinux-8-or-rocky-linux-8.njk
+++ b/install_template/templates/products/edb-odbc-connector/almalinux-8-or-rocky-linux-8.njk
@@ -1,2 +1,3 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "almalinux-8-or-rocky-linux-8" %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/base.njk
+++ b/install_template/templates/products/edb-odbc-connector/base.njk
@@ -3,10 +3,11 @@
 {% block prodprereq %}{% include "platformBase/_epasinstalldiffserver.njk" %}
 
 {% endblock prodprereq %}
-{% block installCommand %}{% block odbcconnector %}
+
+{% block installCommand %}
 ```shell
-sudo {{packageManager}} -y install {{ packageName }}
-sudo {{packageManager}} -y install {{ packageName }}-devel
+sudo {{packageManager}} {{packageManagerNoninteractive}} install {{ packageName }}
+sudo {{packageManager}} {{packageManagerNoninteractive}} install {{ packageName }}{{ packageDevSuffix }}
 ```
-{% endblock odbcconnector %}{% endblock installCommand %}
+{% endblock installCommand %}
 

--- a/install_template/templates/products/edb-odbc-connector/centos-7.njk
+++ b/install_template/templates/products/edb-odbc-connector/centos-7.njk
@@ -1,2 +1,3 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "centos-7" %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/debian.njk
+++ b/install_template/templates/products/edb-odbc-connector/debian.njk
@@ -1,7 +1,2 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
-{% block odbcconnector %}
-```shell
-sudo {{packageManager}} -y install {{ packageName }}
-sudo {{packageManager}} -y install {{ packageName }}-dev
-```
-{% endblock odbcconnector %}
+{% set packageDevSuffix %}-dev{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/rhel-7-or-ol-7.njk
+++ b/install_template/templates/products/edb-odbc-connector/rhel-7-or-ol-7.njk
@@ -1,2 +1,3 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "rhel-7-or-ol-7" %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/rhel-8-or-ol-8.njk
+++ b/install_template/templates/products/edb-odbc-connector/rhel-8-or-ol-8.njk
@@ -1,2 +1,3 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "rhel-8-or-ol-8" %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/sles-12.njk
+++ b/install_template/templates/products/edb-odbc-connector/sles-12.njk
@@ -1,8 +1,3 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "sles-12" %}
-{% block odbcconnector %}
-```shell
-sudo {{packageManager}} -n install {{ packageName }}
-sudo {{packageManager}} -n install {{ packageName }}-devel
-```
-{% endblock odbcconnector %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/sles-12_ppc64le.njk
+++ b/install_template/templates/products/edb-odbc-connector/sles-12_ppc64le.njk
@@ -1,2 +1,3 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "sles-12" %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/sles-15.njk
+++ b/install_template/templates/products/edb-odbc-connector/sles-15.njk
@@ -1,8 +1,3 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "sles-15" %}
-{% block odbcconnector %}
-```shell
-sudo {{packageManager}} -n install {{ packageName }}
-sudo {{packageManager}} -n install {{ packageName }}-devel
-```
-{% endblock odbcconnector %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/sles-15_ppc64le.njk
+++ b/install_template/templates/products/edb-odbc-connector/sles-15_ppc64le.njk
@@ -1,3 +1,4 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
 {% set platformBaseTemplate = "sles-15" %}
 {% set includePPC = true %}
+{% set packageDevSuffix %}-devel{% endset %}

--- a/install_template/templates/products/edb-odbc-connector/ubuntu.njk
+++ b/install_template/templates/products/edb-odbc-connector/ubuntu.njk
@@ -1,7 +1,2 @@
 {% extends "products/edb-odbc-connector/base.njk" %}
-{% block odbcconnector %}
-```shell
-sudo {{packageManager}} -y install {{ packageName }}
-sudo {{packageManager}} -y install {{ packageName }}-dev
-```
-{% endblock odbcconnector %}
+{% set packageDevSuffix %}-dev{% endset %}

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle.mdx
@@ -32,6 +32,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -y install edb-odbc
-sudo zypper -y install edb-odbc-devel
+sudo zypper -n install edb-odbc
+sudo zypper -n install edb-odbc-devel
 ```

--- a/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
+++ b/product_docs/docs/odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle.mdx
@@ -31,6 +31,6 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -y install edb-odbc
-sudo zypper -y install edb-odbc-devel
+sudo zypper -n install edb-odbc
+sudo zypper -n install edb-odbc-devel
 ```


### PR DESCRIPTION
## What Changed?

Probably need to go further in this direction (e.g., macros for every package manager), but as a start: the no-confirmation / non-interactive option should be set in the platform base template and used as necessary elsewhere - that avoids mistakes caused by paring the wrong option with the wrong package manager (or in the wrong order, e.g. zypper supports `-y` but only *after* the install command, vs. the equivalent `-n` as a global option *before* the command). 