### PR TITLE
Fixed confusing location name

### DIFF
--- a/product_docs/docs/pgd/5/quick_start_docker.mdx
+++ b/product_docs/docs/pgd/5/quick_start_docker.mdx
@@ -53,10 +53,10 @@ export EDB_SUBSCRIPTION_TOKEN=<token>
 Then run `tpaexec configure` to generate a configuration folder.
 
 ```shell
-tpaexec configure myedbdpcluster --architecture PGD-Always-ON --platform docker --location-names eu-west-1 --data-nodes-per-location 3 --no-git
+tpaexec configure myedbdpcluster --architecture PGD-Always-ON --platform docker --location-names dc1 --data-nodes-per-location 3 --no-git
 ```
 
-This creates a subdirectory directory in current working directory called `myedbdpcluster` containing the `config.yml` configuration file TPA uses to create the cluster.
+This creates a subdirectory in current working directory called `myedbdpcluster` containing the `config.yml` configuration file TPA uses to create the cluster.
 
 ```shell
 less myedbdpcluster/config.yml


### PR DESCRIPTION
Perhaps it's better not to use an AWS region name for a location in a Docker deployment

This might cause confusion. 

## What Changed?

Changed the TPA deployment location from "eu-west-1" (AWS region name) to a neutral "dc1" (for data centre 1).

Also fixed a typo.
