### PR TITLE
Remove the --dcs flag for harpctl. The flag support has been removed as part of HNG-388

### DIFF
--- a/product_docs/docs/pgd/3.7/harp/08_harpctl.mdx
+++ b/product_docs/docs/pgd/3.7/harp/08_harpctl.mdx
@@ -32,7 +32,6 @@ Available Commands:
 Flags:
   -c, --cluster string       name of cluster.
   -f, --config-file string   config file (default is /etc/harp/config.yml)
-      --dcs stringArray      Address of dcs endpoints. ie: 127.0.0.1:2379
   -h, --help                 help for harpctl
   -o, --output string         'json, yaml'.
   -t, --toggle               Help message for toggle
@@ -45,8 +44,8 @@ series of allowed subcommands and flags.
 
 ## Configuration
 
-`harpctl` must interact with the consensus 
-layer to operate. This means a certain minimum amount of settings must be 
+`harpctl` must interact with the consensus
+layer to operate. This means a certain minimum amount of settings must be
 defined in `config.yml` for successful execution. This includes:
 
 * `dcs.driver`
@@ -76,7 +75,7 @@ Execute `harpctl` like this:
 harpctl command [flags]
 ```
 
-Each command has its own series of subcommands and flags. Further help for 
+Each command has its own series of subcommands and flags. Further help for
 these are available by executing this command:
 
 ```bash
@@ -94,9 +93,9 @@ Execute an `apply` command like this:
 harpctl apply <filename>
 ```
 
-This essentially creates all of the initial cluster metadata, default or custom 
-management settings, and so on. This is done here because the DCS is used as 
-the ultimate source of truth for managing the cluster, and this makes it 
+This essentially creates all of the initial cluster metadata, default or custom
+management settings, and so on. This is done here because the DCS is used as
+the ultimate source of truth for managing the cluster, and this makes it
 possible to change these settings dynamically.
 
 This can either be done once to bootstrap the entire cluster, once per type
@@ -105,7 +104,7 @@ of object, or even on a per-node basis for the sake of simplicity.
 This is an example of a bootstrap file for a single node:
 
 ```yaml
-cluster: 
+cluster:
   name: mycluster
 nodes:
   - name: firstnode
@@ -115,11 +114,11 @@ nodes:
     db_data_dir: /db/pgdata
 ```
 
-As seen here, it is good practice to always include a cluster name preamble to 
-ensure all changes target the correct HARP cluster, in case several are 
+As seen here, it is good practice to always include a cluster name preamble to
+ensure all changes target the correct HARP cluster, in case several are
 operating in the same environment.
 
-Once `apply` completes without error, the node is integrated with the rest 
+Once `apply` completes without error, the node is integrated with the rest
 of the cluster.
 
 !!! Note
@@ -130,10 +129,10 @@ of the cluster.
 
 ## `harpctl fence`
 
-Marks the local or specified node as fenced. A node with this status is 
-essentially completely excluded from the cluster. HARP Proxy doesn't send it 
-traffic, its representative HARP Manager doesn't claim the lead master lease, 
-and further steps are also taken. If running, HARP Manager stops Postgres 
+Marks the local or specified node as fenced. A node with this status is
+essentially completely excluded from the cluster. HARP Proxy doesn't send it
+traffic, its representative HARP Manager doesn't claim the lead master lease,
+and further steps are also taken. If running, HARP Manager stops Postgres
 on the node as well.
 
 Execute a `fence` command like this:
@@ -169,13 +168,13 @@ Fetches information stored in the consensus layer for the current cluster:
 
 Name      Enabled
 ----      -------
-mycluster true              
+mycluster true
 ```
 
 ### `harpctl get leader`
 
-Fetches node information for the current lead master stored in the DCS for the 
-specified location. If no location is passed, `harpctl` attempts to 
+Fetches node information for the current lead master stored in the DCS for the
+specified location. If no location is passed, `harpctl` attempts to
 derive it based on the location of the current node where it was executed.
 
 Example:
