### PR TITLE
Replication Server: removing mentions of v6.1 and 6.0 

### DIFF
--- a/product_docs/docs/eprs/6.2/03_installation/01_installing_with_stackbuilder.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/01_installing_with_stackbuilder.mdx
@@ -43,7 +43,7 @@ Follow the directions for your host operating system to install Java runtime.
 **Step 5 (For Advanced Server):** Expand the EnterpriseDB Tools node and check the box for Replication Server. Click the Next button.
 
 !!! Note
-    Though the following ../images show Replication Server v6.0, use the same process for Replication Server v6.2.
+    Though the following images show Replication Server v6.0, use the same process for Replication Server v6.2.
 
 ![StackBuilder Plus applications](../images/image29.png)
 

--- a/product_docs/docs/eprs/6.2/03_installation/02_installing_from_cli.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/02_installing_from_cli.mdx
@@ -28,7 +28,7 @@ Follow the directions for your host operating system to install Java runtime.
 The following example shows how to start the xDB Replication Server installation in text mode.
 
 ```text
-$ ./xdbreplicationserver-6.1.0-alpha-1-linux-x64.run --mode text
+$ ./xdbreplicationserver-6.2.0-alpha-1-linux-x64.run --mode text
 Language Selection
 
 Please select the installation language
@@ -47,7 +47,7 @@ The following example shows how to start the installation in unattended mode wit
 ```text
 $ su root
 Password:
-$ ./xdbreplicationserver-6.1.0-alpha-1-linux-x64.run --optionfile /home/user/xdb_config
+$ ./xdbreplicationserver-6.2.0-alpha-1-linux-x64.run --optionfile /home/user/xdb_config
 ```
 
 The following is the content of the options file, `xdb_config`.

--- a/product_docs/docs/eprs/6.2/03_installation/03_installing_rpm_package.mdx
+++ b/product_docs/docs/eprs/6.2/03_installation/03_installing_rpm_package.mdx
@@ -116,7 +116,7 @@ For example, to access xDB Replication Server version 6.2, enable the following 
 
 ```text
 [enterprisedb-xdb60]
-name=EnterpriseDB XDB 6.0 $releasever - $basearch
+name=EnterpriseDB XDB 6.2 $releasever - $basearch
 baseurl=http://<username>:<password>@yum.enterprisedb.com/xdb60/redhat/rhel-$releasever-$basearch
 enabled=0
 gpgcheck=1

--- a/product_docs/docs/eprs/6.2/08_xdb_cli/03_xdb_cli_commands/02_print_version.mdx
+++ b/product_docs/docs/eprs/6.2/08_xdb_cli/03_xdb_cli_commands/02_print_version.mdx
@@ -14,7 +14,7 @@ Examples
 
 ```text
 $ java -jar edb-repcli.jar -version
-Version: 6.1.0-alpha
+Version: 6.2.0-alpha
 
                       .
 ```

--- a/product_docs/docs/eprs/6.2/08_xdb_cli/03_xdb_cli_commands/03_print_xdb_server_version.mdx
+++ b/product_docs/docs/eprs/6.2/08_xdb_cli/03_xdb_cli_commands/03_print_xdb_server_version.mdx
@@ -20,7 +20,7 @@ Examples
 
 ```text
 $ java -jar edb-repcli.jar -repversion -repsvrfile ~/pubsvrfile.prop
-6.1.0-alpha
+6.2.0-alpha
 
                       .
 ```


### PR DESCRIPTION
## What Changed?

Removed mentions of v6.1 and 6.0 from documentation. Left upgrading content about updating from these versions.
