### PR TITLE
Include complete example of biganimal CLI installation

### DIFF
--- a/product_docs/docs/biganimal/release/free_trial/detail/create_a_cluster/create_cluster_cli.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/detail/create_a_cluster/create_cluster_cli.mdx
@@ -10,7 +10,16 @@ We'll be using the [BigAnimal command line interface](/biganimal/latest/referenc
 !!! Note Linux and MacOS note
     If you're on a Linux or MacOS system, you'll need to mark the `biganimal` file as executable by
     running `chmod +x [/path/to/biganimal]` before you can use it.  
+    
+Example (for Linux or MacOS):
 
+```shell
+curl -LO "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal"
+mkdir -p $HOME/bin
+export PATH=$HOME/bin:$PATH
+mv ./biganimal $HOME/bin/biganimal
+chmod +x $HOME/bin/biganimal
+```
 
 Next, you need to create a credential on BigAnimal. You can pick any username you prefer.
 


### PR DESCRIPTION
## What Changed?

Probably fine that the reference CLI doc handwaves putting the executable on your path, but the goal with the free trial docs is to do a bit more handholding / require a bit less thinking on the part of the trial user. @VinnieGrack suggested including an example that would walk through putting the biganimal executable on the path,.

Resolves #3055
