### PR TITLE
Add Microsoft.DataProtection and Microsoft.StoragePool as prerequesites for Azure

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/01_understanding_qotas_in_azure.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/01_understanding_qotas_in_azure.mdx
@@ -19,8 +19,10 @@ To prevent failures while creating your clusters, ensure that each of the follow
 | Microsoft.Capacity             | Checks the Azure resource quota                                                                        |
 | Microsoft.AlertsManagement     | Monitors failure anomalies                                                                             |
 | Microsoft.ContainerService     | Manages cluster workloads run on the Azure Kubernetes Service                                          |
+| Microsoft.DataProtection       | Manages the backup instance, backup policies and recovery points                                       |
 | Microsoft.KeyVault             | Encrypts and stores keys of the clusters' data volume and Azure's credential information               |
 | Microsoft.Storage              | Backs up data to the Azure Service Account                                                             |
+| Microsoft.StoragePool          | Provider of the resource DiskPool                                                                      |
 | Microsoft.ManagedIdentity      | Manages software access to the local Azure services using Azure Managed-Identity                       |
 | Microsoft.Network              | Manages cluster workloads run in the Azure Kubernetes Service in the dedicated VNet                    |
 | Microsoft.OperationalInsights  | Manages clusters and performs workload logging (log workspace)                                        |


### PR DESCRIPTION
Microsoft.DataProtection and Microsoft.StoragePool needed to be added to this list in the documentation as part of the Resource Providers (aka "namespaces") that customers need to ensure are Registered prior to onboarding BigAnimal. If @valeriodelsarto wouldn't mind reviewing this change, that would be appreciated.

## What Changed?

