### PR TITLE
Edits to EPRS Windows installation and details page

### DIFF
--- a/product_docs/docs/eprs/7/installing/installation_details.mdx
+++ b/product_docs/docs/eprs/7/installing/installation_details.mdx
@@ -5,17 +5,25 @@ redirects:
  - /eprs/latest/03_installation/03_installing_rpm_package/installation_details/
 ---
 
-On Linux hosts where you installed Replication Server with the graphical user interface or from the command line, you should now have a publication server daemon and a subscription server daemon running on your computer assuming you chose to install the publication server and subscription server components. If you installed the Replication Server RPM package, you must start the publication server and the subscription server based upon the instructions in Section [Registering a Publication Server](../../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for the publication server and [Registering a Subscription Server](../../05_smr_operation/03_creating_subscription/01_registering_subscription_server/#registering_subscription_server) for the subscription server. On Windows systems, the publication server and subscription server run as services named `Publication Service` and `Subscription Service`.
+## Windows details
 
-The Postgres application menu contains a new item for the EPRS Replication Console.
+On Windows systems, the publication server and subscription server run as services named `Publication Service` and `Subscription Service`.
+
+## Linux details
+
+On Linux hosts where you installed Replication Server with the graphical user interface or from the command line, you should now have a publication server daemon and a subscription server daemon running on your computer, assuming you chose to install the publication server and subscription server components. If you installed the Replication Server RPM package, you must start the publication server and the subscription server based on the instructions in [Registering a Publication Server](../../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for the publication server and [Registering a Subscription Server](../../05_smr_operation/03_creating_subscription/01_registering_subscription_server/#registering_subscription_server) for the subscription server.
 
 !!! Note
     On some Linux systems, you may have to restart the server before you can see the EPRS Replication Console choice in the application menu. If the Replication Console choice is still unavailable in the application menu, it can be started by invoking the script `XDB_HOME/bin/runRepConsole.sh`.
 
-!!! Note
-    For Replication Server installed from an Replication Server RPM package, the EPRS Replication Console is started by invoking the script `XDB_HOME/bin/runRepConsole.sh`.
+## Additional details
 
-The following files are created that you may need during the configuration process.
+The Postgres application menu contains a new item for the EPRS Replication Console.
+
+!!! Note
+    If Replication Server is installed from a Replication Server RPM package, start the EPRS Replication Console by invoking the script `XDB_HOME/bin/runRepConsole.sh`.
+
+During the configuration process, you may need the following files that are created during installation.
 
 | File Name                          | Location                              | Description                                                                          |
 | ---------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------ |

--- a/product_docs/docs/eprs/7/installing/windows.mdx
+++ b/product_docs/docs/eprs/7/installing/windows.mdx
@@ -10,16 +10,16 @@ redirects:
 
 EDB provides an interactive installer for Windows. There are two ways you can access it:
 
-- Download the installer from on the [Downloads page](https://www.enterprisedb.com/software-downloads-postgres#replication-server) and invoke the installer directly. See [Installing directly](/eprs/latest/installing/windows/#installing-directly).
+- Download the installer from the [Downloads page](https://www.enterprisedb.com/software-downloads-postgres#replication-server) and invoke the installer directly. See [Installing directly](/eprs/latest/installing/windows/#installing-directly).
 
 - Use Stack Builder (with PostgreSQL) or StackBuilder Plus (with EDB Postgres Advanced Server) to download the EDB installer package and invoke the installer.  See [Using Stack Builder or StackBuilder Plus](/eprs/latest/installing/windows/#using-stack-builder-or-stackbuilder-plus).
 
 
 ## Prerequisites
 
-- You must have Java Runtime Environment (JRE) version 1.8 or later installed on the hosts where you intend to install any Replication Server component (Replication Console, publication server, or subscription server). Any Java product such as Oracle Java or OpenJDK may be used. Follow the directions for your host operating system to install the Java runtime.
+- You must have Java Runtime Environment (JRE) version 1.8 or later installed on the hosts where you intend to install any Replication Server component (Replication Console, publication server, or subscription server). Any Java product such as Oracle Java or OpenJDK may be used. Follow the directions for your host operating system to install the Java runtime environment.
 
-- Be sure the system environment variable, `JAVA_HOME`, is set to the JRE installation directory of the JRE version and bitness (32-bit or 64-bit) you wish to use with the Replication Server. The Replication Server installer for a Windows platform contains both the 32-bit and 64-bit versions. The `JAVA_HOME` setting determines whether the 32-bit or the 64-bit version of Replication Server is installed. (If `JAVA_HOME` is not set, then the first JRE version encountered in the Path system environment variable determines the Replication Server version to be installed.)
+- Be sure the system environment variable, `JAVA_HOME`, is set to the JRE installation directory of the JRE version and bitness (32-bit or 64-bit) you want to use with the Replication Server. The Replication Server installer for a Windows platform contains both the 32-bit and 64-bit versions. The `JAVA_HOME` setting determines whether the 32-bit or the 64-bit version of Replication Server is installed. If `JAVA_HOME` is not set, the first JRE version encountered in the Path system environment variable determines the Replication Server version to be installed.
 
 
 ## Installing directly
@@ -32,25 +32,39 @@ Proceed to the [Using the interactive installer](#using-the-interactive-installe
 
 ## Using Stack Builder or StackBuilder Plus
 
-If you are using PostgreSQL, you can invoke the installer with Stack Builder. See [Using Stack Builder](https://www.enterprisedb.com/docs/supported-open-source/postgresql/installer/03_using_stackbuilder/). Follow the prompts until you get to the module selection window, expand the Registration-Required and Trial Products node, expand the EnterpriseDB Tools node, and select Replication Server. Proceed to the [Using the interactive installer](#using-the-interactive-installer) section in this topic.
+If you are using PostgreSQL, you can invoke the installer with Stack Builder. See [Using Stack Builder](https://www.enterprisedb.com/docs/supported-open-source/postgresql/installer/03_using_stackbuilder/). 
 
-If you are using EDB Postgres Advanced Server, you can invoke the installer with StackBuilder Plus. See [Using StackBuilder Plus](/epas/latest/epas_inst_windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus/). Follow the prompts until you get to the module selection window, expand the EnterpriseDB Tools node and select Replication Server. Proceed to the [Using the interactive installer](#using-the-interactive-installer) section in this topic.
+1. In Stack Builder, follow the prompts until you get to the module selection page.
+
+1. Expand the **Registration-required and trial products** node. 
+
+1. Expand the **EnterpriseDB Tools** node and select **Replication Server**. 
+
+1. Proceed to the [Using the interactive installer](#using-the-interactive-installer) section in this topic.
+
+If you are using EDB Postgres Advanced Server, you can invoke the installer with StackBuilder Plus. See [Using StackBuilder Plus](/epas/latest/epas_inst_windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus/). 
+
+1. In StackBuilder Plus, follow the prompts until you get to the module selection page. 
+
+1. Expand the **EnterpriseDB Tools** node and select **Replication Server**. 
+
+1. Proceed to the [Using the interactive installer](#using-the-interactive-installer) section in this topic.
 
 ## Using the interactive installer 
 
 1. Select the installation language and select **OK**.
 
-1. On the Setup Replication Server screen, select **Next**.
+1. On the Setup Replication Server page, select **Next**.
 
-1. Read the license agreement. If you accept the agreement, select the accept radio button and select **Next**.
+1. Read the license agreement. If you accept the agreement, select the **I accept the agreement** option and select **Next**.
 
-1. Browse to a directory where you want the Replication Server components installed, or allow it to install the components in the default location. Select **Next**.
+1. Browse to a directory where you want the Replication Server components installed, or allow the installer to install the components in the default location. Select **Next**.
 
-1. If you do not want a particular Replication Server component installed on this particular host, uncheck the box next to the component name. Select **Next**.
+1. If you do not want a particular Replication Server component installed, uncheck the box next to the component name. Select **Next**.
 
-1. On the Account Registration screen, select the radio button that applies to you. Select **Next**.
+1. On the Account Registration page, select the option that applies to you. Select **Next**.
 
-   - If you do not have an EnterpriseDB user account, you will be directed to the registration page of the EnterpriseDB website.
+   - If you do not have an EnterpriseDB user account, you are directed to the registration page of the EnterpriseDB website.
 
    - If you already have an EnterpriseDB user account, enter the email address and password for your EnterpriseDB user account. Select **Next**.
 
@@ -61,24 +75,23 @@ If you are using EDB Postgres Advanced Server, you can invoke the installer with
 
    Enter values for the following fields:
 
-    -   **Admin User** &mdash; The Replication Server administrator user name to authenticate certain usage of the Replication Server such as registering a publication server or a subscription server running on this host. Any alphanumeric string may be entered for the admin user name. The default admin user name is admin.
+    -   **Admin User** &mdash; The Replication Server administrator user name needed to authenticate some Replication Server actions such as registering a publication server or subscription server running on this host. Any alphanumeric string may be entered for the admin user name. The default admin user name is *admin*.
 
-   -   `Admin Password.` &mdash; Password of your choice for the Replication Server administrator given in the Admin User field.
+   -   **Admin Password** &mdash; Password of your choice for the Replication Server administrator.
 
    The admin user and the admin password (in encrypted form) are saved to the `XDB_HOME\etc\edb-repl.conf` configuration file. Select **Next**.
 
-1. (Only if publication server is a selected component): Enter an available port on which the publication server will run. Default port number is 9051. Select **Next**.
+1. If a publication server is being installed, enter an available port on which the publication server can run. The default port number is *9051*. Select **Next**.
 
-1. (Only if subscription server is a selected component): Enter an available port on which the subscription server will run. Default port number is 9052. Select **Next**.
+1. If a subscription server is being installed, enter an available port on which the subscription server can run. The default port number is *9052*. Select **Next**.
 
-1. For the operating system account under which the publication server or subscription server is to run, enter `postgres` or `enterprisedb` if you are using EDB Postgres Advanced Server installed in Oracle compatible configuration mode.
+1. If you are using EDB Postgres Advanced Server installed in Oracle compatible configuration mode, enter `postgres` or `enterprisedb` for the operating system account under which the publication server or subscription server runs.
 
-1. On the Ready to Install screen, Select **Next**.
+1. On the Ready to Install page, select **Next**.
 
-   An information box appears showing the installation progress of the Replication Server selected components. This may take a few minutes.
+   An information box shows the installation progress of the selected components. This may take a few minutes.
 
-1. When installation has completed, select **Finish**.
-
+1. When the installation has completed, select **Finish**.
 
 Successful installation of Replication Server results in the creation of directory structures and files in your host environment as described in [Installation details](installation_details). Verify that the path to your Java runtime program set in `XDB_HOME\etc\edb-repl.conf` is correct.
 

--- a/product_docs/docs/eprs/7/installing/windows.mdx
+++ b/product_docs/docs/eprs/7/installing/windows.mdx
@@ -8,11 +8,11 @@ redirects:
 
 <div id="installing_with_stackbuilder" class="registered_link"></div>
 
-EDB provides an interactive installer for Windows. There are two ways you can access it:
+EDB provides a graphical interactive installer for Windows. You can access it two ways:
 
-- Download the installer from the [Downloads page](https://www.enterprisedb.com/software-downloads-postgres#replication-server) and invoke the installer directly. See [Installing directly](/eprs/latest/installing/windows/#installing-directly).
+- Download the graphical installer from the [Downloads page](https://www.enterprisedb.com/software-downloads-postgres#replication-server) and invoke the installer directly. See [Installing directly](/eprs/latest/installing/windows/#installing-directly).
 
-- Use Stack Builder (with PostgreSQL) or StackBuilder Plus (with EDB Postgres Advanced Server) to download the EDB installer package and invoke the installer.  See [Using Stack Builder or StackBuilder Plus](/eprs/latest/installing/windows/#using-stack-builder-or-stackbuilder-plus).
+- Use Stack Builder (with PostgreSQL) or StackBuilder Plus (with EDB Postgres Advanced Server) to download the EDB installer package and invoke the graphical installer.  See [Using Stack Builder or StackBuilder Plus](/eprs/latest/installing/windows/#using-stack-builder-or-stackbuilder-plus).
 
 
 ## Prerequisites
@@ -24,15 +24,15 @@ EDB provides an interactive installer for Windows. There are two ways you can ac
 
 ## Installing directly
 
-After downloading the installer, to start the installation wizard, assume sufficient privileges (superuser or administrator) and double-click the installer icon. If prompted, provide a password.
+After downloading the graphical installer, to start the installation wizard, assume sufficient privileges (superuser or administrator) and double-click the installer icon. If prompted, provide a password.
 
 In some versions of Windows, to invoke the installer with Administrator privileges, you need to right-click on the installer icon and select **Run as Administrator** from the context menu.
 
-Proceed to the [Using the interactive installer](#using-the-interactive-installer) section.
+Proceed to the [Using the graphical installer](#using-the-graphical-installer) section.
 
 ## Using Stack Builder or StackBuilder Plus
 
-If you are using PostgreSQL, you can invoke the installer with Stack Builder. See [Using Stack Builder](https://www.enterprisedb.com/docs/supported-open-source/postgresql/installer/03_using_stackbuilder/). 
+If you are using PostgreSQL, you can invoke the graphical installer with Stack Builder. See [Using Stack Builder](https://www.enterprisedb.com/docs/supported-open-source/postgresql/installer/03_using_stackbuilder/). 
 
 1. In Stack Builder, follow the prompts until you get to the module selection page.
 
@@ -40,17 +40,17 @@ If you are using PostgreSQL, you can invoke the installer with Stack Builder. Se
 
 1. Expand the **EnterpriseDB Tools** node and select **Replication Server**. 
 
-1. Proceed to the [Using the interactive installer](#using-the-interactive-installer) section in this topic.
+1. Proceed to the [Using the graphical installer](#using-the-graphical-installer) section in this topic.
 
-If you are using EDB Postgres Advanced Server, you can invoke the installer with StackBuilder Plus. See [Using StackBuilder Plus](/epas/latest/epas_inst_windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus/). 
+If you are using EDB Postgres Advanced Server, you can invoke the graphical installer with StackBuilder Plus. See [Using StackBuilder Plus](/epas/latest/epas_inst_windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus/). 
 
 1. In StackBuilder Plus, follow the prompts until you get to the module selection page. 
 
 1. Expand the **EnterpriseDB Tools** node and select **Replication Server**. 
 
-1. Proceed to the [Using the interactive installer](#using-the-interactive-installer) section in this topic.
+1. Proceed to the [Using the graphical installer](#using-the-graphical-installer) section in this topic.
 
-## Using the interactive installer 
+## Using the graphical installer 
 
 1. Select the installation language and select **OK**.
 
@@ -58,7 +58,7 @@ If you are using EDB Postgres Advanced Server, you can invoke the installer with
 
 1. Read the license agreement. If you accept the agreement, select the **I accept the agreement** option and select **Next**.
 
-1. Browse to a directory where you want the Replication Server components installed, or allow the installer to install the components in the default location. Select **Next**.
+1. Browse to a directory where you want the Replication Server components to be installed, or allow the installer to install the components in the default location. Select **Next**.
 
 1. If you do not want a particular Replication Server component installed, uncheck the box next to the component name. Select **Next**.
 

--- a/product_docs/docs/eprs/7/installing/windows.mdx
+++ b/product_docs/docs/eprs/7/installing/windows.mdx
@@ -19,7 +19,7 @@ EDB provides a graphical interactive installer for Windows. You can access it tw
 
 - You must have Java Runtime Environment (JRE) version 1.8 or later installed on the hosts where you intend to install any Replication Server component (Replication Console, publication server, or subscription server). Any Java product such as Oracle Java or OpenJDK may be used. Follow the directions for your host operating system to install the Java runtime environment.
 
-- Be sure the system environment variable, `JAVA_HOME`, is set to the JRE installation directory of the JRE version and bitness (32-bit or 64-bit) you want to use with the Replication Server. The Replication Server installer for a Windows platform contains both the 32-bit and 64-bit versions. The `JAVA_HOME` setting determines whether the 32-bit or the 64-bit version of Replication Server is installed. If `JAVA_HOME` is not set, the first JRE version encountered in the Path system environment variable determines the Replication Server version to be installed.
+- Be sure the system environment variable, `JAVA_HOME`, is set to the JRE installation directory of the JRE version and bitness (32-bit or 64-bit) you want to use with Replication Server. The Replication Server installer for a Windows platform contains both the 32-bit and 64-bit versions. The `JAVA_HOME` setting determines whether the 32-bit or the 64-bit version of Replication Server is installed. If `JAVA_HOME` is not set, the first JRE version encountered in the Path system environment variable determines the Replication Server version to be installed.
 
 
 ## Installing directly


### PR DESCRIPTION
I edited the EPRS Windows install page so it could potentially be used as a model for other Windows installation instructions.

The install instructions reference a Details page. I made some modest edits to the Details page because it did not seem to present information in any logical way. (That page could still be improved.)
