### PR TITLE
Quick test for LaunchDarkly integration

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -326,6 +326,13 @@ module.exports = {
       },
     },
     {
+      resolve: "gatsby-plugin-launchdarkly",
+      options: {
+        clientSideID: "616ecb0bd01b5c2442f9cd0e",
+        options: {},
+      },
+    },
+    {
       // This plugin must be placed last in your list of plugins to ensure that it can query all the GraphQL data
       resolve: `gatsby-plugin-algolia`,
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -531,6 +531,14 @@ exports.createSchemaCustomization = ({ actions }) => {
       hideVersion: Boolean
       displayBanner: String
     }
+
+    type File implements Node {
+      fields: FileFields
+    }
+
+    type FileFields {
+      content: String
+    }
   `;
   createTypes(typeDefs);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "gatsby-plugin-catch-links": "^4.7.0",
         "gatsby-plugin-google-fonts": "^1.0.1",
         "gatsby-plugin-google-tagmanager": "^4.7.0",
+        "gatsby-plugin-launchdarkly": "^0.4.0",
         "gatsby-plugin-manifest": "^4.7.0",
         "gatsby-plugin-mdx": "^3.7.0",
         "gatsby-plugin-meta-redirect": "^1.1.1",
@@ -9280,6 +9281,18 @@
         "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
+    "node_modules/gatsby-plugin-launchdarkly": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-launchdarkly/-/gatsby-plugin-launchdarkly-0.4.0.tgz",
+      "integrity": "sha512-BR5BUv5J7O1KlAnweFK5wxfoWdc0aIaQsFpdfqEU0sgK+Mj0fxH8+1z3VTdwAr3msKZsYDJV04anCy4gtJzUBw==",
+      "dependencies": {
+        "launchdarkly-react-client-sdk": "^2.29.2"
+      },
+      "peerDependencies": {
+        "gatsby": "^3.0.0 || ^4.0.0",
+        "react": "^16.12.0 || ^17.0.0"
+      }
+    },
     "node_modules/gatsby-plugin-manifest": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-4.7.0.tgz",
@@ -11733,6 +11746,14 @@
         "upper-case": "^1.1.3"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
@@ -13097,6 +13118,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/launchdarkly-js-client-sdk": {
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.24.2.tgz",
+      "integrity": "sha512-8jrLOia0vfZ4stqQRv9TjAYfRGK2JyWpLIL6PbTl99LqTtJMuYtryFUQp0b8WH1153YN+gVdoqPVI7uwbbzLLQ==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "launchdarkly-js-sdk-common": "3.8.2"
+      }
+    },
+    "node_modules/launchdarkly-js-client-sdk/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-3.8.2.tgz",
+      "integrity": "sha512-pEqZ3FTKtYrTaPdbPntFJs87svzcezrkoRWY2GEFmyPC33txOqU788x0yby2+haC/saFPNfXpH6bbiJE/GjMSA==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1",
+        "uuid": "^3.3.2"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+    },
+    "node_modules/launchdarkly-react-client-sdk": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-2.29.4.tgz",
+      "integrity": "sha512-f0vcrn/PtZl6DC0r2qQwwXg0JY/bkrFahijOfeB9RJY/gEgSAmO/eNmTGEyjKEGdc9SwzVmRzwS6i8OXs8np/w==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2",
+        "launchdarkly-js-client-sdk": "2.24.2",
+        "lodash.camelcase": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.3 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -13232,6 +13302,11 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.chunk": {
       "version": "4.2.0",
@@ -29418,6 +29493,14 @@
         "web-vitals": "^1.1.2"
       }
     },
+    "gatsby-plugin-launchdarkly": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-launchdarkly/-/gatsby-plugin-launchdarkly-0.4.0.tgz",
+      "integrity": "sha512-BR5BUv5J7O1KlAnweFK5wxfoWdc0aIaQsFpdfqEU0sgK+Mj0fxH8+1z3VTdwAr3msKZsYDJV04anCy4gtJzUBw==",
+      "requires": {
+        "launchdarkly-react-client-sdk": "^2.29.2"
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-4.7.0.tgz",
@@ -31049,6 +31132,14 @@
         "upper-case": "^1.1.3"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
@@ -32013,6 +32104,49 @@
         "package-json": "^6.3.0"
       }
     },
+    "launchdarkly-js-client-sdk": {
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.24.2.tgz",
+      "integrity": "sha512-8jrLOia0vfZ4stqQRv9TjAYfRGK2JyWpLIL6PbTl99LqTtJMuYtryFUQp0b8WH1153YN+gVdoqPVI7uwbbzLLQ==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0",
+        "launchdarkly-js-sdk-common": "3.8.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
+    "launchdarkly-js-sdk-common": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-3.8.2.tgz",
+      "integrity": "sha512-pEqZ3FTKtYrTaPdbPntFJs87svzcezrkoRWY2GEFmyPC33txOqU788x0yby2+haC/saFPNfXpH6bbiJE/GjMSA==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+        }
+      }
+    },
+    "launchdarkly-react-client-sdk": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-2.29.4.tgz",
+      "integrity": "sha512-f0vcrn/PtZl6DC0r2qQwwXg0JY/bkrFahijOfeB9RJY/gEgSAmO/eNmTGEyjKEGdc9SwzVmRzwS6i8OXs8np/w==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.2",
+        "launchdarkly-js-client-sdk": "2.24.2",
+        "lodash.camelcase": "^4.3.0"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -32127,6 +32261,11 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.chunk": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gatsby-plugin-catch-links": "^4.7.0",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-google-tagmanager": "^4.7.0",
+    "gatsby-plugin-launchdarkly": "^0.4.0",
     "gatsby-plugin-manifest": "^4.7.0",
     "gatsby-plugin-mdx": "^3.7.0",
     "gatsby-plugin-meta-redirect": "^1.1.1",

--- a/product_docs/docs/biganimal/release/index.mdx
+++ b/product_docs/docs/biganimal/release/index.mdx
@@ -22,3 +22,16 @@ navigation:
 EDB BigAnimal is a fully managed database-as-a-service with built-in Oracle compatibility, running in your cloud account and operated by the Postgres experts. BigAnimal makes it easy to set up, manage, and scale your databases. Provision [PostgreSQL](https://www.enterprisedb.com/docs/supported-open-source/postgresql/) or [EDB Postgres Advanced Server](https://www.enterprisedb.com/docs/epas/latest/) with Oracle compatibility. 
 
 To sample EDB BigAnimal, [get started with a free trial](/biganimal/latest/free_trial/).
+
+<FeatureFlag flagName="dbaasDocsTestFlag">
+
+![Rock in peace](https://i.stack.imgur.com/W23g8.png)
+
+</FeatureFlag>
+
+<FeatureFlag flagName="noSuchFlag">
+
+!!! Warning This should never be visible.
+!!!
+
+</FeatureFlag>

--- a/src/components/feature-flag.js
+++ b/src/components/feature-flag.js
@@ -1,0 +1,13 @@
+import { useFlags } from "gatsby-plugin-launchdarkly";
+
+const FeatureFlag = ({ flagName, children }) => {
+  const flags = useFlags();
+  if (Object.keys(flagName).length && !(flagName in flags))
+    console.warn("No such feature flag: " + flagName);
+  if (flags[flagName]) {
+    return children;
+  }
+  return null;
+};
+
+export default FeatureFlag;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ import CodeBlock from "./code-block";
 import DarkModeToggle from "./dark-mode-toggle";
 import DevOnly from "./dev-only";
 import DevFrontmatter from "./dev-frontmatter";
+import FeatureFlag from "./feature-flag";
 import Footer from "./footer";
 import IndexLinks from "./index-links";
 import IndexSubNav from "./index-sub-nav";
@@ -40,6 +41,7 @@ export {
   DarkModeToggle,
   DevOnly,
   DevFrontmatter,
+  FeatureFlag,
   Footer,
   IndexLinks,
   IndexSubNav,

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -5,6 +5,7 @@ import {
   Archive,
   AuthenticatedContentPlaceholder,
   CodeBlock,
+  FeatureFlag,
   KatacodaPageLink,
   KatacodaPanel,
   LayoutContext,
@@ -85,6 +86,7 @@ const Layout = ({
           }
         ></blockquote>
       ),
+      FeatureFlag,
       KatacodaPanel: () => (
         <KatacodaPanel katacodaPanelData={katacodaPanelData} />
       ),


### PR DESCRIPTION
## What Changed?

This brings in (dev) BigAnimal feature flags, and implements a component (`<FeatureFlag>`) that allows for rendering content when a given flag is set.

### Example

https://github.com/EnterpriseDB/docs/blob/cb4eafbecf8439b59783078cc572dea87829f6c6/product_docs/docs/biganimal/release/index.mdx?plain=1#L26-L30

https://deploy-preview-3530--edb-docs-staging.netlify.app/docs/biganimal/latest/

### Caveats

- Client-side *only* - no flags are fetched during static generation, so all fenced content is excluded until after rehydration. This is a limitation of the plugin, though we could alter the default (so, all fenced content rendered *until* rehydration). Also - and perhaps more constraining - there's no way to selectively exclude entire pages based on flags (nav structure is fixed at build time). Fixing this would require implementing SSR in the plugin (probably not onerous)

### TODO

- Discuss use-cases, identify needed patterns
- Implement negative fencing (e.g., `<FeatureFlag whenNot="dbaasDocsTestFlag">`)

Addresses #3524