### PR TITLE
Remove sql backticks leaking into code blocks

### DIFF
--- a/product_docs/docs/epas/15/epas_compat_ora_dev_guide/02_about_the_examples_used_in_this_guide.mdx
+++ b/product_docs/docs/epas/15/epas_compat_ora_dev_guide/02_about_the_examples_used_in_this_guide.mdx
@@ -38,14 +38,11 @@ Also note the following points:
      on
     ```
 
--   The examples use the sample tables, `dept`, `emp`, and `jobhist`, created and loaded when EDB Postgres Advanced Server was installed. The `emp` table is installed with triggers that you must disable to reproduce the same results as the examples. Log into EDB Postgres Advanced Server as the `enterprisedb` superuser and disable the triggers by issuing the following command:
-
+-   The examples use the sample tables, `dept`, `emp`, and `jobhist`, created and loaded when EDB Postgres Advanced Server was installed. The `emp` table is installed with triggers that you must disable to reproduce the same results as the examples. Log into EDB Postgres Advanced Server as the `enterprisedb` superuser and disable the triggers by issuing the following command:  
     ```sql
     ALTER TABLE emp DISABLE TRIGGER USER;
-    ```
-
-You can later reactivate the triggers on the `emp` table with the following command:
-
+    ``` 
+    You can later reactivate the triggers on the `emp` table with the following command:  
     ```sql
     ALTER TABLE emp ENABLE TRIGGER USER;
     ```

--- a/product_docs/docs/epas/15/epas_compat_ora_dev_guide/02_about_the_examples_used_in_this_guide.mdx
+++ b/product_docs/docs/epas/15/epas_compat_ora_dev_guide/02_about_the_examples_used_in_this_guide.mdx
@@ -38,11 +38,14 @@ Also note the following points:
      on
     ```
 
--   The examples use the sample tables, `dept`, `emp`, and `jobhist`, created and loaded when EDB Postgres Advanced Server was installed. The `emp` table is installed with triggers that you must disable to reproduce the same results as the examples. Log into EDB Postgres Advanced Server as the `enterprisedb` superuser and disable the triggers by issuing the following command:  
+-   The examples use the sample tables, `dept`, `emp`, and `jobhist`, created and loaded when EDB Postgres Advanced Server was installed. The `emp` table is installed with triggers that you must disable to reproduce the same results as the examples. Log into EDB Postgres Advanced Server as the `enterprisedb` superuser and disable the triggers by issuing the following command:
+-   
     ```sql
     ALTER TABLE emp DISABLE TRIGGER USER;
-    ``` 
-    You can later reactivate the triggers on the `emp` table with the following command:  
+    ```
+    
+    You can later reactivate the triggers on the `emp` table with the following command:
+    
     ```sql
     ALTER TABLE emp ENABLE TRIGGER USER;
     ```


### PR DESCRIPTION
## What Changed?

Brought paras together and used end of line double space to introduce line breaks in right place.
