### PR TITLE
PGE install templates - Deb/Ubuntu changes

### DIFF
--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -209,104 +209,104 @@ products:
         supported versions: [1]
       - name: SLES 12
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: SLES 12
         arch: ppc64le
-        supported versions: [1.17]
+        supported versions: [1]
       - name: SLES 15
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [1.17]
+        supported versions: [1]
   - name: EDB Pgpool-II
     platforms:
       - name: CentOS 7
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [4.3]
+        supported versions: [4]
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: RHEL 7 or OL 7
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Debian 10
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Debian 11
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Ubuntu 18.04
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 12
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 12
         arch: ppc64le
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 15
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [4.3]
+        supported versions: [4]
   - name: EDB Pgpool-II Extensions
     platforms:
       - name: CentOS 7
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [4.3]
+        supported versions: [4]
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: RHEL 7 or OL 7
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Debian 10
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Debian 11
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Ubuntu 18.04
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 12
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 12
         arch: ppc64le
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 15
         arch: x86_64
-        supported versions: [4.3]
+        supported versions: [4]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [4.3]
+        supported versions: [4]
   - name: EDB Postgres Advanced Server
     platforms:
       - name: CentOS 7

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -3,46 +3,46 @@ products:
     platforms:
       - name: CentOS 7
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: RHEL 7 or OL 7
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: Debian 10
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: Debian 11
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: Ubuntu 18.04
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: SLES 12
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: SLES 12
         arch: ppc64le
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: SLES 15
         arch: x86_64
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [42.5.1.1]
+        supported versions: [42.5.1.2]
   - name: Migration Toolkit
     platforms:
       - name: RHEL 8 or OL 8
@@ -179,34 +179,34 @@ products:
     platforms:
       - name: CentOS 7
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [1.17]
+        supported versions: [1]
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: RHEL 7 or OL 7
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: Debian 10
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: Debian 11
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: Ubuntu 18.04
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [1.17]
+        supported versions: [1]
       - name: SLES 12
         arch: x86_64
         supported versions: [1.17]

--- a/install_template/templates/products/edb-postgres-extended-server/debian-10.njk
+++ b/install_template/templates/products/edb-postgres-extended-server/debian-10.njk
@@ -1,6 +1,6 @@
 {% extends "products/edb-postgres-extended-server/debian.njk" %}
 {% set platformBaseTemplate = "debian-10" %}
-{% set packageName %}edb-postgresextended-<xx> edb-postgresextended-<xx>-contrib{% endset %}
+{% set packageName %}edb-postgresextended-<xx>{% endset %}
 {% block installCommand %}
 ```shell
 sudo {{ packageManager }} {{ packageManagerNoninteractive }} install {{ packageName }}

--- a/install_template/templates/products/edb-postgres-extended-server/debian-11.njk
+++ b/install_template/templates/products/edb-postgres-extended-server/debian-11.njk
@@ -1,6 +1,6 @@
 {% extends "products/edb-postgres-extended-server/debian.njk" %}
 {% set platformBaseTemplate = "debian-11" %}
-{% set packageName %}edb-postgresextended-<xx> edb-postgresextended-<xx>-contrib{% endset %}
+{% set packageName %}edb-postgresextended-<xx>{% endset %}
 {% block installCommand %}
 ```shell
 sudo {{ packageManager }} {{ packageManagerNoninteractive }} install {{ packageName }}

--- a/install_template/templates/products/edb-postgres-extended-server/ubuntu-18.04.njk
+++ b/install_template/templates/products/edb-postgres-extended-server/ubuntu-18.04.njk
@@ -1,3 +1,3 @@
 {% extends "products/edb-postgres-extended-server/ubuntu.njk" %}
 {% set platformBaseTemplate = "ubuntu-18.04" %}
-{% set packageName %}edb-postgresextended-<xx> edb-postgresextended-<xx>-contrib{% endset %}
+{% set packageName %}edb-postgresextended-<xx>{% endset %}

--- a/install_template/templates/products/edb-postgres-extended-server/ubuntu-20.04.njk
+++ b/install_template/templates/products/edb-postgres-extended-server/ubuntu-20.04.njk
@@ -1,3 +1,3 @@
 {% extends "products/edb-postgres-extended-server/ubuntu.njk" %}
 {% set platformBaseTemplate = "ubuntu-20.04" %}