@@ -183,15 +182,15 @@ Example:
 ```bash
 > harpctl get leader dc1
 
-Cluster   Name   Ready Role    Type Location Fenced Lock Duration 
--------   ----   ----- ----    ---- -------- ------ ------------- 
-mycluster mynode true  primary bdr  dc1      false  30            
+Cluster   Name   Ready Role    Type Location Fenced Lock Duration
+-------   ----   ----- ----    ---- -------- ------ -------------
+mycluster mynode true  primary bdr  dc1      false  30
 ```
 
 ### `harpctl get location`
 
-Fetches location information for the specified location. If no location is 
-passed, `harpctl` attempts to derive it based on the location of the 
+Fetches location information for the specified location. If no location is
+passed, `harpctl` attempts to derive it based on the location of the
 current node where it was executed.
 
 Example:
@@ -199,9 +198,9 @@ Example:
 ```bash
 > harpctl get location dc1
 
-Cluster   Location Leader Previous Leader Target Leader Lease Renewals 
--------   -------- ------ --------------- ------------- -------------- 
-mycluster dc1      mynode mynode                        <nil>          
+Cluster   Location Leader Previous Leader Target Leader Lease Renewals
+-------   -------- ------ --------------- ------------- --------------
+mycluster dc1      mynode mynode                        <nil>
 ```
 
 ### `harpctl get locations`
@@ -213,10 +212,10 @@ Example:
 ```bash
 > harpctl get locations
 
-Cluster   Location Leader   Previous Leader Target Leader Lease Renewals 
--------   -------- ------   --------------- ------------- -------------- 
-mycluster dc1      mynode   mynode                        <nil>          
-mycluster dc2      thatnode thatnode                      <nil>          
+Cluster   Location Leader   Previous Leader Target Leader Lease Renewals
+-------   -------- ------   --------------- ------------- --------------
+mycluster dc1      mynode   mynode                        <nil>
+mycluster dc2      thatnode thatnode                      <nil>
 ```
 
 ### `harpctl get node`
@@ -227,10 +226,10 @@ Example:
 
 ```bash
 > harpctl get node mynode
-Cluster    Name   Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration 
--------    ----   -------- ----- ------ ------------- -------------- ----    ---- ------------- 
-mycluster  mynode dc1      true  false  true          ok               primary bdr  30            
-          
+Cluster    Name   Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration
+-------    ----   -------- ----- ------ ------------- -------------- ----    ---- -------------
+mycluster  mynode dc1      true  false  true          ok               primary bdr  30
+
 ```
 
 ### `harpctl get nodes`
@@ -242,8 +241,8 @@ Example:
 ```bash
 > harpctl get nodes
 
-Cluster    Name  Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration 
--------    ----  -------- ----- ------ ------------- -------------- ----    ---- ------------- 
+Cluster    Name  Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration
+-------    ----  -------- ----- ------ ------------- -------------- ----    ---- -------------
 myclusters bdra1 dc1      true  false  true          ok             primary bdr  30
 myclusters bdra2 dc1      true  false  false         N/A            primary bdr  30
 myclusters bdra3 dc1      true  false  false         N/A            primary bdr  30
@@ -259,14 +258,14 @@ Example:
 ```bash
 > harpctl get proxy proxy1
 
-Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size 
--------   ----   --------- --------- --------------- ----------------- 
-mycluster proxy1 session   md5       1000            20                
+Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size
+-------   ----   --------- --------- --------------- -----------------
+mycluster proxy1 session   md5       1000            20
 ```
 
 ### `harpctl get proxies`
 
-Fetches proxy information stored in the DCS for all proxies in the cluster. 
+Fetches proxy information stored in the DCS for all proxies in the cluster.
 Additionally, lists the `global` pseudo-proxy for default proxy settings.
 
 Example:
@@ -274,8 +273,8 @@ Example:
 ```bash
 > harpctl get proxies
 
-Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size 
--------   ----   --------- --------- --------------- ----------------- 
+Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size
+-------   ----   --------- --------- --------------- -----------------
 mycluster global session   md5       500             25
 mycluster proxy1 session   md5       1000            20
 mycluster proxy2 session   md5       1500            30
@@ -302,8 +301,8 @@ harpctl manage cluster
 
 ## `harpctl promote`
 
-Promotes the next available node that meets leadership requirements to lead 
-master in the current Location. Since this is a requested event, it invokes a 
+Promotes the next available node that meets leadership requirements to lead
+master in the current Location. Since this is a requested event, it invokes a
 smooth handover where:
 
 1. The existing lead master releases the lead master lease, provided:
