### PR TITLE
PGD: fixed tpa naming issue

### DIFF
--- a/product_docs/docs/pgd/5/appusage.mdx
+++ b/product_docs/docs/pgd/5/appusage.mdx
@@ -324,16 +324,16 @@ its different modes.
 You can test BDR applications using the following programs,
 in addition to other techniques.
 
--   [Trusted Platform Architect](#trusted-platform-architect)
+-   [Trusted Postgres Architect](#trusted-postgres-architect)
 -   [pgbench with CAMO/Failover options](#pgbench-with-camofailover-options)
 -   [isolationtester with multi-node access](#isolationtester-with-multi-node-access)
 
-### Trusted Platform Architect
+### Trusted Postgres Architect
 
-[Trusted Platform Architect](/pgd/latest/tpa) is the system used by EDB to
+[Trusted Postgres Architect](/pgd/latest/tpa) is the system used by EDB to
 deploy reference architectures, including those based on EDB Postgres Distributed.
 
-Trusted Platform Architect includes test suites for each reference architecture.
+Trusted Postgres Architect includes test suites for each reference architecture.
 It also simplifies creating and managing a local collection of tests to run
 against a TPA cluster, using a syntax like the following:
 
@@ -342,7 +342,7 @@ tpaexec test mycluster mytest
 ```
 
 We strongly recommend that developers write their own multi-node suite
-of Trusted Platform Architect tests that verify the main expected properties
+of Trusted Postgres Architect tests that verify the main expected properties
 of the application.
 
 ### pgbench with CAMO/Failover options

--- a/product_docs/docs/pgd/5/tpa/quick_start.mdx
+++ b/product_docs/docs/pgd/5/tpa/quick_start.mdx
@@ -17,7 +17,7 @@ architecture using Amazon EC2.
    tpaexec configure myedbdpcluster --architecture PGD-Always-ON --platform aws --location-names eu-west-1 --data-nodes-per-location 3 
    ```
 
-   This creates a subdirectory directory in current working directory called `myedbdpcluster` containing the `config.yml` configuration file TPAexec uses to create the cluster. Edit the `config.yml` as needed, for example to change the IP address range used for servers or adjust locations of nodes.
+   This creates a subdirectory directory in current working directory called `myedbdpcluster` containing the `config.yml` configuration file TPA uses to create the cluster. Edit the `config.yml` as needed, for example to change the IP address range used for servers or adjust locations of nodes.
 
    We included options to specify using AWS, a single location, and three data nodes. By default, PGD will also configure two [PGD Proxy](../proxy/) nodes and a Barman node for backup.
 
@@ -26,13 +26,13 @@ architecture using Amazon EC2.
    ```shell
    tpaexec provision myedbdpcluster
    ```
-   Since we specified AWS as the platform (the default platform), TPAexec provisions EC2 instances, VPCs, subnets, routing tables, internet gateways, security groups, EBS volumes, elastic IPs, and so on.
+   Since we specified AWS as the platform (the default platform), TPA provisions EC2 instances, VPCs, subnets, routing tables, internet gateways, security groups, EBS volumes, elastic IPs, and so on.
 
 1. Deploy the cluster: 
    ```shell
    tpaexec deploy myedbdpcluster
    ```
-   TPAexec installs the needed packages, appliies the configuration and sets up the actual EDB Postgres Distributed cluster
+   TPA installs the needed packages, applies the configuration and sets up the actual EDB Postgres Distributed cluster
    
 1.  Test the cluster:
    


### PR DESCRIPTION
## What Changed?

Only found instances of Trusted Platform Architect in the appusage topic.
Fixed places where we were referring to the product as TPAexec in the quick start topic. 