### PR TITLE
update setup azure marketplace process doc

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/02_azure_market_setup.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_azure_market_setup.mdx
@@ -7,11 +7,7 @@ redirects:
 
 Connect your cloud account with your Azure subscription.
 
-Before starting, within Azure Active Directory, ensure your user type is Member (not Guest). 
-
-You must have one of the following roles in Azure to complete the set up:
-- Global Administrator
-- Privileged Role Administrator
+Before starting, within Azure Active Directory, ensure your user type is Member (not Guest).
 
 ## 1. Select the EDB offer in the Azure portal.
 

--- a/product_docs/docs/biganimal/release/getting_started/identity_provider/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/identity_provider/index.mdx
@@ -4,7 +4,7 @@ navTitle: "Setting up your identity provider"
 description: Applies when you purchased BigAnimal directly from EDB
 ---
 
-If you purchased BigAnimal directly from EDB, you must set up your identity provider (IDP) before accessing BigAnimal for the first time. After setting up your identity provider, you can add users to BigAnimal by adding them to the designated group in your identity provider. Once you've logged into BigAnimal using your identity provider, you can set up your cloud service provider (CSP) in the BigAnimal portal to complete onboarding. If you purchased through Azure Marketplace, BigAnimal authenticates users using Azure Active Directory (AD) and you don't have to complete these steps, as Azure AD is linked during subscription. 
+If you purchased BigAnimal directly from EDB, you must set up your identity provider (IDP) before accessing BigAnimal for the first time. After setting up your identity provider, you can add users to BigAnimal by adding them to the designated group in your identity provider. Once you've logged into BigAnimal using your identity provider, you can set up your cloud service provider (CSP) in the BigAnimal portal to complete onboarding. If you purchased through Azure Marketplace, BigAnimal authenticates users using Azure Active Directory (AD) and you don't have to complete these steps, as Azure AD is linked during subscription.
 
 BigAnimal supports single sign-on through SAML identity providers. The SAML application enables access to BigAnimal for groups selected in your identity provider. You configure your SAML application to send a SAML assertion response to BigAnimal for each user.
 
@@ -32,8 +32,8 @@ http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
 
 On the Set Up Identity Provider page:
 
-1. On the **Connection Info** tab, copy the following URLs to use in your identity provider configuration:  
-   
+1. On the **Connection Info** tab, copy the following URLs to use in your identity provider configuration:
+
    | URL                            | Description |
    | ------------------------------ | ----------- |
    | Assertion Consumer Service URL | BigAnimal-specific URL to which SAML assertions from your identity provider are sent |
@@ -42,10 +42,10 @@ On the Set Up Identity Provider page:
    - `givenname`: BigAnimal uses the value as the given name in the profile of the authenticated user.
    - `surname`: BigAnimal uses the value as the surname in the profile of the authenticated user.
    - `name`: BigAnimal uses the value as the full name (`givenname` joined with `surname`) in the profile of the authenticated user.
-   - `emailaddress` (optional): BigAnimal uses the value for the email address in the profile of the authenticated user. 
-   
+   - `emailaddress` (optional): BigAnimal uses the value for the email address in the profile of the authenticated user.
+
    Provide a `NameID` element in the `Subject` element. Provide your email ID as the value to `NameID`. BigAnimal uses the email ID you provide as your username and primary email, so format `NameID` like an email address.
-      
+
    For example:
 
    ![](../images/nameID.png)
@@ -58,31 +58,31 @@ On the Set Up Identity Provider page:
    | Identity provider signature certificate | Identity provider's assertion signing certificate (`.cer` or `.cert`). Coordinate with your identity provider partner to obtain this certificate securely. |
    | Request Binding | SAML Authentication Request Protocol binding used to send the authentication request: HTTP-Redirect,  HTTP-Post, or Hybrid (SAML request is REDIRECT and response is POST). |
    | Response Signature Algorithm (RSA) Algorithm | The signature algorithm used to sign the SAML AuthNRequest (RSA SHA-1 or RSA SHA-256). |
-4. Select **Test Connection**. If you connect to your identity provider successfully, your identity provider's login screen appears. If an error message appears, contact [Support](/biganimal/latest/overview/support). 
+4. Select **Test Connection**. If you connect to your identity provider successfully, your identity provider's login screen appears. If an error message appears, contact [Support](/biganimal/latest/overview/support).
 
 Once your identity provider is set up, you can view your connection status, ID, login URL, audience URI, and assertion consumer service URL from the BigAnimal portal on the Identity Provider page (select **Admin > Identity Provider** to access).
 
 
 ## Manage roles for added users
 
-You add users through your identity provider. A user who is added in the identity provider is automatically added to BigAnimal. BigAnimal assigns them with the default role of organization member. You manage roles and permissions from BigAnimal. See [Managing portal access](/biganimal/latest/administering_cluster/01_portal_access/). 
+You add users through your identity provider. A user who is added in the identity provider is automatically added to BigAnimal. BigAnimal assigns them with the default role of organization member. You manage roles and permissions from BigAnimal. See [Managing portal access](/biganimal/latest/administering_cluster/01_portal_access/).
 
 !!! Note
-    
+
     A user is created in BigAnimal only after they log in. After they log in, you can change their BigAnimal role.
 
 
-### Add a tile 
+## Add a tile
 
-Once you have established the identity provider, you can create a BigAnimal tile for users to access the organization's BigAnimal  application. To do so, simply copy the quick sign-in URL from the **Settings > Identity Provider** page of the BigAnimal portal to create the tile. For details on how to add a tile, refer to your identify provider documentation for instructions on setting up SSO access to your application. 
+Once you have established the identity provider, you can create a BigAnimal tile for users to access the organization's BigAnimal  application. To do so, simply copy the quick sign-in URL from the **Settings > Identity Provider** page of the BigAnimal portal to create the tile. For details on how to add a tile, refer to your identify provider documentation for instructions on setting up SSO access to your application.
 
 ## Setting up specific identity providers
 
 For step-by-step instructions for setting up specific identity providers, see:
-- [Using Auth0 as your identity provider](auth0) 
+- [Using Auth0 as your identity provider](auth0)
 - [Using AWS IAM Identity Center as your identity provider](aws_sso)
-- [Using Azure AD as your identity provider](azure_ad) 
-- [Using Google Workspace (G Suite) as your identity provider](google) 
+- [Using Azure AD as your identity provider](azure_ad)
+- [Using Google Workspace (G Suite) as your identity provider](google)
 - [Using Okta as your identity provider](okta)
 
 ## Next steps


### PR DESCRIPTION
## What Changed?

1. BigAnimal Azure Marketplace onboarding documention deletes the text of user must be Global Administrator or Privileged Role Administrator. The latest feature in production system does not require the user own these role anymore. 
2. `Add a tile` in *Setup Identity Provider* is one independent topic, it does not belong to *## Manage roles for added users* . So I adjust the `### Add a tile` to `## Add a tile` 
