### PR TITLE
Added End of support notice for EPAS 11

### DIFF
--- a/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.3_rel_notes.mdx
+++ b/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.3_rel_notes.mdx
@@ -19,3 +19,7 @@ New features, enhancements, bug fixes, and other changes in Migration Portal 4.3
 | Bug fix | Fixed an issue related to catalog views not being detected and reported in compatible features in certain cases. |
 
 
+# End of support notice
+Since the end of standard support for EDB Postgres Advanced Server (EPAS) version 11 is scheduled for November 20, 2023, more recent versions of EPAS that will be supported beyond 2023 should be selected for new Migration Portal projects.  Support for EPAS 11 is planned to begin being removed from the Migration Portal on May 20, 2023 to help ensure that no new EPAS 11 projects will be created after this date. 
+
+To maximize the length of available support and to take advantage of new features, particularly those that provide additional compatibility with Oracle, EDB recommends selecting the latest EPAS version as the target of a Migration Portal project.  See the EDB [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) page for more information on the support periods for each EDB Postgres Advanced Server major version. 

--- a/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.3_rel_notes.mdx
+++ b/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.3_rel_notes.mdx
@@ -19,7 +19,3 @@ New features, enhancements, bug fixes, and other changes in Migration Portal 4.3
 | Bug fix | Fixed an issue related to catalog views not being detected and reported in compatible features in certain cases. |
 
 
-# End of support notice
-Since the end of standard support for EDB Postgres Advanced Server (EPAS) version 11 is scheduled for November 20, 2023, more recent versions of EPAS that will be supported beyond 2023 should be selected for new Migration Portal projects.  Support for EPAS 11 is planned to begin being removed from the Migration Portal on May 20, 2023 to help ensure that no new EPAS 11 projects will be created after this date. 
-
-To maximize the length of available support and to take advantage of new features, particularly those that provide additional compatibility with Oracle, EDB recommends selecting the latest EPAS version as the target of a Migration Portal project.  See the EDB [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) page for more information on the support periods for each EDB Postgres Advanced Server major version. 

--- a/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.4_rel_notes.mdx
+++ b/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.4_rel_notes.mdx
@@ -19,3 +19,8 @@ New features, enhancements, bug fixes, and other changes in Migration Portal 4.4
 | Bug fix | Fixed an issue with the ERH-2059 repair handler where the schema name was incorrectly being removed from row type objects specified with a schema name prefix after converting from the Oracle `PIPE ROW` syntax to the Postgres `RETURN NEXT` syntax. |
 | Other | Added a Migration Portal Knowledge Base entry with a proposed workaround for migrating `TO_TIMESTAMP_TZ()` function calls with a single argument, which are not supported in EDB Postgres Advanced Server. |
 | Other | Support for EDB Postgres Advanced Server version 10 has been removed. Users can no longer select EDB Postgres Advanced Server 10 as a target database for new migration projects.  Users are also no longer able to upload new schemas and edit and reassess objects in existing EDB Postgres Advanced Server 10 projects.  |
+
+## End of support notice
+Since the end of standard support for EDB Postgres Advanced Server (EPAS) version 11 is scheduled for November 20, 2023, more recent versions of EPAS that will be supported beyond 2023 should be selected for new Migration Portal projects.  Support for EPAS 11 is planned to begin being removed from the Migration Portal on May 20, 2023 to help ensure that no new EPAS 11 projects will be created after this date. 
+
+To maximize the length of available support and to take advantage of new features, particularly those that provide additional compatibility with Oracle, EDB recommends selecting the latest EPAS version as the target of a Migration Portal project.  See the EDB [Platform Compatibility](https://www.enterprisedb.com/platform-compatibility#epas) page for more information on the support periods for each EDB Postgres Advanced Server major version. 


### PR DESCRIPTION
Added a section to notify users that Migration Portal support for EPAS 11 as a target database is planned to be removed in May;

## What Changed?

