### PR TITLE
BigAnimal: making CLI commands consistent

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
@@ -20,13 +20,13 @@ Perform the following steps:
 1.  Create a BigAnimal CLI credential:
 
    ```shell
-   ./biganimal create-credential --name <cred> --address portal.biganimal.com --port 443
+   biganimal create-credential --name <cred> --address portal.biganimal.com --port 443
    ```
 
 1. Run the `setup-csp` command to set up your cloud provider:
 
    ```shell
-   ./biganimal setup-csp 
+   biganimal setup-csp 
    ```
    The command checks for cloud account readiness and displays the results. 
 
@@ -38,6 +38,6 @@ Perform the following steps:
 
 1. If the cloud readiness checks pass, your cloud account is successfully set up. Connect your cloud account to BigAnimal with following command.
    ```shell
-   ./biganimal connect-csp --provider aws --project <project-name>
+   biganimal connect-csp --provider aws --project <project-name>
    ```
  Once your cloud account is successfully connected to BigAnimal, you, and other users with the correct permissions, can create clusters.

--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
@@ -13,6 +13,9 @@ Before connecting your cloud, ensure that you are assigned the following AWS man
 
 ## To connect your cloud
 
+!!! tip
+    If you are using Cloud Shell, add the ./ prefix to the biganimal command (`./biganimal`).
+    
 Perform the following steps:
 
 1. Open the [AWS Cloud Shell](https://console.aws.amazon.com/cloudshell) in your browser.

--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_azure.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_azure.mdx
@@ -10,6 +10,10 @@ navTitle: Azure
 Before connecting to your cloud, ensure that you are assigned either the Global Administrator role or the Privileged Role Administrator role in Azure AD.
 
 ## To connect your cloud
+
+!!! tip
+    If you are using Cloud Shell, add the ./ prefix to the biganimal command (`./biganimal`).
+    
 Perform the following steps:
 
 1. Open the [Azure Cloud Shell](https://shell.azure.com/) in your browser.

--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_azure.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_azure.mdx
@@ -17,13 +17,13 @@ Perform the following steps:
 1.  Create a BigAnimal CLI credential:
 
    ```shell
-   ./biganimal create-credential --name <cred> --address portal.biganimal.com --port 443
+   biganimal create-credential --name <cred> --address portal.biganimal.com --port 443
    ```
 
 1. Run the `setup-csp` command to set up your cloud provider:
 
     ```shell
-    ./biganimal setup-csp 
+    biganimal setup-csp 
     ```
   The command checks for cloud account readiness and displays the results. 
 
@@ -35,6 +35,6 @@ Perform the following steps:
 
 1. If the cloud readiness checks pass, your cloud account is successfully set up. Connect your cloud account to BigAnimal with following command.
    ```shell
-   ./biganimal connect-csp --provider azure --project <project-name>
+   biganimal connect-csp --provider azure --project <project-name>
    ```
  Once your cloud account is successfully connected to BigAnimal, you, and other users with the correct permissions, can create clusters.

--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/index.mdx
@@ -46,13 +46,13 @@ Perform the following steps:
 1.  Create a BigAnimal CLI credential:
 
    ```shell
-   ./biganimal create-credential --name <cred> --address portal.biganimal.com --port 443
+   biganimal create-credential --name <cred> --address portal.biganimal.com --port 443
    ```
 
 1. Run the `setup-csp` command to set up your cloud provider:
 
     ```shell
-    ./biganimal setup-csp 
+    biganimal setup-csp 
     ```
  !!! Important
      Do not delete the `ba-passport.json` file created in your working directory. It contains important identity and access management information used by `connect-csp` while connecting to your cloud.
@@ -65,7 +65,7 @@ Perform the following steps:
 
 1. If the cloud readiness checks pass, your cloud account is successfully set up. Connect your cloud account to BigAnimal with following command.
    ```shell
-   ./biganimal connect-csp --provider  <cloud-service-provider> --project <project-name>
+   biganimal connect-csp --provider  <cloud-service-provider> --project <project-name>
    ```
  Once your cloud account is successfully connected to BigAnimal, you, and other users with the correct permissions, can create clusters.
 

--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/index.mdx
@@ -41,6 +41,9 @@ For additional cloud provider-specific requirements, see [Setting up specific cl
 
 Perform the following steps:
 
+!!! tip
+    If you are using Cloud Shell, add the ./ prefix to the biganimal command (`./biganimal`).
+    
 1. Open your cloud provider shell in your browser.
 
 1.  Create a BigAnimal CLI credential:

--- a/product_docs/docs/biganimal/release/reference/cli.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli.mdx
@@ -8,44 +8,46 @@ Use the command line interface (CLI) for BigAnimal management activities such as
 
 The CLI is available for Linux, MacOS, and Windows operating systems.
 
-### Download the binary executable
+To install the CLI:
 
--   For Linux operating systems, use the following command to get the latest version of the binary executable:
-    ```shell
-    curl -LO "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal"
-    ```
+1. Download the binary executable
 
--   For all operating systems, download the executable binary [here](https://cli.biganimal.com/). After downloading, move the binary executable under a directory on your executable search path.
+   -   For Linux operating systems, use the following command to get the latest version of the binary executable:
+       ```shell
+       curl -LO "https://cli.biganimal.com/download/$(uname -s)/$(uname -m)/latest/biganimal"
+       ```
 
-### (Optional) Validate the download
+   -   For all operating systems, download the executable binary [here](https://cli.biganimal.com/). 
 
--   For Linux users:
-    1. Copy the SHA256 checksum code for Linux distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_linux_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
-    2. From your local shell, validate the binary executable file against the checksum file:
-        ```shell
-        echo "$(<biganimal_linux_amd64.sha256) biganimal" | sha256sum --check
-        ```
+1. Move the binary executable under a directory on your executable search path.
 
--   For Windows users:
-    1. Download the SHA256 checksum code for Windows distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_windows_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
-    2.  Validate the binary executable file against the checksum file using `CertUtil`:
-        ```shell
-        CertUtil -hashfile biganimal.exe SHA256 type biganiml_windows_amd64.sha256
-        ```
-- For MacOS users:
-    1. Download the SHA256 checksum code for MacOS distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_darwin_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
-    2. From MacOS terminal, validate the binary executable file against the checksum file:
-        ```shell
-        echo "$(<biganimal_darwin_amd64.sha256)  biganimal" | shasum -a256 -c
-        ```
+1. (Optional) Validate the download:
 
-### Make the CLI command executable within Cloud Shell
+    -   For Linux users:
+        1. Copy the SHA256 checksum code for Linux distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_linux_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
+        2. From your local shell, validate the binary executable file against the checksum file:
+           ```shell
+              echo "$(<biganimal_linux_amd64.sha256) biganimal" | sha256sum --check
+           ```
 
-Change the permissions of the CLI to make it executable within Cloud Shell:
+     -   For Windows users:
+         1. Download the SHA256 checksum code for Windows distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_windows_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
+         2.  Validate the binary executable file against the checksum file using `CertUtil`:
+             ```shell
+                CertUtil -hashfile biganimal.exe SHA256 type biganiml_windows_amd64.sha256
+             ```
+      - For MacOS users:
+        1. Download the SHA256 checksum code for MacOS distribution from the [BigAnimal CLI](https://cli.biganimal.com) page and store it as a local file such as `biganimal_darwin_amd64.sha256`. Alternatively, click on the SHA256 code to download it as a file directly and verify the content of the downloaded file is identical to the checksum code showed on the page.
+        2. From MacOS terminal, validate the binary executable file against the checksum file:
+           ```shell
+           echo "$(<biganimal_darwin_amd64.sha256)  biganimal" | shasum -a256 -c
+           ```
 
-```shell
-chmod +x biganimal
-```
+1. Make the CLI command executable:
+
+   ```shell
+      chmod +x biganimal
+   ```
 
 
 ## Authenticate as a valid user


### PR DESCRIPTION
## What Changed?

- Reformatted the install instructions into a procedure to emphasize step for moving the executable into your executable search path.
- Since the install instructions now make this more obvious, removed the (./) command prefix in the Connecting your cloud topics. This makes the command usage consistent between the CLI topic and those topics and the topics in the Free Trial section.
