### PR TITLE
BDR-3342 - Add release note entry for HARP dependencies upgrade

### DIFF
--- a/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.2.2_rel_notes.mdx
+++ b/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.2.2_rel_notes.mdx
@@ -1,0 +1,10 @@
+---
+title: "Version 2.2.2"
+---
+
+This is a patch release of HARP 2 that includes fixes for issues identified
+in previous versions.
+
+| Type | Description |
+| ---- |------------ |
+| Enhancement     | Upgrade dependencies to fix security vulnerabilities |

--- a/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.2.2_rel_notes.mdx
+++ b/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.2.2_rel_notes.mdx
@@ -7,4 +7,4 @@ in previous versions.
 
 | Type | Description |
 | ---- |------------ |
-| Enhancement     | Upgrade dependencies to fix security vulnerabilities |
+| Change | Upgrade 3rd party dependencies to fix Github dependabot alerts |

--- a/product_docs/docs/pgd/3.7/harp/01_release_notes/index.mdx
+++ b/product_docs/docs/pgd/3.7/harp/01_release_notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release Notes
 navigation:
+- harp2.2.2_rel_notes
 - harp2.2.1_rel_notes
 - harp2.2.0_rel_notes
 - harp2.1.1_rel_notes
@@ -21,6 +22,7 @@ The release notes in this section provide information on what was new in each re
 
 | Version                  | Release Date |
 | -----------------------  | ------------ |
+| [2.2.2](harp2.2.2_rel_notes)  | 2023 Mar 30  |
 | [2.2.1](harp2.2.1_rel_notes)  | 2022 Nov 16  |
 | [2.2.0](harp2.2.0_rel_notes)  | 2022 Aug 22  |
 | [2.1.1](harp2.1.1_rel_notes)  | 2022 Jun 21  |

--- a/product_docs/docs/pgd/4/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/index.mdx
@@ -30,7 +30,7 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 
 | Release Date | EDB Postgres Distributed     | BDR   | HARP  | CLI | TPAexec                                                                          |
 | ------------ | ---------------------------- | ----- | ----- | --- | -------------------------------------------------------------------------------- |
-| 2023 Feb 14 | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.2 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
+| 2023 Feb 14 | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.2[^*] | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2022 Dec 14 | [4.2.2](pgd_4.2.2_rel_notes) | 4.2.2 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2022 Nov 16 | [4.2.1](pgd_4.2.1_rel_notes) | 4.2.1 | 2.2.1 | 1.1.0 | [23.7](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/237/)   |
 | 2022 Aug 22 | [4.2.0](pgd_4.2.0_rel_notes) | 4.2.0 | 2.2.0 | 1.1.0 | [23.5](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/235/)   |
@@ -42,4 +42,4 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 | 2021 Dec 01  | [4.0.0](pgd_4.0.0_rel_notes) | 4.0.0 | 2.0.0 | -   | [22.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/2106/)  |
 
 
-- HARP 2.2.1 has been patched to address a security vulnerability and if using 2.2.1 with an earlier version of PGD, we recommend you upgrade to 2.2.2.
+[^*] We released a patch to HARP 2.2.1 to address a security vulnerability. If using 2.2.1 with an earlier version of EDB Postgres Distributed, we recommend you upgrade to 2.2.2.

--- a/product_docs/docs/pgd/4/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/index.mdx
@@ -13,16 +13,16 @@ navigation:
 - pgd_4.0.1_rel_notes
 - pgd_4.0.0_rel_notes
 redirects:
-  - /pgd/latest/rel_notes/pgd_4.0.0_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.0.1_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.0.2_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.0.3_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.1.0_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.1.1_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.2.0_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.2.1_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.2.2_rel_notes/ 
-  - /pgd/latest/rel_notes/pgd_4.3.0_rel_notes/ 
+  - /pgd/latest/rel_notes/pgd_4.0.0_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.0.1_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.0.2_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.0.3_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.1.0_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.1.1_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.2.0_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.2.1_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.2.2_rel_notes/
+  - /pgd/latest/rel_notes/pgd_4.3.0_rel_notes/
 
 ---
 
