### PR TITLE
Removing --subnet-patterns from doc

### DIFF
--- a/product_docs/docs/pgd/5/tpa.mdx
+++ b/product_docs/docs/pgd/5/tpa.mdx
@@ -97,8 +97,6 @@ By default, each cluster is assigned a random /28 subnet under 10.33/16, but dep
 
 Specify `--subnet` to use a particular subnet. For example, `--subnet 192.0.2.128/27`.
 
-Alternatively, specify `--subnet-pattern` to generate random subnets (as many as required by the architecture) matching the given pattern. For example, `--subnet-pattern 192.0.x.x`.
-
 ### Disk space
 Specify `--root-volume-size` to set the size of the root volume in GB. For example, `--root-volume-size 64`. The default is 16GB. (Depending on the image used to create instances, there may be a minimum size for the root volume.)
 


### PR DESCRIPTION
Removing --subnet-patterns from doc as it apparently no longer exists.

## What Changed?

