### PR TITLE
Update _redirects for EFM EOL'd versions

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -96,13 +96,13 @@
 
 # EFM
 #   EOL'd versions
-/docs/efm/3.6/*  /docs/efm/latest/:splat  301
-/docs/efm/3.7/*  /docs/efm/latest/:splat  301
-/docs/efm/3/*    /docs/efm/latest/:splat  301
-#   collapsed versions
+/docs/efm/3.6/*  /docs/efm/3/:splat  301
+/docs/efm/3.7/*  /docs/efm/3/:splat  301
 /docs/efm/3.8/*  /docs/efm/3/:splat  301
 /docs/efm/3.9/*  /docs/efm/3/:splat  301
 /docs/efm/3.10/*  /docs/efm/3/:splat  301
+/docs/efm/3/*    /docs/efm/latest/  301
+#   collapsed versions
 /docs/efm/4.0/*  /docs/efm/4/:splat  301
 /docs/efm/4.1/*  /docs/efm/4/:splat  301
 /docs/efm/4.2/*  /docs/efm/4/:splat  301
@@ -137,7 +137,7 @@
 # Collapsed versions
 /docs/eprs/7.0/*  /docs/eprs/7/:splat  301
 # EOL versions
-/docs/eprs/6.2/*  /docs/eprs/latest/:splat  301
+/docs/eprs/6.2/*  /docs/eprs/latest/   301
 
 # MTK
 # EOL'd versions


### PR DESCRIPTION
## What Changed?

Ensure that EOL'd version paths redirect to the root of latest, not a 404 or matching path
