### PR TITLE
Failover Manager: install template changes

### DIFF
--- a/install_template/templates/products/failover-manager/base.njk
+++ b/install_template/templates/products/failover-manager/base.njk
@@ -12,7 +12,12 @@ redirects:
   - efm/{{ product.version }}/03_installing_efm/{{deploy.expand_arch[platform.arch]}}/efm_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
 {% endblock frontmatter %}
 
-{% block product_prerequisites %}{% include "platformBase/_epasinstallsameserver.njk" %}
+{% block product_prerequisites %}
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+  
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 {{ super() }}
 {% endblock product_prerequisites %}
 {% block postinstall %}

--- a/product_docs/docs/efm/4/installing/linux_ppc64le/efm_rhel_8.mdx
+++ b/product_docs/docs/efm/4/installing/linux_ppc64le/efm_rhel_8.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_ppc64le/efm_sles_12.mdx
+++ b/product_docs/docs/efm/4/installing/linux_ppc64le/efm_sles_12.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_ppc64le/efm_sles_15.mdx
+++ b/product_docs/docs/efm/4/installing/linux_ppc64le/efm_sles_15.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_centos_7.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_centos_7.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_debian_10.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_debian_10.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_debian_11.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_debian_11.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_other_linux_8.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_other_linux_8.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_rhel_7.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_rhel_7.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_rhel_8.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_rhel_8.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_sles_12.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_sles_12.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_sles_15.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_sles_15.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_ubuntu_18.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_ubuntu_18.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_ubuntu_20.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_ubuntu_20.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_ubuntu_22.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_ubuntu_22.mdx
@@ -13,7 +13,11 @@ redirects:
 
 Before you begin the installation process:
 
-- Install EDB Postgres Advanced Server on the same host. See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux).
+- Install Postgres on the same host (not needed for witness nodes)
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/epas_inst_linux)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
 
 - Set up the repository
 


### PR DESCRIPTION
## What Changed?

Clarified that both PG and EPAS are supported and that you don't need to install the db for witness nodes

See related discussion https://edb.slack.com/archives/C016SDV9HLL/p1682341493767469