### PR TITLE
Changes to introduce write leader

### DIFF
--- a/product_docs/docs/pgd/5/overview/index.mdx
+++ b/product_docs/docs/pgd/5/overview/index.mdx
@@ -21,7 +21,7 @@ Each node (database) participating in a PGD group both receives changes from oth
 
 This is distinct from hot or warm standby, where only one master server accepts writes and all the other nodes are standbys that replicate either from the master or from another standby.
 
-You don't have to write to all the masters all of the time. A frequent configuration directs writes mostly to just one master.
+You don't have to write to all the masters all of the time. A frequent configuration directs writes mostly to just one master called the [write leader](../terminology/#write-leader).
 
 ### Asynchronous, by default
 
@@ -44,7 +44,7 @@ Replicated data is sent in binary form when it's safe to do so.
 
 ### Connection management
 
-[Connection management](../routing) leverages consensus-driven quorum to determine the correct connection endpoint in a semi-exclusive manner to prevent unintended multi-node writes from an application. This approach reduces the potential for data conflicts.
+[Connection management](../routing) leverages consensus-driven quorum to determine the correct connection endpoint in a semi-exclusive manner to prevent unintended multi-node writes from an application. This approach reduces the potential for data conflicts. The node selected as the correct connection endpoint, at any particular point in time, is referred to as the [write leader](../terminology/#write-leader).
 
 [PGD Proxy](../routing/proxy) is the tool for application connection management provided as part of EDB Postgres Distributed.
 
@@ -70,7 +70,7 @@ The Always On architectures are built from either one group in a single location
 
 Tables are created across both groups, so any change goes to all nodes, not just to nodes in the local group.
 
-One node in each group is the target for the main application. All other nodes are described as shadow nodes (or "read-write replica"), waiting to take over when needed. If a node loses contact, processsing switches immediately to a shadow node to continue processing. If a group fails, processing can switch to the other group. Scalability isn't the goal of this architecture.
+One node in each group is selected as the group's write leader. The write leader is the target for the main application's writes and queries. All other nodes are described as shadow nodes (or "read-write replica"), waiting to take over when needed. If a node loses contact, processing switches immediately to a shadow node to continue processing. If a group fails, processing can switch to the other group. Scalability isn't the goal of this architecture.
 
 Since writes are mainly to only one node, the possibility of contention between nodes is reduced to almost zero. As a result, performance impact is much reduced.
 

--- a/product_docs/docs/pgd/5/terminology.mdx
+++ b/product_docs/docs/pgd/5/terminology.mdx
@@ -91,3 +91,8 @@ A traditional computing approach of increasing a resource (CPU, memory, storage,
 #### Write scalability
 
 Occurs when replicating the writes from the original node to other cluster members becomes less expensive. In vertical-scaled architectures, write scalability is possible due to shared resources. However, in horizontal scaled (or nothing-shared) architectures, this is possible only in very limited scenarios.
+
+#### Write leader
+
+In always-on architectures, a node is selected as the correct connection endpoint for applications. This is called the write leader. By selecting a write leader for applications to use, unintended multi-node writes can be avoided. The write leader is selected by consensus of a quorum of proxy nodes. If the write leader becomes unavailable, the proxy nodes select another node to become write leader. Nodes which are not the write leader are referred to as shadow nodes.
+


### PR DESCRIPTION
## What Changed?

Added write leader to terminology (mention shadow nodes but only in context of there being a write leader), added links to overview and mention write leader term in body of overview on connection management.