### PR TITLE
correct name of cnp_backends_total

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
@@ -43,7 +43,7 @@ Derived from the `pg_stat_activity` view.
 
 | Metric   | Usage | Description |
 |----------|-------|-------------|
-| `cnp_backends_n_backends` | GAUGE | Number of backends in this group |
+| `cnp_backends_total` | GAUGE | Number of backends in this group |
 | `cnp_backends_max_tx_duration_seconds` | GAUGE | Maximum duration of a transaction in seconds in this group |
 | `cnp_backends_max_backend_xmin_age` | GAUGE | Maximum duration of a transaction in seconds in this group |
 


### PR DESCRIPTION
## What Changed?
Now we only have cnp_backends_total but not cnp_backends_n_backend