### PR TITLE
Support admonition icons, all types in dark mode

### DIFF
--- a/src/styles/_dark.scss
+++ b/src/styles/_dark.scss
@@ -153,11 +153,11 @@ html.dark {
       background-color: darken(#ffd8cc, 70%) !important;
       color: darken($light, 10%) !important;
     }
-    .admonition-tip {
+    .admonition-tip, .admonition-hint {
       background-color: darken(#e7f1db, 70%) !important;
       color: darken($light, 10%) !important;
     }
-    .admonition-note {
+    .admonition-note, .admonition-seealso {
       background-color: darken(#e4eef5, 70%) !important;
       color: darken($light, 10%) !important;
     }
@@ -175,7 +175,7 @@ html.dark {
     }
 
     .admonition-heading h5:before {
-      content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="white" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm6.5-.25A.75.75 0 017.25 7h1a.75.75 0 01.75.75v2.75h.25a.75.75 0 010 1.5h-2a.75.75 0 010-1.5h.25v-2h-.25a.75.75 0 01-.75-.75zM8 6a1 1 0 100-2 1 1 0 000 2z"/></svg>');
+      filter: invert(1);
     }
   }
 


### PR DESCRIPTION
## What Changed?

We were missing a couple of admonition types in dark mode, causing severe retina burns.
Also, we should allow our diversity of icons to... shine through
