### PR TITLE
MySQL FDW: correction to supported platforms

### DIFF
--- a/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/02_requirements_overview.mdx
@@ -2,7 +2,7 @@
 title: "Supported platforms"
 ---
 
-The MySQL Foreign Data Wrapper is supported on the same platforms as EDB Postgres Advanced Server. To determine the platform support for the MySQL Foreign Data Wrapper you can either refer to the platform support for EDB Postgres Advanced Server on the [Platform Compatibility page](https://www.enterprisedb.com/platform-compatibility#epas) on the EDB web site or refer to [Installing MySQL Foreign Data Wrapper](./installing). 
+The MySQL Foreign Data Wrapper is supported on the same Linux platforms as EDB Postgres Advanced Server. To determine the platform support for the MySQL Foreign Data Wrapper you can either refer to the platform support for EDB Postgres Advanced Server on the [Platform Compatibility page](https://www.enterprisedb.com/platform-compatibility#epas) on the EDB web site or refer to [Installing MySQL Foreign Data Wrapper](./installing). 
 
 ## Supported database versions
 


### PR DESCRIPTION
## What Changed?

Added "Linux" qualifier - MySQL FDW isn't supported on Windows or MacOS