### PR TITLE
Update index.mdx

### DIFF
--- a/product_docs/docs/epas/15/epas_compat_ora_dev_guide/index.mdx
+++ b/product_docs/docs/epas/15/epas_compat_ora_dev_guide/index.mdx
@@ -10,9 +10,9 @@ legacyRedirectsGenerated:
 
 <div id="introduction" class="registered_link"></div>
 
-EDB Postgres Advanced Server makes Postgres look, feel, and operate more like Oracle, so when you migrate, there is less code to rewrite and you can be up and running quickly. 
+EDB Postgres Advanced Server makes Postgres look, feel, and operate more like Oracle, so when you migrate, there is less code to rewrite, and you can be up and running quickly. 
 
-You use EDB Postgres Advanced Server features to design an application compatible with Oracle databases. For example, creating a compatible application entails selecting compatible:
+The Oracle compatibility features in EDB Postgres Advanced Server allow you to run many applications written for Oracle in EPAS with minimal changes or potentially no changes. For example, creating a compatible application entails selecting compatible:
 
 -   System and built-in functions for use in SQL statements and procedural logic
 -   Stored procedure language (SPL) when creating database server-side application logic for stored procedures, functions, triggers, and packages

--- a/product_docs/docs/epas/15/epas_compat_ora_dev_guide/index.mdx
+++ b/product_docs/docs/epas/15/epas_compat_ora_dev_guide/index.mdx
@@ -12,7 +12,7 @@ legacyRedirectsGenerated:
 
 EDB Postgres Advanced Server makes Postgres look, feel, and operate more like Oracle, so when you migrate, there is less code to rewrite, and you can be up and running quickly. 
 
-The Oracle compatibility features in EDB Postgres Advanced Server allow you to run many applications written for Oracle in EPAS with minimal changes or potentially no changes. For example, creating a compatible application entails selecting compatible:
+The Oracle compatibility features allow you to run many applications written for Oracle in EDB Postgres Advanced Server with minimal to no changes. For example, creating a compatible application entails selecting compatible:
 
 -   System and built-in functions for use in SQL statements and procedural logic
 -   Stored procedure language (SPL) when creating database server-side application logic for stored procedures, functions, triggers, and packages

--- a/product_docs/docs/epas/15/epas_compat_ora_dev_guide/index.mdx
+++ b/product_docs/docs/epas/15/epas_compat_ora_dev_guide/index.mdx
@@ -10,9 +10,9 @@ legacyRedirectsGenerated:
 
 <div id="introduction" class="registered_link"></div>
 
-EDB Postgres Advanced Server makes Postgres look, feel, and operate more like Oracle, so when you migrate, there is less code to rewrite, and you can be up and running quickly. 
+EDB Postgres Advanced Server makes Postgres look, feel, and operate more like Oracle, so when you migrate, there is less code to rewrite, and you can be up and running quickly. The Oracle compatibility features allow you to run many applications written for Oracle in EDB Postgres Advanced Server with minimal to no changes. 
 
-The Oracle compatibility features allow you to run many applications written for Oracle in EDB Postgres Advanced Server with minimal to no changes. For example, creating a compatible application entails selecting compatible:
+EDB Postgres Advanced Server provides Oracle compatible:
 
 -   System and built-in functions for use in SQL statements and procedural logic
 -   Stored procedure language (SPL) when creating database server-side application logic for stored procedures, functions, triggers, and packages


### PR DESCRIPTION
The wording was changed FROM:
You use EDB Postgres Advanced Server features to design an application compatible with Oracle databases TO:

The Oracle compatibility features in EDB Postgres Advanced Server allow you to run many applications written for Oracle in EPAS with minimal changes or potentially no changes. For example, creating a compatible application entails selecting compatible:

## What Changed?

