### PR TITLE
Correct errantly corrected redirects in MTK install docs

### DIFF
--- a/product_docs/docs/migration_toolkit/55/installing/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/index.mdx
@@ -2,8 +2,8 @@
 title: "Installing Migration Toolkit"
 navTitle: "Installing"
 redirects:
-  - /migration_toolkit/latest/installing/install_on_linux
-  - /migration_toolkit/latest/installing
+  - /migration_toolkit/latest/05_installing_mtk/install_on_linux
+  - /migration_toolkit/latest/05_installing_mtk
 
 legacyRedirects:
   - "/edb-docs/d/edb-postgres-migration-toolkit/user-guides/user-guide/55.0.0/installing_on_mac.html"

--- a/product_docs/docs/migration_toolkit/55/installing/install_on_mac.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/install_on_mac.mdx
@@ -2,7 +2,7 @@
 title: "Installing on Mac OS X"
 navTitle: "On Mac OS X"
 redirects:
-  - /migration_toolkit/latest/installing/install_on_mac/
+    - /migration_toolkit/latest/05_installing_mtk/install_on_mac/
 ---
 
 

--- a/product_docs/docs/migration_toolkit/55/installing/install_on_windows.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/install_on_windows.mdx
@@ -2,7 +2,7 @@
 title: "Installing on Windows"
 navTitle: "On Windows"
 redirects:
-  - /migration_toolkit/latest/installing/install_on_windows/
+  - /migration_toolkit/latest/05_installing_mtk/install_on_windows/
 ---
 
 <div id="windows_installation" class="registered_link"></div>

--- a/product_docs/docs/migration_toolkit/55/installing/installing_jdbc_driver.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/installing_jdbc_driver.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Installing a JDBC driver"
+redirects:
+  - /migration_toolkit/latest/05_installing_mtk/installing_jdbc_driver/
 ---
 <div id="installing_drivers" class="registered_link"></div>
 

--- a/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/index.mdx
@@ -2,7 +2,7 @@
 title: "Installing Migration Toolkit on IBM Power (ppc64le)"
 navTitle: "On Linux ppc64le"
 redirects:
-  - /migration_toolkit/latest/installing/install_on_linux/ibm_power_ppc64le/
+  - /migration_toolkit/latest/05_installing_mtk/install_on_linux/ibm_power_ppc64le/
 navigation: 
  - mtk_rhel_8
  - mtk_sles_15

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/index.mdx
@@ -2,7 +2,7 @@
 title: "Installing Migration Toolkit on Linux x86 (amd64)"
 navTitle: "On Linux x86"
 redirects:
-  - /migration_toolkit/latest/installing/install_on_linux/x86_amd64/
+  - /migration_toolkit/latest/05_installing_mtk/install_on_linux/x86_amd64/
 navigation:
  - mtk_rhel_8
  - mtk_other_linux_8


### PR DESCRIPTION
## What Changed?

Looks like a few paths in redirects were updated as part of #3359 - this caused redirect loops when attempting to navigate to these pages.

Fixes #3473
