### PR TITLE
Update enabling_tde.mdx

### DIFF
--- a/product_docs/docs/tde/15/enabling_tde.mdx
+++ b/product_docs/docs/tde/15/enabling_tde.mdx
@@ -36,7 +36,7 @@ To enable encryption, use the following options with the `initdb` command or the
  
 `--no-key-wrap`
 
-  Disable key wrapping. The data encryption key is instead stored in plaintext in the data directory.   (This option is a shortcut for setting both the wrap and the unwrap command to an empty string.)
+  Disable key wrapping. The data encryption key is instead stored in plaintext in the data directory.   (This option is a shortcut for setting both the wrap and the unwrap command to an empty string, it also set `data_encryption_key_unwrap_command = '-'` in the postgresql.conf.)
   
   !!! Note
       Using this option isn't secure. Use it only for testing purposes. 


### PR DESCRIPTION
added data_encryption_key_unwrap_command default in case of --no-key-wrap is used to add context and expected defaults

## What Changed?

