### PR TITLE
Adjust indentation of a "!!! Important" section

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
@@ -334,9 +334,9 @@ projects with a simple example, by creating an `OperatorGroup` and a
        - bi-prod
     ```
 
-     !!! Important
-         Alternatively, you can list namespaces using a label selector, as explained in
-         ["Target namespace selection"](https://docs.openshift.com/container-platform/4.9/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-target-namespace_olm-understanding-operatorgroups).
+    !!! Important
+        Alternatively, you can list namespaces using a label selector, as explained in
+        ["Target namespace selection"](https://docs.openshift.com/container-platform/4.9/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-target-namespace_olm-understanding-operatorgroups).
 
 4.  Create a `Subscription` object in the `my-operators` namespace to subscribe
     to the `fast` channel of the `cloud-native-postgresql` operator that is


### PR DESCRIPTION
Currently, that section shows up literally as `!!! Important Alternatively, you can list namespaces using a label selector, as explained in` in the documentation. I believe that might be caused by the block being 1 space further in, when compared to the rest of the 3. section, so this change tries to handle that.

## What Changed?

The indentation of the `!!! Important` section went from 4 spaces to 3 spaces, to match the rest of the contents of the 3. section

