### PR TITLE
update ancient links to /resources/product-documentation

### DIFF
--- a/product_docs/docs/eprs/6.2/03_installation/02_installing_from_cli.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/02_installing_from_cli.mdx
@@ -17,9 +17,7 @@ The xDB Replication Server installer program can either be downloaded directly f
 The installer program name may vary depending upon how you obtained it. The following are some examples illustrating command line installation.
 
 !!! Note
-    For additional detailed information on how to install EnterpriseDB products from the command line, see the *EDB Postgres Advanced Server Installation Guide* located at:
-
-    <https://www.enterprisedb.com/resources/product-documentation>
+    For additional detailed information on how to install EnterpriseDB products from the command line, see the [EDB Postgres Advanced Server Installation Guide](https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/)
 
 !!! Note
     You must have Java Runtime Environment (JRE) version 1.8 or later installed on the hosts where you intend to install any xDB Replication Server component (xDB Replication Console, publication server, or subscription server). Any Java product such as Oracle Java or OpenJDK may be used.

--- a/product_docs/docs/eprs/6.2/03_installation/02_installing_from_cli.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/02_installing_from_cli.mdx
@@ -17,7 +17,8 @@ The xDB Replication Server installer program can either be downloaded directly f
 The installer program name may vary depending upon how you obtained it. The following are some examples illustrating command line installation.
 
 !!! Note
-    For additional detailed information on how to install EnterpriseDB products from the command line, see the [EDB Postgres Advanced Server Installation Guide](https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/)
+    For additional detailed information on how to install EnterpriseDB products, see [EDB Postgres Advanced Server
+installation for Linux](/epas/latest/epas_inst_linux/)
 
 !!! Note
     You must have Java Runtime Environment (JRE) version 1.8 or later installed on the hosts where you intend to install any xDB Replication Server component (xDB Replication Console, publication server, or subscription server). Any Java product such as Oracle Java or OpenJDK may be used.

--- a/product_docs/docs/eprs/6.2/03_installation/03_installing_rpm_package.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/03_installing_rpm_package.mdx
@@ -15,7 +15,7 @@ To request credentials to the EDB Yum Repository, visit the following website:
 > <https://www.enterprisedb.com/repository-access-request>
 
 For information about using the EDB Yum Repository see [Installing EDB Postgres Advanced
-Server using the EDB repository](https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/installing_epas_using_edb_repository/)
+Server using the EDB repository](epas/latest/epas_inst_linux/installing_epas_using_edb_repository/)
 
 !!! Note
     Although the following primarily describes the installation of xDB Replication Server version 6.2, access to the RPM packages for prior xDB Replication Server versions are also described in order to differentiate the installation of these different versions.

--- a/product_docs/docs/eprs/6.2/03_installation/03_installing_rpm_package.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/03_installing_rpm_package.mdx
@@ -14,9 +14,8 @@ To request credentials to the EDB Yum Repository, visit the following website:
 
 > <https://www.enterprisedb.com/repository-access-request>
 
-For information about using the EDB Yum Repository see Chapter 3 of the EDB Postgres Advanced Server Installation Guide available from the EnterpriseDB website located at:
-
-> <https://www.enterprisedb.com/resources/product-documentation>
+For information about using the EDB Yum Repository see [Installing EDB Postgres Advanced
+Server using the EDB repository](https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/installing_epas_using_edb_repository/)
 
 !!! Note
     Although the following primarily describes the installation of xDB Replication Server version 6.2, access to the RPM packages for prior xDB Replication Server versions are also described in order to differentiate the installation of these different versions.

--- a/product_docs/docs/eprs/6.2/07_common_operations/10_replicating_postgres_partitioned_tables.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/10_replicating_postgres_partitioned_tables.mdx
@@ -12,9 +12,7 @@ The following are the various partitioning techniques:
 -   Postgres declarative partitioning (applies to both PostgreSQL and Advanced Server version 10 and later)
 -   Postgres table inheritance (applies to both PostgreSQL and Advanced Server)
 
