### PR TITLE
Remove suggestion about harpctl unmanage node

### DIFF
--- a/product_docs/docs/pgd/4/harp/06_harp_manager.mdx
+++ b/product_docs/docs/pgd/4/harp/06_harp_manager.mdx
@@ -109,20 +109,3 @@ There are no arguments to launch `harp-manager` as a forked daemon.
 This software is designed to be launched through systemd or in a container 
 as a top-level process. This also means output is directed to STDOUT and STDERR
 for capture and access through journald or an attached container terminal.
-
-## Disabling and reenabling HARP Manager control of Postgres
-
-You can temporarily pause HARP Manager control of Postgres. This 
-results in a state where the daemon continues running but doesn't perform any 
-operations that can affect existing behavior of the cluster. Reenabling 
-management causes it to resume operation.
-
-An example of temporarily disabling node management is:
-
-```bash
-harpctl unmanage node node1
-```
-
-See [harpctl command-line tool](08_harpctl) for more details.
-
-Node management by HARP Manager is enabled by default.


### PR DESCRIPTION
`harpctl unmanage node <node_name>` doesn't exist. If you try that, the command will fail.

Per [documentation](https://www.enterprisedb.com/docs/pgd/latest/harp/08_harpctl/#harpctl-unmanage), `harpctl unmanage` works only for `cluster` at the moment.

## What Changed?

