### PR TITLE
Added port number to psql command

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/index.mdx
@@ -112,7 +112,8 @@ Now that your endpoint service is created, you can connect it to the cluster VPC
  In your application's AWS account, select **VPC** and then select **Endpoints**. Select the endpoint you created previously and use the DNS name provided in the details section to access your cluster.
 
     ```shell     
-    psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin      
+    # Replace the port 5432 below if that has been changed in the Big Animal DB Configuration
+    psql -h vpce-XXXXXXXXXXXXXXXXXXXX.eu-west-1.vpce.amazonaws.com -U edb_admin -p 5432     
     __OUTPUT__
     Password for user edb_admin: 
 


### PR DESCRIPTION
This tripped us up for some time while testing the endpoint at Datatrak Oracle to EPAS migration

## What Changed?

