### PR TITLE
add v15 async link to efm sync replication section

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
@@ -856,6 +856,10 @@ reconfigure.sync.primary=false
 
     If you're using the `reconfigure.sync.primary` property, ensure that the `wal_sender_timeout` value in the primary database is set to at least 10 seconds less than the `efm.node.timeout` value.
 
+!!! Note
+
+    Starting with database version 15, the primary database can be set to use asynchronous processing when needed. This could be used instead of the `reconfigure.sync.primary` property, which would allow the primary to resume synchronous replication when possible. See https://www.enterprisedb.com/docs/pge/latest/replication/#asynchronous-processing for more information.
+
 
 <div id="minimum_standbys" class="registered_link"></div>
 


### PR DESCRIPTION
Starting with v15, a database property is available that means users may not need the efm reconfigure.sync.primary property. Am creating the PR but don't think I have the link correct (don't know the syntax) yet so will have to ask about it.

## What Changed?

