### PR TITLE
Updating "cluster" to "region"

### DIFF
--- a/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
+++ b/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
@@ -45,7 +45,7 @@ The table shows a breakdown of management costs for Microsoft Azure.
 | Azure blob storage             | BigAnimal uses blob storage to store metadata about your account.                                                                                     |
 | Key vault                      | BigAnimal uses key vault to securely store credentials for managing your infrastructure.                                                              |
 
-At list price, estimated overall monthly management costs are $400&ndash;$700 for a single cluster. Check with your Microsoft Azure account manager for specifics that apply to your account. 
+At list price, estimated overall monthly management costs are $400&ndash;$700 for a single region. Check with your Microsoft Azure account manager for specifics that apply to your account. 
 
 To get a better sense of your Microsoft Azure costs, check out the Microsoft Azure pricing [calculator](https://azure.microsoft.com/en-us/pricing/calculator/) and reach out to [BigAnimal Support](../overview/support). 
 
@@ -60,7 +60,7 @@ The table shows a breakdown of management costs for AWS.
 | Simple Storage Service (S3)             | BigAnimal uses S3 to store metadata about your account.                                                                                     |
 | Key Management Service                      | BigAnimal uses the key management service to securely store credentials for managing your infrastructure.                                                              |
 
-At list price, estimated overall monthly management costs are $400&ndash;$600 for a single cluster. Check with your AWS account manager for specifics that apply to your account.
+At list price, estimated overall monthly management costs are $400&ndash;$600 for a single region. Check with your AWS account manager for specifics that apply to your account.
 
 To get a better sense of your AWS costs, check out the AWS pricing [calculator](https://calculator.aws/#/) and reach out to [BigAnimal Support](../overview/support).  
 


### PR DESCRIPTION
As per discussion with Ben Anderson, management costs are _per region_ and not _per cluster_. Editing for accuracy.

## What Changed?

"cluster" -> "region"