### PR TITLE
Relative paths for links in PEM 8 and 9

### DIFF
--- a/install_template/templates/products/postgres-enterprise-manager-agent/base.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-agent/base.njk
@@ -14,5 +14,5 @@ redirects:
 
 {% block installCommand %}
 {{super()}}
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).
 {% endblock installCommand %}

--- a/install_template/templates/products/postgres-enterprise-manager-server/base.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/base.njk
@@ -23,7 +23,7 @@ redirects:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
   
 {% endblock product_prerequisites %}
 {% block postinstall %}
@@ -34,7 +34,7 @@ redirects:
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
     

--- a/product_docs/docs/pem/8/installing/linux_ppc64le/pem_rhel_8.mdx
+++ b/product_docs/docs/pem/8/installing/linux_ppc64le/pem_rhel_8.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
-- Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/8/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
+- Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/8/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/8/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_ppc64le/pem_sles_12.mdx
+++ b/product_docs/docs/pem/8/installing/linux_ppc64le/pem_sles_12.mdx
@@ -18,7 +18,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -27,13 +26,13 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
-
   ```shell
   # Activate the required SUSE module
   sudo SUSEConnect -p PackageHub/12.5/ppc64le
@@ -56,7 +55,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_ppc64le/pem_sles_15.mdx
+++ b/product_docs/docs/pem/8/installing/linux_ppc64le/pem_sles_15.mdx
@@ -18,7 +18,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -27,10 +26,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
 
@@ -59,7 +59,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_centos_7.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_centos_7.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo yum -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_10.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_10.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_11.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_11.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_other_linux_8.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_other_linux_8.mdx
@@ -15,7 +15,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -24,10 +23,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
-- Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/8/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
+- Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/8/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -42,7 +42,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/8/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_rhel_7.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_rhel_7.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo yum -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_rhel_8.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_rhel_8.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_sles_12.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_sles_12.mdx
@@ -18,7 +18,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -27,13 +26,13 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
-
   ```shell
   # Activate the required SUSE module
   sudo SUSEConnect -p PackageHub/12.5/x86_64
@@ -56,7 +55,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_sles_15.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_sles_15.mdx
@@ -18,7 +18,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -27,10 +26,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
 
@@ -59,7 +59,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_18.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_18.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_20.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_20.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_22.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_22.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   - To set up the EDB repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -23,10 +22,11 @@ Before you begin the installation process:
 
   !!! Note
   The PostgreSQL community repository is required only if you are using PostgreSQL as the backend database for PEM server.
+  !!!
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_rhel_8.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_rhel_8.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
@@ -18,13 +18,11 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
 
 - Address other prerequisites
-
   ```shell
   # Activate the required SUSE module
   sudo SUSEConnect -p PackageHub/12.5/ppc64le
@@ -40,4 +38,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_sles_15.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_sles_15.mdx
@@ -18,7 +18,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -43,4 +42,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_centos_7.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_centos_7.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo yum -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_debian_10.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_debian_10.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_debian_11.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_debian_11.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_other_linux_8.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_other_linux_8.mdx
@@ -15,7 +15,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -26,4 +25,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_rhel_7.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_rhel_7.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo yum -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_rhel_8.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_rhel_8.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
@@ -18,13 +18,11 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
 
 - Address other prerequisites
-
   ```shell
   # Activate the required SUSE module
   sudo SUSEConnect -p PackageHub/12.5/x86_64
@@ -40,4 +38,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_sles_15.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_sles_15.mdx
@@ -18,7 +18,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -43,4 +42,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_18.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_18.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_20.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_20.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_22.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_22.mdx
@@ -14,7 +14,6 @@ redirects:
 Before you begin the installation process:
 
 - Set up the repository
-
   Setting up the repository is a one-time task. If you have already set up your repository, you do not need to perform this step.
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
@@ -25,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_rhel_8.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_rhel_8.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_12.mdx
@@ -30,7 +30,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
   ```shell
@@ -55,7 +55,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_15.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_15.mdx
@@ -30,7 +30,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
 
@@ -59,7 +59,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_centos_7.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_centos_7.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo yum -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_10.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_10.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_11.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_11.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_other_linux_8.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_other_linux_8.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -42,7 +42,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_7.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_7.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo yum -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_8.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_8.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo dnf -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_12.mdx
@@ -30,7 +30,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
   ```shell
@@ -55,7 +55,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_15.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_15.mdx
@@ -30,7 +30,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 - Address other prerequisites
 
@@ -59,7 +59,7 @@ sudo zypper -n install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_18.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_18.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_20.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_20.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_22.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_22.mdx
@@ -26,7 +26,7 @@ Before you begin the installation process:
 
 - Install the Postgres server. See [Installing EDB Postgres Advanced Server on Linux](/epas/latest/installing/) or [Installing PostgreSQL](/supported-open-source/postgresql/installer/).
 
-- Review [configuration and authentication requirements](/pem/latest/installing/prerequisites/) for PEM.
+- Review [configuration and authentication requirements](../prerequisites/) for PEM.
 
 ## Install the package
 
@@ -41,7 +41,7 @@ sudo apt-get -y install edb-pem
 sudo /usr/edb/pem/bin/configure-pem-server.sh
 ```
 
-For more details, see [Configuring the PEM server on Linux](/pem/latest/installing/configuring_the_pem_server_on_linux/).
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
 
 !!! Note
 

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_rhel_8.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_rhel_8.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
@@ -38,4 +38,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_sles_15.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_sles_15.mdx
@@ -42,4 +42,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_centos_7.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_centos_7.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo yum -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_debian_10.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_debian_10.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_debian_11.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_debian_11.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_other_linux_8.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_other_linux_8.mdx
@@ -25,4 +25,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_rhel_7.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_rhel_7.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo yum -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_rhel_8.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_rhel_8.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo dnf -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
@@ -38,4 +38,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_sles_15.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_sles_15.mdx
@@ -42,4 +42,4 @@ Before you begin the installation process:
 sudo zypper -n install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_18.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_18.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_20.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_20.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_22.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_ubuntu_22.mdx
@@ -24,4 +24,4 @@ Before you begin the installation process:
 sudo apt-get -y install edb-pem-agent
 ```
 
-After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](/pem/latest/registering_agent/).
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).


### PR DESCRIPTION
All generated topics with links within PEM now use relative links so the link will show the correct version (8 or 9).