@@ -313,15 +312,15 @@ smooth handover where:
     - Replication lag between the old lead master and the promoted node is
       less than `node.maximum_lag`.
 2. The promoted node is the only valid candidate to take the lead master
-   lease and does so as soon as it is released by the current holder. All 
+   lease and does so as soon as it is released by the current holder. All
    other nodes ignore the unset lead master lease.
     - If CAMO is enabled, the promoted node temporarily disables client
-      traffic until the CAMO queue is fully applied, even though it holds the 
+      traffic until the CAMO queue is fully applied, even though it holds the
       lead master lease.
-3. HARP Proxy, if using pgbouncer, will `PAUSE` connections to allow ongoing 
+3. HARP Proxy, if using pgbouncer, will `PAUSE` connections to allow ongoing
    transactions to complete. Once the lead master lease is claimed by the promoted node, it
    reconfigures PgBouncer for the new connection target and resumes database
-   traffic. If HARP Proxy is using the builtin proxy, it terminates existing 
+   traffic. If HARP Proxy is using the builtin proxy, it terminates existing
    connections and creates new connections to the lead master as new connections are
    requested from the client.
 
@@ -331,20 +330,20 @@ Execute a `promote` command like this:
 harpctl promote (<node-name>)
 ```
 
-Provide the `--force` option to forcibly set a node to lead master, 
-even if it doesn't meet the criteria for becoming lead master. This 
-circumvents any verification of CAMO status or replication lag and causes an 
+Provide the `--force` option to forcibly set a node to lead master,
+even if it doesn't meet the criteria for becoming lead master. This
+circumvents any verification of CAMO status or replication lag and causes an
 immediate transition to the promoted node.  This is the only way to specify
 an exact node for promotion.
 
-The node must be online and operational for this to succeed. Use this 
+The node must be online and operational for this to succeed. Use this
 option with care.
 
 
 ## `harpctl set`
 
-Sets a specific attribute in the cluster to the supplied value. This is used to 
-tweak configuration settings for a specific node, proxy, location, or the 
+Sets a specific attribute in the cluster to the supplied value. This is used to
+tweak configuration settings for a specific node, proxy, location, or the
 cluster rather than using `apply`. You can use this for the following
 object types:
 
@@ -365,7 +364,7 @@ harpctl set cluster event_sync_interval=200
 
 ### `harpctl set node`
 
-Sets node-related attributes for the named node. Any options mentioned in 
+Sets node-related attributes for the named node. Any options mentioned in
 [Node directives](04_configuration#node-directives) are valid here.
 
 Example:
@@ -376,8 +375,8 @@ harpctl set node mynode priority=500
 
 ### `harpctl set proxy`
 
-Sets proxy-related attributes for the named proxy. Any options mentioned in the [Proxy directives](04_configuration#proxy-directives) 
-are valid here.  
+Sets proxy-related attributes for the named proxy. Any options mentioned in the [Proxy directives](04_configuration#proxy-directives)
+are valid here.
 Properties set this way require a restart of the proxy before the new value takes effect.
 
 Example:
@@ -394,8 +393,8 @@ harpctl set proxy global default_pool_size=10
 
 ## `harpctl unfence`
 
-Removes the `fenced` attribute from the local or specified node. This 
-removes all previously applied cluster exclusions from the node so that it can 
+Removes the `fenced` attribute from the local or specified node. This
+removes all previously applied cluster exclusions from the node so that it can
 again receive traffic or hold the lead master lease. Postgres is also started if it isn't running.
 
 Execute an `unfence` command like this:
@@ -409,10 +408,10 @@ the locally configured node.
 
 ## `harpctl unmanage`
 
-Instructs all HARP Manager services in the cluster to remain running but no 
-longer actively monitoring Postgres, or modify the contents of the consensus 
-layer. This means that any ordinary failover event such as a node outage 
-doesn't result in a leadership migration. This is intended for system or HARP 
+Instructs all HARP Manager services in the cluster to remain running but no
+longer actively monitoring Postgres, or modify the contents of the consensus
+layer. This means that any ordinary failover event such as a node outage
+doesn't result in a leadership migration. This is intended for system or HARP
 maintenance prior to making changes to HARP software or
 other significant changes to the cluster.
 

--- a/product_docs/docs/pgd/4/harp/08_harpctl.mdx
+++ b/product_docs/docs/pgd/4/harp/08_harpctl.mdx
@@ -34,7 +34,6 @@ Available Commands:
 Flags:
   -c, --cluster string       name of cluster.
   -f, --config-file string   config file (default is /etc/harp/config.yml)
-      --dcs stringArray      Address of dcs endpoints. ie: 127.0.0.1:2379
   -h, --help                 help for harpctl
   -o, --output string         'json, yaml'.
   -t, --toggle               Help message for toggle
@@ -47,8 +46,8 @@ series of allowed subcommands and flags.
 
 ## Configuration
 
-`harpctl` must interact with the consensus 
-layer to operate. This means a certain minimum amount of settings must be 
+`harpctl` must interact with the consensus
+layer to operate. This means a certain minimum amount of settings must be
 defined in `config.yml` for successful execution. This includes:
 
 * `dcs.driver`
@@ -78,7 +77,7 @@ Execute `harpctl` like this:
 harpctl command [flags]
 ```
 
