### PR TITLE
Update note on troubleshooting repo access to reflect reality

### DIFF
--- a/product_docs/docs/tpa/23/INSTALL.mdx
+++ b/product_docs/docs/tpa/23/INSTALL.mdx
@@ -76,9 +76,12 @@ $ curl -1sLf 'https://downloads.enterprisedb.com/<your-token>/postgres_distribut
 $ curl -1sLf 'https://downloads.enterprisedb.com/<your-token>/postgres_distributed/setup.rpm.sh' | sudo -E bash
 ```
 
-!!! Warning "Troubleshooting older tokens"
-    If the command above fails with "Access denied", you may have an access token that was generated before 
-    February 20th, 2023 and lacks access to this repository. [Contact support](https://support.enterprisedb.com) to gain access.
+!!! Tip "Troubleshooting repo access"
+    The command above should produce output starting with,
+    ```text
+    Executing the  setup script for the 'enterprisedb/postgres_distributed' repository ...
+    ```
+    If it produces no output or an error, double-check that you entered your token correctly, then [contact support](https://support.enterprisedb.com) for assistance.
 
 Alternatively, you may obtain TPA from the legacy 2ndQuadrant
 repository. To do so, login to the EDB Customer Support Portal and

--- a/product_docs/docs/tpa/23/INSTALL.mdx
+++ b/product_docs/docs/tpa/23/INSTALL.mdx
@@ -81,7 +81,7 @@ $ curl -1sLf 'https://downloads.enterprisedb.com/<your-token>/postgres_distribut
     ```text
     Executing the  setup script for the 'enterprisedb/postgres_distributed' repository ...
     ```
-    If it produces no output or an error, double-check that you entered your token correctly, then [contact support](https://support.enterprisedb.com) for assistance.
+    If it produces no output or an error, double-check that you entered your token correctly. It the problem persists, [contact Support](https://support.enterprisedb.com) for assistance.
 
 Alternatively, you may obtain TPA from the legacy 2ndQuadrant
 repository. To do so, login to the EDB Customer Support Portal and


### PR DESCRIPTION
## What Changed?

Rewrite the (still temporary) note in TPA Installation topic to stand a chance of being useful.

## Background

Big problem: the curl command as-written will never produce an explicit error (we tell it to squelch errors!). A token with insufficient access or a mistyped token will fail silently. ...However, a good token will *succeed* noisily!

Other problem: old tokens are not the only issue here. Depending on subscription level, current customers may also encounter (silent) failures. 

Changes attempt to address both of these issues and provide some direction for those encountering them.