@@ -30,7 +30,7 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 
 | Release Date | EDB Postgres Distributed     | BDR   | HARP  | CLI | TPAexec                                                                          |
 | ------------ | ---------------------------- | ----- | ----- | --- | -------------------------------------------------------------------------------- |
-| 2023 Feb 14 | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
+| 2023 Feb 14 | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.2 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2022 Dec 14 | [4.2.2](pgd_4.2.2_rel_notes) | 4.2.2 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2022 Nov 16 | [4.2.1](pgd_4.2.1_rel_notes) | 4.2.1 | 2.2.1 | 1.1.0 | [23.7](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/237/)   |
 | 2022 Aug 22 | [4.2.0](pgd_4.2.0_rel_notes) | 4.2.0 | 2.2.0 | 1.1.0 | [23.5](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/235/)   |
@@ -42,3 +42,4 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 | 2021 Dec 01  | [4.0.0](pgd_4.0.0_rel_notes) | 4.0.0 | 2.0.0 | -   | [22.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/2106/)  |
 
 
+- HARP 2.2.1 has been patched to address a security vulnerability and if using 2.2.1 with an earlier version of PGD, we recommend you upgrade to 2.2.2.

--- a/product_docs/docs/pgd/4/rel_notes/pgd_4.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/pgd_4.3.0_rel_notes.mdx
@@ -16,5 +16,5 @@ EDB Postgres Distributed version 4.3.0 is a patch release of EDB Postgres Distri
 | BDR       | 4.3.0   | Bug fix         | Replicate bdr admin functions to standbys (BDR-1575, RT72698) <p> Always replicate the function call also for the writter process. </p> |
 | BDR       | 4.3.0   | Bug fix         | Fix watermark handling on clusters with multiple sub-groups <p> Watermark is used to ensure data consistency during join. Previously, this didn't work correctly in the presence of multiple data sub-groups. </p> |
 | BDR       | 4.3.0   | Bug fix         | Don't allow switching to CAMO Local Mode if the node is not a write lead <p> In CAMO only one node should be allowed to switch to the Local Mode at given time. We now require the node to be the HARP write leader in order to ensure that rule. </p> |
-| HARP      | 2.2.2   | Enhancement     | Upgrade dependencies to fix security vulnerabilities |
+| HARP      | 2.2.2   | Change          | Upgrade 3rd party dependencies to fix Github dependabot alerts |
 

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.0.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.0.1_rel_notes.mdx
@@ -6,7 +6,7 @@ navTitle: "Version 5.0.1"
 EDB Postgres Distributed version 5.0.1 is a patch version of EDB Postgres Distributed.
 This version addresses security vulnerabilities in dependencies for PGD-Proxy and PGD-CLI.
 
-| Component | Version | Type    | Description                                          |
-|-----------|---------|---------|------------------------------------------------------|
-| CLI       | 5.0.1   | Change | Upgrade dependencies to fix security vulnerabilities  |
-| Proxy     | 5.0.1   | Change | Upgrade dependencies to fix security vulnerabilities  |
+| Component | Version | Type    | Description                                                   |
+|-----------|---------|---------|---------------------------------------------------------------|
+| CLI       | 5.0.1   | Change | Upgrade 3rd party dependencies to fix Github dependabot alerts |
+| Proxy     | 5.0.1   | Change | Upgrade 3rd party dependencies to fix Github dependabot alerts |


### PR DESCRIPTION
* Add entry for HARP 2.2.2 release notes for PGD 3.7
* Add the release version HARP 2.2.2 to index page for PGD 4 along with a footnote to upgrade to this version for all installations using HARP 2.2.1

TBH the entry for PGD 4 still looks odd to me. We are mentioning HARP 2.2.2 to be released as part of PGD 4.3.0 which in fact is not the case. Ideally I would have preferred to have any entry for this under PGD 4.3.1 with release date as `30 March 2023` and then the footnote would have made more sense. The detailed rel_notes for PGD 4.3.1 would contain entry only for HARP 2.2.2.
The upcoming release for PGD in May 2023 would then become 4.3.2. I am not sure about the challenges involved with this change in PGD release schedule so my suggestion may not be a viable option here.

