### PR TITLE
Fix package name and example for failover slots extension

### DIFF
--- a/advocacy_docs/pg_extensions/pg_failover_slots/installing.mdx
+++ b/advocacy_docs/pg_extensions/pg_failover_slots/installing.mdx
@@ -4,8 +4,8 @@ navTitle: Installing
 ---
 
 PG Failover Slots is supported on the same platforms as the Postgres distribution you're using. Support for PG Failover Slots starts with Postgres 12. For details, see:
-- [EDB Postgres Advanced Server Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas)
 
+- [EDB Postgres Advanced Server Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas)
 - [PostgreSQL Product Compatibility](https://www.enterprisedb.com/resources/platform-compatibility#pg)
 - [EDB Postgres Extended Server Product Compatibility](https://www.enterprisedb.com/resources/platform-compatibility#epas_extended)
 
@@ -26,20 +26,18 @@ Before you begin the installation process:
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads), and follow the instructions provided there.
 
-
-
 ## Install the package
 
 The syntax for the RPM package install command is:
 
 ```shell
-sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover_slots<major_version>
+sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover-slots<major_version>
 ```
 
 The syntax for the Debian package install command is:
 
 ```shell
-sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover_slots-<major_version>
+sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover-slots-<major_version>
 ```
 
 Where: 
@@ -67,12 +65,12 @@ Where:
 For example, to install PG Failover Slots 1.0.0 for EDB Postgres Advanced Server 15 on a RHEL 8 platform:
 
 ```shell
-sudo dnf -y install pg-as15-pg-failover_slots
+sudo dnf -y install pg-as15-pg-failover-slots1
 ```
 
 To install PG Failover Slots 1.0.0 for EDB Postgres Advanced Server 15 on a Debian 11 platform:
 
 ```shell
-sudo apt-get -y install pg-as15-pg-failover_slots-1
+sudo apt-get -y install pg-as15-pg-failover-slots-1
 ```
 


### PR DESCRIPTION
## What Changed?

- Format for package name had underscore instead of dash
- Example for RHEL was missing major verison

See: https://edb.slack.com/archives/CU5QEU5L7/p1681834353252679