### PR TITLE
BDR-3166 - Replace "HARP" reference with "PGD Proxy".

### DIFF
--- a/product_docs/docs/pgd/5/durability/group-commit.mdx
+++ b/product_docs/docs/pgd/5/durability/group-commit.mdx
@@ -12,7 +12,7 @@ confirm a transaction at COMMIT time.
 During normal operation, Group Commit is completely transparent to the
 application.  Upon failover, the reconciliation phase needs to be
 explicitly triggered or consolidated by either the application or a
-proxy in between. HARP provides native support for Group Commit and
+proxy in between. PGD proxy provides native support for Group Commit and
 triggers the reconciliation phase, making this equally transparent
 to the client.
 


### PR DESCRIPTION
Have just replaced the word `HARP` with `PGD Proxy`. I hardly have any idea what this is talking about so deferring it to experts on this to help me with correct statement. 
As a wild guess I think we can remove this statement altogether because PGD Proxy doesn't trigger anything on BDR side.

@PJMODOS  @bharattelange I am not sure but this can be related to [BDR-3163](https://enterprisedb.atlassian.net/browse/BDR-3163). 

[BDR-3163]: https://enterprisedb.atlassian.net/browse/BDR-3163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