### PR TITLE
Removed Java requirement from install instructions 

### DIFF
--- a/install_template/templates/products/migration-toolkit/base.njk
+++ b/install_template/templates/products/migration-toolkit/base.njk
@@ -12,10 +12,7 @@ redirects:
   - migration_toolkit/{{ product.version }}/05_installing_mtk/install_on_linux/{{deploy.expand_arch[platform.arch]}}/mtk55_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
 {% endblock frontmatter %}
 
-{% block prodprereq %}
-
-{% include "platformBase/_javainstall.njk" %}
-{% endblock prodprereq %}
+{% block prodprereq %}{% endblock prodprereq %}
 {% block postinstall %}
 ## Initial configuration
 Before invoking Migration Toolkit, you must download and install JDBC drivers for connecting to the source and target databases. See [Installing a JDBC driver](/migration_toolkit/latest/installing/installing_jdbc_driver/) for details.

--- a/install_template/templates/products/replication-server/base.njk
+++ b/install_template/templates/products/replication-server/base.njk
@@ -12,15 +12,7 @@ redirects:
   - eprs/{{ product.version }}/03_installation/03_installing_rpm_package/{{deploy.expand_arch[platform.arch]}}/eprs_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
 {% endblock frontmatter %}
 
-{% block prodprereq %}
-
-{% include "platformBase/_javainstall.njk" %}
-!!!note
-   When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed. 
-
-   If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-!!!
-{% endblock prodprereq %}
+{% block prodprereq %}{% endblock prodprereq %}
 {% block installCommand %}
 You can install all Replication Server components with a single install command, or you may choose to install selected, individual components by installing only those particular packages.
 

--- a/product_docs/docs/eprs/7/10_appendix/02_resolving_problems/04_troubleshooting_areas.mdx
+++ b/product_docs/docs/eprs/7/10_appendix/02_resolving_problems/04_troubleshooting_areas.mdx
@@ -10,6 +10,12 @@ The following topics provide information on specific problem areas you may encou
 
 <div id="java_runtime_errors" class="registered_link"></div>
 
+## Removing Java can remove Replication Server
+
+When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. In this situation the JDK is installed as a dependency of the Replication Server. If you subsequently remove the JDK, Replication Server is also removed. 
+
+If Java 1.8 or greater existed before Replication Server was installed, removing the JDK does not remove the Replication Server.
+
 ## Java runtime errors
 
 If errors are encountered regarding the Java Runtime Environment such as the Java program cannot be found or Java heap space errors, check the parameters set in the Replication Server configuration file `xdbReplicationServer-xx.config`. See [Replication Server configuration file](../../02_overview/03_replication_server_components_and_architecture/01_physical_components/#xdb_replication_conf_file) for information on this file.

--- a/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_rhel_8.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_rhel_8.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo dnf -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_sles_12.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_sles_12.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_sles_15.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_sles_15.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_centos_7.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_centos_7.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo yum -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_debian_10.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_debian_10.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_debian_11.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_debian_11.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_other_linux_8.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_other_linux_8.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo dnf -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_rhel_7.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_rhel_7.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo yum -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_rhel_8.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_rhel_8.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo dnf -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_sles_12.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_sles_12.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_sles_15.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_sles_15.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_ubuntu_18.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_ubuntu_18.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_ubuntu_20.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_ubuntu_20.mdx
@@ -13,18 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
-  !!!note
-  When Replication Server is installed on a machine where Java is not present, the JDK is installed as part of the installation process. Since in this case the JDK was installed via Replication Server as its dependency, if you subsequently remove the JDK, Replication Server is also removed.
-
-  If Java 1.8 or greater exists before installing Replication Server, the installed Replication Server is not removed on removal of the JDK.
-  !!!
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_rhel_8.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_rhel_8.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo dnf -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_sles_12.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_sles_12.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_sles_15.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_sles_15.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_centos_7.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_centos_7.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo yum -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_debian_10.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_debian_10.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_debian_11.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_debian_11.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_other_linux_8.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_other_linux_8.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo dnf -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_rhel_7.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_rhel_7.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo yum -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_rhel_8.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_rhel_8.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo dnf -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_sles_12.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_sles_12.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_sles_15.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_sles_15.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo zypper -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_ubuntu_18.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_ubuntu_18.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_ubuntu_20.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_ubuntu_20.mdx
@@ -13,12 +13,6 @@ redirects:
 
 Before you begin the installation process:
 
-- Install Java (version 1.8 or later) on your server, if not present.
-
-  ```shell
-  sudo apt-get -y install java
-  ```
-
 - Set up the repository
 
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.


### PR DESCRIPTION
In addition to removing the Java prereq bullet, I moved the note about uninstalling Java in EPRS to the troubleshooting topic.
