### PR TITLE
Update Password statement for replica creation & Modification

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
@@ -14,11 +14,7 @@ You can create faraway replicas in different active regions in your cloud. There
 
 1. On the Cluster Settings tab, enter a name for your replica in the **Cluster Name** field.
 
-1. The password for the edb_admin user will be same as Primary and is not required to be entered as part of replica creation
-
-1. Skip the **Database Type** section. The database information is inherited from the source cluster and you can't edit it.
-
-1. In the **Region** section, select an active region where you want to deploy your replica.
+1. Skip to the **Region** section and select an active region where you want to deploy your replica. (The password and database type values are inherited from the source cluster.)
  
 1.  Select the instance type in the **Instance Type** section. See [Creating a cluster](/biganimal/latest/getting_started/creating_a_cluster/#cluster-settings-tab) for details on instance type settings.
 

--- a/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
@@ -14,7 +14,7 @@ You can create faraway replicas in different active regions in your cloud. There
 
 1. On the Cluster Settings tab, enter a name for your replica in the **Cluster Name** field.
 
-1. Enter a password for your replica in the **Password** field. 
+1. The password for the edb_admin user will be same as Primary and is not required to be entered as part of replica creation
 
 1. Skip the **Database Type** section. The database information is inherited from the source cluster and you can't edit it.
 


### PR DESCRIPTION
As per new workflow, the password is not required to be entered during the Faraway Replica creation, I modified the statement however please get it reviewed for sanity check and change the verbiage so it is more appropriate. Same thing applies to Modify replica section, that should not let users modify the password. password change should be done on the primary.

## What Changed?

