### PR TITLE
PEM-3896-Added content for changing agent.cfg file path in pemagent service file

### DIFF
--- a/product_docs/docs/pem/9/registering_agent.mdx
+++ b/product_docs/docs/pem/9/registering_agent.mdx
@@ -231,6 +231,7 @@ To use a nonroot user account to register a PEM agent, you must first install th
 
 6.  Check the agent status on the PEM dashboard.
 
-!!! Note 
-    - Any probes and jobs that require root permission or access to a file owned by another user (for example,  enterprisedb) fail.
-    - If you move the agent.cfg file from its default location to another, the PEM dashboard might display the agent status as “unknown”; see [Agent status on the PEM dashboard is displayed as unknown](/pem/latest/troubleshooting/#agent-status-on-the-pem-dashboard-is-displayed-as-unknown).
+
+!!! Note
+    - Any probes and jobs that require root permission or access to a file owned by another user (for example,  enterprisedb) fail. 
+    - If you move the `agent.cfg` file from its default location to another, the PEM dashboard might display the agent status as “unknown”; see [Agent status on the PEM dashboard is displayed as unknown](/pem/latest/troubleshooting/#agent-status-on-the-pem-dashboard-is-displayed-as-unknown). 

--- a/product_docs/docs/pem/9/registering_agent.mdx
+++ b/product_docs/docs/pem/9/registering_agent.mdx
@@ -233,4 +233,4 @@ To use a nonroot user account to register a PEM agent, you must first install th
 
 !!! Note 
     - Any probes and jobs that require root permission or access to a file owned by another user (for example,  enterprisedb) fail.
-    - If you move the `agent.cfg` file from its default location to another, the agent status on the PEM dashboard may display an error; see [Updating pemagent service file values if agent configuration file path is modified](/pem/latest/troubleshooting/#updating-pemagent-service-file-values-if-agent-configuration-file-path-is-modified).
+    - If you move the agent.cfg file from its default location to another, the PEM dashboard might display the agent status as “unknown”; see [Agent status on the PEM dashboard is displayed as unknown](/pem/latest/troubleshooting/#agent-status-on-the-pem-dashboard-is-displayed-as-unknown).

--- a/product_docs/docs/pem/9/registering_agent.mdx
+++ b/product_docs/docs/pem/9/registering_agent.mdx
@@ -152,6 +152,7 @@ To use a nonroot user account to register a PEM agent, you must first install th
 1.  Log in as edb. Create `pem` and `logs` directories and assign read, write, and execute permissions:
 
     ```shell
+    # Running as nonroot user edb
     mkdir /home/edb/pem
     mkdir /home/edb/pem/logs
     chmod 700 /home/edb/pem
@@ -234,4 +235,4 @@ To use a nonroot user account to register a PEM agent, you must first install th
 
 !!! Note
     - Any probes and jobs that require root permission or access to a file owned by another user (for example,  enterprisedb) fail. 
-    - If you move the `agent.cfg` file from its default location to another, the PEM dashboard might display the agent status as “unknown”; see [Agent status on the PEM dashboard is displayed as unknown](/pem/latest/troubleshooting/#agent-status-on-the-pem-dashboard-is-displayed-as-unknown). 
+    - If you move the `agent.cfg` file from its default location to another, the PEM dashboard might display the agent status as “unknown”. See [Troubleshooting agent issues](troubleshooting_agent/#updating-configuration-file-path-agent-status-displaying-as-unknown), for more information. 

--- a/product_docs/docs/pem/9/registering_agent.mdx
+++ b/product_docs/docs/pem/9/registering_agent.mdx
@@ -152,30 +152,30 @@ To use a nonroot user account to register a PEM agent, you must first install th
 1.  Log in as edb. Create `pem` and `logs` directories and assign read, write, and execute permissions:
 
     ```shell
-    $ mkdir /home/edb/pem
-    $ mkdir /home/edb/pem/logs
-    $ chmod 700 /home/edb/pem
-    $ chmod 700 /home/edb/pem/logs
+    mkdir /home/edb/pem
+    mkdir /home/edb/pem/logs
+    chmod 700 /home/edb/pem
+    chmod 700 /home/edb/pem/logs
     ```
 
 2.  Register the agent with PEM server:
 
     ```shell
-    $ export PEM_SERVER_PASSWORD=edb
+    export PEM_SERVER_PASSWORD=edb
     
     # Use the following command to create agent certificates and an agent 
     # configuration file (`agent.cfg`) in the `/home/edb/pem` directory. 
-    $ /usr/edb/pem/agent/bin/pemworker --register-agent --pem-server <172.19.11.230> --pem-user postgres --pem-port 5432 --display-name non_root_pem_agent --cert-path /home/edb/pem --config-dir /home/edb/pem
+    /usr/edb/pem/agent/bin/pemworker --register-agent --pem-server <172.19.11.230> --pem-user postgres --pem-port 5432 --display-name non_root_pem_agent --cert-path /home/edb/pem --config-dir /home/edb/pem
 
     # Use the following command to assign read and write permissions to 
     # these files:
-    $ chmod -R 600 /home/edb/pem/agent*
+    chmod -R 600 /home/edb/pem/agent*
     ```
 
 3.  Change the parameters of the `agent.cfg` file:
 
     ```ini
-    $ vi /home/edb/pem/agent.cfg
+    vi /home/edb/pem/agent.cfg
     agent_ssl_key=/home/edb/pem/agent<id>.key
     agent_ssl_crt=/home/edb/pem/agent<id>.crt
     log_location=/home/edb/pem/worker.log
@@ -187,16 +187,16 @@ To use a nonroot user account to register a PEM agent, you must first install th
 4.  Create a `tmp` directory, set the environment variable, and start the agent:
     
     ```ini
-    $ mkdir /home/edb/pem/tmp
+    mkdir /home/edb/pem/tmp
     
     # Create a script file, add the environment variable, give permissions, and execute:
-    $ vi /home/edb/pem/run_pemagent.sh
+    vi /home/edb/pem/run_pemagent.sh
     #!/bin/bash
     export TEMP=/home/edb/agent/tmp
     /usr/edb/pem/agent/bin/pemagent -c /home/edb/agent/agent.cfg
-    $ chmod a+x /home/edb/pem/run_pemagent.sh
-    $ cd /home/edb/pem
-    $ ./run_pemagent.sh
+    chmod a+x /home/edb/pem/run_pemagent.sh
+    cd /home/edb/pem
+    ./run_pemagent.sh
     ```
 
     Your PEM agent is now registered and started with the edb user. If your machine restarts, then this agent doesn't restart automatically. You need to start it manually using the previous command.
@@ -206,7 +206,7 @@ To use a nonroot user account to register a PEM agent, you must first install th
     a.  Update the values for the configuration file path and the user in the `pemagent` service file as superuser:
     
        ```ini
-       $ sudo vi  /usr/lib/systemd/system/pemagent.service
+       sudo vi  /usr/lib/systemd/system/pemagent.service
        [Service]
        Type=forking
        WorkingDirectory=/home/edb/pem
@@ -219,45 +219,18 @@ To use a nonroot user account to register a PEM agent, you must first install th
    
        ```shell
        # Find the process id of the running pem agent and pem worker process and kill that process
-       $ ps -ax | grep pemagent
-       $ kill -9 <process_id_of_pemagent>
-       $ ps -ax | grep pemworker
-       $ kill -9 <process_id_of_pemworker>
+       ps -ax | grep pemagent
+       kill -9 <process_id_of_pemagent>
+       ps -ax | grep pemworker
+       kill -9 <process_id_of_pemworker>
        # Enable and start pemagent service
-       $ sudo systemctl enable pemagent
-       $ sudo systemctl start pemagent
-       $ sudo systemctl status pemagent
+       sudo systemctl enable pemagent
+       sudo systemctl start pemagent
+       sudo systemctl status pemagent
        ```
 
 6.  Check the agent status on the PEM dashboard.
 
-!!! Note
-    Any probes and jobs that require root permission or access to a file owned by another user (for example,  enterprisedb) fail.
-
-## Modifying the pemagent service file to update agent configuration file path
-
-In some situations, you might need to move the agent configuration file from its default location `/usr/edb/pem/agent/etc/agent.cfg` to another location. In that case, you need to update the value of the agent configuration file path in the `pemagent` service file. 
-
-1. Use the following command to modify the `pemagent` service file as a superuser:
-
-    ```ini
-    $ sudo vi  /usr/lib/systemd/system/pemagent.service
-    ```
-
-2. Update the value for the `agent.cfg` file path. For example, on a CentOS 7.x host update the value in the following line: 
-
-    ```ini
-    ExecStart=/usr/edb/pem/agent/bin/pemagent -c /usr/edb/pem/agent/etc/agent.cfg
-    ```
-
-3. Reload `systemd`, updating the modified service scripts:
-
-    ```shell
-    $ sudo systemctl daemon-reload
-    ```
-
-4. Restart the PEM agent:
-
-    ```shell
-    $ sudo systemctl restart pemagent
-    ```
+!!! Note 
+    - Any probes and jobs that require root permission or access to a file owned by another user (for example,  enterprisedb) fail.
+    - If you move the `agent.cfg` file from its default location to another, the agent status on the PEM dashboard may display an error; see [Updating pemagent service file values if agent configuration file path is modified](/pem/latest/troubleshooting/#updating-pemagent-service-file-values-if-agent-configuration-file-path-is-modified).

--- a/product_docs/docs/pem/9/registering_agent.mdx
+++ b/product_docs/docs/pem/9/registering_agent.mdx
@@ -233,3 +233,31 @@ To use a nonroot user account to register a PEM agent, you must first install th
 
 !!! Note
     Any probes and jobs that require root permission or access to a file owned by another user (for example,  enterprisedb) fail.
+
+## Modifying the pemagent service file to update agent configuration file path
+
+In some situations, you might need to move the agent configuration file from its default location `/usr/edb/pem/agent/etc/agent.cfg` to another location. In that case, you need to update the value of the agent configuration file path in the `pemagent` service file. 
+
+1. Use the following command to modify the `pemagent` service file as a superuser:
+
+    ```ini
+    $ sudo vi  /usr/lib/systemd/system/pemagent.service
+    ```
+
+2. Update the value for the `agent.cfg` file path. For example, on a CentOS 7.x host update the value in the following line: 
+
+    ```ini
+    ExecStart=/usr/edb/pem/agent/bin/pemagent -c /usr/edb/pem/agent/etc/agent.cfg
+    ```
+
+3. Reload `systemd`, updating the modified service scripts:
+
+    ```shell
+    $ sudo systemctl daemon-reload
+    ```
+
+4. Restart the PEM agent:
+
+    ```shell
+    $ sudo systemctl restart pemagent
+    ```

--- a/product_docs/docs/pem/9/troubleshooting.mdx
+++ b/product_docs/docs/pem/9/troubleshooting.mdx
@@ -88,3 +88,32 @@ In some situations, you might need to uninstall the PEM server, reinstall it, an
     ```shell
     /usr/edb/pem/bin/configure-pem-server.sh
     ```
+
+## Updating pemagent service file values if agent configuration file path is modified
+
+In some situations, you might need to move the agent configuration file from its default location `/usr/edb/pem/agent/etc/agent.cfg` to another location. In that case, you need to update the value of the agent configuration file path in the `pemagent` service file. 
+
+1. Use the following command to modify the `pemagent` service file as a superuser:
+
+    ```shell
+    # Running as a superuser
+    sudo vi  /usr/lib/systemd/system/pemagent.service
+    ```
+
+2. Update the `agent.cfg` file path. For example, on a Redhat host, update the file path: 
+
+    ```shell
+    ExecStart=/usr/edb/pem/agent/bin/pemagent -c /usr/edb/pem/agent/etc/agent.cfg
+    ```
+
+3. Reload `systemd`, to update the modified service script:
+
+    ```shell
+    sudo systemctl daemon-reload
+    ```
+
+4. Restart the PEM agent:
+
+    ```shell
+    sudo systemctl restart pemagent
+    ```

--- a/product_docs/docs/pem/9/troubleshooting.mdx
+++ b/product_docs/docs/pem/9/troubleshooting.mdx
@@ -89,9 +89,9 @@ In some situations, you might need to uninstall the PEM server, reinstall it, an
     /usr/edb/pem/bin/configure-pem-server.sh
     ```
 
-## Updating pemagent service file values if agent configuration file path is modified
+## Agent status on the PEM dashboard is displayed as unknown
 
-In some situations, you might need to move the agent configuration file from its default location `/usr/edb/pem/agent/etc/agent.cfg` to another location. In that case, you need to update the value of the agent configuration file path in the `pemagent` service file. 
+If you move the agent configuration file (`agent.cfg`) from its default location `/usr/edb/pem/agent/etc` to another location, the PEM dashboard might display the agent status as “unknown”. In that case, you need to update the value of the agent configuration file path in the `pemagent` service file. 
 
 1. Use the following command to modify the `pemagent` service file as a superuser:
 

--- a/product_docs/docs/pem/9/troubleshooting.mdx
+++ b/product_docs/docs/pem/9/troubleshooting.mdx
@@ -89,31 +89,3 @@ In some situations, you might need to uninstall the PEM server, reinstall it, an
     /usr/edb/pem/bin/configure-pem-server.sh
     ```
 
-## Agent status on the PEM dashboard is displayed as unknown
-
-If you move the agent configuration file (`agent.cfg`) from its default location `/usr/edb/pem/agent/etc` to another location, the PEM dashboard might display the agent status as “unknown”. In that case, you need to update the value of the agent configuration file path in the `pemagent` service file. 
-
-1. Use the following command to modify the `pemagent` service file as a superuser:
-
-    ```shell
-    # Running as a superuser
-    sudo vi  /usr/lib/systemd/system/pemagent.service
-    ```
-
-2. Update the `agent.cfg` file path. For example, on a Redhat host, update the file path: 
-
-    ```shell
-    ExecStart=/usr/edb/pem/agent/bin/pemagent -c /usr/edb/pem/agent/etc/agent.cfg
-    ```
-
-3. Reload `systemd`, to update the modified service script:
-
-    ```shell
-    sudo systemctl daemon-reload
-    ```
-
-4. Restart the PEM agent:
-
-    ```shell
-    sudo systemctl restart pemagent
-    ```

--- a/product_docs/docs/pem/9/troubleshooting_agent.mdx
+++ b/product_docs/docs/pem/9/troubleshooting_agent.mdx
@@ -31,25 +31,55 @@ If an agent was deleted from the PEM web client but still has an entry in the `p
 
 The deleted agent is restored. However, the servers that were bound to that agent might appear to be down. To resolve this issue, modify the PEM agent properties of the server to add the bound agent again. After the successful modification, the servers appear as running properly.
 
+
+## Updating configuration file path (agent status displaying as unknown)
+
+If you move the agent configuration file (`agent.cfg`) from its default location `/usr/edb/pem/agent/etc` to another location, the PEM dashboard might display the agent status as “unknown”. In that case, you need to update the value of the agent configuration file path in the `pemagent` service file. 
+
+1. Use the following command to modify the `pemagent` service file as a superuser:
+
+    ```shell
+    # Running as superuser
+    sudo vi  /usr/lib/systemd/system/pemagent.service
+    ```
+
+2. Update the `agent.cfg` file path. For example, on a Redhat host, update the file path: 
+
+    ```shell
+    ExecStart=/usr/edb/pem/agent/bin/pemagent -c /usr/edb/pem/agent/etc/agent.cfg
+    ```
+
+3. Reload `systemd`, to update the modified service script:
+
+    ```shell
+    sudo systemctl daemon-reload
+    ```
+
+4. Restart the PEM agent:
+
+    ```shell
+    sudo systemctl restart pemagent
+    ```
+
 ## Using the command line to delete a PEM agent with down or unknown status
 
 Using the PEM web interface to delete PEM agents with Down or Unknown status can be difficult if the number of such agents is large. In this situation, you can use the command line interface to delete Down or Unknown agents.
 
 Use the following query to delete the agents that are Down for more than *N* number of hours:
 
-    ```
-    UPDATE pem.agent SET active=false WHERE id IN
-    (SELECT a.id FROM pem.agent
-    a JOIN pem.agent_heartbeat b ON (b.agent_id=a.id)
-    WHERE a.id IN
-    (SELECT agent_id FROM pem.agent_heartbeat WHERE (EXTRACT (HOUR FROM now())-
-    EXTRACT (HOUR FROM last_heartbeat)) > <N> ));
-    ```
+```sql
+UPDATE pem.agent SET active=false WHERE id IN
+(SELECT a.id FROM pem.agent
+a JOIN pem.agent_heartbeat b ON (b.agent_id=a.id)
+WHERE a.id IN
+(SELECT agent_id FROM pem.agent_heartbeat WHERE (EXTRACT (HOUR FROM now())-
+EXTRACT (HOUR FROM last_heartbeat)) > <N> ));
+```
 
 Use the following query to delete the agents with an Unknown status:
 
-    ```
-    UPDATE pem.agent SET active=false WHERE id IN
-    (SELECT id FROM pem.agent WHERE id NOT IN
-    (SELECT agent_id FROM pem.agent_heartbeat));
-    ```
+```sql
+UPDATE pem.agent SET active=false WHERE id IN
+(SELECT id FROM pem.agent WHERE id NOT IN
+(SELECT agent_id FROM pem.agent_heartbeat));
+```


### PR DESCRIPTION
## What Changed?

Added the following sub-heading in the "Registering a PEM agent"- "Modifying the pemagent service file to update agent configuration file path" for steps to update the service file