### PR TITLE
EPAS: link issue

### DIFF
--- a/product_docs/docs/epas/14/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/14/epas_compat_sql/21_create_public_database_link.mdx
@@ -172,7 +172,6 @@ systemctl restart edb-as-14
 
 The script file that you need to modify to include the `LD_LIBRARY_PATH` setting depends on the EDB Postgres Advanced Server version and the Linux system on which it was installed.
 
-See the appropriate version of the [EDB Postgres Advanced Server installation documentation](/epas/latest/epas_inst_linux/) to determine the service script that affects the startup environment. 
 
 ### Oracle instant client for Windows
 

--- a/product_docs/docs/epas/14/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/14/epas_compat_sql/21_create_public_database_link.mdx
@@ -170,9 +170,9 @@ Restart the EDB Postgres Advanced Server service:
 systemctl restart edb-as-14
 ```
 
-The script file that you need to modify to include the `LD_LIBRARY_PATH` setting depends on the EDB Postgres Advanced Server version, the Linux system on which it was installed, and whether it was installed with the graphical installer or an RPM package.
+The script file that you need to modify to include the `LD_LIBRARY_PATH` setting depends on the EDB Postgres Advanced Server version and the Linux system on which it was installed.
 
-See the appropriate version of the [EDB Postgres Advanced Server installation documentation](https://www.enterprisedb.com/docs/epas/latest/epas_inst_linux/) to determine the service script that affects the startup environment. 
+See the appropriate version of the [EDB Postgres Advanced Server installation documentation](/epas/latest/epas_inst_linux/) to determine the service script that affects the startup environment. 
 
 ### Oracle instant client for Windows
 


### PR DESCRIPTION
## What Changed?

- Updated the path to a link that the PDF link checker indicated was broken, but I think we should either remove the paragraph that contains the link or change the destination to a topic that actually contains the information about service script (if there is one).
- Removed reference to Linux interactive installer.
