### PR TITLE
Set products for search within extensions

### DIFF
--- a/advocacy_docs/pg_extensions/advanced_storage_pack/index.mdx
+++ b/advocacy_docs/pg_extensions/advanced_storage_pack/index.mdx
@@ -7,6 +7,8 @@ navigation:
 - rel_notes
 - installing
 - configuring
+directoryDefaults:
+  product: EDB Advanced Storage Pack
 ---
 
 EDB Advanced Storage Pack provides advanced storage options for Postgres databases in the form of table access method (TAM) extensions. These storage options can enhance the performance and reliability of databases without requiring application changes.

--- a/advocacy_docs/pg_extensions/ldap_sync/index.mdx
+++ b/advocacy_docs/pg_extensions/ldap_sync/index.mdx
@@ -4,10 +4,12 @@ indexCards: none
 directoryDefaults:
    product: 'EDB LDAP Sync'
 navigation:
- - rel_notes
- - installing
- - configuring
- - using
+  - rel_notes
+  - installing
+  - configuring
+  - using
+directoryDefaults:
+  product: EDB LDAP Sync
 ---
 
 EDB LDAP Sync is a collection of utilities and configurations for synchronizing Postgres with directory servers that support the LDAP protocol, such as OpenLDAP and Active Directory. Database administrators can schedule ldap2pg to synchronize Postgres users and groups with LDAP users and groups. EDB LDAP Sync replaces external schedulers, like cron, while using a similar syntax. 

--- a/advocacy_docs/pg_extensions/pg_failover_slots/index.mdx
+++ b/advocacy_docs/pg_extensions/pg_failover_slots/index.mdx
@@ -8,6 +8,8 @@ navigation:
    - installing
    - configuring
    - using
+directoryDefaults:
+  product: PG Failover Slots
 ---
 
 PG Failover Slots (pg_failover_slots) is an extension released as open source software under the PostgreSQL LICENSE. If you have logical replication publications on Postgres databases that are also part of a streaming replication architecture,

--- a/advocacy_docs/pg_extensions/pg_tuner/index.mdx
+++ b/advocacy_docs/pg_extensions/pg_tuner/index.mdx
@@ -8,6 +8,8 @@ navigation:
    - installing
    - configuring
    - using
+directoryDefaults:
+  product: EDB Postgres Tuner
 ---
 
 EDB Postgres Tuner is a PostgreSQL extension that automates 15+ years of EDB Postgres tuning experience. 

--- a/src/constants/products.js
+++ b/src/constants/products.js
@@ -4,14 +4,18 @@ export const products = {
   bart: { name: "Backup and Recovery Tool", iconName: IconNames.EDB_BART },
   barman: { name: "Barman" },
   biganimal: { name: "BigAnimal", iconName: IconNames.BIGANIMAL },
+  "EDB Advanced Storage Pack": { name: "EDB Advanced Storage Pack" },
   edb_plus: { name: "EDB*Plus" },
   efm: { name: "Failover Manager", iconName: IconNames.EDB_EFM },
+  "EDB LDAP Sync": { name: "EDB LDAP Sync" },
   epas: { name: "EDB Postgres Advanced Server", iconName: IconNames.EDB_EPAS },
   pgd: {
     name: "EDB Postgres Distributed (PGD)",
     iconName: IconNames.HIGH_AVAILABILITY,
   },
   pge: { name: "EDB Postgres Extended Server", iconName: IconNames.POSTGRESQL },
+  "EDB Postgres Tuner": { name: "EDB Postgres Tuner" },
+
   eprs: { name: "EDB Replication Server", iconName: IconNames.EDB_EPAS },
   hadoop_data_adapter: {
     name: "Hadoop Data Adapter",
@@ -47,7 +51,7 @@ export const products = {
   Patroni: { name: "Patroni" },
   pgBackRest: { name: "pgBackRest" },
   pgbouncer: { name: "PgBouncer", iconName: IconNames.POSTGRESQL },
-  pg_failover_slots: {
+  "PG Failover Slots": {
     name: "PG Failover Slots",
     iconName: IconNames.POSTGRESQL,
   },


### PR DESCRIPTION
## What Changed?

To fully enable search for these, we need two things:

1. Set a product name in directory defaults for each extension (this associates each extension's content with the product name and enables the facet in advanced search)
2. Add these names to products.js (this enables selecting the name from the search dropdown)