### PR TITLE
BigAnimal: Fixed link and typo in Restoring an EHA cluster

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/04_backup_and_restore.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/04_backup_and_restore.mdx
@@ -50,7 +50,7 @@ The restore operation is available for any cluster that has at least one availab
 
 ### Perform an extreme-high-availability cluster restore
 
-You can restore one data group from a PGD cluster into a new PGD cluster. To restore a two data groups, restore one data group into a new cluster, and add the second data group manually.  
+You can restore one data group from a PGD cluster into a new PGD cluster. To restore two data groups, restore one data group into a new cluster, and add the second data group manually.  
 
 1.  On the [Clusters](https://portal.biganimal.com/clusters) page in the [BigAnimal](https://portal.biganimal.com) portal, select the cluster you want to restore.
 1.  Select **Quick Actions > Restore**.
@@ -60,5 +60,5 @@ You can restore one data group from a PGD cluster into a new PGD cluster. To res
    1. Select the data group you want to restore. You can restore only one data group into a new cluster.
    1. Select **Fully Restore** or **Point in Time Restore**. A point-in-time restore restores the data group as it was at the specified date and time. 
 1. In the **Nodes** section, select **Two Data Nodes** or **Three Data Nodes**. For more information on node architecture, see [Extreme high availability](/biganimal/latest/overview/02_high_availability/#extreme-high-availability-preview).
-1. Follow Steps 9-18 in [Create a data group](#create-a-data-group). 
+1. Follow Steps 3-5 in [Create an extreme-high-availability cluster](../getting_started/creating_a_cluster/creating_an_eha_cluster). 
 1. Select **Restore**.


### PR DESCRIPTION
## What Changed?

Fixed link and typo in https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/04_backup_and_restore/#perform-an-extreme-high-availability-cluster-restore