### PR TITLE
Nav bar usability enhancements

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -10,6 +10,13 @@ exports.onRouteUpdate = ({ location }) => scrollToAnchor(location);
  * @param {Number} [mainNavHeight] - the height of any persistent nav -> document.querySelector(`nav`)
  */
 function scrollToAnchor(location, mainNavHeight = 0) {
+  // left nav: scroll
+  const navItem = document.querySelector(".sidebar .active");
+  if (navItem) navItem.scrollIntoView({ block: "nearest" });
+  // right-nav: scroll
+  const toc = document.querySelector(".toc-sticky .active");
+  if (toc) toc.scrollIntoView({ block: "nearest" });
+
   // Check for location so build does not fail
   if (location && location.hash) {
     try {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -171,7 +171,6 @@ module.exports = {
     "gatsby-plugin-sass",
     "gatsby-plugin-react-helmet",
     "gatsby-transformer-sharp",
-    "gatsby-transformer-json",
     "gatsby-plugin-catch-links",
     "gatsby-plugin-sharp",
     {
@@ -283,6 +282,7 @@ module.exports = {
             options: {
               linkImagesToOriginal: false,
               showCaptions: false,
+              maxWidth: 1080,
             },
           },
           {

--- a/product_docs/docs/pgd/5/cli/command_ref/index.mdx
+++ b/product_docs/docs/pgd/5/cli/command_ref/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: Command reference
-navTitle: "CLI Command reference ▶"
 redirects:
   - /pgd/latest/cli/command_ref/pgd_show-camo/
 ---

--- a/product_docs/docs/pgd/5/cli/index.mdx
+++ b/product_docs/docs/pgd/5/cli/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "EDB Postgres Distributed Command Line Interface"
-navTitle: "Command line interface ▶"
+navTitle: "Command line interface"
 indexCards: none
 navigation:
 - installing_cli

--- a/product_docs/docs/pgd/5/consistency/index.mdx
+++ b/product_docs/docs/pgd/5/consistency/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Consistency
-navTitle: "Consistency ▶"
+
 navigation:
  - conflicts
  - column-level-conflicts

--- a/product_docs/docs/pgd/5/durability/index.mdx
+++ b/product_docs/docs/pgd/5/durability/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Durability and performance options
-navTitle: "Durability options ▶"
+
 navigation:
  - commit-scopes
  - group-commit

--- a/product_docs/docs/pgd/5/monitoring/index.mdx
+++ b/product_docs/docs/pgd/5/monitoring/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: Monitoring
-navTitle: "Monitoring ▶"
 originalFilePath: monitoring.md
 
 ---

--- a/product_docs/docs/pgd/5/quickstart/index.mdx
+++ b/product_docs/docs/pgd/5/quickstart/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introducing PGD quick starts"
-navTitle: "Quick start ▶"
+navTitle: "Quick start"
 description: >
   How to select your PGD quick start deployment and what to expect from the experience.
 indexCards: none

--- a/product_docs/docs/pgd/5/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "EDB Postgres Distributed Release notes"
-navTitle: "Release notes ▶"
+navTitle: "Release notes"
 navigation:
 - pgd_5.1.0_rel_notes
 - pgd_5.0.1_rel_notes

--- a/product_docs/docs/pgd/5/routing/index.mdx
+++ b/product_docs/docs/pgd/5/routing/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Application connection management"
-navTitle: "Connection management ▶"
+navTitle: "Connection management"
 indexCards: none
 
 navigation:

--- a/product_docs/docs/pgd/5/upgrades/index.mdx
+++ b/product_docs/docs/pgd/5/upgrades/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Upgrading"
-navTitle: "Upgrading ▶"
 ---
 
 Because EDB Postgres Distributed consists of multiple software components,

--- a/src/components/side-navigation.js
+++ b/src/components/side-navigation.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useScrollRestoration } from "gatsby";
 import { DarkModeToggle, Link, Logo } from "./";
 
 const DocsLink = () => (
@@ -52,9 +53,11 @@ const SideNavigation = ({
   footer = true,
   hideKBLink = false,
 }) => {
+  const scrollRestoration = useScrollRestoration("navigation-sidebar");
+
   return (
     <nav className={`sidebar d-block bg-${background} border-right`}>
-      <div className="sidebar-sticky pl-4 pr-4 pb-4">
+      <div className="sidebar-sticky pl-4 pr-4 pb-4" {...scrollRestoration}>
         <LogoLink />
         {children}
         {footer && <SideNavigationFooter hideKBLink={hideKBLink} />}

--- a/src/components/table-of-contents.js
+++ b/src/components/table-of-contents.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { Link } from "./";
 import { useScrollRestoration } from "gatsby";
+import { useLocation } from "@reach/router";
 
 const TableOfContents = ({ toc }) => {
   const scrollRestoration = useScrollRestoration("header-navigation-sidebar");
+  const hash = useLocation().hash;
 
   return (
     <ul
@@ -19,7 +21,7 @@ const TableOfContents = ({ toc }) => {
           <li key={item.title}>
             <Link
               className={`d-block py-2 align-middle ${
-                window.location.hash === item.url ? "active" : ""
+                hash === item.url ? "active" : ""
               }`}
               to={item.url}
             >

--- a/src/components/table-of-contents.js
+++ b/src/components/table-of-contents.js
@@ -1,21 +1,34 @@
 import React from "react";
 import { Link } from "./";
+import { useScrollRestoration } from "gatsby";
 
-const TableOfContents = ({ toc }) => (
-  <ul className="list-unstyled border-left pl-4 lh-12 toc-sticky pt-3">
-    <li className="mb-2 font-weight-bold text-muted text-uppercase small">
-      On this page
-    </li>
-    {toc
-      .filter((item) => item.title)
-      .map((item) => (
-        <li key={item.title}>
-          <Link className="d-block py-2 align-middle" to={item.url}>
-            {item.title}
-          </Link>
-        </li>
-      ))}
-  </ul>
-);
+const TableOfContents = ({ toc }) => {
+  const scrollRestoration = useScrollRestoration("header-navigation-sidebar");
+
+  return (
+    <ul
+      className="list-unstyled border-left pl-4 lh-12 toc-sticky pt-3"
+      {...scrollRestoration}
+    >
+      <li className="mb-2 font-weight-bold text-muted text-uppercase small">
+        On this page
+      </li>
+      {toc
+        .filter((item) => item.title)
+        .map((item) => (
+          <li key={item.title}>
+            <Link
+              className={`d-block py-2 align-middle ${
+                window.location.hash === item.url ? "active" : ""
+              }`}
+              to={item.url}
+            >
+              {item.title}
+            </Link>
+          </li>
+        ))}
+    </ul>
+  );
+};
 
 export default TableOfContents;

--- a/src/components/tree-node.js
+++ b/src/components/tree-node.js
@@ -38,7 +38,8 @@ const TreeNode = ({ node, path, hideIfEmpty }) => {
       <div className="d-flex align-items-center">
         <Link
           to={node.path}
-          className={`d-inline-block py-1 align-middle lh-12 ${
+          className={`d-inline-block py-1 align-middle lh-12
+          ${node.childCount ? "section-title" : ""} ${
             path === node.path ? "active font-weight-bold text-dark" : ""
           }`}
         >

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -156,6 +156,7 @@ const treeNodeToNavNode = (treeNode, withItems = false) => {
     iconName: frontmatter?.iconName,
     description: frontmatter?.description,
     interactive: interactive,
+    childCount: treeNode.children.length,
   };
   if (withItems) navNode.items = [];
   return navNode;

--- a/src/styles/_docs.scss
+++ b/src/styles/_docs.scss
@@ -66,6 +66,15 @@ label.link-label {
   }
 }
 
+/* sidebar item that contains other items */
+.section-title
+{
+  @include caret(right);
+  &::after {
+    vertical-align: 0;
+  }
+}
+
 .font-weight-400 {
   font-weight: 400;
 }

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -11,7 +11,12 @@
 .toc-sticky {
   position: sticky;
   top: 0;
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
+
+.toc-sticky li .active { font-weight: bold; }
 
 .overflow-scroll {
   overflow: scroll;


### PR DESCRIPTION
## What Changed?

Build #4024 into the system as follows:

- record number of children when building nav tree
- apply CSS class to nav links where childCount > 0
- CSS class renders arrow using Bootstrap's weird-ass border technique

Result: arrows next to expandable items in list.
TODO: figure out if accessibility can be improved here (ARIA role?)

Partially address https://github.com/EnterpriseDB/docs/issues/4120 as follows:
- fix height of right nav bar, enable scrollbar when content exceeds
- indicate currently-selected section via CSS class
- on navigation, ensure currently selected items in both left and right nav
  are scrolled into view if not currently visible
- using gatsby hook, record current scroll state for left/right navs,
  restore this state when navigating back

