### PR TITLE
Moved pgbouncer refs assuming builtin is default

### DIFF
--- a/product_docs/docs/pgd/4/harp/03_installation.mdx
+++ b/product_docs/docs/pgd/4/harp/03_installation.mdx
@@ -21,7 +21,6 @@ version as listed here.
 | Software  | Min version |
 |-----------|---------|
 | etcd      | 3.4     |
-| PgBouncer | 1.14    |
 
 ## TPAExec
 

--- a/product_docs/docs/pgd/4/harp/04_configuration.mdx
+++ b/product_docs/docs/pgd/4/harp/04_configuration.mdx
@@ -198,7 +198,7 @@ Specify Proxy-based settings under a `proxy` heading, and include:
   state are available in status checks and other interactive events.
 
 - **`type`**: Defaults to `builtin` to use the built-in passthrough proxy. Can also be set to `pgbouncer`
-  to use the deprecated (since HARP 2.1) embedded PgBouncer support. . 
+  to use the deprecated (since HARP 2.1) embedded PgBouncer support. 
   
   * Default: `builtin`
 

--- a/product_docs/docs/pgd/4/harp/04_configuration.mdx
+++ b/product_docs/docs/pgd/4/harp/04_configuration.mdx
@@ -5,11 +5,9 @@ redirects:
   - /pgd/latest/harp/04_configuration/
 ---
 
-The HARP configuration file follows a standard YAML-style formatting that was simplified for readability. This file is located in the `/etc/harp`
-directory by default and is named `config.yml`
+The HARP configuration file follows a standard YAML-style formatting that was simplified for readability. This file is located in the `/etc/harp` directory by default and is named `config.yml`
 
-You can explicitly provide the configuration file location to all HARP 
-executables by using the `-f`/`--config` argument.
+You can explicitly provide the configuration file location to all HARP executables by using the `-f`/`--config` argument.
 
 ## Standard configuration
 
@@ -40,13 +38,9 @@ component.
 
 ### Cluster name
 
-The `name` entry under the `cluster` heading is required for all 
-interaction with HARP. Each HARP cluster has a name for both disambiguation
-and for labeling data in the DCS for the specific cluster.
+The `name` entry under the `cluster` heading is required for all interaction with HARP. Each HARP cluster has a name for both disambiguation and for labeling data in the DCS for the specific cluster.
 
-HARP Manager writes information about the cluster here for consumption by 
-HARP Proxy and harpctl. HARP Proxy services direct traffic to nodes in 
-this cluster. The `harpctl` management tool interacts with this cluster.
+HARP Manager writes information about the cluster here for consumption by HARP Proxy and harpctl. HARP Proxy services direct traffic to nodes in this cluster. The `harpctl` management tool interacts with this cluster.
 
 ### DCS settings
 
@@ -203,14 +197,14 @@ Specify Proxy-based settings under a `proxy` heading, and include:
   Each proxy node is named to ensure any associated statistics or operating
   state are available in status checks and other interactive events.
 
-- **`type`**: Specifies whether to use pgbouncer or the experimental built-in passthrough proxy. All proxies must use the same proxy type. We recommend to experimenting with only the simple proxy in combination with the experimental BDR DCS.
-  Can be `pgbouncer` or `builtin`.
+- **`type`**: Specifies whether to use built-in passthrough proxy or pgbouncer. 
+  Can be `builtin` or `pgbouncer`.
   
-  * Default: `pgbouncer`
+  * Default: `builtin`
 
 - **`pgbouncer_bin_dir`**: Directory where PgBouncer binaries are located.
-  As HARP uses PgBouncer binaries, it needs to know where they are 
-  located. This can be depend on the platform or distribution, so it has no
+  If HARP is configured to use PgBouncer, it needs to know where the PgBouncer binaries 
+  are located. This can be depend on the platform or distribution, so it has no
   default. Otherwise, the assumption is that the appropriate binaries are in the 
   environment's `PATH` variable.
 
@@ -233,7 +227,6 @@ dcs:
 proxy:
   name: proxy1
   location: dc1
