### PR TITLE
Hotfix: Add index link to Postgres for Kubernetes 1.8.1 release notes

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
@@ -47,6 +47,7 @@ The EDB Postgres for Kubernetes documentation describes the major version of EDB
 
 |          Version           | Release date |                                       Upstream merges                                       |
 | -------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| [1.18.1](1_18_1_rel_notes) | 2022 Dec 21   | Upstream [1.18.1](https://cloudnative-pg.io/documentation/1.18/release_notes/v1.18/) |
 | [1.18.0](1_18_0_rel_notes) | 2022 Nov 14   | Upstream [1.18.0](https://cloudnative-pg.io/documentation/1.18/release_notes/v1.18/) |
 | [1.17.2](1_17_2_rel_notes) | 2022 Nov 14   | Upstream [1.17.2](https://cloudnative-pg.io/documentation/1.17/release_notes/v1.17/) |
 | [1.17.1](1_17_1_rel_notes) | 2022 Oct 7   | Upstream [1.17.1](https://cloudnative-pg.io/documentation/1.17/release_notes/v1.17/) |


### PR DESCRIPTION
## What Changed?

Forgot to add link to release notes index page; address this.