-Each command has its own series of subcommands and flags. Further help for 
+Each command has its own series of subcommands and flags. Further help for
 these are available by executing this command:
 
 ```bash
@@ -96,9 +95,9 @@ Execute an `apply` command like this:
 harpctl apply <filename>
 ```
 
-This essentially creates all of the initial cluster metadata, default or custom 
-management settings, and so on. This is done here because the DCS is used as 
-the ultimate source of truth for managing the cluster, and this makes it 
+This essentially creates all of the initial cluster metadata, default or custom
+management settings, and so on. This is done here because the DCS is used as
+the ultimate source of truth for managing the cluster, and this makes it
 possible to change these settings dynamically.
 
 This can either be done once to bootstrap the entire cluster, once per type
@@ -107,7 +106,7 @@ of object, or even on a per-node basis for the sake of simplicity.
 This is an example of a bootstrap file for a single node:
 
 ```yaml
-cluster: 
+cluster:
   name: mycluster
 nodes:
   - name: firstnode
@@ -117,11 +116,11 @@ nodes:
     db_data_dir: /db/pgdata
 ```
 
-As seen here, it is good practice to always include a cluster name preamble to 
-ensure all changes target the correct HARP cluster, in case several are 
+As seen here, it is good practice to always include a cluster name preamble to
+ensure all changes target the correct HARP cluster, in case several are
 operating in the same environment.
 
-Once `apply` completes without error, the node is integrated with the rest 
+Once `apply` completes without error, the node is integrated with the rest
 of the cluster.
 
 !!! Note
@@ -132,10 +131,10 @@ of the cluster.
 
 ## `harpctl fence`
 
-Marks the local or specified node as fenced. A node with this status is 
-essentially completely excluded from the cluster. HARP Proxy doesn't send it 
-traffic, its representative HARP Manager doesn't claim the lead master lease, 
-and further steps are also taken. If running, HARP Manager stops Postgres 
+Marks the local or specified node as fenced. A node with this status is
+essentially completely excluded from the cluster. HARP Proxy doesn't send it
+traffic, its representative HARP Manager doesn't claim the lead master lease,
+and further steps are also taken. If running, HARP Manager stops Postgres
 on the node as well.
 
 Execute a `fence` command like this:
@@ -171,12 +170,12 @@ Fetches information stored in the consensus layer for the current cluster:
 
 Name      Enabled
 ----      -------
-mycluster true              
+mycluster true
 ```
 
 ### `harpctl get leader`
 
-Fetches node information for the current lead master stored in the DCS for the 
+Fetches node information for the current lead master stored in the DCS for the
 specified location. Use [`harpctl get locations`](#harpctl-get-locations) to list the defined locations.
 
 Example:
@@ -184,9 +183,9 @@ Example:
 ```bash
 > harpctl get leader dc1
 
-Cluster   Name   Ready Role    Type Location Fenced Lock Duration 
--------   ----   ----- ----    ---- -------- ------ ------------- 
-mycluster mynode true  primary bdr  dc1      false  30            
+Cluster   Name   Ready Role    Type Location Fenced Lock Duration
+-------   ----   ----- ----    ---- -------- ------ -------------
+mycluster mynode true  primary bdr  dc1      false  30
 ```
 
 ### `harpctl get location`
@@ -199,9 +198,9 @@ Example:
 ```bash
 > harpctl get location dc1
 
