### PR TITLE
BigAnimal: API v3 updates

### DIFF
--- a/product_docs/docs/biganimal/release/reference/api.mdx
+++ b/product_docs/docs/biganimal/release/reference/api.mdx
@@ -3,7 +3,7 @@ title: Using the BigAnimal API
 ---
 
 !!!important "Deprecation notice"
-EDB released v2 of BigAnimal API in June 2022. v1 of BigAnimal API goes out of support on Dec 31, 2022. To see the changes in v2, see the [Change log](https://portal.biganimal.com/api/docs/v2migration.html). Update your applications accordingly.
+EDB released v3 of BigAnimal API in January 2023. v2 of BigAnimal API goes out of support on Dec 31, 2022. To see the changes in v3, see the [Change log](https://portal.biganimal.com/api/docs/v3migration.html). Update your applications accordingly.
 !!!
 
 Use the BigAnimal API to integrate directly with BigAnimal for management activities such as cluster provisioning, de-provisioning, and scaling.
@@ -28,7 +28,7 @@ This call returns the information that either:
 -   The `get-token` script uses to generate the tokens for you.
 
 ```shell
-curl https://portal.biganimal.com/api/v2/auth/provider
+curl https://portal.biganimal.com/api/v3/auth/provider
 ```
 
 The response returns the `clientId`, `freetrialClientId`, `issuerUri`, `scope`, and `audience`. For example:
@@ -143,7 +143,7 @@ For example:
 {
   "access_token": "eyJhbGc.......1Qtkaw2fyho",
   "id_token": "eyJhbGci.......FBra7tA",
-  "refresh_token": "v2.MTvuZpu.......sbiionEhtTw",
+  "refresh_token": "v3.MTvuZpu.......sbiionEhtTw",
   "scope": "openid profile email offline_access",
   "expires_in": 86400,
   "token_type": "Bearer"
@@ -154,7 +154,7 @@ Store the access token and refresh token in environment variables for future use
 
 ```ini
 RAW_ACCESS_TOKEN="eyJhbGc.......1Qtkaw2fyho"
-REFRESH_TOKEN="v2.MTvuZpu.......sbiionEhtTw"
+REFRESH_TOKEN="v3.MTvuZpu.......sbiionEhtTw"
 ```
 
 !!!note
@@ -181,7 +181,7 @@ Use the raw token you obtained in the previous step [Request the raw token using
 
 ```shell
 curl -s --request POST \
-     --url "https://portal.biganimal.com/api/v2/auth/token" \
+     --url "https://portal.biganimal.com/api/v3/auth/token" \
      --header "content-type: application/json" \
      --data "{\"token\":\"$RAW_ACCESS_TOKEN\"}"
 ```
@@ -215,7 +215,7 @@ To call the BigAnimal API, your application must pass the retrieved access token
 
 ```shell
 curl --request GET \
-  --url "$AUDIENCE/v2/pg-types" \
+  --url "$AUDIENCE/v3/pg-types" \
   --header "authorization: Bearer $ACCESS_TOKEN"  \
   --header "content-type: application/json"
 ```
@@ -274,7 +274,7 @@ The response of this API call includes the `access_token`. For example:
   "expires_in": 86400,
   "scope": "openid offline_access",
   "id_token": "eyJ...0NE",
-  "refresh_token": "v2.Mjv..._2pRs",
+  "refresh_token": "v3.Mjv..._2pRs",
   "token_type": "Bearer"
 }
 ```
@@ -283,7 +283,7 @@ Store the access token and refresh token in environment variables for future use
 
 ```ini
 RAW_ACCESS_TOKEN="eyJhbGc.......1Qtkaw2fyho"
-REFRESH_TOKEN="v2.MTvuZpu.......sbiionEhtTw"
+REFRESH_TOKEN="v3.MTvuZpu.......sbiionEhtTw"
 ```
 
 The token you obtain from this step is the raw-access token. You need to exchange this token for a BigAnimal token. See [Exchange for BigAnimal token](#exchange-the-biganimal-token-using-curl) for more information.
@@ -345,7 +345,7 @@ xxxxxxxxxx
 To use the `get-token` script to refresh your token, use the script with the `--refresh  <refresh_token>` option. For example:
 
 ```shell
-./get-token.sh -o json --refresh v2.MVZ9_xxxxxxxx_FRs
+./get-token.sh -o json --refresh v3.MVZ9_xxxxxxxx_FRs
 __OUTPUT__
 {
   "access_token": "xxxxxxxxxx",

--- a/product_docs/docs/biganimal/release/reference/api.mdx
+++ b/product_docs/docs/biganimal/release/reference/api.mdx
@@ -215,7 +215,7 @@ To call the BigAnimal API, your application must pass the retrieved access token
 
 ```shell
 curl --request GET \
-  --url "$AUDIENCE/v3/pg-types" \
+  --url "$AUDIENCE/v3/projects" \
   --header "authorization: Bearer $ACCESS_TOKEN"  \
   --header "content-type: application/json"
 ```
@@ -224,18 +224,18 @@ Example response:
 
 ```json
 {
-  "pgTypesList": [
+    "projectId": "prj_abcd1234",
+    "projectName": "Test project",
+    "clusterCount": 4,
+    "userCount": 10,
+    "cloudProviders": [
     {
-      "id": "epas",
-      "name": "Oracle Compatible",
-      "description": "",
-      "dockerImage": ""
+       "cloudProviderId": "aws",
+       "cloudProviderName": "AWS"
     },
     {
-      "id": "postgres",
-      "name": "PostgreSQL",
-      "description": "",
-      "dockerImage": ""
+       "cloudProviderId": "azure",
+       "cloudProviderName": "Azure"
     }
   ]
 }

--- a/product_docs/docs/biganimal/release/reference/api.mdx
+++ b/product_docs/docs/biganimal/release/reference/api.mdx
@@ -3,7 +3,7 @@ title: Using the BigAnimal API
 ---
 
 !!!important "Deprecation notice"
-EDB released v3 of BigAnimal API in January 2023. v2 of BigAnimal API goes out of support on Dec 31, 2022. To see the changes in v3, see the [Change log](https://portal.biganimal.com/api/docs/v3migration.html). Update your applications accordingly.
+EDB released v3 of BigAnimal API in January 2023. v2 of BigAnimal API goes out of support on June 30, 2023. To see the changes in v3, see the [Change log](https://portal.biganimal.com/api/docs/v3migration.html). Update your applications accordingly.
 !!!
 
 Use the BigAnimal API to integrate directly with BigAnimal for management activities such as cluster provisioning, de-provisioning, and scaling.


### PR DESCRIPTION
## What Changed?

Updated deprecation note including the link to the change log (this needs to be verified)
Changed v2 to v3 in paths
Changed the example in the Call the API section

[UPM-13711]: https://enterprisedb.atlassian.net/browse/UPM-13711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