### PR TITLE
Add information about how efm interprets ping

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
@@ -82,7 +82,7 @@ PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
  time 3000ms
 ```
 
-You see 100% packet loss.
+You see 100% packet loss. Important: Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code is not zero. If using a different command, it must return a non-zero exit code if the address is not reachable.
 
 2.  Run the `efm_address add4` command on the Primary node to assign the VIP, and then confirm with ip address:
 
@@ -105,7 +105,7 @@ PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
 rtt min/avg/max/mdev = 0.023/0.025/0.029/0.006 ms
 ```
 
-No packet loss occurs.
+No packet loss occurs. Important: Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code is zero. If using a different command, it must return a zero exit code if the address is reachable.
 
 4.  Use the `efm_address del` command to release the address on the primary node and confirm the node was released with ip address:
 

--- a/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
@@ -84,7 +84,7 @@ When instructed to ping the VIP from a node, use the command defined by the `pin
 
    You see 100% packet loss. 
    !!!important
-   Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code isn't zero. If using a different command, it must return a non-zero exit code if the address isn't reachable.
+   Failover Manager uses the exit code of the ping command to determine whether or not the address was reachable. In this case the exit code isn't zero. If using a command other than, it must return a non-zero exit code if the address isn't reachable.
 
 2. Run the `efm_address add4` command on the Primary node to assign the VIP, and then confirm with ip address:
 
@@ -109,7 +109,7 @@ When instructed to ping the VIP from a node, use the command defined by the `pin
 
    No packet loss occurs. 
    !!!Important
-   Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code is zero. If using a different command, it must return a zero exit code if the address is reachable.
+   Failover Manager uses the exit code of the ping command to determine whether or not the address was reachable. In this case the exit code is zero. If using a command other than ping, it must return a zero exit code if the address is reachable.
 
 4. Use the `efm_address del` command to release the address on the primary node and confirm the node was released with ip address:
 

--- a/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
@@ -72,75 +72,79 @@ ping.server.command=/bin/ping -q -c3 -w5
 
 When instructed to ping the VIP from a node, use the command defined by the `ping.server.command` property.
 
-1.  Ping the VIP from all nodes to confirm that the address isn't already in use:
+1. Ping the VIP from all nodes to confirm that the address isn't already in use:
 
-```text
-# /bin/ping -q -c3 -w5 172.24.38.239
-PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
---- 172.24.38.239 ping statistics ---
-4 packets transmitted, 0 received, +3 errors, 100% packet loss,
- time 3000ms
-```
+   ```text
+   # /bin/ping -q -c3 -w5 172.24.38.239
+   PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
+   --- 172.24.38.239 ping statistics ---
+   4 packets transmitted, 0 received, +3 errors, 100% packet loss,
+   time 3000ms
+   ```
 
-You see 100% packet loss. Important: Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code is not zero. If using a different command, it must return a non-zero exit code if the address is not reachable.
+   You see 100% packet loss. 
+   !!!important
+   Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code isn't zero. If using a different command, it must return a non-zero exit code if the address isn't reachable.
 
-2.  Run the `efm_address add4` command on the Primary node to assign the VIP, and then confirm with ip address:
+2. Run the `efm_address add4` command on the Primary node to assign the VIP, and then confirm with ip address:
 
-```text
-# efm_address add4 eth0 172.24.38.239/24
-# ip address
-<output truncated>
-eth0 Link encap:Ethernet HWaddr 36:AA:A4:F4:1C:40
-inet addr:172.24.38.239 Bcast:172.24.38.255
-...
-```
+   ```text
+   # efm_address add4 eth0 172.24.38.239/24
+   # ip address
+   <output truncated>
+   eth0 Link encap:Ethernet HWaddr 36:AA:A4:F4:1C:40
+   inet addr:172.24.38.239 Bcast:172.24.38.255
+   ...
+   ```
 
-3.  Ping the VIP from the other nodes to verify that they can reach the VIP:
+3. Ping the VIP from the other nodes to verify that they can reach the VIP:
 
