### PR TITLE
Advanced Storage pack: changing to generic Postgres terminology

### DIFF
--- a/advocacy_docs/pg_extensions/advanced_storage_pack/index.mdx
+++ b/advocacy_docs/pg_extensions/advanced_storage_pack/index.mdx
@@ -6,7 +6,7 @@ navigation:
 - configuring
 ---
 
-EDB Advanced Storage Pack provides advanced storage options for PostgreSQL databases in the form of table access method (TAM) extensions. These storage options can enhance the performance and reliability of databases without requiring application changes.
+EDB Advanced Storage Pack provides advanced storage options for Postgres databases in the form of table access method (TAM) extensions. These storage options can enhance the performance and reliability of databases without requiring application changes.
 
 For tables whose access patterns you know, you might prefer a targeted TAM that makes different tradeoffs. For instance, if a table has a specific usage pattern, you might consider using a specialized TAM that is designed to enhance that usage pattern.
 


### PR DESCRIPTION
## What Changed?

We use Postgres when referring to our set of Postgres distributions: PG, EPAS, and PGE