### PR TITLE
Update INSTALL.mdx

### DIFF
--- a/product_docs/docs/tpa/23/INSTALL.mdx
+++ b/product_docs/docs/tpa/23/INSTALL.mdx
@@ -140,7 +140,7 @@ When you run `tpaexec setup`, it will ordinarily download the Python
 packages from the network. The `tpaexec-deps` package (available from
 the same repository as tpaexec) bundles everything that would have been
 downloaded, so that they can be installed without network access. Just
-install the package before you run `tpaexec setup` and the bundled
+install both the packages before you run `tpaexec setup` and the bundled
 copies will be used automatically.
 
 ## Verification


### PR DESCRIPTION
Faced an issue due to the wording 
https://edb.slack.com/archives/C01CK2TSPG9/p1682732636526719

## What Changed?

Just install  the package before you run `tpaexec setup`
to
Just install both the packages before you run `tpaexec setup`