-  pgbouncer_bin_dir: /usr/sbin
 ```
 
 All other attributes are obtained from the DCS on proxy startup.
@@ -475,12 +468,12 @@ Properties set by `harpctl set proxy` require a restart of the proxy.
   * Default: `extra_float_digits`
 
 - **`listen_address`**: IP addresses where Proxy should listen for
-  connections. Used by pgbouncer and builtin proxy.
+  connections. Used by the builtin and pgbouncer proxy.
 
   * Default: 0.0.0.0
 
 - **`listen_port`**: System port where Proxy listens for connections. 
-     Used by pgbouncer and builtin proxy.
+     Used by the builtin and pgbouncer proxy.
 
   * Default: 6432
 

--- a/product_docs/docs/pgd/4/harp/04_configuration.mdx
+++ b/product_docs/docs/pgd/4/harp/04_configuration.mdx
@@ -197,8 +197,8 @@ Specify Proxy-based settings under a `proxy` heading, and include:
   Each proxy node is named to ensure any associated statistics or operating
   state are available in status checks and other interactive events.
 
-- **`type`**: Specifies whether to use built-in passthrough proxy or pgbouncer. 
-  Can be `builtin` or `pgbouncer`.
+- **`type`**: Defaults to `builtin` to use the built-in passthrough proxy. Can also be set to `pgbouncer`
+  to use the deprecated (since HARP 2.1) embedded PgBouncer support. . 
   
   * Default: `builtin`
 
@@ -206,7 +206,7 @@ Specify Proxy-based settings under a `proxy` heading, and include:
   If HARP is configured to use PgBouncer, it needs to know where the PgBouncer binaries 
   are located. This can be depend on the platform or distribution, so it has no
   default. Otherwise, the assumption is that the appropriate binaries are in the 
-  environment's `PATH` variable.
+  environment's `PATH` variable. Deprecated (since HARP 2.1).
 
 #### Example
 
@@ -400,14 +400,14 @@ Properties set by `harpctl set proxy` require a restart of the proxy.
   HARP Proxy uses this file to store a `pgbouncer` user that has
   access to PgBouncer's Admin database. You can use this for other users
   as well. Proxy modifies this file to add and modify the password for the
-  `pgbouncer` user.
+  `pgbouncer` user. Deprecated (since HARP 2.1).
 
   * Default: `/etc/harp/userlist.txt`
 
 - **`auth_type`**: The type of Postgres authentication to use for password
   matching. This is actually a PgBouncer setting and isn't fully compatible
   with the Postgres `pg_hba.conf` capabilities. We recommend using `md5`, `pam`
-  `cert`, or `scram-sha-256`.
+  `cert`, or `scram-sha-256`. Deprecated (since HARP 2.1).
 
   * Default: `md5`
 
@@ -416,7 +416,7 @@ Properties set by `harpctl set proxy` require a restart of the proxy.
   non-superuser that calls a `SECURITY DEFINER` function instead. If using
   TPAexec to create a cluster, a function named `pgbouncer_get_auth` is
   installed on all databases in the `pg_catalog` namespace to fulfill this
-  purpose.
+  purpose. Deprecated (since HARP 2.1).
 
 - **`auth_user`**: If `auth_user` is set, then any user not specified in
   `auth_file` is queried through the `auth_query` query from `pg_shadow` 
@@ -454,26 +454,22 @@ Properties set by `harpctl set proxy` require a restart of the proxy.
 
 - **`default_pool_size`**: The maximum number of active connections to allow
   per database/user combination. This is for connection pooling purposes
-  but does nothing in session pooling mode. This is a PgBouncer setting.
+  but does nothing in session pooling mode. This is a PgBouncer setting. Deprecated (since HARP 2.1).
 
   * Default: 25
 
 - **`ignore_startup_parameters`**: By default, PgBouncer allows only
-  parameters it can keep track of in startup packets: `client_encoding`,
-  `datestyle`, `timezone`, and `standard_conforming_strings`. All other
-  parameters raise an error. To allow other parameters, you can specify them here so that PgBouncer knows that they are handled by the admin
-  and it can ignore them. Often, you need to set this to 
-  `extra_float_digits` for Java applications to function properly.
+  parameters it can keep track of in startup packets: `client_encoding`, `datestyle`, `timezone`, and `standard_conforming_strings`. All other parameters raise an error. To allow other parameters, you can specify them here so that PgBouncer knows that they are handled by the admin and it can ignore them. Often, you need to set this to `extra_float_digits` for Java applications to function properly. Deprecated (since HARP 2.1).
 
   * Default: `extra_float_digits`
 
 - **`listen_address`**: IP addresses where Proxy should listen for
-  connections. Used by the builtin and pgbouncer proxy.
+  connections. Used by the builtin and deprecated pgbouncer proxy.
 
   * Default: 0.0.0.0
 
 - **`listen_port`**: System port where Proxy listens for connections. 
-     Used by the builtin and pgbouncer proxy.
+     Used by the builtin and deprecated pgbouncer proxy.
 
   * Default: 6432
 
@@ -481,7 +477,7 @@ Properties set by `harpctl set proxy` require a restart of the proxy.
   connections that are allowed on the proxy. This can be many orders of 
   magnitude greater than `default_pool_size`, as these are all connections that
   have yet to be assigned a session or have released a session for use by
-  another client connection. This is a PgBouncer setting.
+  another client connection. This is a PgBouncer setting. Deprecated (since HARP 2.1).
 
   * Default: 100
 
@@ -489,6 +485,7 @@ Properties set by `harpctl set proxy` require a restart of the proxy.
   Since HARP Proxy manages PgBouncer as the actual connection management
   layer, it needs to periodically check various status and stats to verify
   it's still operational. You can also log or register some of this information to the DCS.
+  Deprecated (since HARP 2.1).
 
   * Default: 5
 
@@ -505,8 +502,7 @@ Properties set by `harpctl set proxy` require a restart of the proxy.
 
   * Default: `disable`
 
-- **`session_transfer_mode`**: Method by which to transfer sessions.
-  Possible values are `fast`, `wait`, and `reconnect`.
+- **`session_transfer_mode`**: Method by which to transfer sessions. Possible values are `fast`, `wait`, and `reconnect`. Deprecated (since HARP 2.1).
 
   * Default: `wait`
 


### PR DESCRIPTION
## What Changed?

On what information we have, have moved builtin proxy to default, removed experimental warnings, removed requirement for pgbouncer binaries from docs.

BUT: Have kept references to pgbouncer as it does appear this is only a default change, so this will need PM/Tech review for correctness.