### PR TITLE
Make language inclusive of EHA

### DIFF
--- a/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
+++ b/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
@@ -6,13 +6,15 @@ The costs include database pricing for BigAnimal and the associated costs from o
 
 ## Database pricing 
 
-Pricing is based on the number of virtual central processing units (vCPUs) provisioned for the database software offering. Consumption of vCPUs is metered hourly. A deployment is made up of either one instance or one primary and two standby replica instances of either PostgreSQL or EDB Postgres Advanced Server. When high availability is enabled, multiply the number of vCPUs per instance by three to calculate the full price for all resources used. The table shows the cost breakdown:
+Pricing is based on the number of virtual central processing units (vCPUs) provisioned for the database software offering. Consumption of vCPUs is metered hourly. A deployment is typically made up of either one instance or one primary and two standby replica instances of either PostgreSQL or EDB Postgres Advanced Server. When high availability configurations are enabled, multiply the number of vCPUs per instance by the number of replicas configured to calculate the full price for all resources used. This table shows the cost breakdown:
 
 | Database type                | Hourly price   | Monthly price\* | Subscription plan |
 | ---------------------------- | -------------- | --------------- | ----------------- |
 | PostgreSQL                   | $0.0856 / vCPU | $62.49 / vCPU  | Community 360 |
 | PostgreSQL                   | $0.1655 / vCPU | $120.82 / vCPU  | Standard |
 | EDB Postgres Advanced Server | $0.2397 / vCPU | $174.98 / vCPU  | Enterprise  |
+
+Extreme High Availability powered by EDB Postgres Distributed is now available in beta! Contact Sales for additional information regarding pricing.
 
 \* The monthly cost is approximate and assumes 730 hours in a month. 
   

--- a/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
+++ b/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
@@ -14,7 +14,7 @@ Pricing is based on the number of virtual central processing units (vCPUs) provi
 | PostgreSQL                   | $0.1655 / vCPU | $120.82 / vCPU  | Standard |
 | EDB Postgres Advanced Server | $0.2397 / vCPU | $174.98 / vCPU  | Enterprise  |
 
-Extreme High Availability powered by EDB Postgres Distributed is now available in beta! Contact Sales for additional information regarding pricing.
+Extreme high availability powered by EDB Postgres Distributed is now available in beta! Contact Sales for additional information regarding pricing.
 
 \* The monthly cost is approximate and assumes 730 hours in a month. 
   


### PR DESCRIPTION
A note: The "Contact Sales for additional information regarding pricing." line may not be necessary if pricing is literally as simple as: "multiply the number of vCPUs per instance by the number of replicas configured".

## What Changed?

Pricing should accommodate both High Availability and Extreme High Availability use cases. 