### PR TITLE
Fix link that points to the configuration page

### DIFF
--- a/product_docs/docs/pem/9/pem_upgrade/upgrading_pem_installation/upgrading_pem_installation_linux_rpm.mdx
+++ b/product_docs/docs/pem/9/pem_upgrade/upgrading_pem_installation/upgrading_pem_installation_linux_rpm.mdx
@@ -191,7 +191,7 @@ The configure script uses the values from the old PEM server configuration file 
 
 After executing the PEM server configuration file, use your version-specific service control command to restart the httpd service.
 
-For detailed information, see [Configuring the PEM server on Linux platforms](../..).
+For detailed information, see [Configuring the PEM server on Linux platforms](/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/).
 
 !!! Note
     From PEM version 7.11 and later, the configure script requires a superuser password only after the upgrade process.


### PR DESCRIPTION
The previous link got the reader to the root of the PEM docs, not to the intended destination, which is https://www.enterprisedb.com/docs/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/

## What Changed?

Link changed from ../.. to https://www.enterprisedb.com/docs/pem/latest/installing_pem_server/pem_server_inst_linux/configuring_the_pem_server_on_linux/, in a location that had the text "Configuring the PEM server on Linux platforms"

Note: I don't know why the last line is shown as edited. I edited one line of the link in the Github web interface, now the diff contains two changes, but I didn't intend for the last one and I don't know how to prevent it in this PR.