### PR TITLE
Docs/fix/1363 feedback on jdbc connector42212305 using the advanced server jdbc connector with java applicationsindexmdx

### DIFF
--- a/advocacy_docs/postgresql_journey/04_developing/connecting_to_postgres/java/02_JDBC.mdx
+++ b/advocacy_docs/postgresql_journey/04_developing/connecting_to_postgres/java/02_JDBC.mdx
@@ -30,9 +30,6 @@ public class Example
    {
       try
       {
-         // this is only needed when running against JDBC versions < 4
-         // Class.forName("org.postgresql.Driver");
-
          String url = "jdbc:postgresql://javadb:5432/coffee?user=postgres&password=password";
          Connection conn = DriverManager.getConnection(url);
 

--- a/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/01_loading_the_advanced_server_jdbc_connector.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/01_loading_the_advanced_server_jdbc_connector.mdx
@@ -12,4 +12,4 @@ legacyRedirectsGenerated:
 
 <div id="loading_the_advanced_server_jdbc_connector" class="registered_link"></div>
 
-The EDB Postgres Advanced Server JDBC driver is written in Java and is distributed as a compiled Java Archive (JAR) file. Include the driver's JAR file in your classpath for the Java runtime to register the driver when it starts up. The registered driver will be used when an application requests a connection URL beginning with the "jdbc:edb:" schema.
+The EDB Postgres Advanced Server JDBC driver is written in Java and is distributed as a compiled Java Archive (JAR) file. Include the driver's JAR file in your classpath so that the Java runtime can register the driver as it starts up. The registered driver will be used when an application requests a connection with a URL beginning with the "jdbc:edb:" schema.

--- a/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/01_loading_the_advanced_server_jdbc_connector.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/01_loading_the_advanced_server_jdbc_connector.mdx
@@ -12,4 +12,4 @@ legacyRedirectsGenerated:
 
 <div id="loading_the_advanced_server_jdbc_connector" class="registered_link"></div>
 
-The EDB Postgres Advanced Server JDBC driver is written in Java and is distributed in the form of a compiled Java Archive (JAR) file. Ensure the JAR file is included in your class path and it will automatically be registered when the Java runtime stats up. It will then be used when a application requests a connection URL beginning with the "jdbc:edb:" schema.
+The EDB Postgres Advanced Server JDBC driver is written in Java and is distributed as a compiled Java Archive (JAR) file. Include the driver's JAR file in your classpath for the Java runtime to register the driver when it starts up. The registered driver will be used when an application requests a connection URL beginning with the "jdbc:edb:" schema.

--- a/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/01_loading_the_advanced_server_jdbc_connector.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/01_loading_the_advanced_server_jdbc_connector.mdx
@@ -12,12 +12,4 @@ legacyRedirectsGenerated:
 
 <div id="loading_the_advanced_server_jdbc_connector" class="registered_link"></div>
 
-The EDB Postgres Advanced Server JDBC driver is written in Java and is distributed in the form of a compiled Java Archive (JAR) file. Use the `Class.forName()` method to load the driver. The `forName()` method dynamically loads a Java class at runtime. When an application calls the `forName()` method, the Java Virtual Machine (JVM) attempts to find the compiled form (the bytecode) that implements the requested class.
-
-The EDB Postgres Advanced Server JDBC driver is named `com.edb.Driver`:
-
-`Class.forName("com.edb.Driver");`
-
-After loading the bytecode for the driver, the driver registers itself with another JDBC class (named `DriverManager`) that's responsible for managing all the JDBC drivers installed on the current system.
-
-If the JVM can't locate the named driver, it reports a `ClassNotFound` exception (which is intercepted with a `catch` block near the end of the program). The `DriverManager` is designed to handle multiple JDBC driver objects. You can write a Java application that connects to more than one database system by way of JDBC. 
+The EDB Postgres Advanced Server JDBC driver is written in Java and is distributed in the form of a compiled Java Archive (JAR) file. Ensure the JAR file is included in your class path and it will automatically be registered when the Java runtime stats up. It will then be used when a application requests a connection URL beginning with the "jdbc:edb:" schema.

--- a/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/02_connecting_to_the_database/02_preferring_synchronous_secondary_database_servers.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/02_connecting_to_the_database/02_preferring_synchronous_secondary_database_servers.mdx
@@ -30,6 +30,7 @@ The IP address or a name assigned to the primary database server followed by its
 
 !!! Note
 You can specify the primary database server in any location in the list. It doesn't have to precede the secondary database servers.
+!!!
 
 `secondary_n:port_n`
 
@@ -144,7 +145,6 @@ The following table lists the basic `postgresql.conf` configuration parameter se
 | ------------------------- | ----------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | archive_mode              | on                                  | off       | Completed WAL segments sent to archive storage                                                                                                                                                                                                  |
 | archive_command           | cp %p /*archive_dir*/%f             | n/a       | Archive completed WAL segments                                                                                                                                                                                                                  |
-
 | wal_level (10 or later)  | replica                             | minimal   | Information written to WAL segment                                                                                                                                                                                                              |
 | max_wal_senders           | *n* (positive integer)              | 0         | Maximum concurrent connections from standby servers                                                                                                                                                                                             |
 | wal_keep_segments         | *n* (positive integer)              | 0         | Minimum number of past log segments to keep for standby servers                                                                                                                                                                                 |
@@ -202,7 +202,6 @@ public class InetServer
   {
     try
     {
-      Class.forName("com.edb.Driver");
       String url =
  "jdbc:edb://primary:5444,secondary1:5445,secondary2:5446/edb?targetServerType=preferSyncSecondary";
       String user     = "enterprisedb";

--- a/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/index.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/05_using_the_advanced_server_jdbc_connector_with_java_applications/index.mdx
@@ -23,7 +23,6 @@ public class ListEmployees
   {
     try
     {
-      Class.forName("com.edb.Driver");
       String url      = "jdbc:edb://localhost:5444/edb";
       String user     = "enterprisedb";
       String password = "enterprisedb";
@@ -39,10 +38,6 @@ public class ListEmployees
       stmt.close();
       con.close();
       System.out.println("Command successfully executed");
-    }
-    catch(ClassNotFoundException e)
-    {
-      System.out.println("Class Not Found : " + e.getMessage());
     }
     catch(SQLException exp)
     {

--- a/product_docs/docs/jdbc_connector/42.5.4.1/08_advanced_jdbc_connector_functionality/06_using_object_types_and_collections_with_java.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/08_advanced_jdbc_connector_functionality/06_using_object_types_and_collections_with_java.mdx
@@ -27,7 +27,6 @@ public static Connection getEDBConnection() throws
   String url = "jdbc:edb://localhost:5444/test";
   String user = "enterprisedb";
   String password = "edb";
-  Class.forName("com.edb.Driver");
   Connection conn = DriverManager.getConnection(url, user, password);
   return conn;
 }

--- a/product_docs/docs/jdbc_connector/42.5.4.1/09_security_and_encryption/03_support_for_gssapi_encrypted_connection.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/09_security_and_encryption/03_support_for_gssapi_encrypted_connection.mdx
@@ -41,7 +41,6 @@ This default behavior is controlled using the `gsslib` connection parameter that
 When the EDB Postgres Advanced Server and JDBC client both are on Windows, the JDBC driver connects with SSPI authentication using one of the following connection strings:
 
 ```java
-Class.forName("com.edb.Driver"); 
 con = DriverManager.getConnection("jdbc:edb://localhost:5444/edb");
 OR
 con = DriverManager.getConnection("jdbc:edb://localhost:5444/edb?gsslib=sspi"); 
@@ -67,7 +66,6 @@ java JEdb
 When the EDB Postgres Advanced Server and JDBC client both are on Linux, the JDBC driver connects with GSSAPI authentication using the following connection string:
 
 ```java
-Class.forName("com.edb.Driver");
 Properties connectionProps = new Properties();
 connectionProps.setProperty("user", "postgres/myrealm.example@MYREALM.EXAMPLE");
 String databaseUrl = "jdbc:edb://myrealm.example:5444/edb";
@@ -116,7 +114,6 @@ This example assumes that GSS authentication is configured between Windows Activ
 In this scenario, JDBC is using SSPI authentication. Create the connection using the following code: 
 
 ```java  
-Class.forName("com.edb.Driver");   	
 Properties connectionProps = new Properties();
 connectionProps.setProperty("user", "david@MYREALM.EXAMPLE");
 String databaseUrl = "jdbc:edb://pg.myrealm.example:5444/edb?gsslib=sspi";
@@ -129,7 +126,6 @@ Running an EDB JDBC-based app in this case is the same as described in [Using SS
 In this scenario, JDBC is using GSSAPI authentication. Create the connection using the following code: 
 
 ```java  
-Class.forName("com.edb.Driver"); 		
 Properties connectionProps = new Properties();
 connectionProps.setProperty("user", "david@MYREALM.EXAMPLE");
 String databaseUrl = "jdbc:edb://pg.myrealm.example:5444/edb?gsslib=gssapi";


### PR DESCRIPTION
## What Changed?

Class.forName() removed from examples

Section on loading the driver simplified to *almost* nothing.

Repaired overrunning note and broken table on one page.