### PR TITLE
Update bdr.mdx

### DIFF
--- a/product_docs/docs/tpa/23/reference/bdr.mdx
+++ b/product_docs/docs/tpa/23/reference/bdr.mdx
@@ -152,7 +152,7 @@ cluster_vars:
   bdr_commit_scopes:
   - name: somescope
     origin: somegroup
-    rule: 'ALL (somegroup) ON received …`
+    rule: 'ALL (somegroup) ON received …'
   - name: otherscope
     origin: othergroup
     rule: '…'


### PR DESCRIPTION
There was a back tick where a single quote should be inside the block code. This didn't show up too bad in the web docs, but did mangle the PDF a lot

## What Changed?

