### PR TITLE
Modify Replica section

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
@@ -73,11 +73,7 @@ You can promote a faraway replica to a full-fledged cluster, which makes it capa
 
 1. Go to the [Clusters](https://portal.biganimal.com/clusters) page. A list of previously created clusters appears.
 
-1. Select the cluster with the replica you want to modify. In the **Overview** tab, you can see the cluster's replicas under **Faraway Replicas**.
-
-1. Select the **Edit Cluster** icon next to the replica you want to modify. The Edit Faraway Replica page appears. 
-
-1. In the **Cluster Settings** tab, in the **Cluster Name** field, enter the name for your replica.
+1. Select the **Edit Cluster** icon next to the faraway replica you want to modify. The Edit Faraway Replica page appears. 
 
 1. In the **Password** field, enter a password for your replica. 
  


### PR DESCRIPTION
I changed couple of lines however looks like the whole section needs a relook. Most of the points are referring to the Create Replica options. Like we should be saying - customer can modify these settings under the replica...then then provide a list like Modify Cluster Page - https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/03_modifying_your_cluster/

## What Changed?

