### PR TITLE
Incorrect link to "Eager replication" description

### DIFF
--- a/product_docs/docs/pgd/5/index.mdx
+++ b/product_docs/docs/pgd/5/index.mdx
@@ -51,7 +51,7 @@ By default EDB Postgres Distributed uses asynchronous replication, applying chan
 the peer nodes only after the local commit. Additional levels of synchronicity can
 be configured between different nodes, groups of nodes or all nodes by configuring
 [Group Commit](durability/group-commit), [CAMO](durability/camo), or
-[Eager](consistency/eager) replication.
+[Eager](https://www.enterprisedb.com/docs/pgd/5/bdr/eager) replication.
 
 ## Compatibility matrix
 


### PR DESCRIPTION
On this page page
 https://www.enterprisedb.com/docs/pgd/latest/
"CAMO, or Eager replication.", Eager text link points to 
  https://www.enterprisedb.com/docs/pgd/latest/consistency/eager/
it should be
 https://www.enterprisedb.com/docs/pgd/5/bdr/eager/
But that link doesn't exist

## What Changed?

