### PR TITLE
Update 08_mtk_command_options.mdx

### DIFF
--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -327,7 +327,7 @@ For example,
 
 `COUNTRIES=COUNTRY_ID<>'AR'`
 
-migrates only those countries with a `COUNTRY_ID` value that is not equal to `AR`. This constraint applies to the countries table. 
+migrates only those countries with a `COUNTRY_ID` value that is not equal to `AR`. This constraint applies to the COUNTRIES table. 
 
 You can also specify conditions for multiple tables. However, the condition for each table must be on a new line in the property file.
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -327,7 +327,7 @@ For example,
 
 `COUNTRIES=COUNTRY_ID<>'AR'`
 
-migrates only those countries with a `country_id` value that is not equal to `AR`. This constraint applies to the countries table. 
+migrates only those countries with a `COUNTRY_ID` value that is not equal to `AR`. This constraint applies to the countries table. 
 
 You can also specify conditions for multiple tables. However, the condition for each table must be on a new line in the property file.
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -315,7 +315,9 @@ MySQL users note: By default, the MySQL JDBC driver fetches all of the rows in a
 
 `-filterProp <file_name>`
 
- `<file_name>` specifies the name of a file that contains constraints in key=value pairs. Each record read from the database is evaluated against the constraints. Those that satisfy the constraints are migrated. The left side of the pair lists a table name. The table name must not be schema qualified. The right side specifies a condition that must be true for each row migrated. For example, including the following constraints in the property file
+ `<file_name>` specifies the name of a file that contains constraints in key=value pairs. Each record read from the database is evaluated against the constraints. Those that satisfy the constraints are migrated. The left side of the pair lists a table name. The table name must not be schema qualified. The right side specifies a condition that must be true for each row migrated. 
+NOTE: The tablename should be uppercase for Oracle, else it cannot be matched by MTK and it will ignore the constraint
+For example, including the following constraints in the property file
 
 `countries=country_id<>'AR'`
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -319,7 +319,7 @@ MySQL users note: By default, the MySQL JDBC driver fetches all of the rows in a
  
  The left side of the pair lists a table name: 
  - The table name must not be schema qualified. 
- - Oracle table names are not case sensitive, but Oracle defaults to uppercase. Postgres, on the other hand defaults to lowercase. When migrating Oracle data, make sure that the case you are using matches the case in Oracle. Otherwise, Migration Toolkit can't match it and ignores the constraint. 
+ - Oracle table names are not case sensitive, but Oracle defaults to uppercase. Postgres, on the other hand defaults to lowercase. When migrating Oracle data, make sure that the case you are using matches the case in Oracle; otherwise, Migration Toolkit can't match it and ignores the constraint. 
  
 The right side specifies a condition that must be true for each row migrated.  
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -315,13 +315,19 @@ MySQL users note: By default, the MySQL JDBC driver fetches all of the rows in a
 
 `-filterProp <file_name>`
 
- `<file_name>` specifies the name of a file that contains constraints in key=value pairs. Each record read from the database is evaluated against the constraints. Those that satisfy the constraints are migrated. The left side of the pair lists a table name. The table name must not be schema qualified. The right side specifies a condition that must be true for each row migrated. 
-NOTE: The tablename should be uppercase for Oracle, else it cannot be matched by MTK and it will ignore the constraint
-For example, including the following constraints in the property file
+ `<file_name>` specifies the name of a file that contains constraints in key=value pairs. Each record read from the database is evaluated against the constraints. Those that satisfy the constraints are migrated. 
+ 
+ The left side of the pair lists a table name: 
+ - The table name must not be schema qualified. 
+ - Oracle table names are not case sensitive, but Oracle defaults to uppercase. Postgres, on the other hand defaults to lowercase. When migrating Oracle data, make sure that the case you are using matches the case in Oracle. Otherwise, Migration Toolkit can't match it and ignores the constraint. 
+ 
+The right side specifies a condition that must be true for each row migrated.  
 
-`countries=country_id<>'AR'`
+For example, 
 
-migrates only those countries with a `country_id` value that is not equal to `AR`. This constraint applies to the countries table.
+`COUNTRIES=COUNTRY_ID<>'AR'`
+
+migrates only those countries with a `country_id` value that is not equal to `AR`. This constraint applies to the countries table. 
 
 You can also specify conditions for multiple tables. However, the condition for each table must be on a new line in the property file.
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -319,7 +319,7 @@ MySQL users note: By default, the MySQL JDBC driver fetches all of the rows in a
  
  The left side of the pair lists a table name: 
  - The table name must not be schema qualified. 
- - Oracle table names are not case sensitive, but Oracle defaults to uppercase. Postgres, on the other hand, defaults to lowercase. When migrating Oracle data, make sure that the case you are using matches the case in Oracle; otherwise, Migration Toolkit can't match it and ignores the constraint. 
+ - Oracle table names are not case sensitive, but Oracle defaults to uppercase. Postgres, on the other hand, defaults to lowercase. When migrating Oracle data, ensure the case you are using matches the case in Oracle; otherwise, Migration Toolkit can't match it and ignores the constraint. 
  
 The right side specifies a condition that must be true for each row migrated.  
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -319,7 +319,7 @@ MySQL users note: By default, the MySQL JDBC driver fetches all of the rows in a
  
  The left side of the pair lists a table name: 
  - The table name must not be schema qualified. 
- - Oracle table names are not case sensitive, but Oracle defaults to uppercase. Postgres, on the other hand defaults to lowercase. When migrating Oracle data, make sure that the case you are using matches the case in Oracle; otherwise, Migration Toolkit can't match it and ignores the constraint. 
+ - Oracle table names are not case sensitive, but Oracle defaults to uppercase. Postgres, on the other hand, defaults to lowercase. When migrating Oracle data, make sure that the case you are using matches the case in Oracle; otherwise, Migration Toolkit can't match it and ignores the constraint. 
  
 The right side specifies a condition that must be true for each row migrated.  
 


### PR DESCRIPTION
Added the following to save time for us all:
The tablename should be uppercase for Oracle, else it cannot be matched by MTK and it will ignore the constraint

## What Changed?

