### PR TITLE
modules-to-resources

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/terraform_provider.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/terraform_provider.mdx
@@ -4,7 +4,7 @@ title: BigAnimal Terraform provider
 
 BigAnimal’s [Terraform provider](https://registry.terraform.io/providers/EnterpriseDB/biganimal/latest/docs) is an infrastructure-as-code service that allows you to provision cloud resources with the Terraform CLI and incorporate those resources into your existing BigAnimal cloud infrastructure workflows.  
 
-The current version of the Terraform provider offers modules for creating, reading, updating, and deleting clusters and regions.
+The current version of the Terraform provider offers resources for creating, reading, updating, and deleting clusters and regions.
 
 The Terraform provider is licensed under the [MPL v2](https://www.mozilla.org/en-US/MPL/2.0/).
 


### PR DESCRIPTION
Changed 'modules' to 'resources' - use of modules is incorrect terminology since that is what the customer makes not what we provide

## What Changed?

