### PR TITLE
docs(UPM-13774): Fix the superset role docs

### DIFF
--- a/product_docs/docs/biganimal/release/administering_cluster/01a_superset_access.mdx
+++ b/product_docs/docs/biganimal/release/administering_cluster/01a_superset_access.mdx
@@ -13,16 +13,15 @@ Superset has three roles mapped to BigAnimal roles:
 
 Learn more about Superset roles, users, and permissions management in [Superset Security](https://superset.apache.org/docs/security). 
 
-The Superset roles map to BigAnimal permissions as below.
+The Superset roles map to BigAnimal permissions:
 
-| Superset role   | Description | BigAnimal permissions mapped to Superset role   
-| --------------- | ------------- | ------------------------------------------ |
-| Gamma | View data that user has been granted access to, create dashboards | Reader |
-| Alpha | All Superset Gamma privileges, plus the ability to add or modify data sources | Contributor |
-| Admin | All Superset Alpha privileges, plus access to SQL Lab and the ability to grant or revoke access to data to other users | Account owner |
+| Superset role |                                                      Description                                                       | BigAnimal permissions mapped to Superset role |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Gamma         | View data that user has been granted access to, create dashboards                                                      | Reader                                        |
+| Alpha         | All Superset Gamma privileges, plus the ability to add or modify data sources                                          | Contributor                                   |
+| Admin         | All Superset Alpha privileges, plus access to SQL Lab and the ability to grant or revoke access to data to other users | Account owner                                 |
 
 !!! Note
-    The sql_lab role grants access to SQL Lab. Note that while Admin users have access to all databases by default, both Alpha and Gamma
-    users need to be given access on a per database basis.
+    While Admin users have access to all databases by default, both Alpha and Gamma users need to be given access via the Superset sql_lab role on a per database basis. The sql_lab role grants access to SQL Lab. 
 
 To assign Superset permissions to the BigAnimal user role, see [Changing role permissions](01_portal_access/#assign-roles-to-users).

--- a/product_docs/docs/biganimal/release/administering_cluster/01a_superset_access.mdx
+++ b/product_docs/docs/biganimal/release/administering_cluster/01a_superset_access.mdx
@@ -24,4 +24,4 @@ The Superset roles map to BigAnimal permissions:
 !!! Note
     While Admin users have access to all databases by default, both Alpha and Gamma users need to be given access via the Superset sql_lab role on a per database basis. The sql_lab role grants access to SQL Lab. 
 
-To assign Superset permissions to the BigAnimal user role, see [Changing role permissions](01_portal_access/#assign-roles-to-users).
+To assign BigAnimal user roles, see [Changing role permissions](01_portal_access/#assign-roles-to-users).

--- a/product_docs/docs/biganimal/release/administering_cluster/01a_superset_access.mdx
+++ b/product_docs/docs/biganimal/release/administering_cluster/01a_superset_access.mdx
@@ -13,12 +13,16 @@ Superset has three roles mapped to BigAnimal roles:
 
 Learn more about Superset roles, users, and permissions management in [Superset Security](https://superset.apache.org/docs/security). 
 
-The Superset roles map to BigAnimal permissions. You can add the Superset BigAnimal permissions to BigAnimal user roles, as needed.
+The Superset roles map to BigAnimal permissions as below.
 
 | Superset role   | Description | BigAnimal permissions mapped to Superset role   
 | --------------- | ------------- | ------------------------------------------ |
 | Gamma | View data that user has been granted access to, create dashboards | Reader |
 | Alpha | All Superset Gamma privileges, plus the ability to add or modify data sources | Contributor |
 | Admin | All Superset Alpha privileges, plus access to SQL Lab and the ability to grant or revoke access to data to other users | Account owner |
+
+!!! Note
+    The sql_lab role grants access to SQL Lab. Note that while Admin users have access to all databases by default, both Alpha and Gamma
+    users need to be given access on a per database basis.
 
 To assign Superset permissions to the BigAnimal user role, see [Changing role permissions](01_portal_access/#assign-roles-to-users).


### PR DESCRIPTION
## What Changed?

The BigAnimal Superset role mapping page on docs needed a fix, as it was telling about users can manage the superset roles from the BA portal, which is incorrect. The admin doesn't assign the superset permissions, but just assigns the BA role, which is then mapped with the superset roles. 

Also, added a note about to SQL lab where the admin needs to assign the SQL lab permission on a per-database basis.