### PR TITLE
Removing EPAS 10 column from products that have an EPAS compatibility table

### DIFF
--- a/product_docs/docs/edb_plus/40/02a_supported_platforms.mdx
+++ b/product_docs/docs/edb_plus/40/02a_supported_platforms.mdx
@@ -4,11 +4,11 @@ title: "Supported platforms"
 
 This table lists the EDB\*Plus versions and their supported corresponding EDB Postgres Advanced Server  versions.  EDB\*Plus is supported on the same platforms as EDB Postgres Advanced Server. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
-| EDB*Plus | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 | 
-| -------- | ------- | ------- | ------- | ------- | ------- | 
-| 40       | Y       | Y       | Y       | Y       | Y       | 
-| 39       | N       | Y       | Y       | Y       | Y       | 
-| 38       | N       | Y       | Y       | Y       | Y       | 
-| 37       | N       | N       | Y       | Y       | Y       | 
-| 36       | N       | N       | N       | Y       | Y       | 
+| EDB*Plus | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | 
+| -------- | ------- | ------- | ------- | ------- | 
+| 40       | Y       | Y       | Y       | Y       | 
+| 39       | N       | Y       | Y       | Y       |  
+| 38       | N       | Y       | Y       | Y       |  
+| 37       | N       | N       | Y       | Y       |  
+| 36       | N       | N       | N       | Y       | 
 

--- a/product_docs/docs/hadoop_data_adapter/2/02_requirements_overview.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/02_requirements_overview.mdx
@@ -4,13 +4,13 @@ title: "Supported database versions"
 
 This table lists the latest Hadoop Foreign Data Wrapper versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. Hadoop Foreign Data Wrapper is supported on the same platforms as EDB Postgres Advanced Server. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
-| Hadoop Foreign Data Wrapper | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 | 
-| --------------------------- | ------- | ------- | ------- | ------- | ------- | 
-| 2.1.0                       | Y       | Y       | Y       | Y       | Y       |  
-| 2.0.8                       | N       | Y       | Y       | Y       | Y       | 
-| 2.0.7                       | N       | Y       | Y       | N       | N       | 
-| 2.0.5                       | N       | N       | Y       | N       | N       | 
-| 2.0.4                       | N       | N       | N       | Y       | Y       |  
+| Hadoop Foreign Data Wrapper | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 |  
+| --------------------------- | ------- | ------- | ------- | ------- | 
+| 2.1.0                       | Y       | Y       | Y       | Y       |  
+| 2.0.8                       | N       | Y       | Y       | Y       |  
+| 2.0.7                       | N       | Y       | Y       | N       |  
+| 2.0.5                       | N       | N       | Y       | N       | 
+| 2.0.4                       | N       | N       | N       | Y       |  
 
 
 

--- a/product_docs/docs/mongo_data_adapter/5/02_requirements_overview.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/02_requirements_overview.mdx
@@ -4,11 +4,11 @@ title: "Supported database versions"
 
  This table lists the latest MongoDB Foreign Data Wrapper versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. MongoDB Foreign Data Wrapper is supported on the same platforms as EDB Postgres Advanced Server. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
-| MongoDB Foreign Data Wrapper | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 | 
-| ---------                    | ------- | ------- | ------- | ------- | ------- | 
-| 5.3.0                        | Y       | Y       | Y       | Y       | Y       |  
-| 5.2.9                        | N       | Y       | Y       | Y       | Y       | 
-| 5.2.8                        | N       | Y       | N       | N       | N       | 
-| 5.2.6                        | N       | N       | Y       | N       | N       | 
-| 5.2.3                        | N       | Y       | N       | Y       | N       |  
+| MongoDB Foreign Data Wrapper | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 |  
+| ---------                    | ------- | ------- | ------- | ------- |  
+| 5.3.0                        | Y       | Y       | Y       | Y       |   
+| 5.2.9                        | N       | Y       | Y       | Y       | 
+| 5.2.8                        | N       | Y       | N       | N       |  
+| 5.2.6                        | N       | N       | Y       | N       |  
+| 5.2.3                        | N       | Y       | N       | Y       |   
 

--- a/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
@@ -6,14 +6,14 @@ title: "Supported database and versions"
 
 This table lists the latest MySQL Foreign Data Wrapper versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. MySQL Foreign Data Wrapper is supported on the same platforms as EDB Postgres Advanced Server. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
-| MySQL Foreign Data Wrapper | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 | 
-| -------------------------- | ------- | ------- | ------- | ------- | ------- | 
-| 2.8.0                      | Y       | Y       | Y       | Y       | Y       |  
-| 2.7.0                      | Y       | Y       | Y       | Y       | Y       |  
-| 2.6.0                      | N       | Y       | Y       | Y       | Y       | 
-| 2.5.5                      | N       | Y       | N       | N       | N       | 
-| 2.5.3                      | N       | N       | Y       | N       | N       | 
-| 2.5.1                      | N       | N       | N       | Y       | N       |  
+| MySQL Foreign Data Wrapper | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | 
+| -------------------------- | ------- | ------- | ------- | ------- | 
+| 2.8.0                      | Y       | Y       | Y       | Y       |  
+| 2.7.0                      | Y       | Y       | Y       | Y       | 
+| 2.6.0                      | N       | Y       | Y       | Y       | 
+| 2.5.5                      | N       | Y       | N       | N       | 
+| 2.5.3                      | N       | N       | Y       | N       | 
+| 2.5.1                      | N       | N       | N       | Y       | 
 
 ## Supported MySQL versions
 

