### PR TITLE
Update installing_the_sql_profiler_plugin.mdx

### DIFF
--- a/product_docs/docs/pem/9/profiling_workloads/pem_sqlprofiler/installing_the_sql_profiler_plugin.mdx
+++ b/product_docs/docs/pem/9/profiling_workloads/pem_sqlprofiler/installing_the_sql_profiler_plugin.mdx
@@ -7,11 +7,9 @@ redirects:
 - /pem/latest/pem_sqlprofiler/01_installing_the_sql_profiler_plugin/
 ---
 
-You must install the plugin on each server on which you want to use SQL Profiler. For example, if you have a host running PostgreSQL 10 and PostgreSQL 11, you must install two versions of the plugin, one for each server.
+You must install the plugin on each server on which you want to use SQL Profiler. For example, if you have a host running PostgreSQL 13 and PostgreSQL 14, you must install two versions of the plugin, one for each server.
 
-Install the plugin for PostgreSQL before configuring it. If you're using EDB Postgres Advanced Server, you can skip installation and go to [Configuring SQL Profiler](#configuring-sql-profiler).
-
-You can use the graphical installer to install any version of SQL Profiler on the Windows platform. On Linux, use an RPM package to install the SQL Profiler. For detailed information about configuring the EDB repository for your host platform, see the [Installing](/pem/latest/installing/) section.
+You can use the graphical installer to install any version of SQL Profiler on the Windows platform. On Linux, use your package manager to install the SQL Profiler package from the EDB repository. For detailed information about configuring the EDB repository for your host platform, see the [Installing](/pem/latest/installing/) section.
 
 ## Installing SQL Profiler on Windows
 


### PR DESCRIPTION
Removed the statement that you don't need to install with EPAS as it seems to be untrue (and there are instructions for doing exactly that below). I think this page will need much bigger changes very soon as the server team are releasing a new version that is installed differently.

## What Changed?

