### PR TITLE
BigAnimal: region limitations for faraway clusters

### DIFF
--- a/product_docs/docs/biganimal/release/overview/03a_region_support.mdx
+++ b/product_docs/docs/biganimal/release/overview/03a_region_support.mdx
@@ -12,7 +12,7 @@ When using Azure, you can create clusters in the following regions:
   - Australia East (New South Wales)
   - Central India (Pune)
   - Japan East (Tokyo, Saitama)
-  - South East Asia (Singapore)
+  - South East Asia (Singapore) - Does not support the creation of faraway replicas.
 - Europe, Middle East, Africa (EMEA)
   - France Central (Paris)
   - Germany West Central (Frankfurt)

--- a/product_docs/docs/biganimal/release/overview/replication.mdx
+++ b/product_docs/docs/biganimal/release/overview/replication.mdx
@@ -16,7 +16,7 @@ You can create faraway (read) replicas of your single node and high availability
 
 - **Replication lag** — Promoting a faraway replica to a BigAnimal cluster can result in loss of data. See [Log shipping](/biganimal/latest/using_cluster/04_backup_and_restore/#faraway-replicas).
 
-- **South East Asia region** - The South East Asia region does not support the creation of faraway replicas from source clusters in the region.
+- **South East Asia region** - The South East Asia region does not support the creation of faraway replicas.
 
 ## Example
 

--- a/product_docs/docs/biganimal/release/overview/replication.mdx
+++ b/product_docs/docs/biganimal/release/overview/replication.mdx
@@ -16,6 +16,8 @@ You can create faraway (read) replicas of your single node and high availability
 
 - **Replication lag** — Promoting a faraway replica to a BigAnimal cluster can result in loss of data. See [Log shipping](/biganimal/latest/using_cluster/04_backup_and_restore/#faraway-replicas).
 
+- **South East Asia region** - The South East Asia region does not support the creation of faraway replicas from source clusters in the region.
+
 ## Example
 
 **Fig 1**: A three-node high availability cluster with two faraway replicas.


### PR DESCRIPTION
## What Changed?

Updated overview topics for regions and faraway replicas with the limitation for the South East Asia region.

Addressed https://enterprisedb.atlassian.net/browse/UPM-15019.