--- a/product_docs/docs/ocl_connector/14.1.0.1/02_supported_platforms.mdx
+++ b/product_docs/docs/ocl_connector/14.1.0.1/02_supported_platforms.mdx
@@ -5,5 +5,5 @@ title: "Product compatability"
 
 <div id="supported_platforms" class="registered_link"></div>
 
-The EDB OCL Connector is certified with EDB Postgres Advanced Server version 10 and later. The EDB Connector is supported on the same platforms as EDB Postgres Advanced Server. See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
+The EDB OCL Connector is certified with EDB Postgres Advanced Server version 11 and later. The EDB Connector is supported on the same platforms as EDB Postgres Advanced Server. See [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 

--- a/product_docs/docs/odbc_connector/13/02_requirements_overview.mdx
+++ b/product_docs/docs/odbc_connector/13/02_requirements_overview.mdx
@@ -5,8 +5,8 @@ title: "Product compatibility"
 
 This table lists the latest ODBC Connector versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
-| ODBC Connector                            | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 | 
-| ----------------------------------------- | ------- | ------- | ------- | ------- | ------- |
-| [13.01.0.02](01_odbc_rel_notes/03_odbc_13.1.0.02_rel_notes) | Y       | Y       | Y       | Y       | Y       |
-| [13.01.0.01](01_odbc_rel_notes/04_odbc_13.1.0.01_rel_notes) | N       | Y       | Y       | Y       | Y       |
-| [13.00.0.01](01_odbc_rel_notes/05_odbc_13.0.0.01_rel_notes) | N       | Y       | Y       | Y       | Y       |  
+|                       ODBC Connector                        | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | 
+| ----------------------------------------------------------- | ------- | ------- | ------- | ------- | 
+| [13.01.0.02](01_odbc_rel_notes/03_odbc_13.1.0.02_rel_notes) | Y       | Y       | Y       | Y       | 
+| [13.01.0.01](01_odbc_rel_notes/04_odbc_13.1.0.01_rel_notes) | N       | Y       | Y       | Y       | 
+| [13.00.0.01](01_odbc_rel_notes/05_odbc_13.0.0.01_rel_notes) | N       | Y       | Y       | Y       | 

--- a/product_docs/docs/pgbouncer/1.17/supported_platforms.mdx
+++ b/product_docs/docs/pgbouncer/1.17/supported_platforms.mdx
@@ -5,15 +5,15 @@ title: "Supported platforms"
 
 This table lists the latest EDB PgBouncer versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. EDB PgBouncer is supported on the same platforms as EDB Postgres Advanced Server. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
-| EDB PgBouncer | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 | 
-| ------------- | ------- | ------- | ------- | ------- | ------- | 
-| 1.17          | Y       | Y       | Y       | Y       | Y       | 
-| 1.16          | Y       | Y       | Y       | Y       | Y       |  
-| 1.15          | N       | Y       | Y       | Y       | Y       | 
-| 1.14          | N       | Y       | Y       | Y       | Y       | 
-| 1.13          | N       | N       | Y       | N       | N       | 
-| 1.12          | N       | N       | Y       | N       | N       | 
-| 1.9           | N       | N       | N       | Y       | Y       | 
-| 1.7           | N       | N       | N       | N       | Y       | 
+| EDB PgBouncer | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 |  
+| ------------- | ------- | ------- | ------- | ------- | 
+| 1.17          | Y       | Y       | Y       | Y       | 
+| 1.16          | Y       | Y       | Y       | Y       |  
+| 1.15          | N       | Y       | Y       | Y       |  
+| 1.14          | N       | Y       | Y       | Y       |  
+| 1.13          | N       | N       | Y       | N       | 
+| 1.12          | N       | N       | Y       | N       | 
+| 1.9           | N       | N       | N       | Y       |  
+| 1.7           | N       | N       | N       | N       |  
 
 The documented and supported functionality of each version of EDB PgBouncer is the same. The information in this documentation applies to all supported versions of EDB PgBouncer.

--- a/product_docs/docs/pgpool/4.3/supported_platforms.mdx
+++ b/product_docs/docs/pgpool/4.3/supported_platforms.mdx
@@ -4,12 +4,12 @@ title: "Supported platforms"
 
 This table lists the latest  EDB Pgpool-II versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions.  EDB Pgpool-II is supported on the same platforms as EDB Postgres Advanced Server. See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) for details.
 
-| EDB Pgpool-II | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | EPAS 10 |
-| ------ | ------- | ------- | ------- | ------- | ------- |
-| 4.3    | Y       | Y       | Y       | Y       | Y       |
-| 4.2    | N       | Y       | Y       | Y       | Y       |
-| 4.1    | N       | Y       | Y       | Y       | N       |
-| 4.0    | N       | N       | Y       | Y       | N       |
-| 3.7    | N       | N       | N       | Y       | Y       |
+| EDB Pgpool-II | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 | 
+| ------------- | ------- | ------- | ------- | ------- | 
+| 4.3           | Y       | Y       | Y       | Y       | 
+| 4.2           | N       | Y       | Y       | Y       | 
+| 4.1           | N       | Y       | Y       | Y       | 
+| 4.0           | N       | N       | Y       | Y       | 
+| 3.7           | N       | N       | N       | Y       | 
 
 


### PR DESCRIPTION
## What Changed?

Removed EPAS 10 column from the products that have the EPAS compatibility table:

- EDB*Plus
- OCL Connector (didn't have the table but fixed the sentence that referenced v10
- ODBC Connector
- PgBouncer
- pgPool
- FDWs