### PR TITLE
Add pgvision banner to Docs

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ import SideNavigation from "./side-navigation";
 import StubCards from "./stub-cards";
 import TableOfContents from "./table-of-contents";
 import TextBalancer from "./text-balancer";
+import TimedBanner from "./timed-banner";
 import TopBar from "./top-bar";
 import TreeNode from "./tree-node";
 import VersionDropdown from "./version-dropdown";
@@ -60,6 +61,7 @@ export {
   StubCards,
   TableOfContents,
   TextBalancer,
+  TimedBanner,
   TopBar,
   TreeNode,
   VersionDropdown,

--- a/src/components/main-content.js
+++ b/src/components/main-content.js
@@ -1,5 +1,6 @@
 import React from "react";
 import SearchNavigation from "./search-navigation";
+import TimedBanner from "./timed-banner";
 
 const MainContent = ({
   children,
@@ -8,6 +9,16 @@ const MainContent = ({
 }) => {
   return (
     <div className="flex-grow-1 min-w-50">
+      <TimedBanner toDate={new Date("2023-05-02")}>
+        EDB Postgres Vision 2023: Make the Move with EDB May 9-11 Bellagio Hotel
+        & Casino, Las Vegas{" "}
+        <a
+          className="pl-1 font-weight-bold"
+          href="https://events.enterprisedb.com/oxVGNv?RefId=web"
+        >
+          Register Today
+        </a>
+      </TimedBanner>
       <SearchNavigation logo={searchNavLogo} searchProduct={searchProduct} />
       <main role="main" className="content-container mt-0 p-5">
         {children}

--- a/src/components/timed-banner.js
+++ b/src/components/timed-banner.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+const TimedBanner = ({ fromDate = 0, toDate = 0, children }) => {
+  if (Date.now() >= (fromDate || 0) && Date.now() <= (toDate || Date.now())) {
+    return (
+      <div class="alert alert-warning m-0" role="alert">
+        {children}
+      </div>
+    );
+  }
+  return null;
+};
+
+export default TimedBanner;


### PR DESCRIPTION
## What Changed?

Add a banner to docs pages (above the search bar) with a CTA and registration link for PG Vision. Will disappear after May 2nd, 2023.

Fixes #3763
