### PR TITLE
Update pgbouncer_configuring.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/pgbouncer_configuring.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/pgbouncer_configuring.mdx
@@ -56,7 +56,7 @@ Configure EDB PgBouncer according to the connection information:
 
    The default username is in the **User** field in BigAnimal. The password is the same one you set when configuring the cluster.
    
-1. Launch PgBouncer
+1. Launch PgBouncer.
     
    ```sql
       pgbouncer -d pgbouncer.ini

--- a/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/pgbouncer_configuring.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/02_connecting_your_cluster/pgbouncer_configuring.mdx
@@ -55,6 +55,12 @@ Configure EDB PgBouncer according to the connection information:
    ```
 
    The default username is in the **User** field in BigAnimal. The password is the same one you set when configuring the cluster.
+   
+1. Launch PgBouncer
+    
+   ```sql
+      pgbouncer -d pgbouncer.ini
+   ```
 
 For more information, see [Configuring EDB PgBouncer](/pgbouncer/latest/02_configuration_and_usage/). 
 


### PR DESCRIPTION
After step 2. Add your cluster username and password to the `auth_file`, located in `/etc/pgbouncer/` by default. For example:

   ```text
      "user1" "password1"
   ```

   The default username is in the **User** field in BigAnimal. The password is the same one you set when configuring the cluster.

Add step 3. Launch PgBouncer 
pgbouncer -d pgbouncer.ini

## What Changed?

