### PR TITLE
BigAnimal: remove beta from PostgreSQL references

### DIFF
--- a/product_docs/docs/biganimal/release/free_trial/index.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/index.mdx
@@ -17,7 +17,7 @@ The free trial provides a subset of the full-featured BigAnimal environment so t
 ## What you get as part of the free trial
 
 - **The latest & greatest PostgreSQL and EDB Postgres Advanced Server databases.** 
-  - [PostgreSQL 14](https://www.enterprisedb.com/blog/cool-new-contributions-postgresql-14) is more flexible, more secure, and faster than ever ([release notes](https://www.postgresql.org/docs/14/release.html)). Or, try out BigAnimal's beta support of PostgresSQL 15 ([release notes](https://www.postgresql.org/docs/15/release.html)).
+  - [PostgreSQL 14](https://www.enterprisedb.com/blog/cool-new-contributions-postgresql-14) is more flexible, more secure, and faster than ever ([release notes](https://www.postgresql.org/docs/14/release.html)). Or, try out BigAnimal's support of PostgresSQL 15 ([release notes](https://www.postgresql.org/docs/15/release.html)).
 
   - [EDB Postgres Advanced Server 14](https://www.enterprisedb.com/docs/epas/latest/epas_rel_notes/) builds on PostgreSQL 14 with a host of features for Oracle database compatibility, security, and usability ([more on Oracle database compatibility](/epas/latest/epas_compat_ora_dev_guide/)).
 - **One active cluster, unlimited inactive ones.** 

--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -15,7 +15,7 @@ Postgres distribution and version support varies by cluster type.
 
 | Postgres distribution |     Versions     |          Cluster type          |
 | --------------------- | ---------------- | ------------------------------ |
-| PostgreSQL            | 11–14, 15        | Single node, high availability |
+| PostgreSQL            | 11–15            | Single node, high availability |
 | Oracle Compatible     | 11–14            | Single node, high availability |
 | Oracle Compatible     | 12–14            | Extreme high availability      |
 | PostgreSQL Compatible | 12-14            | Extreme high availability      |

--- a/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
+++ b/product_docs/docs/biganimal/release/overview/02_high_availability.mdx
@@ -15,7 +15,7 @@ Postgres distribution and version support varies by cluster type.
 
 | Postgres distribution |     Versions     |          Cluster type          |
 | --------------------- | ---------------- | ------------------------------ |
-| PostgreSQL            | 11–14, 15 (beta) | Single node, high availability |
+| PostgreSQL            | 11–14, 15        | Single node, high availability |
 | Oracle Compatible     | 11–14            | Single node, high availability |
 | Oracle Compatible     | 12–14            | Extreme high availability      |
 | PostgreSQL Compatible | 12-14            | Extreme high availability      |

--- a/product_docs/docs/biganimal/release/overview/05_database_version_policy.mdx
+++ b/product_docs/docs/biganimal/release/overview/05_database_version_policy.mdx
@@ -8,6 +8,6 @@ PostgreSQL and EDB Postgres Advanced Server major versions are supported from th
 
 |    Postgres distribution     |                      Versions                       |
 | ---------------------------- | --------------------------------------------------- |
-| PostgreSQL                   | 11–14, 15                                           |
+| PostgreSQL                   | 11–15                                               |
 | EDB Postgres Advanced Server | 11–14, 12-14 for extreme high availability clusters |
 | EDB Postgres Extended Server | 12-14                                               |

--- a/product_docs/docs/biganimal/release/overview/05_database_version_policy.mdx
+++ b/product_docs/docs/biganimal/release/overview/05_database_version_policy.mdx
@@ -8,6 +8,6 @@ PostgreSQL and EDB Postgres Advanced Server major versions are supported from th
 
 |    Postgres distribution     |                      Versions                       |
 | ---------------------------- | --------------------------------------------------- |
-| PostgreSQL                   | 11–14, 15 (beta)                                    |
+| PostgreSQL                   | 11–14, 15                                           |
 | EDB Postgres Advanced Server | 11–14, 12-14 for extreme high availability clusters |
 | EDB Postgres Extended Server | 12-14                                               |


### PR DESCRIPTION

This reverts commit 16fb4340f6af42c053fac7d7caff63141f166e04.

## What Changed?

