### PR TITLE
Provide more details on how to upgrade a CAMO enabled cluster.

### DIFF
--- a/product_docs/docs/pgd/5/upgrades/index.mdx
+++ b/product_docs/docs/pgd/5/upgrades/index.mdx
@@ -111,8 +111,8 @@ Upgrading CAMO-Enabled Cluster requires upgrading CAMO groups one by one, while
 disabling the CAMO protection for the group being upgraded and reconfiguring it
 using the new [Commit Scope](../durability/commit-scopes) based settings.
 
-The following approach is recommended for upgrade two BDR nodes that
-consitute a CAMO pair:
+The following approach is recommended for upgrade two BDR nodes, that
+constitute a CAMO pair, to PGD 5.0:
 
 - Ensure `bdr.enable_camo` remains `off` for transactions on any of
   the two nodes or redirect clients away from the two nodes. Removing
@@ -121,7 +121,7 @@ consitute a CAMO pair:
 - Uncouple the pair by deconfiguring CAMO either by resetting
   `bdr.camo_origin_for` and `bdr.camo_parter_of` (when upgrading from
   BDR 3.7.x) or by using `bdr.remove_camo_pair` (on BDR 4.x).
-- Upgrade the two nodes to BDR 5.0
+- Upgrade the two nodes to PGD 5.0
 - Create a dedicated node group for the two nodes and move them into
   that node group.
 - Create a [Commit Scope](../durability/commit-scopes) for this node

--- a/product_docs/docs/pgd/5/upgrades/index.mdx
+++ b/product_docs/docs/pgd/5/upgrades/index.mdx
@@ -111,6 +111,28 @@ Upgrading CAMO-Enabled Cluster requires upgrading CAMO groups one by one, while
 disabling the CAMO protection for the group being upgraded and reconfiguring it
 using the new [Commit Scope](../durability/commit-scopes) based settings.
 
+The following approach is recommended for upgrade two BDR nodes that
+consitute a CAMO pair:
+
+- Ensure `bdr.enable_camo` remains `off` for transactions on any of
+  the two nodes or redirect clients away from the two nodes. Removing
+  the CAMO pairing while attempting to use CAMO will lead to errors
+  and prevent further transactions.
+- Uncouple the pair by deconfiguring CAMO either by resetting
+  `bdr.camo_origin_for` and `bdr.camo_parter_of` (when upgrading from
+  BDR 3.7.x) or by using `bdr.remove_camo_pair` (on BDR 4.x).
+- Upgrade the two nodes to BDR 5.0
+- Create a dedicated node group for the two nodes and move them into
+  that node group.
+- Create a [Commit Scope](../durability/commit-scopes) for this node
+  group and thus the pair of nodes to use CAMO.
+- Reactivate CAMO protection again by either setting a
+  `default_commit_scope` or by changing the clients to explicitly set
+  `bdr.commit_scope` (instead of `bdr.enable_camo`) for their sessions
+  or transactions.
+- If necessary, allow clients to connect to the CAMO protected nodes,
+  again.
+
 ## Upgrade preparation
 
 Each major release of the software contains several changes that may affect


### PR DESCRIPTION
BDR-3002

## What Changed?

Provide more detailed instructions on how to upgrade a CAMO enabled cluster from BDR 3.7 or 4.x to BDR 5.0.