### PR TITLE
EPAS 14 - DBMS_CRYPTO correction as per DF-313

### DIFF
--- a/product_docs/docs/epas/14/epas_compat_bip_guide/03_built-in_packages/04_dbms_crypto/index.mdx
+++ b/product_docs/docs/epas/14/epas_compat_bip_guide/03_built-in_packages/04_dbms_crypto/index.mdx
@@ -20,7 +20,6 @@ The table lists the `DBMS_CRYPTO` functions and procedures.
 | `ENCRYPT(dst INOUT, src, typ, key, iv)` | N/A         | Encrypts `BLOB` data.                                                                               |
 | `ENCRYPT(dst INOUT, src, typ, key, iv)` | N/A         | Encrypts `CLOB` data.                                                                               |
 | `HASH(src, typ)`                        | `RAW`       | Applies a hash algorithm to `RAW` data.                                                             |
-| `HASH(src)`                             | `RAW`       | Applies a hash algorithm to `CLOB` data.                                                            |
 | `MAC(src, typ, key)`                    | `RAW`       | Returns the hashed `MAC` value of the given `RAW` data using the specified hash algorithm and key.  |
 | `MAC(src, typ, key)`                    | `RAW`       | Returns the hashed `MAC` value of the given `CLOB` data using the specified hash algorithm and key. |
 | `RANDOMBYTES(number_bytes)`             | `RAW`       | Returns a specified number of cryptographically strong random bytes.                                |


### PR DESCRIPTION
Removed single variant HASH function from the docs as per the comment on DF-313

