### PR TITLE
Conflict to string functions no longer exist

### DIFF
--- a/product_docs/docs/pgd/4/bdr/functions.mdx
+++ b/product_docs/docs/pgd/4/bdr/functions.mdx
@@ -927,20 +927,6 @@ The following are also internal BDR sequence manipulation functions.
 Retrieves information about the subscription status and is used mainly to
 implement the `bdr.subscription_summary` view.
 
-### bdr.conflict_resolution_to_string
-
-Transforms the conflict resolution from oid to text.
-
-The view `bdr.conflict_history_summary` uses this to give user-friendly information for the
-conflict resolution.
-
-### bdr.conflict_type_to_string
-
-Transforms the conflict type from oid to text.
-
-The view `bdr.conflict_history_summary` uses this to give user-friendly information for the
-conflict resolution.
-
 ### bdr.get_node_conflict_resolvers
 
 Displays a text string of all the conflict resolvers on the local node.


### PR DESCRIPTION
`bdr.conflict_type_to_string()` and `bdr.conflict_resolution_to_string()` were required on 3.6 when we used the old `bdr.apply_log` table. Since 3.7, with the `bdr.conflict_history` table, those 2 functions no longer exist.

## What Changed?