-If you are using Advanced Server, partitioned tables can be created using the `CREATE TABLE` statement with partitioning syntax compatible with Oracle databases. For information on partitioning compatible with Oracle databases, see Chapter 10 *Table Partitioning* in the *EDB Postgres Advanced Server 10.0 Database Compatibility for Oracle Developers Guide* available from the EnterpriseDB website located at:
-
-> <https://www.enterprisedb.com/resources/product-documentation>
+If you are using Advanced Server, partitioned tables can be created using the `CREATE TABLE` statement with partitioning syntax compatible with Oracle databases. For information on partitioning compatible with Oracle databases, see [Database Compatibility: Table Partitioning](https://www.enterprisedb.com/docs/epas/latest/epas_compat_table_partitioning/) in the EDB Postgres Advanced Server documentation.
 
 If you are using version 10 or later of PostgreSQL or Advanced Server, declarative partitioning can be used to create partitioned tables. The `CREATE TABLE` syntax for creating a declarative partitioned table is similar to the partitioning compatible with Oracle databases, but the individual partitions of the declarative partitioned table must be separately created with their own CREATE TABLE statements.
 

--- a/product_docs/docs/eprs/6.2/07_common_operations/10_replicating_postgres_partitioned_tables.mdx
+++ b/product_docs/docs/eprs/6.2/07_common_operations/10_replicating_postgres_partitioned_tables.mdx
@@ -12,7 +12,7 @@ The following are the various partitioning techniques:
 -   Postgres declarative partitioning (applies to both PostgreSQL and Advanced Server version 10 and later)
 -   Postgres table inheritance (applies to both PostgreSQL and Advanced Server)
 
-If you are using Advanced Server, partitioned tables can be created using the `CREATE TABLE` statement with partitioning syntax compatible with Oracle databases. For information on partitioning compatible with Oracle databases, see [Database Compatibility: Table Partitioning](https://www.enterprisedb.com/docs/epas/latest/epas_compat_table_partitioning/) in the EDB Postgres Advanced Server documentation.
+If you are using Advanced Server, partitioned tables can be created using the `CREATE TABLE` statement with partitioning syntax compatible with Oracle databases. For information on partitioning compatible with Oracle databases, see [Database Compatibility: Table Partitioning](/epas/latest/epas_compat_table_partitioning/) in the EDB Postgres Advanced Server documentation.
 
 If you are using version 10 or later of PostgreSQL or Advanced Server, declarative partitioning can be used to create partitioned tables. The `CREATE TABLE` syntax for creating a declarative partitioned table is similar to the partitioning compatible with Oracle databases, but the individual partitions of the declarative partitioned table must be separately created with their own CREATE TABLE statements.
 

--- a/product_docs/docs/eprs/6.2/10_appendix/01_permitted_conf_and_permutations.mdx
+++ b/product_docs/docs/eprs/6.2/10_appendix/01_permitted_conf_and_permutations.mdx
@@ -26,7 +26,7 @@ Advanced Server supports two compatibility configuration modes of operation, whi
 -   Oracle compatible configuration mode. Operations are performed using Oracle syntax and semantics for data types, functions, database object creation, and so forth. This mode is useful when your applications are migrated from Oracle, or you want your applications built in an Oracle compatible fashion.
 -   PostgreSQL compatible configuration mode. Operations are performed using native PostgreSQL syntax and semantics. This mode is useful when your applications are migrated from PostgreSQL, or you want your applications built in a PostgreSQL compatible fashion.
 
-For more information on features supported in Oracle compatible configuration mode, see [Database Compatibility for Oracle Developers](https://www.enterprisedb.com/docs/epas/latest/epas_compat_ora_dev_guide/) in the EDB Postgres Advanced Server documentation.
+For more information on features supported in Oracle compatible configuration mode, see [Database Compatibility for Oracle Developers](/epas/latest/epas_compat_ora_dev_guide/) in the EDB Postgres Advanced Server documentation.
 
 The compatibility configuration mode is selected at the time you install Advanced Server.
 

--- a/product_docs/docs/eprs/6.2/10_appendix/01_permitted_conf_and_permutations.mdx
+++ b/product_docs/docs/eprs/6.2/10_appendix/01_permitted_conf_and_permutations.mdx
@@ -26,9 +26,7 @@ Advanced Server supports two compatibility configuration modes of operation, whi
 -   Oracle compatible configuration mode. Operations are performed using Oracle syntax and semantics for data types, functions, database object creation, and so forth. This mode is useful when your applications are migrated from Oracle, or you want your applications built in an Oracle compatible fashion.
 -   PostgreSQL compatible configuration mode. Operations are performed using native PostgreSQL syntax and semantics. This mode is useful when your applications are migrated from PostgreSQL, or you want your applications built in a PostgreSQL compatible fashion.
 
-For more information on features supported in Oracle compatible configuration mode, see the *Database Compatibility for Oracle Developer’s Guide* located at:
-
-> <https://www.enterprisedb.com/resources/product-documentation>
+For more information on features supported in Oracle compatible configuration mode, see [Database Compatibility for Oracle Developers](https://www.enterprisedb.com/docs/epas/latest/epas_compat_ora_dev_guide/) in the EDB Postgres Advanced Server documentation.
 
 The compatibility configuration mode is selected at the time you install Advanced Server.
 

--- a/product_docs/docs/eprs/6.2/10_appendix/02_upgrading_to_xdb6_2/index.mdx
+++ b/product_docs/docs/eprs/6.2/10_appendix/02_upgrading_to_xdb6_2/index.mdx
@@ -10,12 +10,6 @@ It is assumed that you will be installing xDB Replication Server 6.2 on the same
 
 A direct upgrade is supported only from xDB Replication Server versions 6.1.x or 6.0.x.
 
-If you have xDB Replication Server 5.1.x, you must first upgrade this version to xDB Replication Server 6.0. See Section 10.2 *Upgrading to xDB Replication Server 6.0* in the EDB Replication Server 6.0 User’s Guide located at:
-
-> <https://www.enterprisedb.com/resources/product-documentation>
-
-After upgrading to version 6.0, you can then upgrade to 6.2.
-
 The following sections illustrate the upgrade process from xDB Replication Server 6.1. The same steps apply for upgrading from xDB Replication Server 6.0, but with different version numbers in the file and directory names of the older product.
 
 <div class="toctree" maxdepth="3">


### PR DESCRIPTION
## What Changed?

This path ([/resources/product-documentation](https://www.enterprisedb.com/resources/product-documentation)) hasn't been useful in ages and should probably be dropped at some point; if nothing else, it indicates docs that haven't been updated in a very long time.

Was reminded of its existence (and remaining references in the xDB docs) due to work currently ongoing to migrate redirects on the main website. Taking this opportunity to expunge them from docs, though references to this path may yet exist elsewhere.

Of particular note in this set of changes: there was a note in the upgrade index discussing upgrades from 5.x to 6.0, which referenced a topic that... Hasn't been accessible on the web for a good while. Removed that entire section, as I cannot think of a good alternative.