### PR TITLE
BDR-3342 - Add rel_notes for HARP 2.2.2

### DIFF
--- a/product_docs/docs/pgd/4/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/index.mdx
@@ -32,7 +32,7 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 
 | Release Date | EDB Postgres Distributed     | BDR   | HARP  | CLI | TPAexec                                                                          |
 | ------------ | ---------------------------- | ----- | ----- | --- | -------------------------------------------------------------------------------- |
-| TBD          | [4.3.1](pgd_4.3.1_rel_notes) | 4.3.1 | TBA | TBA | TBA   |
+| TBD          | [4.3.1](pgd_4.3.1_rel_notes) | 4.3.1 | 2.2.2 | 1.1.0 | TBA   |
 | 2023 Feb 14 | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2022 Dec 14 | [4.2.2](pgd_4.2.2_rel_notes) | 4.2.2 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2022 Nov 16 | [4.2.1](pgd_4.2.1_rel_notes) | 4.2.1 | 2.2.1 | 1.1.0 | [23.7](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/237/)   |

--- a/product_docs/docs/pgd/4/rel_notes/pgd_4.3.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/pgd_4.3.1_rel_notes.mdx
@@ -11,4 +11,6 @@ EDB Postgres Distributed version 4.3.1 is a patch release of EDB Postgres Distri
 | Component | Version |  Type           |                                                   Description                                                           |
 | --------- | ------- | --------------- | ------------------------------------------------------------------------------------------------------------------------|
 | BDR       | 4.3.1   | Feature         | Add pid to the log message emitted upon writer process death (BDR-2534) |
+| HARP      | 2.2.2   | Enhancement     | Upgrade dependencies to fix security vulnerabilities |
+
 


### PR DESCRIPTION
Update release notes to add record for HARP release 2.2.2.

Have updated the release notes however I am not sure and have few queries regarding this as mentioned below:

1. The release date for PGD 4.3.1 is a TBD however we are releasing HARP 2.2.2 sometime this week. So will there be a new release like PGD 4.3.2 for BDR side of changes ?
2. The fix that is being pushed out for HARP 2.2.2 also needs to be applied for `PGD CLI 1` also. The release for CLI is planned for sometime in May 2023. Will that we a separate release for this too ?
3. Will all these components be released as part of a single PGD release `4.3.1` with `BDR 4.3.1`, `HARP 2.2.2` and `CLI 1.1.1` ? In that case do we have a single release date for all of them ?
4. Can I just add the `HARP 2.2.2` stuff under `PGD 4.3.0` itself ? 


