### PR TITLE
Update 08_harpctl.mdx

### DIFF
--- a/product_docs/docs/pgd/4/harp/08_harpctl.mdx
+++ b/product_docs/docs/pgd/4/harp/08_harpctl.mdx
@@ -177,8 +177,7 @@ mycluster true
 ### `harpctl get leader`
 
 Fetches node information for the current lead master stored in the DCS for the 
-specified location. If no location is passed, `harpctl` attempts to 
-derive it based on the location of the current node where it was executed.
+specified location. Use [`harpctl get locations`](#harpctl-get-locations) to list the defined locations.
 
 Example:
 
@@ -192,9 +191,8 @@ mycluster mynode true  primary bdr  dc1      false  30
 
 ### `harpctl get location`
 
-Fetches location information for the specified location. If no location is 
-passed, `harpctl` attempts to derive it based on the location of the 
-current node where it was executed.
+Fetches location information for the specified location. Use [`harpctl get locations`](#harpctl-get-locations)
+to list the defined locations.
 
 Example:
 


### PR DESCRIPTION
Descriptions for `harpctl get location` and `harpctl get leader` erroneously state that the location name is optional and will be determined automatically if omitted. In fact both commands fail if the location is omitted.

## What Changed?

Descriptions for `harpctl get location` and `harpctl get leader`.