-Cluster   Location Leader Previous Leader Target Leader Lease Renewals 
--------   -------- ------ --------------- ------------- -------------- 
-mycluster dc1      mynode mynode                        <nil>          
+Cluster   Location Leader Previous Leader Target Leader Lease Renewals
+-------   -------- ------ --------------- ------------- --------------
+mycluster dc1      mynode mynode                        <nil>
 ```
 
 ### `harpctl get locations`
@@ -213,10 +212,10 @@ Example:
 ```bash
 > harpctl get locations
 
-Cluster   Location Leader   Previous Leader Target Leader Lease Renewals 
--------   -------- ------   --------------- ------------- -------------- 
-mycluster dc1      mynode   mynode                        <nil>          
-mycluster dc2      thatnode thatnode                      <nil>          
+Cluster   Location Leader   Previous Leader Target Leader Lease Renewals
+-------   -------- ------   --------------- ------------- --------------
+mycluster dc1      mynode   mynode                        <nil>
+mycluster dc2      thatnode thatnode                      <nil>
 ```
 
 ### `harpctl get node`
@@ -227,10 +226,10 @@ Example:
 
 ```bash
 > harpctl get node mynode
-Cluster    Name   Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration 
--------    ----   -------- ----- ------ ------------- -------------- ----    ---- ------------- 
-mycluster  mynode dc1      true  false  true          ok               primary bdr  30            
-          
+Cluster    Name   Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration
+-------    ----   -------- ----- ------ ------------- -------------- ----    ---- -------------
+mycluster  mynode dc1      true  false  true          ok               primary bdr  30
+
 ```
 
 ### `harpctl get nodes`
@@ -242,8 +241,8 @@ Example:
 ```bash
 > harpctl get nodes
 
-Cluster    Name  Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration 
--------    ----  -------- ----- ------ ------------- -------------- ----    ---- ------------- 
+Cluster    Name  Location Ready Fenced Allow Routing Routing Status Role    Type Lock Duration
+-------    ----  -------- ----- ------ ------------- -------------- ----    ---- -------------
 myclusters bdra1 dc1      true  false  true          ok             primary bdr  30
 myclusters bdra2 dc1      true  false  false         N/A            primary bdr  30
 myclusters bdra3 dc1      true  false  false         N/A            primary bdr  30
@@ -259,14 +258,14 @@ Example:
 ```bash
 > harpctl get proxy proxy1
 
-Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size 
--------   ----   --------- --------- --------------- ----------------- 
-mycluster proxy1 session   md5       1000            20                
+Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size
+-------   ----   --------- --------- --------------- -----------------
+mycluster proxy1 session   md5       1000            20
 ```
 
 ### `harpctl get proxies`
 
-Fetches proxy information stored in the DCS for all proxies in the cluster. 
+Fetches proxy information stored in the DCS for all proxies in the cluster.
 Additionally, lists the `global` pseudo-proxy for default proxy settings.
 
 Example:
@@ -274,8 +273,8 @@ Example:
 ```bash
 > harpctl get proxies
 
-Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size 
--------   ----   --------- --------- --------------- ----------------- 
+Cluster   Name   Pool Mode Auth Type Max Client Conn Default Pool Size
+-------   ----   --------- --------- --------------- -----------------
 mycluster global session   md5       500             25
 mycluster proxy1 session   md5       1000            20
 mycluster proxy2 session   md5       1500            30
@@ -302,8 +301,8 @@ harpctl manage cluster
 
 ## `harpctl promote`
 
-Promotes the next available node that meets leadership requirements to lead 
-master in the current Location. Since this is a requested event, it invokes a 
+Promotes the next available node that meets leadership requirements to lead
+master in the current Location. Since this is a requested event, it invokes a
 smooth handover where:
 
 1. The existing lead master releases the lead master lease, provided:
@@ -313,15 +312,15 @@ smooth handover where:
     - Replication lag between the old lead master and the promoted node is
       less than `node.maximum_lag`.
 2. The promoted node is the only valid candidate to take the lead master
-   lease and does so as soon as it is released by the current holder. All 
+   lease and does so as soon as it is released by the current holder. All
    other nodes ignore the unset lead master lease.
     - If CAMO is enabled, the promoted node temporarily disables client
-      traffic until the CAMO queue is fully applied, even though it holds the 
+      traffic until the CAMO queue is fully applied, even though it holds the
       lead master lease.
-3. HARP Proxy, if using pgbouncer, will `PAUSE` connections to allow ongoing 
+3. HARP Proxy, if using pgbouncer, will `PAUSE` connections to allow ongoing
    transactions to complete. Once the lead master lease is claimed by the promoted node, it
    reconfigures PgBouncer for the new connection target and resumes database
-   traffic. If HARP Proxy is using the builtin proxy, it terminates existing 
+   traffic. If HARP Proxy is using the builtin proxy, it terminates existing
    connections and creates new connections to the lead master as new connections are
    requested from the client.
 
@@ -331,20 +330,20 @@ Execute a `promote` command like this:
 harpctl promote (<node-name>)
 ```
 
