### PR TITLE
Update activating_regions.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/activating_regions.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/activating_regions.mdx
@@ -5,7 +5,7 @@ title: "Activating regions"
 
 When you activate a region, BigAnimal prepares the compute and networking resources required to deploy clusters. Note that these added resources can increase your cloud costs. 
 
-You can activate a region ahead of time or when you create or restore a cluster. 
+Activation of a region prior to creating or restoring a cluster is required. 
 
 Each region you activate displays a status. The status is available on the Create cluster and Restore cluster pages and the Regions page. For more information on the different region statuses, see [Region status reference](#region-status-reference).
 
@@ -13,7 +13,7 @@ Each region you activate displays a status. The status is available on the Creat
 
 ## Activate a new region from the Regions page
 
-You can activate a region ahead of time using the **Regions** page. Alternatively, you can activate a region by selecting an inactive region at the time of cluster creation or restore.
+You can activate a region ahead of time using the **Regions** page. 
 
 1. To activate a region ahead of cluster creation, go to the **Regions** page.
      

--- a/product_docs/docs/biganimal/release/getting_started/activating_regions.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/activating_regions.mdx
@@ -5,7 +5,7 @@ title: "Activating regions"
 
 When you activate a region, BigAnimal prepares the compute and networking resources required to deploy clusters. Note that these added resources can increase your cloud costs. 
 
-Activation of a region prior to creating or restoring a cluster is required. 
+You must activate a region prior to creating or restoring a cluster. 
 
 Each region you activate displays a status. The status is available on the Create cluster and Restore cluster pages and the Regions page. For more information on the different region statuses, see [Region status reference](#region-status-reference).
 


### PR DESCRIPTION
As of a few weeks ago, activation of a region prior to cluster creation (or restoration into a region) is now a requirement.  Customers can no longer activate a region at the time of cluster creation, so made a few minor changes.  Please reach out if you have any questions.  Thanks!

## What Changed?

