### PR TITLE
Minor corrections for CAMO and Group Commit chapters

### DIFF
--- a/product_docs/docs/pgd/4/bdr/camo.mdx
+++ b/product_docs/docs/pgd/4/bdr/camo.mdx
@@ -64,14 +64,14 @@ No designated CAMO partner must be configured in this mode.
 ## Requirements
 
 To use CAMO, an application must issue an explicit COMMIT message
-a separate request (not as part of a multi-statement request).
+as a separate request (not as part of a multi-statement request).
 CAMO can't provide status for transactions issued from procedures
 or from single-statement transactions that use implicit commits.
 
 ## Configuration
 
 Assume an existing EDB Postgres Distributed cluster consists of the nodes `node1` and
-`node2`. Both notes are part of a BDR-enabled database called `bdrdemo`, and both part
+`node2`. Both nodes are part of a BDR-enabled database called `bdrdemo`, and both part
 of the same node group `mygroup`. You can configure the nodes
 to be CAMO partners for each other.
 
@@ -155,7 +155,7 @@ with remote write.
 
 To cover an outage of both nodes of a CAMO pair, you can use
 `bdr.synchronous_commit = local` to enforce a flush prior to the
-pre-commit confirmation. This doesn't work in with
+pre-commit confirmation. This doesn't work with
 either remote write or local mode and has a performance
 impact due to I/O requirements on the CAMO partner in the
 latency sensitive commit path.
@@ -296,7 +296,7 @@ allowing such a switch in general.
 
 ```sql
 bdr.add_camo_pair(node_group text, left_node text, right_node text,
-                  require_raft bool)
+                  require_raft boolean)
 ```
 
 !!! Note
@@ -318,7 +318,7 @@ the nodes of a pairing. You must instead use `bdr.remove_camo_pair` followed by
 
 ```sql
 bdr.alter_camo_pair(node_group text, left_node text, right_node text,
-                    require_raft bool)
+                    require_raft boolean)
 ```
 
 ### Removing a CAMO pair
@@ -413,7 +413,8 @@ To check the status of a transaction that was being committed when the node
 failed, the application must use this function:
 
 ```sql
-bdr.logical_transaction_status(node_id, xid, require_camo_partner)
+bdr.logical_transaction_status(node_id OID, xid OID,
+                               require_camo_partner boolean)
 ```
 
 With CAMO used in pair mode, use this function only on
@@ -442,9 +443,8 @@ forced to roll back.
 #### Synopsis
 
 ```sql
-bdr.logical_transaction_status(node_id OID,
-                               xid     OID,
-                               require_camo_partner BOOL DEFAULT true)
+bdr.logical_transaction_status(node_id OID, xid OID,
+                               require_camo_partner boolean DEFAULT true)
 ```
 
 #### Parameters

--- a/product_docs/docs/pgd/4/bdr/group-commit.mdx
+++ b/product_docs/docs/pgd/4/bdr/group-commit.mdx
@@ -35,6 +35,8 @@ SET LOCAL bdr.commit_scope = 'example_scope';
 COMMIT;
 ```
 
+The commit scope must be set before the transaction has written any data.
+
 For this example, you might previously have defined the commit scope as:
 
 ```sql


### PR DESCRIPTION
Correct grammatical errors

Correct when SET LOCAL bdr.commit_scope and be assigned.

Use boolean type spelling. Seems most consistent with BDR function signatures for Node Management and System Functions

Emphasize that Group Commit must be set before transaction has written data.

BDR-2805

## What Changed?

