### PR TITLE
Use backslash at end of paths when importing TPA docs

### DIFF
--- a/product_docs/docs/tpa/23/INSTALL.mdx
+++ b/product_docs/docs/tpa/23/INSTALL.mdx
@@ -16,7 +16,7 @@ We publish TPA packages for Debian 10 (buster), Ubuntu 22.04 (jammy), Ubuntu 20.
 (focal), Ubuntu 18.04 (bionic), RHEL/CentOS 7.x and 8.x, Rocky 8.x and AlmaLinux 8.x. These
 distributions provide a usable Python 3.6+ environment out of the box,
 which TPA requires. However, TPA supports a wider range of
-[distributions on target instances](reference/distributions).
+[distributions on target instances](reference/distributions/).
 
 ## Quickstart
 

--- a/product_docs/docs/tpa/23/ansible-and-sudo.mdx
+++ b/product_docs/docs/tpa/23/ansible-and-sudo.mdx
@@ -137,7 +137,7 @@ increasing overhead with increased logging.
 ## Local privileges
 
 The
-[installation instructions for TPA](INSTALL)
+[installation instructions for TPA](INSTALL/)
 mention sudo only as shorthand for “run these commands as root somehow”.
 Once TPA is installed and you have run `tpaexec setup`, TPA
 itself does not require elevated privileges on the local machine. (But

--- a/product_docs/docs/tpa/23/architecture-BDR-Always-ON.mdx
+++ b/product_docs/docs/tpa/23/architecture-BDR-Always-ON.mdx
@@ -9,7 +9,7 @@ suitable for use in test and production.
 
 This architecture requires a subscription to the legacy 2ndQuadrant
 repositories, and some options require a subscription to EDB Repos 1.0.
-See [How TPA uses 2ndQuadrant and EDB repositories](reference/2q_and_edb_repositories)
+See [How TPA uses 2ndQuadrant and EDB repositories](reference/2q_and_edb_repositories/)
 for more detail on this topic.
 
 The BDR-Always-ON architecture has four variants, which can be
@@ -54,7 +54,7 @@ to ensure odd number of nodes for Raft consensus majority. Witness nodes do
 not participate in the data replication.
 
 You must specify `--harp-consensus-protocol protocolname`. The supported
-protocols are bdr and etcd; see [`Configuring HARP`](reference/harp) for more details.
+protocols are bdr and etcd; see [`Configuring HARP`](reference/harp/) for more details.
 
 You may optionally specify `--bdr-database dbname` to set the name of
 the database with BDR enabled (default: bdrdb).
@@ -65,4 +65,4 @@ primary instances in each region to be each other's CAMO partners.
 Please note we enable HARP2 by default in BDR-Always-ON architecture.
 
 You may also specify any of the options described by
-[`tpaexec help configure-options`](tpaexec-configure).
+[`tpaexec help configure-options`](tpaexec-configure/).

--- a/product_docs/docs/tpa/23/architecture-M1.mdx
+++ b/product_docs/docs/tpa/23/architecture-M1.mdx
@@ -15,7 +15,7 @@ only. To use subscription-only EDB software with this architecture
 requires credentials for EDB Repos 1.0. If you choose EDB Advanced
 Server (EPAS) you will also require credentials for the legacy
 2ndQuadrant repos.
-See [How TPA uses 2ndQuadrant and EDB repositories](reference/2q_and_edb_repositories)
+See [How TPA uses 2ndQuadrant and EDB repositories](reference/2q_and_edb_repositories/)
 for more detail on this topic.
 
 ## Default layout
@@ -48,4 +48,4 @@ You may optionally specify `--num-cascaded-replicas N` to request N
 cascaded replicas (including 0 for none; default: 1).
 
 You may also specify any of the options described by
-[`tpaexec help configure-options`](tpaexec-configure).
+[`tpaexec help configure-options`](tpaexec-configure/).

--- a/product_docs/docs/tpa/23/architecture-PGD-Always-ON.mdx
+++ b/product_docs/docs/tpa/23/architecture-PGD-Always-ON.mdx
@@ -8,7 +8,7 @@ EDB Postgres Distributed 5 in an Always-ON configuration,
 suitable for use in test and production.
 
 This architecture is valid for use with PGD version 5 only and requires
-a subscription to [EDB Repos 2.0](reference/2q_and_edb_repositories).
+a subscription to [EDB Repos 2.0](reference/2q_and_edb_repositories/).
 
 ## Cluster configuration
 
@@ -78,4 +78,4 @@ You may optionally specify `--enable-camo` to set the pair of BDR
 primary instances in each region to be each other's CAMO partners.
 
 You may also specify any of the options described by
-[`tpaexec help configure-options`](tpaexec-configure).
+[`tpaexec help configure-options`](tpaexec-configure/).

--- a/product_docs/docs/tpa/23/configure-cluster.mdx
+++ b/product_docs/docs/tpa/23/configure-cluster.mdx
@@ -9,7 +9,7 @@ to edit config.yml and run the provision/deploy/test cycle. The process
 is carefully designed to be idempotent, and to make changes only in
 response to a change in the configuration or a change on the instances.
 
-The [`tpaexec configure`](tpaexec-configure) command will generate
+The [`tpaexec configure`](tpaexec-configure/) command will generate
 a sensible config.yml file for you, but it covers only the most common
 topology and configuration options. If you need something beyond the
 defaults, or you need to make changes after provisioning the cluster,
@@ -17,7 +17,7 @@ you will need to edit config.yml anyway.
 
 This page is an overview of the configuration mechanisms available.
 There's a separate page with more details about the specific
-[variables you can set to customise the deployment process](configure-instance).
+[variables you can set to customise the deployment process](configure-instance/).
 
 ## config.yml
 
@@ -58,7 +58,7 @@ instance or for the whole cluster are the basic building blocks of
 every TPA configuration.
 
 All
-[`tpaexec configure`](tpaexec-configure)
+[`tpaexec configure`](tpaexec-configure/)
 options translate to config.yml variables in
 some way. A single option may affect several variables (e.g.,
 `--bdr-version` could set `postgres_version`,

--- a/product_docs/docs/tpa/23/configure-instance.mdx
+++ b/product_docs/docs/tpa/23/configure-instance.mdx
@@ -9,7 +9,7 @@ offers to customise the deployment process on cluster instances, with
 links to more detailed documentation.
 
 Before you dive into the details of deployment, it may be helpful to
-read [an overview of configuring a cluster](configure-cluster) to
+read [an overview of configuring a cluster](configure-cluster/) to
 understand how cluster and instance variables and the other mechanisms
 in config.yml work together to allow you to write a concise,
 easy-to-review configuration.
@@ -21,30 +21,30 @@ and ready to execute Ansible modules (a distribution-specific process).
 Then it completes various system-level configuration tasks before moving
 on to [Postgres configuration](#postgres) below.
 
--   [Distribution support](reference/distributions)
--   [Python environment](reference/python) (`preferred_python_version`)
--   [Environment variables](reference/target_environment) (e.g., `https_proxy`)
+-   [Distribution support](reference/distributions/)
+-   [Python environment](reference/python/) (`preferred_python_version`)
+-   [Environment variables](reference/target_environment/) (e.g., `https_proxy`)
 
 ### Package repositories
 
 You can use the
-[pre-deploy hook](tpaexec-hooks#pre-deploy)
+[pre-deploy hook](tpaexec-hooks/#pre-deploy)
 to execute tasks before any package repositories are configured.
 
--   [Configure YUM repositories](reference/yum_repositories)
+-   [Configure YUM repositories](reference/yum_repositories/)
     (for RHEL, Rocky and AlmaLinux)
 
--   [Configure APT repositories](reference/apt_repositories)
+-   [Configure APT repositories](reference/apt_repositories/)
     (for Debian and Ubuntu)
 
--   [Configure 2ndQuadrant and EDB repositories](reference/2q_and_edb_repositories)
+-   [Configure 2ndQuadrant and EDB repositories](reference/2q_and_edb_repositories/)
     (on any system)
 
--   [Configure a local package repository](reference/local-repo)
+-   [Configure a local package repository](reference/local-repo/)
     (to ship packages to target instances)
 
 You can use the
-[post-repo hook](tpaexec-hooks#post-repo)
+[post-repo hook](tpaexec-hooks/#post-repo)
 to execute tasks after package repositories have been configured (e.g.,
 to correct a problem with the repository configuration before installing
 any packages).
@@ -55,7 +55,7 @@ Once the repositories are configured, packages are installed at various
 stages throughout the deployment, beginning with a batch of system
 packages:
 
--   [Install non-Postgres packages](reference/packages)
+-   [Install non-Postgres packages](reference/packages/)
     (e.g., acl, openssl, sysstat)
 
 Postgres and other components (e.g., Barman, repmgr, pgbouncer) will be
@@ -64,13 +64,13 @@ documented in their own sections below.
 
 ### Other system-level tasks
 
--   [Create and mount filesystems](reference/volumes) (including RAID,
+-   [Create and mount filesystems](reference/volumes/) (including RAID,
     LUKS setup)
--   [Upload artifacts](reference/artifacts) (files, directories,
+-   [Upload artifacts](reference/artifacts/) (files, directories,
     tar archives)
--   [Set sysctl values](reference/sysctl_values)
--   [Configure /etc/hosts](reference/hosts)
--   [Manage ssh_known_hosts entries](reference/manage_ssh_hostkeys)
+-   [Set sysctl values](reference/sysctl_values/)
+-   [Configure /etc/hosts](reference/hosts/)
+-   [Manage ssh_known_hosts entries](reference/manage_ssh_hostkeys/)
 
 ## Postgres
 
@@ -81,7 +81,7 @@ with installing Postgres itself.
 ### Version selection
 
 Use the
-[`--postgres-version`](tpaexec-configure#software-versions)
+[`--postgres-version`](tpaexec-configure/#software-versions)
 configure option or set `postgres_version` in config.yml to specify
 which Postgres major version you want to install. The default version is
 currently 11, but you can select 9.4, 9.5, 9.6, 10, 12, or 13 instead.
@@ -97,10 +97,10 @@ The default `postgres_installation_method` is to install packages for
 the version of Postgres you selected, along with various extensions,
 according to the architecture's needs:
 
--   [Install Postgres and Postgres-related packages](reference/postgres_installation_method_pkg)
+-   [Install Postgres and Postgres-related packages](reference/postgres_installation_method_pkg/)
     (e.g., pglogical, BDR, etc.)
 
--   [Build and install Postgres and extensions from source](reference/postgres_installation_method_src)
+-   [Build and install Postgres and extensions from source](reference/postgres_installation_method_src/)
     (for development and testing)
 
 Whichever installation method you choose, TPA can give you the same
@@ -108,18 +108,18 @@ cluster configuration with a minimum of effort.
 
 ### Configuration
 
--   [Configure the postgres Unix user](reference/postgres_user)
+-   [Configure the postgres Unix user](reference/postgres_user/)
 
--   [Run initdb to create the PGDATA directory](reference/initdb)
+-   [Run initdb to create the PGDATA directory](reference/initdb/)
 
--   [Configure pg_hba.conf](reference/pg_hba.conf)
+-   [Configure pg_hba.conf](reference/pg_hba.conf/)
 
--   [Configure pg_ident.conf](reference/pg_ident.conf)
+-   [Configure pg_ident.conf](reference/pg_ident.conf/)
 
--   [Configure postgresql.conf](reference/postgresql.conf)
+-   [Configure postgresql.conf](reference/postgresql.conf/)
 
 You can use the
-[postgres-config hook](tpaexec-hooks#postgres-config)
+[postgres-config hook](tpaexec-hooks/#postgres-config)
 to execute tasks after the Postgres configuration files have been
 installed (e.g., to install additional configuration files).
 
@@ -129,11 +129,11 @@ pgbouncer, and haproxy, according to the details of the architecture.
 
 ## Other components
 
--   [Configure Barman](reference/barman)
--   [Configure pgbouncer](reference/pgbouncer)
--   [Configure haproxy](reference/haproxy)
--   [Configure HARP](reference/harp)
--   [Configure EFM](reference/efm)
+-   [Configure Barman](reference/barman/)
+-   [Configure pgbouncer](reference/pgbouncer/)
+-   [Configure haproxy](reference/haproxy/)
+-   [Configure HARP](reference/harp/)
+-   [Configure EFM](reference/efm/)
 
 ### Configuring and starting services
 
@@ -151,23 +151,23 @@ In any case, Postgres will be running at the end of this step.
 
 ## After starting Postgres
 
--   [Create Postgres users](reference/postgres_users)
+-   [Create Postgres users](reference/postgres_users/)
 
--   [Create Postgres tablespaces](reference/postgres_tablespaces)
+-   [Create Postgres tablespaces](reference/postgres_tablespaces/)
 
--   [Create Postgres databases](reference/postgres_databases)
+-   [Create Postgres databases](reference/postgres_databases/)
 
--   [Configure pglogical replication](reference/pglogical)
+-   [Configure pglogical replication](reference/pglogical/)
 
--   [Configure .pgpass](reference/pgpass)
+-   [Configure .pgpass](reference/pgpass/)
 
 You can use the
-[postgres-config-final hook](tpaexec-hooks#postgres-config-final)
+[postgres-config-final hook](tpaexec-hooks/#postgres-config-final)
 to execute tasks after the post-startup Postgres configuration has been
 completed (e.g., to perform SQL queries to create objects or load data).
 
--   [Configure BDR](reference/bdr)
+-   [Configure BDR](reference/bdr/)
 
 You can use the
-[post-deploy hook](tpaexec-hooks#post-deploy)
+[post-deploy hook](tpaexec-hooks/#post-deploy)
 to execute tasks after the deployment process has completed.

--- a/product_docs/docs/tpa/23/configure-source.mdx
+++ b/product_docs/docs/tpa/23/configure-source.mdx
@@ -76,9 +76,9 @@ can, therefore, build things other than Postgres, pglogical, and BDR.
 
 The available options are documented here:
 
--   [Building Postgres from source](reference/postgres_installation_method_src)
+-   [Building Postgres from source](reference/postgres_installation_method_src/)
 
--   [Building extensions with `install_from_source`](reference/install_from_source)
+-   [Building extensions with `install_from_source`](reference/install_from_source/)
 
 ## Local source directories
 

--- a/product_docs/docs/tpa/23/index.mdx
+++ b/product_docs/docs/tpa/23/index.mdx
@@ -48,7 +48,7 @@ various scenarios. These recommendations are as applicable to quick
 testbed setups as to production environments.
 
 (You can skip straight to the [TPA installation
-instructions](INSTALL) if you want to get started.)
+instructions](INSTALL/) if you want to get started.)
 
 ## What can TPA do?
 
@@ -76,16 +76,16 @@ TPA operates in four distinct stages to bring up a Postgres cluster:
 You can run TPA from your laptop, an EC2 instance, or any machine
 that can reach the cluster's servers over the network.
 
-Here's a [list of capabilities and supported software](reference/tpaexec-support).
+Here's a [list of capabilities and supported software](reference/tpaexec-support/).
 
 ### Configuration
 
-The [`tpaexec configure`](tpaexec-configure)
+The [`tpaexec configure`](tpaexec-configure/)
 command generates a simple YAML configuration file to describe a
 cluster, based on the options you select. The configuration is ready for
 immediate use, and you can modify it to better suit your needs. Editing
 the configuration file is the usual way to [make any configuration
-changes to your cluster](configure-cluster), both before and after
+changes to your cluster](configure-cluster/), both before and after
 it's created.
 
 At this stage, you must select an architecture and a platform for the
@@ -98,7 +98,7 @@ e.g., AWS, Docker, or bare-metal servers.
 
 ### Provisioning
 
-The [`tpaexec provision`](tpaexec-provision)
+The [`tpaexec provision`](tpaexec-provision/)
 command creates instances and other resources required by the cluster.
 The details of the process depend on the architecture (e.g., M1) and
 platform (e.g., AWS) that you selected while configuring the cluster.
@@ -122,7 +122,7 @@ can access via SSH (with sudo to root).
 
 ### Deployment
 
-The [`tpaexec deploy`](tpaexec-deploy)
+The [`tpaexec deploy`](tpaexec-deploy/)
 command installs and configures Postgres and other software on the
 provisioned servers (which may or may not have been created by TPA;
 but it doesn't matter who created them so long as SSH and sudo access is
@@ -132,7 +132,7 @@ At the end of the deployment stage, Postgres will be up and running.
 
 ### Testing
 
-The [`tpaexec test`](tpaexec-test) command executes various
+The [`tpaexec test`](tpaexec-test/) command executes various
 architecture and platform-specific tests against the deployed cluster to
 ensure that it is working as expected.
 
@@ -157,23 +157,23 @@ safer to manage your cluster than making the changes by hand.
 ### Extensible through Ansible
 
 TPA supports a [variety of configuration
-options](configure-instance), so you can do a lot just by editing
+options](configure-instance/), so you can do a lot just by editing
 config.yml and re-running provision/deploy/test. If you do need to go
 beyond what TPA already supports, you can write
 
--   [Custom commands](reference/tpaexec-commands), which make it simple to write
+-   [Custom commands](reference/tpaexec-commands/), which make it simple to write
     playbooks to run on the cluster. Just create
     `commands/xyz.yml` in your cluster directory, and invoke it
     using `tpaexec xyz /path/to/cluster`. Ideal for any management tasks
     or processes that you need to automate.
 
--   [Custom tests](reference/tpaexec-tests), which augment the builtin tests with
+-   [Custom tests](reference/tpaexec-tests/), which augment the builtin tests with
     in-depth verifications specific to your environment and application.
     Using `tpaexec test` to run all tests in a uniform, repeatable way
     ensures that you will not miss out on anything important, either when
     dealing with a crisis, or just during routine cluster management.
 
--   [Hook scripts](tpaexec-hooks), which are invoked during various
+-   [Hook scripts](tpaexec-hooks/), which are invoked during various
     stages of the deployment. For example, tasks in `hooks/pre-deploy.yml`
     will be run before the main deployment; there are many other hooks,
     including `post-deploy`. This places the full range of Ansible
@@ -189,5 +189,5 @@ on a TPA cluster that you could do on any other Postgres installation.
 
 ## Getting started
 
-Follow the [TPA installation instructions](INSTALL) for your
-system, then [configure your first cluster](tpaexec-configure).
+Follow the [TPA installation instructions](INSTALL/) for your
+system, then [configure your first cluster](tpaexec-configure/).

--- a/product_docs/docs/tpa/23/platform-bare.mdx
+++ b/product_docs/docs/tpa/23/platform-bare.mdx
@@ -69,8 +69,8 @@ output and then exits instead, e.g., `'id'`.)
 
 For more details:
 
--   [Use a different ssh key](reference/ssh_key_file)
--   [Manage ssh host keys for bare instances](reference/manage_ssh_hostkeys)
+-   [Use a different ssh key](reference/ssh_key_file/)
+-   [Manage ssh host keys for bare instances](reference/manage_ssh_hostkeys/)
 
 ## Distribution support
 

--- a/product_docs/docs/tpa/23/reference/2q_and_edb_repositories.mdx
+++ b/product_docs/docs/tpa/23/reference/2q_and_edb_repositories.mdx
@@ -10,10 +10,10 @@ selected software, and how to configure access to each source.
 
 Note that this page only describes the special configuration options and
 logic for EDB and 2ndQuadrant sources. Arbitrary
-[yum](yum_repositories) or [apt](apt_repositories) repositories
+[yum](yum_repositories/) or [apt](apt_repositories/) repositories
 can be added independently of the logic described here. Likewise,
-packages can be [downloaded in advance](tpaexec-download-packages)
-and added to a [local repository](local-repo) if preferred.
+packages can be [downloaded in advance](tpaexec-download-packages/)
+and added to a [local repository](local-repo/) if preferred.
 
 ## Package sources used by TPA
 

--- a/product_docs/docs/tpa/23/reference/INSTALL-docker.mdx
+++ b/product_docs/docs/tpa/23/reference/INSTALL-docker.mdx
@@ -5,13 +5,13 @@ originalFilePath: INSTALL-docker.md
 ---
 
 If you are using a system for which there are no [TPA
-packages](../INSTALL) available, and it's difficult to run TPA after
-[installing from source](INSTALL-repo) (for example, because it's not
+packages](../INSTALL/) available, and it's difficult to run TPA after
+[installing from source](INSTALL-repo/) (for example, because it's not
 easy to obtain a working Python 3.6+ interpreter), your last resort may
 be to build a Docker image and run TPA inside a Docker container.
 
 Please note that you do not need to run TPA in a Docker container in
-order to [deploy to Docker containers](../platform-docker). It's always
+order to [deploy to Docker containers](../platform-docker/). It's always
 preferable to run TPA directly if you can (even on MacOS X).
 
 ## Quickstart

--- a/product_docs/docs/tpa/23/reference/INSTALL-repo.mdx
+++ b/product_docs/docs/tpa/23/reference/INSTALL-repo.mdx
@@ -7,14 +7,14 @@ originalFilePath: INSTALL-repo.md
 This document explains how to use TPA from a copy of the source code
 repository.
 
-Please [install TPA from packages](../INSTALL) if you can; install
+Please [install TPA from packages](../INSTALL/) if you can; install
 from source only if no packages are available for your system (e.g., on
 MacOS X), or if you are collaborating with the TPA developers to
 test unreleased code.
 
 To run TPA from source, you must install all of the dependencies
 (e.g., Python 3.6+) that the packages would handle for you, or download
-the source and [run TPA in a Docker container](INSTALL-docker).
+the source and [run TPA in a Docker container](INSTALL-docker/).
 (Either way will work fine on Linux and MacOS X.)
 
 ## Quickstart
@@ -52,7 +52,7 @@ Install the various dependencies as described above.
 
 If your system does not have Python 3.6+ packages, you can use `pyenv`
 to install a more recent Python in your home directory (see below), or
-you can [run TPA in a Docker container](INSTALL-docker).
+you can [run TPA in a Docker container](INSTALL-docker/).
 
 Next, clone the TPA repository into, say, `~/tpaexec`. (It doesn't
 matter where you put it, but don't use `/opt/EDB/TPA` or

--- a/product_docs/docs/tpa/23/reference/air-gapped.mdx
+++ b/product_docs/docs/tpa/23/reference/air-gapped.mdx
@@ -9,8 +9,8 @@ Internet is allowed, it is necessary to provide all packages needed by
 TPA to complete the deployment. This can be done via a local-repo on
 each node in the cluster. TPA supports the addition of custom
 repositories on each node via a
-[local-repo](local-repo) and the required packages can be downloaded
-using the [download-packages](tpaexec-download-packages) command.
+[local-repo](local-repo/) and the required packages can be downloaded
+using the [download-packages](tpaexec-download-packages/) command.
 
 ## Preparation
 
@@ -44,19 +44,19 @@ cluster_vars:
 Note: that you do not need separate cluster configurations for internet
 connected and disconnected environments, the options below work in both.
 
-More info on [using local-repo for distributing packages](local-repo)
+More info on [using local-repo for distributing packages](local-repo/)
 
 ## Downloading packages
 
 On the internet connected machine, ensure that you
-have [docker installed](../platform-docker) and run:
+have [docker installed](../platform-docker/) and run:
 
 ```shell
 tpaexec download-packages cluster-dir --os <OS> --os-version <version>
 ```
 
 See detailed description for
-the [package downloader](tpaexec-download-packages).
+the [package downloader](tpaexec-download-packages/).
 
 ## Copying packages to the target environment
 

--- a/product_docs/docs/tpa/23/reference/artifacts.mdx
+++ b/product_docs/docs/tpa/23/reference/artifacts.mdx
@@ -50,4 +50,4 @@ module accepts.
 
 Copying files and directories to target instances is a common-enough
 need that this feature provides a convenient shortcut you can use
-instead of writing a [custom hook](../tpaexec-hooks).
+instead of writing a [custom hook](../tpaexec-hooks/).

--- a/product_docs/docs/tpa/23/reference/bdr.mdx
+++ b/product_docs/docs/tpa/23/reference/bdr.mdx
@@ -172,7 +172,7 @@ scopes alone.
 ### Hooks
 
 TPAexec invokes the bdr-node-pre-creation, bdr-post-group-creation, and
-bdr-pre-group-join [hooks](../tpaexec-hooks) during the BDR cluster
+bdr-pre-group-join [hooks](../tpaexec-hooks/) during the BDR cluster
 setup process.
 
 ### Database collations

--- a/product_docs/docs/tpa/23/reference/distributions.mdx
+++ b/product_docs/docs/tpa/23/reference/distributions.mdx
@@ -9,7 +9,7 @@ instance.
 
 (This page is about distribution support on target instances that you
 are deploying *to*, not about the system you are running TPA *from*.
-See the [installation instructions](../INSTALL#distribution-support) for
+See the [installation instructions](../INSTALL/#distribution-support) for
 more on the latter.)
 
 ## Debian
@@ -41,4 +41,4 @@ packages yet.
 
 Some platforms may not support all of the distributions mentioned here.
 For example, Debian 8 and Ubuntu 16.04 are not supported in [Docker
-containers](../platform-docker).
+containers](../platform-docker/).

--- a/product_docs/docs/tpa/23/reference/edb_repositories.mdx
+++ b/product_docs/docs/tpa/23/reference/edb_repositories.mdx
@@ -8,7 +8,7 @@ This page explains how to configure EDB Repos 2.0 package repositories
 on any system.
 
 For more details on the EDB and 2ndQuadrant package sources used by
-TPA see [this page](2q_and_edb_repositories).
+TPA see [this page](2q_and_edb_repositories/).
 
 To specify the complete list of repositories from EDB Repos 2.0 to
 install on each instance, set `edb_repositories` to a list of EDB

--- a/product_docs/docs/tpa/23/reference/git-credentials.mdx
+++ b/product_docs/docs/tpa/23/reference/git-credentials.mdx
@@ -8,8 +8,8 @@ This page explains how to clone Git repositories that require
 authentication.
 
 This may be required when you change `postgres_git_url`
-to [install Postgres from source](postgres_installation_method_src) or
-[use `install_from_source`](install_from_source) to compile and
+to [install Postgres from source](postgres_installation_method_src/) or
+[use `install_from_source`](install_from_source/) to compile and
 install extensions.
 
 You have two options to authenticate without writing the credentials to

--- a/product_docs/docs/tpa/23/reference/haproxy.mdx
+++ b/product_docs/docs/tpa/23/reference/haproxy.mdx
@@ -8,7 +8,7 @@ TPA will install and configure haproxy on instances whose `role`
 contains `haproxy`.
 
 By default, haproxy listens on `127.0.0.1:5432` for requests forwarded
-by [`pgbouncer`](pgbouncer) running on the same instance. You must
+by [`pgbouncer`](pgbouncer/) running on the same instance. You must
 specify a list of `haproxy_backend_servers` to forward requests to.
 
 TPA will install the latest available version of haproxy by default.
@@ -16,7 +16,7 @@ You can install a specific version instead by setting
 `haproxy_package_version: 1.9.15*` (for example).
 
 Note: see limitations of using wildcards in package_version in
-[tpaexec-configure](../tpaexec-configure#known-issue-with-wildcard-use).
+[tpaexec-configure](../tpaexec-configure/#known-issue-with-wildcard-use).
 
 You can set the following variables on any `haproxy` instance.
 

--- a/product_docs/docs/tpa/23/reference/harp.mdx
+++ b/product_docs/docs/tpa/23/reference/harp.mdx
@@ -42,7 +42,7 @@ for more details on HARP configuration.
 | `harp_db_request_timeout`         | `10s`         | similar to dcs -> request_timeout, but for connection to the database itself.                                                                                                               |
 
 You can use the
-[harp-config hook](../tpaexec-hooks#harp-config)
+[harp-config hook](../tpaexec-hooks/#harp-config)
 to execute tasks after the HARP configuration files have been
 installed (e.g., to install additional configuration files).
 

--- a/product_docs/docs/tpa/23/reference/initdb.mdx
+++ b/product_docs/docs/tpa/23/reference/initdb.mdx
@@ -10,7 +10,7 @@ Then, unless the directory already contains a `VERSION` file, it will
 run `initdb` to initialise `postgres_data_dir`.
 
 You can use the
-[pre-initdb hook](../tpaexec-hooks#pre-initdb)
+[pre-initdb hook](../tpaexec-hooks/#pre-initdb)
 to execute tasks before `postgres_data_dir` is created and `initdb` is
 run. If the hook initialises `postgres_data_dir`, TPA will find the
 `VERSION` file and realise that it does not need to run `initdb` itself.

--- a/product_docs/docs/tpa/23/reference/install_from_source.mdx
+++ b/product_docs/docs/tpa/23/reference/install_from_source.mdx
@@ -31,7 +31,7 @@ pglogical and BDR) by mentioning them in the correct order.
 
 Each entry must specify a `name`, `git_repository_url`, and
 `git_repository_ref` (default: `master`) to build. You can use
-[SSH agent forwarding or an HTTPS username/password](git-credentials)
+[SSH agent forwarding or an HTTPS username/password](git-credentials/)
 to authenticate to the Git repository; and also set
 `source_directory`, `build_directory`, `build_environment`, and
 `build_commands` as shown above.
@@ -39,7 +39,7 @@ to authenticate to the Git repository; and also set
 Run `tpaexec deploy … --skip-tags build-clean` in order to reuse the
 build directory when doing repeated deploys. (Otherwise the old build
 directory is emptied before starting the build.) You can also configure
-[local source directories](../configure-source#local-source-directories)
+[local source directories](../configure-source/#local-source-directories)
 to speed up your development builds.
 
 Whenever you run a source build, Postgres will be restarted.
@@ -48,7 +48,7 @@ Whenever you run a source build, Postgres will be restarted.
 
 If you're building from source, TPA will ensure that the basic
 Postgres build dependencies are installed. If you need any additional
-packages, mention them in [`packages`](packages). For example
+packages, mention them in [`packages`](packages/). For example
 
 ```yaml
 cluster_vars:

--- a/product_docs/docs/tpa/23/reference/local-repo.mdx
+++ b/product_docs/docs/tpa/23/reference/local-repo.mdx
@@ -27,7 +27,7 @@ directory and OS-specific subdirectories. See below for details of the
 
 ## Disconnected environments
 
-See instructions for managing clusters in an [air-gapped](air-gapped)
+See instructions for managing clusters in an [air-gapped](air-gapped/)
 environment.
 
 ## Local repo layout
@@ -67,7 +67,7 @@ different distributions, they'll all use the same subdirectory.
 
 ## Populating the repository
 
-Run [`tpaexec download-packages`](tpaexec-download-packages) to
+Run [`tpaexec download-packages`](tpaexec-download-packages/) to
 download all the packages required by a cluster into the local-repo.
 
 You must copy packages into the appropriate repository directory and

--- a/product_docs/docs/tpa/23/reference/manage_ssh_hostkeys.mdx
+++ b/product_docs/docs/tpa/23/reference/manage_ssh_hostkeys.mdx
@@ -10,7 +10,7 @@ subdirectory. These host keys are automatically installed into
 `/etc/ssh` on AWS EC2 instances and Docker containers.
 
 By default, these host keys are not installed on
-[bare instances](../platform-bare),
+[bare instances](../platform-bare/),
 but you can set `manage_ssh_hostkeys` to enable it:
 
 ```yaml
@@ -24,7 +24,7 @@ instances:
 
 You must initially set up `known_hosts` in your cluster directory with
 correct entries, as described in the docs for
-[bare instances](../platform-bare). TPA will replace the host keys
+[bare instances](../platform-bare/). TPA will replace the host keys
 during deployment.
 
 The `manage_ssh_hostkeys` setting is meaningful only for bare instances.

--- a/product_docs/docs/tpa/23/reference/packages.mdx
+++ b/product_docs/docs/tpa/23/reference/packages.mdx
@@ -35,7 +35,7 @@ based on which distribution the instance is running. If any of these
 packages is not available, the deployment will fail.
 
 Don't list any packages that depend on Postgres; use
-[`extra_postgres_packages`](postgres_installation_method_pkg)
+[`extra_postgres_packages`](postgres_installation_method_pkg/)
 instead.
 
 ## Optional packages

--- a/product_docs/docs/tpa/23/reference/pem.mdx
+++ b/product_docs/docs/tpa/23/reference/pem.mdx
@@ -20,8 +20,8 @@ cluster configured for use as PEM backend. All configuration options available
 for a normal postgres instance are valid for PEM's backend postgres instance
 as well. See following for details:
 
--   [Configure pg_hba.conf](pg_hba.conf)
--   [Configure postgresql.conf](postgresql.conf)
+-   [Configure pg_hba.conf](pg_hba.conf/)
+-   [Configure postgresql.conf](postgresql.conf/)
 
 Note that PEM is only available via EDB's package repositories and therefore
 requires a valid subscription.

--- a/product_docs/docs/tpa/23/reference/pg-backup-api.mdx
+++ b/product_docs/docs/tpa/23/reference/pg-backup-api.mdx
@@ -18,8 +18,8 @@ cluster_vars:
 
 pg-backup-api will be installed via packages by default, but you can
 also install from a git branch or a local directory. See
-[configure-source.md](../configure-source) and
-[install_from_source.md](install_from_source) for more details.
+[configure-source.md](../configure-source/) and
+[install_from_source.md](install_from_source/) for more details.
 
 Run `pg-backup-api status` on the barman node running pg-backup-api - if
 you get "OK" back, the pg-backup-api service is running.

--- a/product_docs/docs/tpa/23/reference/pgbouncer.mdx
+++ b/product_docs/docs/tpa/23/reference/pgbouncer.mdx
@@ -9,7 +9,7 @@ contains `pgbouncer`.
 
 By default, pgbouncer listens for connections on port 6432 and forwards
 connections to `127.0.0.1:5432` (which may be either Postgres or
-[haproxy](haproxy), depending on the architecture).
+[haproxy](haproxy/), depending on the architecture).
 
 You can set the following variables on any `pgbouncer` instance.
 

--- a/product_docs/docs/tpa/23/reference/pgd-proxy.mdx
+++ b/product_docs/docs/tpa/23/reference/pgd-proxy.mdx
@@ -7,7 +7,7 @@ originalFilePath: pgd-proxy.md
 TPA will install and configure pgd-proxy for the PGD-Always-ON
 architecture with BDR 5 on any instance with `pgd-proxy` in its `role`.
 
-(By default, the [PGD-Always-ON architecture](../architecture-PGD-Always-ON)
+(By default, the [PGD-Always-ON architecture](../architecture-PGD-Always-ON/)
 includes standalone `pgd-proxy` instances in each location, but using
 the `--cohost-proxies` configure option will install pgd-proxy on the
 BDR instances instead.)

--- a/product_docs/docs/tpa/23/reference/pglogical.mdx
+++ b/product_docs/docs/tpa/23/reference/pglogical.mdx
@@ -80,10 +80,10 @@ subscriptions.
 
 TPA will configure pglogical after creating users, extensions, and
 databases, but before any BDR configuration. You can set
-[`postgres_users`](postgres_users) and
-[`postgres_databases`](postgres_databases) to create databases
+[`postgres_users`](postgres_users/) and
+[`postgres_databases`](postgres_databases/) to create databases
 for replication, and use the
-[`postgres-config-final`](../tpaexec-hooks#postgres-config-final)
+[`postgres-config-final`](../tpaexec-hooks/#postgres-config-final)
 hook to populate the databases before pglogical is configured.
 
 ## Publications

--- a/product_docs/docs/tpa/23/reference/postgres_databases.mdx
+++ b/product_docs/docs/tpa/23/reference/postgres_databases.mdx
@@ -35,7 +35,7 @@ Each entry must specify the `name` of the database to create. All
 other attributes are optional.
 
 The `owner` is `postgres` by default, but you can set it to any
-valid username (the users in [`postgres_users`](postgres_users)
+valid username (the users in [`postgres_users`](postgres_users/)
 will have been created by this time).
 
 The `encoding`, `lc_collate`, and `lc_ctype` values default to the
@@ -46,13 +46,13 @@ database with non-default locale settings, you will also need to specify
 
 You can optionally specify the default `tablespace` for a database; the
 tablespace must already exist
-(see [`postgres_tablespaces`](postgres_tablespaces)).
+(see [`postgres_tablespaces`](postgres_tablespaces/)).
 
 You can specify optional lists of `extensions` and `languages` to create
 within each database (in addition to any extensions or languages
 inherited from the template database). Any packages required must be
 installed already, for example by including them in
-[`extra_postgres_packages`](postgres_installation_method_pkg).
+[`extra_postgres_packages`](postgres_installation_method_pkg/).
 
 TPA will not drop existing databases that are not mentioned in
 `postgres_databases`, and it may create additional databases if required

--- a/product_docs/docs/tpa/23/reference/postgres_installation_method_pkg.mdx
+++ b/product_docs/docs/tpa/23/reference/postgres_installation_method_pkg.mdx
@@ -33,4 +33,4 @@ instance, together with the default list of Postgres packages, and any
 distribution-specific packages you specify.
 
 There's a separate page about
-[compiling and installing Postgres from source](postgres_installation_method_src).
+[compiling and installing Postgres from source](postgres_installation_method_src/).

--- a/product_docs/docs/tpa/23/reference/postgres_installation_method_src.mdx
+++ b/product_docs/docs/tpa/23/reference/postgres_installation_method_src.mdx
@@ -27,7 +27,7 @@ cluster_vars:
 
 The default git.postgresql.org repository does not require
 authentication, but if necessary, you can use
-[SSH agent forwarding or an HTTPS username/password](git-credentials)
+[SSH agent forwarding or an HTTPS username/password](git-credentials/)
 to authenticate to other repositories.
 
 The repository will be cloned into `postgres_src_dir` (default:
@@ -73,7 +73,7 @@ cluster_vars:
 Run `tpaexec deploy … --skip-tags build-clean` in order to reuse the
 build directory when doing repeated deploys. (Otherwise the old build
 directory is emptied before starting the build.) You can also configure
-[local source directories](../configure-source#local-source-directories)
+[local source directories](../configure-source/#local-source-directories)
 to speed up your development builds.
 
 Whenever you run a source build, Postgres will be restarted.
@@ -82,7 +82,7 @@ Whenever you run a source build, Postgres will be restarted.
 
 Even if you install Postgres from packages, you can compile and install
 extensions from source. There's a separate page about how to configure
-[`install_from_source`](install_from_source).
+[`install_from_source`](install_from_source/).
 
 If you install Postgres from source, however, you will need to install
 extensions from source as well, because the extension packages typically
@@ -91,5 +91,5 @@ depend on the Postgres package(s) being installed.
 ## Package installation
 
 There's a separate page about
-[installing Postgres and Postgres-related packages](postgres_installation_method_pkg)
+[installing Postgres and Postgres-related packages](postgres_installation_method_pkg/)
 with `postgres_installation_method: pkg` (the default).

--- a/product_docs/docs/tpa/23/reference/postgres_tablespaces.mdx
+++ b/product_docs/docs/tpa/23/reference/postgres_tablespaces.mdx
@@ -8,7 +8,7 @@ To create Postgres tablespaces during deployment, define their names and
 locations in `postgres_tablespaces` under `cluster_vars` or a particular
 instance's `vars` in config.yml.
 
-If you [define volumes](volumes) with
+If you [define volumes](volumes/) with
 `volume_for: postgres_tablespace` set and a `tablespace_name` defined,
 they will be added as default entries to `postgres_tablespaces`.
 
@@ -43,11 +43,11 @@ volume mountpoint directly as a tablespace location (`lost+found` will
 confuse some tools into thinking the directory is not empty).
 
 By default, the tablespace `owner` is `postgres`, but you can set it to
-any valid username (the users in [`postgres_users`](postgres_users)
+any valid username (the users in [`postgres_users`](postgres_users/)
 will have been created by this time).
 
 Streaming replicas must have the same `postgres_tablespace` volumes and
 `postgres_tablespaces` setting as their upstream instance
 
 You can set the default tablespace for a database in
-[`postgres_databases`](postgres_databases).
+[`postgres_databases`](postgres_databases/).

--- a/product_docs/docs/tpa/23/reference/postgres_user.mdx
+++ b/product_docs/docs/tpa/23/reference/postgres_user.mdx
@@ -8,7 +8,7 @@ This page documents how the postgres user and its home directory are
 configured.
 
 There's a separate page about how to create
-[Postgres users in the database](postgres_users).
+[Postgres users in the database](postgres_users/).
 
 ## Shell configuration
 

--- a/product_docs/docs/tpa/23/reference/python.mdx
+++ b/product_docs/docs/tpa/23/reference/python.mdx
@@ -5,7 +5,7 @@ originalFilePath: python.md
 ---
 
 TPA decides which Python interpreter to use based on the
-[distribution it detects](distributions) on a target instance. It
+[distribution it detects](distributions/) on a target instance. It
 will use Python 3 wherever possible, and fall back to Python 2 only when
 unavoidable.
 

--- a/product_docs/docs/tpa/23/reference/target_environment.mdx
+++ b/product_docs/docs/tpa/23/reference/target_environment.mdx
@@ -19,5 +19,5 @@ with any others it needs) during deployment and the later execution of
 any cluster management commands.
 
 These environment settings are not persistent, but you can instead use
-[`extra_bashrc_lines`](postgres_user) to set environment variables
+[`extra_bashrc_lines`](postgres_user/) to set environment variables
 for the postgres user.

--- a/product_docs/docs/tpa/23/reference/tpa_2q_repositories.mdx
+++ b/product_docs/docs/tpa/23/reference/tpa_2q_repositories.mdx
@@ -8,7 +8,7 @@ This page explains how to configure 2ndQuadrant package repositories on
 any system.
 
 For more details on the EDB and 2ndQuadrant package sources used by 
-TPA see [this page](2q_and_edb_repositories).
+TPA see [this page](2q_and_edb_repositories/).
 
 To specify the complete list of 2ndQuadrant repositories to install on
 each instance in addition to the 2ndQuadrant public repository, set

--- a/product_docs/docs/tpa/23/reference/tpaexec-archive-logs.mdx
+++ b/product_docs/docs/tpa/23/reference/tpaexec-archive-logs.mdx
@@ -18,8 +18,8 @@ in the cluster into a separate directory.
 
 If you have an existing cluster you can run `tpaexec archive-logs`
 immediately. But if you are configuring a new cluster, you must at least
-[provision](../tpaexec-provision) the cluster. You will get more logs if
-you also [deploy](../tpaexec-deploy) the cluster.
+[provision](../tpaexec-provision/) the cluster. You will get more logs if
+you also [deploy](../tpaexec-deploy/) the cluster.
 
 ## Quickstart
 

--- a/product_docs/docs/tpa/23/reference/tpaexec-download-packages.mdx
+++ b/product_docs/docs/tpa/23/reference/tpaexec-download-packages.mdx
@@ -20,7 +20,7 @@ are supported.
 
 An existing cluster configuration needs to exist which can be achieved
 using the `tpaexec configure` command. No specific options are required
-to use the downloader. See [configuring a cluster](../configure-cluster)
+to use the downloader. See [configuring a cluster](../configure-cluster/)
 .
 
 Execute the download-packages subcommand to start the download process.
@@ -59,5 +59,5 @@ cluster-dir/
 ```
 
 You can use this in the cluster as is or copy it to a target control
-node. See [recommendations for installing to an air-gapped environment](air-gapped). A [local-repo](local-repo) will be detected and used
+node. See [recommendations for installing to an air-gapped environment](air-gapped/). A [local-repo](local-repo/) will be detected and used
 automatically by TPA.

--- a/product_docs/docs/tpa/23/reference/tpaexec-support.mdx
+++ b/product_docs/docs/tpa/23/reference/tpaexec-support.mdx
@@ -4,20 +4,22 @@ originalFilePath: tpaexec-support.md
 
 ---
 
--   [Python requirements](python)
--   [Supported distributions](distributions)
+-   [Python requirements](python/)
+-   [Supported distributions](distributions/)
 
 ## Supported software
 
 TPA can install and configure the following major components.
 
--   Postgres 14, 13, 12, 11, 10
+-   Postgres 15, 14, 13, 12, 11, 10
 
--   EPAS (EDB Postgres Advanced Server) 14, 13, 12
+-   EPAS (EDB Postgres Advanced Server) 15, 14, 13, 12
 
--   BDR 4, 3.7, 3.6, and earlier versions (deprecated)
+-   BDR 5, 4, 3.7, 3.6
 
 -   pglogical 3, 2 (open source)
+
+-   pgd-cli and pgd-proxy
 
 -   HARP 2
 
@@ -30,9 +32,5 @@ TPA can install and configure the following major components.
 -   haproxy (supported only for BDR 3.x)
 
 -   Failover Manager (EFM)
-
-Support for the following components is in development.
-
--   pgbackrest
 
 -   Postgres Enterprise Manager (PEM)

--- a/product_docs/docs/tpa/23/reference/tpaexec-tests.mdx
+++ b/product_docs/docs/tpa/23/reference/tpaexec-tests.mdx
@@ -5,7 +5,7 @@ originalFilePath: tpaexec-tests.md
 ---
 
 You can easily define in-depth tests specific to your environment and
-application to augment TPA's [builtin tests](../tpaexec-test).
+application to augment TPA's [builtin tests](../tpaexec-test/).
 
 We strongly recommend writing tests for any tasks, no matter how simple,
 that you would run on your cluster to reassure yourself that everything

--- a/product_docs/docs/tpa/23/reference/volumes.mdx
+++ b/product_docs/docs/tpa/23/reference/volumes.mdx
@@ -62,7 +62,7 @@ Volumes are properties of an instance. You cannot set them in
 `cluster_vars`, because they contain platform-specific settings.
 
 The
-[`instance_defaults`](../configure-cluster#instance_defaults)
+[`instance_defaults`](../configure-cluster/#instance_defaults)
 mechanism makes special allowances for volume definitions. Since volume
 definitions in a large cluster may be quite repetitive (especially since
 we recommend that instances in a cluster be configured as close to each

--- a/product_docs/docs/tpa/23/reference/yum_repositories.mdx
+++ b/product_docs/docs/tpa/23/reference/yum_repositories.mdx
@@ -49,7 +49,7 @@ You can set `yum_repository_list: []` to not install any repositories
 (but things will break without an alternative source of EPEL packages).
 
 If you need to perform any special steps to configure repository access,
-you can use a [pre-deploy hook](../tpaexec-hooks) to create the .repo
+you can use a [pre-deploy hook](../tpaexec-hooks/) to create the .repo
 file yourself:
 
 ```yaml

--- a/product_docs/docs/tpa/23/tower.mdx
+++ b/product_docs/docs/tpa/23/tower.mdx
@@ -93,7 +93,7 @@ neptune
   for this cluster so it doesn't matter what branches already exist
   in it. (This allows you to use the same repository for all of your
   clusters.)  All other options to `tpaexec configure`, as described in
-  [Configuration](tpaexec-configure) are still valid.
+  [Configuration](tpaexec-configure/) are still valid.
 
   This will create a cluster directory named after your cluster.
 

--- a/product_docs/docs/tpa/23/tpaexec-configure.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-configure.mdx
@@ -26,7 +26,7 @@ architecture or platform) to modify the configuration, but the defaults
 are sensible and intended to be usable straightaway. You are encouraged
 to read the generated config.yml and fine-tune the configuration to suit
 your needs. (Here's an overview of [configuration settings that affect
-the deployment](configure-instance).)
+the deployment](configure-instance/).)
 
 It's possible to write config.yml entirely by hand, but it's much easier
 to edit the generated file.
@@ -40,8 +40,8 @@ e.g., `~/clusters` in the example above.
 
 The next argument must be `--architecture <name>` to select an
 architecture, e.g.,
-[M1](architecture-M1) or
-[BDR-Always-ON](architecture-BDR-Always-ON).
+[M1](architecture-M1/) or
+[BDR-Always-ON](architecture-BDR-Always-ON/).
 For a complete list of architectures, run
 `tpaexec info architectures`.
 
@@ -65,7 +65,7 @@ documentation for an architecture for a list of options that it accepts
 ### Platform options
 
 Next, you may use `--platform <name>` to select a platform, e.g.,
-[aws](platform-aws) or [bare](platform-bare).
+[aws](platform-aws/) or [bare](platform-bare/).
 
 An architecture may or may not support a particular platform. If not, it
 will fail to configure the cluster.
@@ -119,7 +119,7 @@ architecture.
 Specify `--network 192.168.0.0/16` to assign subnets from a different network.
 
 **Note:** On AWS clusters, this corresponds to the VPC CIDR.
-See [aws](platform-aws#vpc-required) documentation for details.
+See [aws](platform-aws/#vpc-required) documentation for details.
 
 Specify `--subnet-prefix 26` to assign subnets of a different size, /26 instead
 of /28 in this case.
@@ -211,7 +211,7 @@ does not need a subscription) and add on any product repositories that
 the architecture may require (e.g., the BDR repository).
 
 More detailed explanation of how TPA uses 2ndQuadrant and EDB
-repositories is available [here](reference/2q_and_edb_repositories)
+repositories is available [here](reference/2q_and_edb_repositories/)
 
 Specify `--2Q-repositories source/name/maturity …` or
 `--edb-repositories repository …` to specify the complete list of
@@ -225,7 +225,7 @@ Use this option with care. TPA will configure the named repositories
 with no attempt to make sure the combination is appropriate.
 
 To use these options, you must `export TPA_2Q_SUBSCRIPTION_TOKEN=xxx`
-or `export EDB_SUBSCRIPTION_TOKEN=xxx` before you run tpaexec. 
+or `export EDB_SUBSCRIPTION_TOKEN=xxx` before you run tpaexec.
 You can get a 2ndQuadrant token from the 2ndQuadrant Portal under
 "Company info" in the left menu, then "Company". You can get an EDB
 token from enterprisedb.com/repos.
@@ -240,7 +240,7 @@ In environments with restricted network access, you can instead use
 other package repositories on target instances, so that packages are
 installed only from the local repository.
 
-The page about [Local repository support](reference/local-repo) has more
+The page about [Local repository support](reference/local-repo/) has more
 details.
 
 ### Software versions
@@ -378,7 +378,7 @@ sure you understand the effect of all the overrides.
 
 Use the `--use-ansible-tower` and `--tower-git-repository` options to
 create a cluster adapted for deployment with Ansible Tower. See [Ansible
-Tower](tower) for details.
+Tower](tower/) for details.
 
 ## git repository
 
@@ -507,7 +507,7 @@ instances:
 
 ```
 
-The next step is to run [`tpaexec provision`](tpaexec-provision)
+The next step is to run [`tpaexec provision`](tpaexec-provision/)
 or learn more about how to customise the configuration of
-[the cluster as a whole](configure-cluster) or how to configure an
-[individual instance](configure-instance).
+[the cluster as a whole](configure-cluster/) or how to configure an
+[individual instance](configure-instance/).

--- a/product_docs/docs/tpa/23/tpaexec-deploy.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-deploy.mdx
@@ -16,14 +16,14 @@ along with other components like repmgr, Barman, pgbouncer, etc.
 ## Prerequisites
 
 Before you can run `tpaexec deploy`, you must have already run
-[`tpaexec configure`](tpaexec-configure) to generate the cluster
+[`tpaexec configure`](tpaexec-configure/) to generate the cluster
 configuration and then provisioned the servers with
-[`tpaexec provision`](tpaexec-provision).
+[`tpaexec provision`](tpaexec-provision/).
 
 Before deployment, you must
 `export TPA_2Q_SUBSCRIPTION_TOKEN=xxx` to enable any 2ndQuadrant
 repositories that require subscription. You can use the subscription
-token that you used to [install TPA](INSTALL) itself. If you
+token that you used to [install TPA](INSTALL/) itself. If you
 forget to do this, an error message will soon remind you.
 
 ## Quickstart
@@ -69,7 +69,7 @@ does not stop soon afterwards, the error is of no consequence, and the
 code will recover from it automatically.
 
 When the deployment is complete, you can run
-[`tpaexec test`](tpaexec-test) to verify the installation.
+[`tpaexec test`](tpaexec-test/) to verify the installation.
 
 ## Selective deployment
 
@@ -91,12 +91,12 @@ Ansible's `--limit` option, which TPA does not support.)
 
 The deployment process is architecture-specific. Here's an overview of
 the various
-[configuration settings that affect the deployment](configure-instance).
+[configuration settings that affect the deployment](configure-instance/).
 If you are familiar with Ansible playbooks, you can follow along as
 tpaexec applies various roles to the cluster's instances.
 
 Unlike config.yml, deploy.yml is not designed to be edited (and is
 usually a link into the architectures directory). Even if you want to
 extend the deployment process to run your own Ansible tasks, you should
-do so by [creating hooks](tpaexec-hooks). This protects you from
+do so by [creating hooks](tpaexec-hooks/). This protects you from
 future implementation changes within a particular architecture.

--- a/product_docs/docs/tpa/23/tpaexec-hooks.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-hooks.mdx
@@ -7,7 +7,7 @@ originalFilePath: tpaexec-hooks.md
 
 TPA can set up fully-functional clusters with no user intervention,
 and already provides a broad variety of
-[settings to control your cluster configuration](configure-instance),
+[settings to control your cluster configuration](configure-instance/),
 including custom repositories and packages, custom Postgres
 configuration (both pg_hba.conf and postgresql.conf), and so on.
 
@@ -51,8 +51,8 @@ your own code.
 
 You can use this hook to set up custom repository configuration, beyond
 what you can do with
-[`apt_repositories`](reference/apt_repositories) or
-[`yum_repositories`](reference/yum_repositories).
+[`apt_repositories`](reference/apt_repositories/) or
+[`yum_repositories`](reference/yum_repositories/).
 
 ### post-repo
 
@@ -63,7 +63,7 @@ configuration before beginning to install packages.
 ### pre-initdb
 
 TPA invokes `hooks/pre-initdb.yml` before deciding whether or not to
-[run initdb to create PGDATA](reference/initdb) if it does not exist. You
+[run initdb to create PGDATA](reference/initdb/) if it does not exist. You
 should not ordinarily need to use this hook (but if you use it to create
 `PGDATA` yourself, then TPA will skip `initdb`).
 
@@ -138,7 +138,7 @@ automatically add new tables and create DDL filters in general.
 
 ### postgres-pre-update, postgres-post-update
 
-The [`update-postgres`](tpaexec-update-postgres) command invokes
+The [`update-postgres`](tpaexec-update-postgres/) command invokes
 `hooks/postgres-pre-update.yml` on a particular instance before it
 installs any packages, and invokes `hooks/postgres-post-update.yml`
 after the package installation is complete. Both hooks are invoked only

--- a/product_docs/docs/tpa/23/tpaexec-provision.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-provision.mdx
@@ -8,8 +8,8 @@ originalFilePath: tpaexec-provision.md
 Provision creates instances and other resources required by the cluster.
 
 The exact details of this process depend both on
-the architecture (e.g. [M1](architecture-M1))
-and platform (e.g. [AWS](platform-aws))
+the architecture (e.g. [M1](architecture-M1/))
+and platform (e.g. [AWS](platform-aws/))
 that you selected while configuring the cluster.
 
 At the end of the provisioning stage, you will have the required number
@@ -19,7 +19,7 @@ can access via ssh (with sudo to root).
 ## Prerequisites
 
 Before you can provision a cluster, you must generate the cluster
-configuration with [`tpaexec configure`](tpaexec-configure)
+configuration with [`tpaexec configure`](tpaexec-configure/)
 (and edit config.yml to fine-tune the configuration if needed).
 
 You may need additional platform-dependent steps. For example, you need
@@ -62,7 +62,7 @@ by setting the environment variable `ANSIBLE_LOG_PATH` to the path and name of
 the desired logfile.
 
 If it completes without error, you may proceed to run
-[`tpaexec deploy`](tpaexec-deploy) to install and configure
+[`tpaexec deploy`](tpaexec-deploy/) to install and configure
 software.
 
 ## Options
@@ -125,7 +125,7 @@ admin@quirk:~$ sudo -i
 root@quirk:~# 
 ```
 
-You can run [`tpaexec deploy`](tpaexec-deploy) immediately after
+You can run [`tpaexec deploy`](tpaexec-deploy/) immediately after
 provisioning. It will wait as long as required for the instances to come
 up. You do not need to wait for the instances to come up, or ssh in to
 them before you start deployment.

--- a/product_docs/docs/tpa/23/tpaexec-rehydrate.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-rehydrate.mdx
@@ -25,16 +25,16 @@ wiped out during the instance replacement).
 TPA makes it simple to minimise disruption to the cluster as a whole
 during the rehydration, even though the process must necessarily involve
 downtime for individual servers as they are terminated and replaced. On
-a [streaming replication cluster](architecture-M1), you can rehydrate
-the replicas first, then use [`tpaexec switchover`](tpaexec-switchover)
+a [streaming replication cluster](architecture-M1/), you can rehydrate
+the replicas first, then use [`tpaexec switchover`](tpaexec-switchover/)
 to convert the primary to a replica before rehydrating it. On
-[BDR-Always-ON clusters](architecture-BDR-Always-ON), you can [remove
-each server from the haproxy server pool](tpaexec-server-pool) before
+[BDR-Always-ON clusters](architecture-BDR-Always-ON/), you can [remove
+each server from the haproxy server pool](tpaexec-server-pool/) before
 rehydrating it, then add it back afterwards.
 
 If you just want to install minor-version updates to Postgres and
 associated components, you can use the
-[`tpaexec update-postgres`](tpaexec-update-postgres) command instead.
+[`tpaexec update-postgres`](tpaexec-update-postgres/) command instead.
 
 ## Prerequisites
 
@@ -126,10 +126,10 @@ In order to maintain cluster continuity, we recommend rehydrating the
 cluster in phases.
 
 For example, in a [cluster that uses streaming
-replication](architecture-M1) with a primary instance, two replicas,
+replication](architecture-M1/) with a primary instance, two replicas,
 and a Barman backup server, you could rehydrate the Barman instance and
 one replica first, then another replica, then
-[switchover](tpaexec-switchover) from the primary to one of the
+[switchover](tpaexec-switchover/) from the primary to one of the
 rehydrated replicas, rehydrate the former primary, and (optionally),
 switchover back to the original primary. This sequence ensures that one
 primary and one replica are always available.

--- a/product_docs/docs/tpa/23/tpaexec-server-pool.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-server-pool.mdx
@@ -7,12 +7,12 @@ originalFilePath: tpaexec-server-pool.md
 
 The `tpaexec pool-disable-server` and `pool-enable-server` commands
 allow a BDR instance in a [BDR-Always-ON
-cluster](architecture-BDR-Always-ON) to be temporarily removed from
+cluster](architecture-BDR-Always-ON/) to be temporarily removed from
 the HAProxy active server pool for maintenance, and then added back
 afterwards.
 
 These commands follow the same process as [rolling
-updates](tpaexec-update-postgres) by default, so
+updates](tpaexec-update-postgres/) by default, so
 `pool-disable-server` will wait for active transactions against a BDR
 instance to complete and for pgbouncer to direct new connections to
 another instance before completing. Use the `--nowait` option if you

--- a/product_docs/docs/tpa/23/tpaexec-switchover.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-switchover.mdx
@@ -7,7 +7,7 @@ originalFilePath: tpaexec-switchover.md
 
 The `tpaexec switchover` command performs a controlled switchover
 between a primary and a replica in a [cluster that uses streaming
-replication](architecture-M1). After you run this command, the
+replication](architecture-M1/). After you run this command, the
 selected replica is promoted to be the new primary, the former primary
 becomes a new replica, and any other replicas in the cluster will be
 reconfigured to follow the new primary.
@@ -30,10 +30,10 @@ $ tpaexec switchover ~/clusters/speedy replicaname
 
 ## Architecture options
 
-This command is applicable only to [M1 clusters](architecture-M1)
+This command is applicable only to [M1 clusters](architecture-M1/)
 that have a single writable primary instance and one or more read-only
 replicas.
 
 For BDR-Always-ON clusters, use the
-[HAProxy server pool management commands](tpaexec-server-pool) to
+[HAProxy server pool management commands](tpaexec-server-pool/) to
 perform maintenance on BDR instances.

--- a/product_docs/docs/tpa/23/tpaexec-update-postgres.mdx
+++ b/product_docs/docs/tpa/23/tpaexec-update-postgres.mdx
@@ -42,14 +42,14 @@ by listing the active BDR primary instances last, so that the shadow
 servers are updated first.
 
 If your environment requires additional actions, the
-[postgres-pre-update and postgres-post-update hooks](tpaexec-hooks)
+[postgres-pre-update and postgres-post-update hooks](tpaexec-hooks/)
 allow you to execute custom Ansible tasks before and after the package
 installation step.
 
 ## M1
 
 For M1 clusters, `update-postgres` will first update the streaming
-replicas one by one, then perform a [switchover](tpaexec-switchover)
+replicas one by one, then perform a [switchover](tpaexec-switchover/)
 from the primary to one of the replicas, update the primary, and
 switchover back to it again.
 
@@ -62,7 +62,7 @@ you created the cluster.
 
 If you did select specific versions, for example by using any of the
 `--xxx-package-version` options (e.g., postgres, bdr, pglogical) to
-[`tpaexec configure`](tpaexec-configure), or by defining
+[`tpaexec configure`](tpaexec-configure/), or by defining
 `xxx_package_version` variables in config.yml, the update will do
 nothing because the installed packages already satisfy the requested
 versions.
@@ -84,7 +84,7 @@ package manager. In particular, yum accepts `*xyz*` wildcards, while
 apt only understands `xyz*` (as in the example above).
 
 Note: see limitations of using wildcards in package_version in
-[tpaexec-configure](tpaexec-configure#known-issue-with-wildcard-use).
+[tpaexec-configure](tpaexec-configure/#known-issue-with-wildcard-use).
 
 It is your responsibility to ensure that the combination of Postgres,
 BDR, and pglogical package versions that you request are sensible. That

--- a/scripts/source/tpaexec.js
+++ b/scripts/source/tpaexec.js
@@ -225,7 +225,7 @@ function transformer() {
     visit(tree, ["link", "image"], (node) => {
       let url = node.url || node.src;
       if (isAbsoluteUrl(url) || url[0] === "/") return;
-      url = url.replace(/\.md(?=$|\?|#)/, "");
+      url = url.replace(/\.md(?=$|\?|#)/, "/");
       const parsed = new URL(url, "base:/reference/");
       if (parsed.protocol !== "base:" || parsed.pathname === "/reference/")
         return;
@@ -233,7 +233,7 @@ function transformer() {
         referenceMarkdownFiles.find(
           (file) =>
             path.basename(file, ".md") ===
-            parsed.pathname.replace(/^\/reference\//, ""),
+            parsed.pathname.replace(/^\/reference\/|\/$/g, ""),
         )
       ) {
         if (!isInReferences) url = parsed.href.replace(/^base:\//, "");


### PR DESCRIPTION
## What Changed?

Changes to the import script for TPA and regenerated 
Avoids issue where paths with periods
(postgres.conf pg_hba.conf etc) are interpreted as non-docs paths
