### PR TITLE
Subscriber-Only nodes are not considered in quorum

### DIFF
--- a/product_docs/docs/pgd/4/harp/09_consensus-layer.mdx
+++ b/product_docs/docs/pgd/4/harp/09_consensus-layer.mdx
@@ -21,7 +21,7 @@ The `bdr` native consensus layer is available from BDR versions
 and [3.7.3](/bdr/3.7/release-notes/#bdr-373).
 
 For the purpose of maintaining a voting quorum, BDR Logical Standby 
-nodes don't participate in consensus communications in a EDB Postgres Distributed cluster. Don't count these in the total node list to fulfill DCS quorum requirements.
+nodes and BDR Subscriber-Only nodes don't participate in consensus communications in a EDB Postgres Distributed cluster. Don't count these in the total node list to fulfill DCS quorum requirements.
 
 ## Maintaining quorum
 


### PR DESCRIPTION
Documentation only mentions Logical Standby nodes, but we also need to mention Subscriber-Only nodes.

## What Changed?

