### PR TITLE
Migration Toolkit 55.4.0 release

### DIFF
--- a/product_docs/docs/migration_toolkit/55/02_supported_operating_systems_and_database_versions.mdx
+++ b/product_docs/docs/migration_toolkit/55/02_supported_operating_systems_and_database_versions.mdx
@@ -9,7 +9,7 @@ title: "Supported platforms and databases"
 
 You can use the following database product versions with Migration Toolkit:
 
--   PostgreSQL versions 10, 11, 12, 13, and 14
+-   PostgreSQL versions 11, 12, 13, 14, and 15
 -   EDB Postgres Advanced Server versions 10, 11, 12, 13, and 14
 -   Oracle 10g
 -   Oracle 11g


### PR DESCRIPTION
## What Changed?

Updates in this release are:

- Support for PostgreSQL 15 ([MIG-4158](https://enterprisedb.atlassian.net/browse/MIG-4158))
- End of support for PostgreSQL 10 ([MIG-4158](https://enterprisedb.atlassian.net/browse/MIG-4158))
