### PR TITLE
EPAS: fixing link in the Initial config section of install topics

### DIFF
--- a/install_template/templates/products/edb-postgres-advanced-server/base.njk
+++ b/install_template/templates/products/edb-postgres-advanced-server/base.njk
@@ -29,7 +29,7 @@ Where `package_name` can be any of the available packages from the [available pa
 {% block debian_ubuntu %}
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password. 
 
-First you need to initialize and start the database cluster. The `edb-as-{{ product.version | replace(".", "") }}-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-{{ product.version | replace(".", "") }}-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as{{ product.version }}/bin/edb-as-{{ product.version | replace(".", "") }}-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_install_details/managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/11/installing/linux_install_details/managing_an_advanced_server_installation.mdx
@@ -216,39 +216,90 @@ To list all the available clusters, use the following command:
 
 <div id="specifying_cluster_options_with_initdbopts" class="registered_link"></div>
 
-## Specifying Cluster Options with INITDBOPTS
+## Specifying cluster options with INITDBOPTS
 
-You can use the `INITDBOPTS` variable to specify your cluster configuration preferences. By default, the `INITDBOPTS` variable is commented out in the service configuration file; unless modified, when you run the service startup script, the new cluster will be created in a mode compatible with Oracle databases. Clusters created in this mode will contain a database named `edb`, and have a database superuser named `enterprisedb`.
+You can use the `INITDBOPTS` variable to specify your cluster configuration preferences. By default, the `INITDBOPTS` variable is commented out in the service configuration file. Unless you modify it, when you run the service startup script, the new cluster is created in a mode compatible with Oracle databases. Clusters created in this mode contain a database named `edb` and have a database superuser named `enterprisedb`.
 
-To create a new cluster in PostgreSQL mode, remove the pound sign (#) in front of the `INITDBOPTS` variable, enabling the `"---no-redwood-compat"-` option. Clusters created in PostgreSQL mode will contain a database named `postgres`, and have a database superuser named `postgres`.
+### Initializing the cluster in Oracle mode
 
-You may also specify multiple `initdb` options. For example, the following statement:
+If you initialize the database using Oracle compatibility mode, the installation includes:
+
+-   Data dictionary views compatible with Oracle databases.
+-   Oracle data type conversions.
+-   Date values displayed in a format compatible with Oracle syntax.
+-   Support for Oracle-styled concatenation rules. If you concatenate a string value with a `NULL` value, the returned value is the value of the string.
+-   Support for the following Oracle built-in packages.
+
+| Package          | Functionality compatible with Oracle databases                                                                                                                               |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dbms_alert`     | Provides the capability to register for, send, and receive alerts.                                                                                                           |
+| `dbms_job`       | Provides the capability to create, schedule, and manage jobs.                                                                                                  |
+| `dbms_lob`       | Provides the capability to manage on large objects.                                                                                                                          |
+| `dbms_output`    | Provides the capability to send messages to a message buffer or get messages from the message buffer.                                                                       |
+| `dbms_pipe`      | Provides the capability to send messages through a pipe within or between sessions connected to the same database cluster.                                                   |
+| `dbms_rls`       | Enables the implementation of Virtual Private Database on certain EDB Postgres Advanced Server database objects.                                                                          |
+| `dbms_sql`       | Provides an application interface to the EDB dynamic SQL functionality.                                                                                                      |
+| `dbms_utility`   | Provides various utility programs.                                                                                                                                           |
+| `dbms_aqadm`     | Provides supporting procedures for Advanced Queueing functionality.                                                                                                          |
+| `dbms_aq`        | Provides message queueing and processing for EDB Postgres Advanced Server.                                                                                                                |
+| `dbms_profiler`  | Collects and stores performance information about the PL/pgSQL and SPL statements that are executed during a performance profiling session.                                  |
+| `dbms_random`    | Provides a number of methods to generate random values.                                                                                                                      |
+| `dbms_redact`    | Enables redacting or masking data that's returned by a query.                                                                                                        |
+| `dbms_lock`      | Provides support for the `DBMS_LOCK.SLEEP` procedure.                                                                                                                        |
+| `dbms_scheduler` | Provides a way to create and manage jobs, programs, and job schedules.                                                                                                       |
+| `dbms_crypto`    | Provides functions and procedures to encrypt or decrypt RAW, BLOB or CLOB data. You can also use `DBMS_CRYPTO` functions to generate cryptographically strong random values. |
+| `dbms_mview`     | Provides a way to manage and refresh materialized views and their dependencies.                                                                                              |
+| `dbms_session`   | Provides support for the `DBMS_SESSION.SET_ROLE` procedure.                                                                                                                  |
+| `utl_encode`     | Provides a way to encode and decode data.                                                                                                                                    |
+| `utl_http`       | Provides a way to use the HTTP or HTTPS protocol to retrieve information found at an URL.                                                                                    |
+| `utl_file`       | Provides the capability to read from and write to files on the operating system’s file system.                                                                              |
+| `utl_smtp`       | Provides the capability to send e-mails over the Simple Mail Transfer Protocol (SMTP).                                                                                       |
+| `utl_mail`       | Provides the capability to manage email.                                                                                                                                    |
+| `utl_url`        | Provides a way to escape illegal and reserved characters in a URL.                                                                                                      |
+| `utl_raw`        | Provides a way to manipulate or retrieve the length of raw data types.                                                                                                       |
+
+
+### Initializing the cluster in Postgres mode
+
+Clusters created in PostgreSQL mode don't include compatibility features. To create a new cluster in PostgreSQL mode, remove the pound sign (#) in front of the `INITDBOPTS` variable, enabling the `"--no-redwood-compat"` option. Clusters created in PostgreSQL mode contain a database named `postgres` and have a database superuser named `postgres`.
+
+You can also specify multiple `initdb` options. For example, the following statement creates a database cluster without compatibility features for Oracle. The cluster contains a database named `postgres` that's owned by a user named `alice`. The cluster uses `UTF-8` encoding.
 
 ```text
 INITDBOPTS="--no-redwood-compat -U alice --locale=en_US.UTF-8"
 ```
 
-Creates a database cluster (without compatibility features for Oracle) that contains a database named `postgres` that is owned by a user named `alice`; the cluster uses `UTF-8` encoding.
+If you initialize the database using `"--no-redwood-compat"` mode, the installation includes the following package:
 
-In addition to the cluster configuration options documented in the PostgreSQL core documentation, Advanced Server supports the following `initdb` options:
+| Package            | Functionality noncompatible with Oracle databases                                                               |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `dbms_aqadm`       | Provides supporting procedures for Advanced Queueing functionality.                                              |
+| `dbms_aq`          | Provides message queueing and processing for EDB Postgres Advanced Server.                                                    |
+| `edb_bulkload`     | Provides direct/conventional data loading capability when loading huge amount of data into a database.           |
+| `edb_gen`          | Provides miscellaneous packages to run built-in packages.                                                        |
+| `edb_objects`      | Provides Oracle-compatible objects such as packages and procedures.                                             |
+| `waitstates`       | Provides monitor session blocking.                                                                               |
+| `edb_dblink_libpq` | Provides link to foreign databases via libpq.                                                                    |
+| `edb_dblink_oci`   | Provides link to foreign databases via OCI.                                                                      |
+| `snap_tables`      | Creates tables to hold wait information. Included with DRITA scripts.                                            |
+| `snap_functions`   | Creates functions to return a list of snap ids and the time the snapshot was taken. Included with DRITA scripts. |
+| `sys_stats`        | Provides OS performance statistics.                                                                              |
+
+In addition to the cluster configuration options documented in the PostgreSQL core documentation, EDB Postgres Advanced Server supports the following `initdb` options:
 
 `--no-redwood-compat`
 
- Include the `--no-redwood-compat` keywords to instruct the server to create the cluster in PostgreSQL mode. When the cluster is created in PostgreSQL mode, the name of the database superuser will be `postgres` and the name of the default database will be `postgres`. The few Advanced Server’s features compatible with Oracle databases will be available with this mode. However, we recommend using the Advanced server in redwood compatibility mode to use all its features.
- 
+Include the `--no-redwood-compat` keywords to create the cluster in PostgreSQL mode. When the cluster is created in PostgreSQL mode, the name of the database superuser is `postgres`, and the name of the default database is `postgres`. The few EDB Postgres Advanced Server features compatible with Oracle databases are available with this mode. However, we recommend using the EDB Postgres Advanced Server in redwood compatibility mode to use all its features.
+
 `--redwood-like`
 
- Include the `--redwood-like` keywords to instruct the server to use an escape character (an empty string ('')) following the `LIKE` (or PostgreSQL-compatible `ILIKE`) operator in a SQL statement that is compatible with Oracle syntax.
+Include the `--redwood-like` keywords to use an escape character, that is, an empty string (''), following the `LIKE` (or PostgreSQL-compatible `ILIKE`) operator in a SQL statement that's compatible with Oracle syntax.
 
 `--icu-short-form`
 
- Include the `--icu-short-form` keywords to create a cluster that uses a default ICU (International Components for Unicode) collation for all databases in the cluster. For more information about Unicode collations, refer to the *EDB Postgres Advanced Server Guide* available at:
+Include the `--icu-short-form` keywords to create a cluster that uses a default International Components for Unicode (ICU) collation for all databases in the cluster. For more information about Unicode collations, see [Unicode collation algorithm](../../epas_guide/03_database_administration/06_unicode_collation_algorithm/).
 
-[https://www.enterprisedb.com/docs](/epas/latest/)
-
-For more information about using `initdb`, and the available cluster configuration options, see the PostgreSQL Core Documentation available at:
-
-<https://www.postgresql.org/docs/11/static/app-initdb.html>
+For more information about using `initdb` and the available cluster configuration options, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/app-initdb.html).
 
 You can also view online help for `initdb` by assuming superuser privileges and entering:
 
@@ -257,6 +308,7 @@ You can also view online help for `initdb` by assuming superuser privileges and 
 ```
 
 Where `path_to_initdb_installation_directory` specifies the location of the `initdb` binary file.
+
 
 ### Modifying the Data Directory Location on RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -56,7 +56,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_centos_7.mdx
@@ -46,7 +46,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_7.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_8.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -56,7 +56,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_centos_7.mdx
@@ -46,7 +46,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_7.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_8.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -56,7 +56,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_centos_7.mdx
@@ -46,7 +46,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_7.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_8.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -56,7 +56,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_centos_7.mdx
@@ -46,7 +46,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_7.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_8.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -56,7 +56,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_centos_7.mdx
@@ -46,7 +46,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_7.mdx
@@ -52,7 +52,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_8.mdx
@@ -54,7 +54,7 @@ Installing the server package creates an operating system user named enterprised
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_15.mdx
@@ -49,7 +49,7 @@ Where `package_name` can be any of the available packages from the [available pa
 
 This section steps you through getting started with your cluster including logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
 
-First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](/epas/latest/installing/linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+First you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
 
 ```shell
 sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb


### PR DESCRIPTION
## What Changed?

Made path relative
Updated v11 section we are linking to to match updates in 12-15