### PR TITLE
Fix Markdown in table

### DIFF
--- a/product_docs/docs/epas/12/epas_rel_notes/19_epas12.1.2_rel_notes.mdx
+++ b/product_docs/docs/epas/12/epas_rel_notes/19_epas12.1.2_rel_notes.mdx
@@ -19,7 +19,7 @@ New features, enhancements, bug fixes, and other changes in EDB Postgres Advance
 | Feature     | General Functionality | Advanced Server now supports a Redwood compatible `to_timestamp` implementation, which facilitates stricter input string parsing for timestamp columns for EDB Loader. |
 | Feature     | General Functionality | Advanced Server has re-implemented `ROWIDs` using identity data type after PG v12 PostgreSQL community removed support for `OIDs` (to which `ROWIDs` were mapped). |
 | Feature     | General Functionality | Advanced Server has added the `SYS_GUID` function to generate and return a globally unique identifier in the form of 16-bytes of RAW data. |
-| Feature     | General Functionality| Advanced Server now offers a new view that provides information that is compatible with the Oracle data dictionary views: `{USER|ALL|DBA}_TAB_PRIVS`, `{USER|ALL|DBA}_COL_PRIVS`, and `{USER|ALL|DBA}_TAB_DEPENDENCIES`.|
+| Feature     | General Functionality| Advanced Server now offers a new view that provides information that is compatible with the Oracle data dictionary views: `{USER\|ALL\|DBA}_TAB_PRIVS`, `{USER\|ALL\|DBA}_COL_PRIVS`, and `{USER\|ALL\|DBA}_TAB_DEPENDENCIES`.|
 | Enhancement | Partitioning   | Improve performance of many operations on partitioned tables. |
 | Enhancement | Partitioning   | Allow tables with thousands of child partitions to be processed efficiently by operations that only affect a small number of partitions. |
 | Enhancement | Partitioning   | Allow foreign keys to reference partitioned tables. |


### PR DESCRIPTION
Pipes were used inline with backquotes. 

## What Changed?

Now escaped.