### PR TITLE
Add warning to TPA install for folks with old tokens

### DIFF
--- a/product_docs/docs/tpa/23/INSTALL.mdx
+++ b/product_docs/docs/tpa/23/INSTALL.mdx
@@ -76,6 +76,10 @@ $ curl -1sLf 'https://downloads.enterprisedb.com/<your-token>/postgres_distribut
 $ curl -1sLf 'https://downloads.enterprisedb.com/<your-token>/postgres_distributed/setup.rpm.sh' | sudo -E bash
 ```
 
+!!! Warning "Troubleshooting older tokens"
+    If the command above fails with "Access denied", you may have an access token that was generated before 
+    February 20th, 2023 and lacks access to this repository. [Contact support](https://support.enterprisedb.com) to gain access.
+
 Alternatively, you may obtain TPA from the legacy 2ndQuadrant
 repository. To do so, login to the EDB Customer Support Portal and
 subscribe to the ["products/tpa/release" repository](https://techsupport.enterprisedb.com/software_subscriptions/add/products/tpa/)

--- a/product_docs/docs/tpa/23/reference/barman.mdx
+++ b/product_docs/docs/tpa/23/reference/barman.mdx
@@ -1,5 +1,5 @@
 ---
-title: ''
+title: 'Barman'
 originalFilePath: barman.md
 
 ---


### PR DESCRIPTION
## What Changed?

This can probably be removed in a couple of months, but for now there's a chance that someone with a trial token will be unable to access the postgres_distributed repo if the token was generated prior to (some time in the last week).