### PR TITLE
Use alias of the private link service

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/index.mdx
@@ -63,6 +63,13 @@ To walk through an example in your own environment, you need:
    BigAnimal automatically provisions an Azure Private Link Service for every private Postgres cluster. You can easily find this managed Private Link Service by looking for the one that has the Cluster ID in its name, like `p-mckwlbakq5-rw-internal-lb`.
 !!!
 
+-   Alias of the Private Link Service from Azure portal or Azure CLI command
+    ```shell
+    az network private-link-service list --query "[?name=='p-mckwlbakq5-rw-internal-lb'].alias" -o tsv
+    __OUTPUT__
+    p-mckwlbakq5-rw-internal-lb.81cf1c67-cf27-4407-84a8-2f951790eb3a.japaneast.azure.privatelinkservice
+    ```
+
 In this example, you create an Azure Private Endpoint in your client VM's virtual network. After you create the private endpoint, you can use its private IP address to access the Postgres cluster. You must perform this procedure for every virtual network you want to connect from.
 
 
@@ -97,16 +104,10 @@ Create an Azure Private Endpoint in each client virtual network that needs to co
    !!!Note
       In a later step, you need the private endpoint's name to get its private IP address.
 
-1. On the **Resource** tab, connect the private endpoint to the private link service that 
-you created by entering the following details:
+1. On the **Resource** tab, connect the private endpoint to the private link service
 
-   ![](../images/create_private_endpoint_resource.png)
-
-   - Connection Method &mdash; Select *Connect to an Azure resource in my directory*.
-
-   - Subscription &mdash; Select the subscription in which the target BigAnimal Postgres cluster resides. In this example it is `development`.
-   - Resource type &mdash; Select *Microsoft.Network/privateLinkServices*.  This is the type of resource you would like to connect to using this private endpoint.
-   - Resource &mdash; Select the Private Link Service resource whose name starts with the cluster ID.  In this case, it is *p-mckwlbakq5-rw-internal-lb*.
+   - Connection Method &mdash; Select *Connect to an Azure resource by resource ID or alias.*.
+   - Input the alias of *p-mckwlbakq5-rw-internal-lb*
 
    !!!Note
       The Private Link Service is automatically created by BigAnimal in a resource group managed by Azure Kubernetes Service in the corresponding project/region. Its name follows this pattern: `MC_dp-PROJECT_ID-REGION-counter_REGION`. In this example it  is `MC_dp-brcxzr08qr7rbei1-japaneast-1_japaneast`.
@@ -126,7 +127,9 @@ you created by entering the following details:
 
 9.  Select **Create**. 
 
-10. Proceed to [Accessing the cluster](accessing-the-cluster).
+10. Go to **Private endpoint connections** of *p-mckwlbakq5-rw-internal-lb*, and approve the connection. 
+
+11. Proceed to [Accessing the cluster](accessing-the-cluster).
 
 #### Using the Azure CLI 
 
@@ -216,7 +219,7 @@ With a Private DNS Zone, you configure a DNS entry for your cluster's public hos
     dig +short p-mckwlbakq5.brcxzr08qr7rbei1.biganimal.io
     psql -h p-mckwlbakq5.brcxzr08qr7rbei1.biganimal.io -U edb_admin
     __OUTPUT__
-    10.240.1.123
+    100.64.111.5
     Password for user edb_admin:
 
     psql (13.4 (Ubuntu 13.4-1.pgdg28.84+1), server 13.4.8 (Debian 13.4.8-1+deb10))


### PR DESCRIPTION
## What Changed?
1. Connect to an Azure resource by resource ID or alias. -> allows the private link service in a different account
2. update the last IP to make it consistent.
