### PR TITLE
Prepare BDR 5.1.0 release and add BDR-2534

### DIFF
--- a/product_docs/docs/pgd/4/rel_notes/pgd_4.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/pgd_4.3.0_rel_notes.mdx
@@ -10,6 +10,7 @@ EDB Postgres Distributed version 4.3.0 is a patch release of EDB Postgres Distri
 
 | Component | Version |  Type           |                                                   Description                                                           |
 | --------- | ------- | --------------- | ------------------------------------------------------------------------------------------------------------------------|
+| BDR       | 4.3.0   | Feature         | Add pid to the log message emitted upon writer process death (BDR-2534) |
 | BDR       | 4.3.0   | Bug fix         | Handle ALTER TABLE...ALTER COLUMN...TYPE...on a non-data node (BDR-2768 RT86808) <p> A global DML lock is required if a table rewrite is needed, however this cannot be taken if the query is executed on a non-data node (logical standby or subscriber-only). </p> |
 | BDR       | 4.3.0   | Bug fix         | Separate autopartition leader from Raft leader (BDR-2721) <p> Raft leader can be a witness node but autopartitioning can only be managed on data nodes. This change ensures that autopatition leader is always a data node. </p> |
 | BDR       | 4.3.0   | Feature         | Implement bdr.alter node_kind() <p> Function to change a node kind, the kind can also be checked in bdr.node now. </p> |

--- a/product_docs/docs/pgd/5/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/index.mdx
@@ -2,6 +2,7 @@
 title: "EDB Postgres Distributed Release notes"
 navTitle: "Release notes"
 navigation:
+- pgd_5.1.0_rel_notes
 - pgd_5.0.1_rel_notes
 - pgd_5.0.0_rel_notes
 
@@ -15,6 +16,7 @@ that introduced the feature.
 
 | Release Date  |   EDB Postgres Distributed   | BDR extension | PGD CLI | PGD Proxy |
 | ------------- | ---------------------------- | ------------- | ------- | --------- |
+| TBD           | [5.1.0](pgd_5.1.0_rel_notes) | 5.1.0         | TBD     | TBD       |
 | 2023 Mar 21   | [5.0.1](pgd_5.0.1_rel_notes) | 5.0.0         | 5.0.1   | 5.0.1     |
 | 2023 Feb 21   | [5.0.0](pgd_5.0.0_rel_notes) | 5.0.0         | 5.0.0   | 5.0.0     |
 

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.1.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.1.0_rel_notes.mdx
@@ -1,0 +1,11 @@
+---
+title: "Release notes for EDB Postgres Distributed version 5.1.0"
+navTitle: "Version 5.1.0"
+---
+
+EDB Postgres Distributed version 5.0.1 is a patch version of EDB Postgres Distributed.
+This version addresses security vulnerabilities in dependencies for PGD-Proxy and PGD-CLI.
+
+| Component | Version | Type    | Description                                          |
+|-----------|---------|---------|------------------------------------------------------|
+| PGD       | 5.1.0   | Feature | Add pid to the log message emitted upon writer process death (BDR-2534) |

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.1.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.1.0_rel_notes.mdx
@@ -3,7 +3,7 @@ title: "Release notes for EDB Postgres Distributed version 5.1.0"
 navTitle: "Version 5.1.0"
 ---
 
-EDB Postgres Distributed version 5.0.1 is a patch version of EDB Postgres Distributed.
+EDB Postgres Distributed version 5.1.0 is a patch version of EDB Postgres Distributed.
 This version addresses security vulnerabilities in dependencies for PGD-Proxy and PGD-CLI.
 
 | Component | Version | Type    | Description                                          |


### PR DESCRIPTION
## What Changed?

- Prepare BDR 5.1.0 release file
- Add BDR-2534 to BDR 5.1.0 release notes
- Add BDR-2534 to BDR 4.3.0 release notes

Related BDR PRs:
https://github.com/EnterpriseDB/bdr/pull/1842
https://github.com/EnterpriseDB/bdr/pull/1841
https://github.com/EnterpriseDB/bdr/pull/1840

