### PR TITLE
Fix for example deploy text for EPES (PGE)

### DIFF
--- a/install_template/templates/products/edb-postgres-extended-server/base.njk
+++ b/install_template/templates/products/edb-postgres-extended-server/base.njk
@@ -12,6 +12,6 @@ redirects:
 {% endblock frontmatter %}
 {% block installCommand %}
 {{super()}}
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version {{ product.version }}, the package name would be {{packageName | replace('<xx>', product.version)}}.
 
 {% endblock installCommand %}

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_centos_7.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_centos_7.mdx
@@ -34,4 +34,4 @@ Before you begin the installation process:
 sudo yum -y install edb-postgresextended<xx>-server edb-postgresextended<xx>-contrib
 ```
 
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be edb-postgresextended15-server edb-postgresextended15-contrib.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_other_linux_8.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_other_linux_8.mdx
@@ -38,4 +38,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-postgresextended<xx>-server edb-postgresextended<xx>-contrib
 ```
 
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be edb-postgresextended15-server edb-postgresextended15-contrib.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_rhel_7.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_rhel_7.mdx
@@ -33,4 +33,4 @@ Before you begin the installation process:
 sudo yum -y install edb-postgresextended<xx>-server edb-postgresextended<xx>-contrib
 ```
 
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be edb-postgresextended15-server edb-postgresextended15-contrib.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_rhel_8.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_rhel_8.mdx
@@ -34,4 +34,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-postgresextended<xx>-server edb-postgresextended<xx>-contrib
 ```
 
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be edb-postgresextended15-server edb-postgresextended15-contrib.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_18.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_18.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-postgresextended-<xx>
 ```
 
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be edb-postgresextended-15.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_20.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_20.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-postgresextended-<xx>
 ```
 
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be edb-postgresextended-15.

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_22.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_ubuntu_22.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-postgresextended-<xx> edb-postgresextended-<xx>-contrib
 ```
 
-Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be `edb-postgresextended15`.
+Where `<xx>` is the version of EDB Postgres Extended Server you are installing. For example, if you are installing version 15, the package name would be edb-postgresextended-15 edb-postgresextended-15-contrib.


### PR DESCRIPTION
Using syntax from Josh, I made this elegant fix to the problem of example text that explains the deploy command varying between platforms. 

