### PR TITLE
PEM-4760-Troubleshooting the 'oversized response headers' webserver error

### DIFF
--- a/product_docs/docs/pem/9/troubleshooting.mdx
+++ b/product_docs/docs/pem/9/troubleshooting.mdx
@@ -89,3 +89,16 @@ In some situations, you might need to uninstall the PEM server, reinstall it, an
     /usr/edb/pem/bin/configure-pem-server.sh
     ```
 
+## Editing Apache HTTPD configuration file (PEM client not displaying)
+
+If the PEM client is not displaying, you might see the following HTTPD log in the `/var/log/httpd/error_log` file:
+
+```text
+Truncated or oversized response headers received from daemon process 'edbpem': /usr/edb/pem/web/pem.wsgi
+```
+
+In that case, you must add the following statement at the bottom of the Apache `httpd.conf` file located in `/etc/httpd/conf` folder:
+
+```shell
+WSGIApplicationGroup %{GLOBAL}
+```


### PR DESCRIPTION
## What Changed?

Updated the Troubleshooting (https://www.enterprisedb.com/docs/pem/latest/troubleshooting/) topic with the content for updating the Apache httpd configuration file for resolving the 'oversized response headers' webserver error.