-{% set packageName %}edb-postgresextended-<xx> edb-postgresextended-<xx>-contrib{% endset %}
+{% set packageName %}edb-postgresextended-<xx>{% endset %}

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_ppc64le/jdbc_rhel_8.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_ppc64le/jdbc_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel8_ppcle
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_ppc64le/jdbc_sles_12.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_ppc64le/jdbc_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_ppc64le/jdbc_sles_15.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_ppc64le/jdbc_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_centos_7.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_centos_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on CentOS 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_centos7_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_debian_10.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_debian_10.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Debian 10 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb10_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_debian_11.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_debian_11.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Debian 11 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb11_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_other_linux_8.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_other_linux_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on AlmaLinux 8 or Rocky Linux 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux8_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_rhel_7.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_rhel_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 7 or OL 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel7_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_rhel_8.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 8 or OL 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel8_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_sles_12.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 12 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_sles_15.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 15 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_ubuntu_18.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_ubuntu_18.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Ubuntu 18.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu18_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_ubuntu_20.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.1.2/installing/linux_x86_64/jdbc_ubuntu_20.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Ubuntu 20.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/42.5.1.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86
+  - /jdbc_connector/42.5.1.2/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_rhel_8.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_rhel8_ppcle
+  - /pgbouncer/1/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_sles_12.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles12_ppcle
+  - /pgbouncer/1/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_sles_15.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles15_ppcle
+  - /pgbouncer/1/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_centos_7.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_centos_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on CentOS 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_centos7_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_debian_10.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_debian_10.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on Debian 10 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_deb10_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_debian_11.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_debian_11.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on Debian 11 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_deb11_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_other_linux_8.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_other_linux_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on AlmaLinux 8 or Rocky Linux 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_other_linux8_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_rhel_7.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_rhel_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on RHEL 7 or OL 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel7_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_rhel_8.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on RHEL 8 or OL 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel8_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_sles_12.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on SLES 12 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_sles12_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_sles_15.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on SLES 15 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_sles15_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_ubuntu_18.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_ubuntu_18.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on Ubuntu 18.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu18_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_ubuntu_20.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_ubuntu_20.mdx
@@ -6,7 +6,7 @@ title: Installing EDB pgBouncer on Ubuntu 20.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgbouncer/1.17/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu20_x86
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_debian_10.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_debian_10.mdx
@@ -21,7 +21,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get -y install edb-postgresextended-<xx> 
+sudo apt-get -y install edb-postgresextended-<xx>
 ```
 
 Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended-15`.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_18.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_18.mdx
@@ -21,7 +21,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get -y install edb-postgresextended-<xx> 
+sudo apt-get -y install edb-postgresextended-<xx>
 ```
 
 Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_20.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_20.mdx
@@ -21,7 +21,7 @@ Before you begin the installation process:
 ## Install the package
 
 ```shell
-sudo apt-get -y install edb-postgresextended-<xx> 
+sudo apt-get -y install edb-postgresextended-<xx>
 ```
 
 Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.

--- a/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_rhel_8.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_rhel8_ppcle
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles12_ppcle
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_sles_15.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles15_ppcle
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_centos_7.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_centos_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on CentOS 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_centos7_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_debian_10.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_debian_10.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on Debian 10 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb10_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_debian_11.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_debian_11.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on Debian 11 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb11_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_8.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on AlmaLinux 8 or Rocky Linux 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_other_linux8_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_rhel_7.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_rhel_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on RHEL 7 or OL 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel7_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_rhel_8.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on RHEL 8 or OL 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel8_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on SLES 12 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles12_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_sles_15.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on SLES 15 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles15_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_ubuntu_18.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_ubuntu_18.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on Ubuntu 18.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu18_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_ubuntu_20.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_ubuntu_20.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II on Ubuntu 20.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu20_x86
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_rhel_8.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_rhel8_ppcle
+  - /pgpool/4/02_extensions/ibm_power_ppc64le/pgpoolext_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles12_ppcle
+  - /pgpool/4/02_extensions/ibm_power_ppc64le/pgpoolext_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_sles_15.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/ibm_power_ppc64le/pgpoolext_sles15_ppcle
+  - /pgpool/4/02_extensions/ibm_power_ppc64le/pgpoolext_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_centos_7.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_centos_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on CentOS 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_centos7_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_debian_10.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_debian_10.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on Debian 10 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb10_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_debian_11.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_debian_11.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on Debian 11 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_deb11_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_other_linux_8.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_other_linux_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on AlmaLinux 8 or Rocky Linux 8 x86_6
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_other_linux8_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_rhel_7.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_rhel_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on RHEL 7 or OL 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_rhel7_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_rhel_8.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on RHEL 8 or OL 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_rhel8_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on SLES 12 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles12_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_sles_15.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on SLES 15 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_sles15_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_ubuntu_18.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_ubuntu_18.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on Ubuntu 18.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu18_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_ubuntu_20.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_ubuntu_20.mdx
@@ -6,7 +6,7 @@ title: Installing EDB Pgpool-II Extensions on Ubuntu 20.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /pgpool/4.3/02_extensions/x86_amd64/pgpoolext_ubuntu20_x86
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/static/_redirects
+++ b/static/_redirects
@@ -36,10 +36,11 @@
 /docs/harp/1.0/*       /docs/harp/latest/:splat   301
 
 # PgPool collapsed versions
-/docs/pgppol/4.3/*  /docs/pgpool/latest/:splat 301
+/docs/pgpool/4.3/*  /docs/pgpool/latest/:splat 301
 
 # PgBouncer collapsed versions
-/docs/pgbouncer/1/*   /docs/pgbouncer/latest/:splat 301
+/docs/pgbouncer/1.17/*   /docs/pgbouncer/latest/:splat 301
+
 
 # PGD
 /docs/pgd/latest/overview/bdr/*        /docs/pgd/latest/bdr/:splat  302
@@ -112,7 +113,7 @@
 /docs/jdbc_connector/42.2.24.1/*  /docs/jdbc_connector/latest/:splat  301
 /docs/jdbc_connector/42.2.24.1/*  /docs/jdbc_connector/latest/:splat  301
 /docs/jdbc_connector/42.3.2.1/*   /docs/jdbc_connector/latest/:splat  301
-
+/docs/jdbc_connector/42.5.1.1/*   /docs/jdbc_connector/latest/:splat  301
 
 # ODBC Connector
 #   collapsed versions


### PR DESCRIPTION
## What Changed?

Remove the contrib packages from Debian and Ubuntu templates for PGE

I manually made the change to the generated topics in another PR because when I generate and deploy nstall topics are generated for a number of other products. Something is amiss. - fixed by updating config.yaml with the latest version numbers for those other products