### PR TITLE
BigAnimal: fixing links

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -151,7 +151,7 @@ For information on replication lag while using read-only workloads, see [Synchro
 
 ### Authentication
 
-Enable **Identity and Access Management (IAM) Authentication** to turn on the ability to log in to Postgres using your AWS IAM credentials. For this feature to take effect, after you create the cluster, you must add each user to a role that uses AWS IAM authentication in Postgres. For details, see [IAM authentication for Postgres](../../using_cluster/01_postgres_access/#iam_authentication_for_postgres).
+Enable **Identity and Access Management (IAM) Authentication** to turn on the ability to log in to Postgres using your AWS IAM credentials. For this feature to take effect, after you create the cluster, you must add each user to a role that uses AWS IAM authentication in Postgres. For details, see [IAM authentication for Postgres](/biganimal/latest/using_cluster/01_postgres_access/#iam-authentication-for-postgres).
 
 ## What’s next
 

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -88,7 +88,7 @@ Provision your cluster before configuring IAM for Postgres.
     1. On the **Additional Settings** tab, under **Authentication**, select **Identity and Access Management (IAM) Authentication**. 
     1. Select **Create Cluster** or **Save**.
     !!!note
-    To turn on IAM authentication using the CLI, see the [Using IAM authentication on AWS](biganimal/latest/reference/cli/#using-iam-authentication-on-aws) section in the Using the BigAnimal CLI topic.
+    To turn on IAM authentication using the CLI, see the [Using IAM authentication on AWS](/biganimal/latest/reference/cli/#using-iam-authentication-on-aws) section in the Using the BigAnimal CLI topic.
 1. In AWS, get the ARN of each IAM user requiring database access. In the AWS account connected to BigAnimal, use AWS Identity and Access Management (IAM) to perform user management. See the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html). 
 
 1. In Postgres, if the IAM role doesn’t exist yet, run this Postgres command:


### PR DESCRIPTION
## What Changed?
Fixing these links: 
⚠️   https://github.com/EnterpriseDB/docs/blob/refs/heads/develop/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx?plain=1#L154
 cannot find slug for iam_authentication_for_postgres in /biganimal/release/using_cluster/01_postgres_access/
⚠️⚠️  https://github.com/EnterpriseDB/docs/blob/refs/heads/develop/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx?plain=1#L91
 cannot find topic for path: /biganimal/release/using_cluster/biganimal/latest/reference/cli/