### PR TITLE
PG: Mac uninstall

### DIFF
--- a/advocacy_docs/supported-open-source/postgresql/installer/05_uninstalling_postgresql.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/05_uninstalling_postgresql.mdx
@@ -51,7 +51,11 @@ Fig. 5: An Info dialog confirms the uninstallation
 ## Uninstalling PostgreSQL on Mac
 
 !!! note
-    These instructions apply if you used EDB's interactive Mac installer to install PostgreSQL. If you used another installer, refer to this [topic](https://support.apple.com/guide/mac-help/install-and-uninstall-other-apps-mh35835/mac) in the macOS documentation for instructions on uninstalling an app. 
+    These instructions apply if you used EDB's interactive Mac installer to install PostgreSQL. 
+    
+    - If you used another installer, refer to this [topic](https://support.apple.com/guide/mac-help/install-and-uninstall-other-apps-mh35835/mac) in the macOS documentation for instructions on uninstalling an app. 
+    - If you used [Homebrew](https://brew.sh/), use the `brew uninstall` command to uninstall PostgreSQL and any related packages (use `brew list` to see what you have installed).
+    
 
 To uninstall PostgreSQL on a Mac system, assume the identity of an operating system superuser, and navigate into the folder in which the uninstaller resides:
 

--- a/advocacy_docs/supported-open-source/postgresql/installer/05_uninstalling_postgresql.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installer/05_uninstalling_postgresql.mdx
@@ -50,9 +50,14 @@ Fig. 5: An Info dialog confirms the uninstallation
 
 ## Uninstalling PostgreSQL on Mac
 
+!!! note
+    These instructions apply if you used EDB's interactive Mac installer to install PostgreSQL. If you used another installer, refer to this [topic](https://support.apple.com/guide/mac-help/install-and-uninstall-other-apps-mh35835/mac) in the macOS documentation for instructions on uninstalling an app. 
+
 To uninstall PostgreSQL on a Mac system, assume the identity of an operating system superuser, and navigate into the folder in which the uninstaller resides:
 
-`/Library/PostgreSQL/13`
+`/Library/PostgreSQL/<version>`
+
+Where `version` is the version of PostgreSQL you installed.
 
 Then, invoke the uninstaller with the command:
 


### PR DESCRIPTION
## What Changed?

Added note about using a standard Mac uninstall process for users that didn't use our installer to install PG.

Fixes https://github.com/EnterpriseDB/docs/issues/2484