### PR TITLE
Install instructions: fixed for EPRS and pgPool

### DIFF
--- a/install_template/templates/products/edb-pgpool-ii-extensions/base.njk
+++ b/install_template/templates/products/edb-pgpool-ii-extensions/base.njk
@@ -1,5 +1,5 @@
 {% extends "platformBase/" + platformBaseTemplate + '.njk' %}
-{% set packageName %}edb-as-<xx>-pgpool<yy>-extensions{% endset %}
+{% set packageName %}edb-as<xx>-pgpool<yy>-extensions{% endset %}
 
 {% import "platformBase/_deploymentConstants.njk" as deploy %}
 {% block frontmatter %}
@@ -18,5 +18,5 @@ redirects:
 {% endblock prodprereq %}
 {% block installCommand %}
 {{super()}}
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.
 {% endblock installCommand %}

--- a/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_rhel_8.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_rhel_8.mdx
@@ -39,9 +39,6 @@ Before you begin the installation process:
 
   # Refresh the cache:
   sudo dnf makecache
-  # Enable additional repositories to resolve dependencies:
-  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
-
   #  Disable the built-in PostgreSQL module:
   sudo dnf -qy module disable postgresql
   ```

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_rhel_8.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_rhel_8.mdx
@@ -37,9 +37,6 @@ Before you begin the installation process:
   # Install the EPEL repository:
   sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
-  # Enable additional repositories to resolve dependencies:
-  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
-
   #  Disable the built-in PostgreSQL module:
   sudo dnf -qy module disable postgresql
   ```

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_ppc64le/pgpoolext_rhel_8.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_ppc64le/pgpoolext_rhel_8.mdx
@@ -36,7 +36,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo dnf -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo dnf -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_ppc64le/pgpoolext_sles_12.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_ppc64le/pgpoolext_sles_12.mdx
@@ -35,7 +35,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -n install edb-as-<xx>-pgpool<yy>-extensions
+sudo zypper -n install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_ppc64le/pgpoolext_sles_15.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_ppc64le/pgpoolext_sles_15.mdx
@@ -34,7 +34,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -n install edb-as-<xx>-pgpool<yy>-extensions
+sudo zypper -n install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_centos_7.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_centos_7.mdx
@@ -32,7 +32,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo yum -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo yum -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_debian_10.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_debian_10.mdx
@@ -24,7 +24,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo apt-get -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_debian_11.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_debian_11.mdx
@@ -24,7 +24,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo apt-get -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_other_linux_8.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_other_linux_8.mdx
@@ -34,7 +34,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo dnf -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo dnf -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_rhel_7.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_rhel_7.mdx
@@ -32,7 +32,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo yum -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo yum -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_rhel_8.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_rhel_8.mdx
@@ -34,7 +34,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo dnf -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo dnf -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_sles_12.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_sles_12.mdx
@@ -35,7 +35,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -n install edb-as-<xx>-pgpool<yy>-extensions
+sudo zypper -n install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_sles_15.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_sles_15.mdx
@@ -34,7 +34,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo zypper -n install edb-as-<xx>-pgpool<yy>-extensions
+sudo zypper -n install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_ubuntu_18.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_ubuntu_18.mdx
@@ -24,7 +24,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo apt-get -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.

--- a/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_ubuntu_20.mdx
+++ b/product_docs/docs/pgpool/4.3/installing_extensions/linux_x86_64/pgpoolext_ubuntu_20.mdx
@@ -24,7 +24,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get -y install edb-as-<xx>-pgpool<yy>-extensions
+sudo apt-get -y install edb-as<xx>-pgpool<yy>-extensions
 ```
 
-Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as-14-pgpool43-extensions`.
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.3 and EDB Postgres Advanced Server version 14, the package name would be `edb-as14-pgpool43-extensions`.


### PR DESCRIPTION
## What Changed?

- Removed codeready-builder instructions for EPRS - updating the instructions for codeready-builder was done in another PR (https://github.com/EnterpriseDB/docs/pull/3499), but the EPRS changes didn't get in at that time - adding them now
- Fixed package names for pgPool extensions - there is no hyphen between "as" and the as version number in the package names (see https://edb.slack.com/archives/CU5QEU5L7/p1673878714011569). Note that I verified that the change applies to all the OSs by checking Repos 2.0. I found that the pgPool Debian 11 packages weren't in the repo. I notified Hayee about that.