### PR TITLE
Dev/pgd5 remove wait flush and fallback group options

### DIFF
--- a/product_docs/docs/pgd/5/routing/index.mdx
+++ b/product_docs/docs/pgd/5/routing/index.mdx
@@ -37,8 +37,6 @@ There are additional group-level options that affect the routing decisions:
   selected automatically.
 - route_reader_max_lag - Maximum lag in bytes for node to be considered viable
   read-only node (currently reserved for future use).
-- route_writer_wait_flush - Whether to wait for replication queue flush before
-  switching to new leader when using `bdr.routing_leadership_transfer()`.
 
 Per node configuration of routing is set using `bdr.alter_node_option()`. The
 available options that affect routing are following:
@@ -70,11 +68,6 @@ The available option are:
   Postgres node.
 - server_conn_timeout - Connection timeout for server connections.
 - server_conn_keepalive - Keepalive interval for server connections.
-- fallback_groups - Array of groups (in priority order) to route to if the main
-  group does not have any write lead. This is useful primarily for cross-region
-  fail-over.
-- fallback_group_timeout - Interval after which the routing falls back to one
-  of the fallback_groups.
 
 The current configuration of every group is visible in the
 `bdr.node_group_routing_config_summary` view. Similarly the


### PR DESCRIPTION

- As mentioned in  [BDR-2752](https://enterprisedb.atlassian.net/browse/BDR-2752) `route_writer_wait_flush was replaced by ‘strict’ mode and is not used for anything anymore` so remove the option.
- Remove the options for fallback_groups since it's already removed from PGD CLI as mentioned [here](https://enterprisedb.atlassian.net/browse/BDR-2973?focusedCommentId=396225).



[BDR-2752]: https://enterprisedb.atlassian.net/browse/BDR-2752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