### PR TITLE
pgBackRest 2.46

### DIFF
--- a/advocacy_docs/supported-open-source/pgbackrest/06-use_case_1.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/06-use_case_1.mdx
@@ -10,7 +10,7 @@ tags:
 
 ### Description
 
-* pgBackRest runs locally on database servers and stores repository on remote storage (NFS, S3, Azure or GCS compatible object stores).
+* pgBackRest runs locally on database servers and stores repository on remote storage (NFS, SFTP, S3, Azure or GCS compatible object stores).
 * Cron task active on the node where to take backups.
 * Manually reconfigure cron task to take backup from another server.
 
@@ -89,6 +89,23 @@ repo1-gcs-key=/etc/pgbackrest/gcs-key.json
 ```
 
 `repo1-gcs-key` is a **token** or **service** key file depending on the `repo1-gcs-key-type` option.
+
+##### SFTP repository host
+
+```ini
+repo1-bundle=y
+repo1-type=sftp
+repo1-path=/repo1
+repo1-sftp-host=sftp-srv
+repo1-sftp-host-key-hash-type=sha1
+repo1-sftp-host-user=pgbackrest
+repo1-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp
+repo1-sftp-private-key-passphrase=BeSureToGenerateAndUseASecurePassphrase
+```
+
+`repo1-sftp-host` defines the SFTP host containing the repository. It is also possible to generate a dedicated SSH key pair for the SFTP connection using a secured passphrase with it (stored in `repo1-sftp-private-key-passphrase`).
+
+Note: the SFTP file transfer is relatively slow compared to the other supported repository types.
 
 ##### Recommended Settings
 
@@ -205,6 +222,7 @@ See the **Quick start** [backups](03-quick_start#backups) and [restore](03-quick
 [`repo-azure-container`](https://pgbackrest.org/configuration.html#section-repository/option-repo-azure-container)
 [`repo-azure-key-type`](https://pgbackrest.org/configuration.html#section-repository/option-repo-azure-key-type)
 [`repo-azure-key`](https://pgbackrest.org/configuration.html#section-repository/option-repo-azure-key)
+[`repo-bundle`](https://pgbackrest.org/configuration.html#section-repository/option-repo-bundle)
 [`repo-cipher-pass`](https://pgbackrest.org/configuration.html#section-repository/option-repo-cipher-pass)
 [`repo-cipher-type`](https://pgbackrest.org/configuration.html#section-repository/option-repo-cipher-type)
 [`repo-path`](https://pgbackrest.org/configuration.html#section-repository/option-repo-path)
@@ -217,6 +235,11 @@ See the **Quick start** [backups](03-quick_start#backups) and [restore](03-quick
 [`repo-s3-kms-key-id`](https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-kms-key-id)
 [`repo-s3-region`](https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-region)
 [`repo-s3-role`](https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-role)
+[`repo-sftp-host`](https://pgbackrest.org/configuration.html#section-repository/option-repo-sftp-host)
+[`repo-sftp-host-key-hash-type`](https://pgbackrest.org/configuration.html#section-repository/option-repo-sftp-host-key-hash-type)
+[`repo-sftp-host-user`](https://pgbackrest.org/configuration.html#section-repository/option-repo-sftp-host-user)
+[`repo-sftp-private-key-file`](https://pgbackrest.org/configuration.html#section-repository/option-repo-sftp-private-key-file)
+[`repo-sftp-private-key-passphrase`](https://pgbackrest.org/configuration.html#section-repository/option-repo-sftp-private-key-passphrase)
 [`repo-type`](https://pgbackrest.org/configuration.html#section-repository/option-repo-type)
 [`start-fast`](https://pgbackrest.org/configuration.html#section-backup/option-start-fast)
 

--- a/advocacy_docs/supported-open-source/pgbackrest/07-use_case_2.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/07-use_case_2.mdx
@@ -10,7 +10,7 @@ tags:
 
 ### Description
 
-* pgBackRest runs on a dedicated backup server and stores repository on local or remote storage (NFS, S3, Azure or GCS compatible object stores).
+* pgBackRest runs on a dedicated backup server and stores repository on local or remote storage (NFS, SFTP, S3, Azure or GCS compatible object stores).
 * Cron task active to take backups from the primary database cluster.
 * Manually reconfigure cron task to take backup from another server.
 

--- a/advocacy_docs/supported-open-source/pgbackrest/99-faq.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/99-faq.mdx
@@ -22,7 +22,7 @@ The databases that are not explicitly included with this option will be restored
 
 Yes. Since the 2.37 release, pgBackRest can use TLS with client certificates to enable communication between the hosts. A TLS server must then be configured and started on each host.
 
-See [Setup TLS[(https://pgbackrest.org/user-guide-rhel.html#repo-host/config) for more information.
+See [Setup TLS](https://pgbackrest.org/user-guide-rhel.html#repo-host/config) for more information.
 
 ---
 

--- a/advocacy_docs/supported-open-source/pgbackrest/index.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/index.mdx
@@ -17,6 +17,6 @@ pgBackRest is an easy-to-use backup and restore tool that aims to enable your or
 !!! Note
     Looking for pgBackRest documentation? Head over to [http://www.pgbackrest.org](http://www.pgbackrest.org)
 
-pgBackRest [v2.45](https://github.com/pgbackrest/pgbackrest/releases/tag/release/2.45) is the current stable release. Release notes are on the [Releases](http://www.pgbackrest.org/release.html) page.
+pgBackRest [v2.46](https://github.com/pgbackrest/pgbackrest/releases/tag/release/2.46) is the current stable release. Release notes are on the [Releases](http://www.pgbackrest.org/release.html) page.
 
 EDB collaborates with the community on this open-source software. The packages are provided by the **PostgreSQL** community. All of the use cases shown in this document are fully tested and supported by **EDB Postgres Advanced Server**.


### PR DESCRIPTION
## What Changed?

pgBackRest 2.46 was released (and the community packages provided).

SFTP support for repository storage has also been introduced in this release.