-```text
-# /bin/ping -q -c3 -w5 172.24.38.239
-PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
---- 172.24.38.239 ping statistics ---
-3 packets transmitted, 3 received, 0% packet loss, time 1999ms
-rtt min/avg/max/mdev = 0.023/0.025/0.029/0.006 ms
-```
+   ```text
+   # /bin/ping -q -c3 -w5 172.24.38.239
+   PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
+   --- 172.24.38.239 ping statistics ---
+   3 packets transmitted, 3 received, 0% packet loss, time 1999ms
+   rtt min/avg/max/mdev = 0.023/0.025/0.029/0.006 ms
+   ```
 
-No packet loss occurs. Important: Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code is zero. If using a different command, it must return a zero exit code if the address is reachable.
+   No packet loss occurs. 
+   !!!Important
+   Failover Manager uses the exit code of the command to determine whether or not the address was reachable. In this case the exit code is zero. If using a different command, it must return a zero exit code if the address is reachable.
 
-4.  Use the `efm_address del` command to release the address on the primary node and confirm the node was released with ip address:
+4. Use the `efm_address del` command to release the address on the primary node and confirm the node was released with ip address:
 
-```text
-# efm_address del eth0 172.24.38.239/24
-# ip address
-eth0 Link encap:Ethernet HWaddr 22:00:0A:89:02:8E
-inet addr:10.137.2.142 Bcast:10.137.2.191
-...
-```
+   ```text
+   # efm_address del eth0 172.24.38.239/24
+   # ip address
+   eth0 Link encap:Ethernet HWaddr 22:00:0A:89:02:8E
+   inet addr:10.137.2.142 Bcast:10.137.2.191
+   ...
+   ```
 
-The output from this step doesn't show an eth0 interface.
+   The output from this step doesn't show an eth0 interface.
 
-5.  Repeat step 3, this time verifying that the standby and witness don't see the VIP in use:
+5. Repeat step 3, this time verifying that the standby and witness don't see the VIP in use:
 
-```text
-# /bin/ping -q -c3 -w5 172.24.38.239
-PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
---- 172.24.38.239 ping statistics ---
-4 packets transmitted, 0 received, +3 errors, 100% packet loss,
- time 3000ms
-```
+   ```text
+   # /bin/ping -q -c3 -w5 172.24.38.239
+   PING 172.24.38.239 (172.24.38.239) 56(84) bytes of data.
+   --- 172.24.38.239 ping statistics ---
+   4 packets transmitted, 0 received, +3 errors, 100% packet loss,
+   time 3000ms
+   ```
 
-100% packet loss occurs. Repeat this step on all nodes.
+   100% packet loss occurs. Repeat this step on all nodes.
 
-6.  Repeat step 2 on all standby nodes to assign the VIP to every node. You can ping the VIP from any node to verify that it's in use.
+6. Repeat step 2 on all standby nodes to assign the VIP to every node. You can ping the VIP from any node to verify that it's in use.
 
-```text
-# efm_address add4 eth0 172.24.38.239/24
-# ip address
-<output truncated>
-eth0 Link encap:Ethernet HWaddr 36:AA:A4:F4:1C:40
-inet addr:172.24.38.239 Bcast:172.24.38.255
-...
-```
+   ```text
+   # efm_address add4 eth0 172.24.38.239/24
+   # ip address
+   <output truncated>
+   eth0 Link encap:Ethernet HWaddr 36:AA:A4:F4:1C:40
+   inet addr:172.24.38.239 Bcast:172.24.38.255
+   ...
+   ```
 
 After the test steps above, release the VIP from any nonprimary node before attempting to start Failover Manager.
 


### PR DESCRIPTION
Adding a note that the important part about pinging the VIP is the exit code of the ping command. This comes from a customer replacing /bin/ping with something else that always exited with zero even though the human-readable output. In that case EFM always thought the address being pinged was reachable, breaking failover when using a VIP.
