### PR TITLE
Minor consistency for calls to the biganimal CLI in free trial docs

### DIFF
--- a/product_docs/docs/biganimal/release/free_trial/detail/create_a_cluster/create_cluster_cli.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/detail/create_a_cluster/create_cluster_cli.mdx
@@ -90,7 +90,7 @@ highAvailability: false
 Use the config file to create a new cluster:
 
 ```shell
-biganimal create-cluster --clusterConfigFile create_cluster.yaml
+biganimal create-cluster --cluster-config-file create_cluster.yaml
 __OUTPUT__
 Are you sure you want to create cluster "test_cluster"? [y|n]: y
 Create Cluster operation is started

--- a/product_docs/docs/biganimal/release/free_trial/detail/experiment/backup_and_restore.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/detail/experiment/backup_and_restore.mdx
@@ -102,7 +102,7 @@ For the free trial, you're limited to one active cluster. Restoring a cluster cr
     For more on using the BigAnimal CLI, refer to [Creating a cluster on the command line](../create_a_cluster/create_cluster_cli) and the [BigAnimal CLI reference](/biganimal/latest/reference/cli/).
 
 ```shell
-./biganimal delete-cluster --id p-xxxxxxxxxxx
+biganimal delete-cluster --id p-xxxxxxxxxxx
 ```
 
 Restore the cluster using the timestamp before the time you dropped the table.
@@ -137,7 +137,7 @@ To check current state, run: biganimal show-clusters --id p-yyyyyyyyyy
 Check the status of the new cluster from the command line.
 
 ```shell
-./biganimal show-clusters
+biganimal show-clusters
 ```
 
 Once provisioning is complete, you'll want to grab the new connection information. The hostname will have changed!


### PR DESCRIPTION
## What Changed?

Use unprefixed calls (assumes `biganimal` is on the path) everywhere for consistency. Also avoid old, camelCase flags.

Fixes #3054
