### PR TITLE
chore(UPM-12468): Docs changes for superset PGD dashboard

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
@@ -63,29 +63,31 @@ To add the dashboard:
 
 1. Clone the [cloud-utilities](https://github.com/EnterpriseDB/cloud-utilities) repository on your local system.
 
-2. Using Python 3.4 or later, use the following syntax to create an output JSON file:
+2. Using Python 3.4 or later, create an output JSON file:
 
-   Change your working directory:
+   1. Change your working directory:
 
-   ```py
-   cd cloud-utilities/utils/superset
-   ```
+      ```py
+      cd cloud-utilities/utils/superset
+      ```
 
-   Give executable permission to the script:
-   ```
-   chmod +x db_name_change.py
-   ```
-   Now run the script:
+   1. Change the permissions on the script to make it executable:
+      
+      ```
+      chmod +x db_name_change.py
+      ```
 
-   ```
-   ./db_name_change.py <database_name> -i <input_file> -o <output_file>
-   ```
+   1. Run the script:
+
+      ```
+      ./db_name_change.py <database_name> -i <input_file> -o <output_file>
+      ```
    
-   For example:
+      For example:
 
-   ```py
-   ./db_name_change.py edb -i utils/superset/pgd_monitoring_template.json  -o utils/superset/upload.json
-   ```
+      ```py
+      ./db_name_change.py edb -i utils/superset/pgd_monitoring_template.json  -o utils/superset/upload.json
+      ```
 
    To get more information on the `db_name_change` script, run:
 

--- a/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_analyze_with_superset.mdx
@@ -63,25 +63,37 @@ To add the dashboard:
 
 1. Clone the [cloud-utilities](https://github.com/EnterpriseDB/cloud-utilities) repository on your local system.
 
-1. Using Python 3.4 or later, use the following syntax to create an output JSON file:
+2. Using Python 3.4 or later, use the following syntax to create an output JSON file:
+
+   Change your working directory:
 
    ```py
-   db_name_change.py <database_name> -i <input_file> -o <output_file>
+   cd cloud-utilities/utils/superset
+   ```
+
+   Give executable permission to the script:
+   ```
+   chmod +x db_name_change.py
+   ```
+   Now run the script:
+
+   ```
+   ./db_name_change.py <database_name> -i <input_file> -o <output_file>
    ```
    
    For example:
 
    ```py
-   python3 db_name_change.py edb -i utils/superset/pgd_monitoring_template.json  -o utils/superset/upload.json
+   ./db_name_change.py edb -i utils/superset/pgd_monitoring_template.json  -o utils/superset/upload.json
    ```
 
    To get more information on the `db_name_change` script, run:
 
    ```py
-   python3 db_name_change.py -h 
+   ./db_name_change.py -h
    ```
 
-1. In Superset, import your output file by selecting **Analyze > Dashboards > Import dashboard**.
+3. In Superset, import your output file by selecting **Analyze > Dashboards > Import dashboard**.
 
 ## Using Superset charts
 


### PR DESCRIPTION
## What Changed?

Changing the command to execute the database name change script as we added a shebang line in the script to execute the script without using `python3 <script.py>`. We just need to give the executable permissions to the script and need to call the script using `./`.

This PR is to make these changes on docs as the same has been updated in the cloud-utilities repo.