### PR TITLE
BigAnimal: improving CLI links and headings

### DIFF
--- a/product_docs/docs/biganimal/release/reference/cli/using_features.mdx
+++ b/product_docs/docs/biganimal/release/reference/cli/using_features.mdx
@@ -3,7 +3,7 @@ title: Using BigAnimal features with the CLI
 navTitle: Using BigAnimal features
 ---
 
-## Managing faraway replicas
+## Faraway replicas CLI commands
 
 You can use the faraway replica-specific CLI commands to [create](#create-a-faraway-replica), [promote](#promote-a-faraway-replica), and [get information](#get-information-on-faraway-replicas) on faraway replicas. 
 
@@ -79,7 +79,7 @@ __OUTPUT__
 ```
 You are prompted to confirm you want to promote the faraway replica. After the faraway replica promotion process is completed, it generates a cluster ID.
 
-## Using IAM authentication on AWS
+## IAM authentication CLI commands
 
 To create a cluster that is enabled for IAM authentication, set the `--iam-authentication` flag on the create-cluster command or in the configuration file to `Yes` or `true`, respectively.
 

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -114,7 +114,7 @@ If IAM integration is configured for your cluster, you can log in to Postgres us
 1. Connect to Postgres using your IAM credentials.
 1. When prompted for the password, enter your access key (&lt;access key ID>:&lt;secret access key>).
 
-### See also
+### Using IAM authentication CLI commands
 
-For information on integrating with IAM using the CLI, see the [Using IAM authentication on AWS](/biganimal/latest/reference/cli/using_features/#using-iam-authentication-on-aws) section in the [Using BigAnimal features with the CLI](/biganimal/latest/reference/cli/using_features) topic.
+For information on integrating with IAM on AWS using the CLI, see [IAM authentication CLI commands](/biganimal/latest/reference/cli/using_features/#iam-authentication-cli-commands).
 

--- a/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/managing_replicas.mdx
@@ -134,6 +134,6 @@ You can restore a replica backup to a standalone cluster. A new stand alone clus
 
 
 
-## See also
+## Using the CLI to manage faraway replicas
 
-- [Managing faraway replicas using the CLI](/biganimal/latest/reference/cli/using_features/#managing-replicas)
+See [Faraway replicas CLI commands](/biganimal/latest/reference/cli/using_features/#managing-faraway-replicas-using-the-cli) for information on CLI commands for managing faraway replicas.


### PR DESCRIPTION
## What Changed?

Instead of hiding CLI links under See also sections, created CLI headings in feature topics
Included CLI in the headings on the CLI use case topics so the link labels make more sense
