### PR TITLE
Update index.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -43,7 +43,7 @@ Prior to creating your cluster, make sure you have enough resources. Without eno
     !!! Note
        You can't switch from a single node or high-availability cluster to an extreme high-availability cluster or vice versa. 
 
-1. Select the number of standby replicas for your High availability cluster. 
+1. Select the number of standby replicas for your high availability cluster. 
 
 1. Select the cloud provider for your cluster. If you're using your own account and haven't connected it to BigAnimal yet, see [Connecting to your cloud](/biganimal/latest/getting_started/02_connecting_to_your_cloud).
 

--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -43,7 +43,7 @@ Prior to creating your cluster, make sure you have enough resources. Without eno
     !!! Note
        You can't switch from a single node or high-availability cluster to an extreme high-availability cluster or vice versa. 
 
-1. Select the number of standby replicas for your cluster. 
+1. Select the number of standby replicas for your High availability cluster. 
 
 1. Select the cloud provider for your cluster. If you're using your own account and haven't connected it to BigAnimal yet, see [Connecting to your cloud](/biganimal/latest/getting_started/02_connecting_to_your_cloud).
 


### PR DESCRIPTION
## What Changed?
we can select number of standby replicas only for  High availability cluster.
In the BA [document](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/#cluster-info-tab ), point number 2, it is mentioned that **Select the number of standby replicas for your cluster**.
It should be like **Select the number of standby replicas for your High availability cluster.**