### PR TITLE
TDE: replacing ascii code with the correct characters

### DIFF
--- a/product_docs/docs/tde/15/key_stores.mdx
+++ b/product_docs/docs/tde/15/key_stores.mdx
@@ -47,8 +47,8 @@ Key unwrap commands that prompt for passwords on the terminal don't work when th
 For example, for systemd, you can use `systemd-ask-password`:
 
 ```
-PGDATAKEYWRAPCMD="bash -c 'openssl enc -e -aes-128-cbc -pbkdf2 -out %p -pass file:&lt;(sudo systemd-ask-password --no-tty)'"
-PGDATAKEYUNWRAPCMD="bash -c 'openssl enc -d -aes-128-cbc -pbkdf2 -in %p -pass file:&lt;(sudo systemd-ask-password --no-tty)'"
+PGDATAKEYWRAPCMD="bash -c 'openssl enc -e -aes-128-cbc -pbkdf2 -out %p -pass file:<(sudo systemd-ask-password --no-tty)'"
+PGDATAKEYUNWRAPCMD="bash -c 'openssl enc -d -aes-128-cbc -pbkdf2 -in %p -pass file:<(sudo systemd-ask-password --no-tty)'"
 ```
 
 You also need an entry like in `/etc/sudoers`:
@@ -141,8 +141,8 @@ vault secrets enable transit
 # create a key (pick a name)
 vault write -f transit/keys/pg-tde-master-1
 
-PGDATAKEYWRAPCMD='base64 | vault write -field=ciphertext transit/encrypt/pg-tde-master-1 plaintext=- &gt; %p'
-PGDATAKEYUNWRAPCMD='vault write -field=plaintext transit/decrypt/pg-tde-master-1 ciphertext=- &lt; %p | base64 -d'
+PGDATAKEYWRAPCMD='base64 | vault write -field=ciphertext transit/encrypt/pg-tde-master-1 plaintext=- > %p'
+PGDATAKEYUNWRAPCMD='vault write -field=plaintext transit/decrypt/pg-tde-master-1 ciphertext=- < %p | base64 -d'
 ```
 
 ## Key rotation


### PR DESCRIPTION
## What Changed?

Neglected to convert the ascii codes in code blocks when moving content over from the DocBook source