### PR TITLE
Fix typo in URL to the 3.7 version

### DIFF
--- a/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
@@ -8,7 +8,7 @@ Currently there are no direct upgrade paths from 3.6 to 4.  You must first upgra
 
 ## Upgrading from version 3.7 to version 4
 
-Currently it is recommended that you are using 3.7.15 or later before upgrading to 4. See [Upgrading within from 3.7](/pgd/3.7/bdr/updrades/supported_paths/#upgrading-within-version-37) in the 3.7 documentation for more information.  After upgrading to 3.7.15 or later the following combinations are allowed
+Currently it is recommended that you are using 3.7.15 or later before upgrading to 4. See [Upgrading within from 3.7](/pgd/3.7/bdr/upgrades/supported_paths/#upgrading-within-version-37) in the 3.7 documentation for more information.  After upgrading to 3.7.15 or later the following combinations are allowed
 
 | 3.7.15 | 3.7.16 | 3.7.17 | Target BDR version |
 |--------|--------|--------|--------------------|


### PR DESCRIPTION
Fix typo in URL to the 3.7 version, from updrades to upgrades
