### PR TITLE
To add the warning for User

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -24,6 +24,9 @@ psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmod
 
 - The `edb_admin` role does not have superuser privileges by default. Contact [Support](../overview/support) to request superuser privileges for `edb_admin`. If you request superuser privileges, you **must** take care to limit the number of connections used by superusers to avoid degraded service and/or compromising availability.
 
+  !!! note
+      Superuser privileges allow you to make Postgres configuration changes using `ALTER SYSTEM` queries. We recommend you don't do this because it may lead to an unpredictable/unrecoverable state of the cluster. In addition, `ALTER SYSTEM` changes are not replicated across the cluster.
+
 - Changes to system configuration (GUCs) made by edb_admin or other Postgres users are not persisted though a reboot or maintenance. Use the BigAnimal portal to modify system configuration.
 
 -   You have to remember your `edb_admin` password as EDB does not have access to it. If you forget it, you can set a new one in the BigAnimal portal on the Edit Cluster page.
@@ -32,12 +35,7 @@ psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmod
 
 -   BigAnimal stores all database-level authentication securely and directly in PostgreSQL. The `edb_admin` user password is SCRAM-SHA-256 hashed prior to storage. This hash, even if compromised, cannot be replayed by an attacker to gain access to the system.
 
-!!! Warning
-    Please don't use the `ALTER SYSTEM` query to change the configuration of
-    the PostgreSQL instances in an imperative way. Changing some of the options
-    that are normally controlled by the operator might indeed lead to an
-    unpredictable/unrecoverable state of the cluster.
-    Moreover, `ALTER SYSTEM` changes are not replicated across the cluster.
+
 
 ## One database with one application
 

--- a/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/01_postgres_access.mdx
@@ -32,6 +32,13 @@ psql -W "postgres://edb_admin@xxxxxxxxx.xxxxx.biganimal.io:5432/edb_admin?sslmod
 
 -   BigAnimal stores all database-level authentication securely and directly in PostgreSQL. The `edb_admin` user password is SCRAM-SHA-256 hashed prior to storage. This hash, even if compromised, cannot be replayed by an attacker to gain access to the system.
 
+!!! Warning
+    Please don't use the `ALTER SYSTEM` query to change the configuration of
+    the PostgreSQL instances in an imperative way. Changing some of the options
+    that are normally controlled by the operator might indeed lead to an
+    unpredictable/unrecoverable state of the cluster.
+    Moreover, `ALTER SYSTEM` changes are not replicated across the cluster.
+
 ## One database with one application
 
 For one database hosting a single application, replace app1 with your preferred user name:


### PR DESCRIPTION
Alert user for not using ALTER SYSTEM` query to change the configuration of the PostgreSQL instances in an imperative way.

## What Changed?

