### PR TITLE
Update replication.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/overview/replication.mdx
+++ b/product_docs/docs/biganimal/release/overview/replication.mdx
@@ -2,21 +2,22 @@
 title: "Faraway replicas"
 ---
 
-Faraway replicas are read-only replicas of EDB BigAnimal clusters that you can provision in any supported region. You can create faraway (read) replicas of your single node and high availability clusters in different regions of your cloud. Database users/applications can read from a nearby faraway replica instead of the source cluster. This relieves some of the workload on the source cluster and frees it up to handle write traffic. In case of a failure, you can manually promote the faraway replica to a full-fledged BigAnimal cluster, making it capable of accepting writes. See [Managing replicas](/biganimal/release/using_cluster/managing_replicas).
+Faraway replicas are read-only replicas of BigAnimal clusters that you can provision in any supported region. You can create faraway (read) replicas of your single node and high availability clusters in different regions of your cloud. Database users and applications can read from a nearby faraway replica instead of the source cluster. This relieves some of the workload on the source cluster and frees it up to handle write traffic. In case of a failure, you can manually promote the faraway replica to a full-fledged BigAnimal cluster, making it capable of accepting writes. See [Managing replicas](/biganimal/release/using_cluster/managing_replicas).
 
-In BigAnimal, faraway replicas use log shipping to replicate from their source clusters. This means that a replica cluster will access the Write-Ahead Log (WAL) of its source cluster and “replay” the changes described in the WAL. A WAL is a file logging any changes made to a database. Databases write the change to the WAL before actually making the change. This way, if the database goes down before the change can be applied, the WAL will have a record of the changes that were supposed to be made. The replica will pull in the changes from the WAL every time a new WAL file is closed, so replication is asynchronous.
+In BigAnimal, faraway replicas use log shipping to replicate from their source clusters. This means that a replica cluster accesses the write-ahead log (WAL) of its source cluster and “replays” the changes described in it. A WAL is a file logging any changes made to a database. Databases write the change to the WAL before actually making the change. This way, if the database goes down before the change can be applied, the WAL has a record of the intended changes. The replica pulls in the changes from the WAL every time a new WAL file is closed, so replication is asynchronous.
 
-In the spirit of flexibility, our faraway replicas also give you options you might not find anywhere else:
- - Your choice of instance type and size
- - Your choice of storage volume and properties
- - No limit the number of replicas you can create
- - Replicas are priced the same as single-node clusters
+Replicas are priced the same as single-node clusters.
 
 ## Advantages
 
-- **Disaster recovery** — You can create faraway replicas in different regions in your cloud. Deploying faraway replicas across regions can help you build a more solid disaster recovery (DR) plan.
+- **Disaster recovery** &mdash; You can create faraway replicas in different regions in your cloud. Deploying faraway replicas across regions can help you build a more solid disaster recovery (DR) plan.
 
-- **Improved read query performance** — For an improved read query performance, set up the faraway replica in the same region as your application. For example, applications can read the writes made to a cluster in the `us-east` region from a `us-west` replica.
+- **Improved read query performance** &mdash; For an improved read query performance, set up the faraway replica in the same region as your application. For example, applications can read the writes made to a cluster in the `us-east` region from a `us-west` replica.
+
+- **Flexibility** &mdash; Options you might not find anywhere else:
+  - Your choice of instance type and size
+  - Your choice of storage volume and properties
+  - No limit to the number of replicas you can create
 
 ## Limitations
 
@@ -26,7 +27,7 @@ In the spirit of flexibility, our faraway replicas also give you options you mig
 
 - **South East Asia region** - The South East Asia region does not support the creation of faraway replicas.
 
-## Example
+## Examples
 
 **Fig 1**: A three-node high availability cluster with two faraway replicas.
 

--- a/product_docs/docs/biganimal/release/overview/replication.mdx
+++ b/product_docs/docs/biganimal/release/overview/replication.mdx
@@ -2,7 +2,15 @@
 title: "Faraway replicas"
 ---
 
-You can create faraway (read) replicas of your single node and high availability clusters in different regions of your cloud. In case of a failure, you can manually promote the faraway replica to a full-fledged BigAnimal cluster, making it capable of accepting writes. See [Managing replicas](/biganimal/release/using_cluster/managing_replicas).
+Faraway replicas are read-only replicas of EDB BigAnimal clusters that you can provision in any supported region. You can create faraway (read) replicas of your single node and high availability clusters in different regions of your cloud. Database users/applications can read from a nearby faraway replica instead of the source cluster. This relieves some of the workload on the source cluster and frees it up to handle write traffic. In case of a failure, you can manually promote the faraway replica to a full-fledged BigAnimal cluster, making it capable of accepting writes. See [Managing replicas](/biganimal/release/using_cluster/managing_replicas).
+
+In BigAnimal, faraway replicas use log shipping to replicate from their source clusters. This means that a replica cluster will access the Write-Ahead Log (WAL) of its source cluster and “replay” the changes described in the WAL. A WAL is a file logging any changes made to a database. Databases write the change to the WAL before actually making the change. This way, if the database goes down before the change can be applied, the WAL will have a record of the changes that were supposed to be made. The replica will pull in the changes from the WAL every time a new WAL file is closed, so replication is asynchronous.
+
+In the spirit of flexibility, our faraway replicas also give you options you might not find anywhere else:
+ - Your choice of instance type and size
+ - Your choice of storage volume and properties
+ - No limit the number of replicas you can create
+ - Replicas are priced the same as single-node clusters
 
 ## Advantages
 


### PR DESCRIPTION
I agree that the FAQ provides more than the BA Docs, so I took a stab at moving some of the Faraway Replicas FAQ content over. There is still FAQ content that "could" be moved over, but truthfully, the Sales/PreSales team should be speaking to most of the remaining points during their discussions with the Customer.

## What Changed?