-Provide the `--force` option to forcibly set a node to lead master, 
-even if it doesn't meet the criteria for becoming lead master. This 
-circumvents any verification of CAMO status or replication lag and causes an 
+Provide the `--force` option to forcibly set a node to lead master,
+even if it doesn't meet the criteria for becoming lead master. This
+circumvents any verification of CAMO status or replication lag and causes an
 immediate transition to the promoted node.  This is the only way to specify
 an exact node for promotion.
 
-The node must be online and operational for this to succeed. Use this 
+The node must be online and operational for this to succeed. Use this
 option with care.
 
 
 ## `harpctl set`
 
-Sets a specific attribute in the cluster to the supplied value. This is used to 
-tweak configuration settings for a specific node, proxy, location, or the 
+Sets a specific attribute in the cluster to the supplied value. This is used to
+tweak configuration settings for a specific node, proxy, location, or the
 cluster rather than using `apply`. You can use this for the following
 object types:
 
@@ -365,7 +364,7 @@ harpctl set cluster event_sync_interval=200
 
 ### `harpctl set node`
 
-Sets node-related attributes for the named node. Any options mentioned in 
+Sets node-related attributes for the named node. Any options mentioned in
 [Node directives](04_configuration#node-directives) are valid here.
 
 Example:
@@ -376,8 +375,8 @@ harpctl set node mynode priority=500
 
 ### `harpctl set proxy`
 
-Sets proxy-related attributes for the named proxy. Any options mentioned in the [Proxy directives](04_configuration#proxy-directives) 
-are valid here.  
+Sets proxy-related attributes for the named proxy. Any options mentioned in the [Proxy directives](04_configuration#proxy-directives)
+are valid here.
 Properties set this way require a restart of the proxy before the new value takes effect.
 
 Example:
@@ -394,8 +393,8 @@ harpctl set proxy global default_pool_size=10
 
 ## `harpctl unfence`
 
-Removes the `fenced` attribute from the local or specified node. This 
-removes all previously applied cluster exclusions from the node so that it can 
+Removes the `fenced` attribute from the local or specified node. This
+removes all previously applied cluster exclusions from the node so that it can
 again receive traffic or hold the lead master lease. Postgres is also started if it isn't running.
 
 Execute an `unfence` command like this:
@@ -409,10 +408,10 @@ the locally configured node.
 
 ## `harpctl unmanage`
 
-Instructs all HARP Manager services in the cluster to remain running but no 
-longer actively monitoring Postgres, or modify the contents of the consensus 
-layer. This means that any ordinary failover event such as a node outage 
-doesn't result in a leadership migration. This is intended for system or HARP 
+Instructs all HARP Manager services in the cluster to remain running but no
+longer actively monitoring Postgres, or modify the contents of the consensus
+layer. This means that any ordinary failover event such as a node outage
+doesn't result in a leadership migration. This is intended for system or HARP
 maintenance prior to making changes to HARP software or
 other significant changes to the cluster.
 


### PR DESCRIPTION
Remove the --dcs flag for harpctl from docs. 
The flag support has been removed as part of HNG-388

The actual change is on line#35. Please ignore the whitespace changes that my IDE added automatically. This isn't visible when I see the diff in my IDE 

