### PR TITLE
Fix typo in `allow_incremental_backups`

### DIFF
--- a/product_docs/docs/bart/2.6/bart_inst/03_configuring_bart.mdx
+++ b/product_docs/docs/bart/2.6/bart_inst/03_configuring_bart.mdx
@@ -62,7 +62,7 @@ For information about configuring BART host parameters, see the [BART Host Param
 | `<cluster_owner>`          | Mandatory | `enterprisedb` for EPAS<br /><br />`postgres` for PostgreSQL | Yes           | N/A         |
 | `<remote_host>`            | Optional  | N/A                                                          | Yes           | N/A         |
 | `<tablespace_path>`        | Optional  | N/A                                                          | Yes           | N/A         |
-| `allow_incremental_backup` | Optional  | `Disabled`                                                   | Yes           | N/A         |
+| `allow_incremental_backups`| Optional  | `Disabled`                                                   | Yes           | N/A         |
 | `description`              | Optional  | N/A                                                          | Yes           | N/A         |
 
 <div id="configuring_the_bart_host" class="registered_link"></div>


### PR DESCRIPTION
The configuration name is plural (...backupS), but this one occurrence in the docs was written as singular, by accident.

I didn't adjust the table to have an extra space in that column, or it would make the diff difficult to read. But let me know if that's desirable.

## What Changed?

`allow_incremental_backup` (singular) -> `allow_incremental_backups`  (plural)
