### PR TITLE
Update pgd_5.1.0_rel_notes.mdx remove JIRA refs

### DIFF
--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.1.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.1.0_rel_notes.mdx
@@ -23,39 +23,39 @@ This version is required for EDB Postgres Advanced Server versions 12.15, 13.11,
 
 | Component | Version | Type            | Description  |
 |-----------|---------|-----------------|--------------|
-| BDR       | 5.1.0   | Feature         | Added pid to the log message emitted upon writer process death (BDR-2534) |
-| BDR       | 5.1.0   | Feature         | Added group name in the bdr.event_summary view (BDR-3315) |
-| BDR       | 5.1.0   | Feature         | Added SLES support (BDR-3101)<br/>SLES 15sp4 is now supported |
-| BDR       | 5.1.0   | Feature         | Added subscription status column to the group subscription summary view. (BDR-2198)<br/>This will allow you to distinguish whether NULL values are due to a node being down or a subscription being disabled.|
-| BDR       | 5.1.0   | Feature         | Added NOT group filter to Group Commit (BDR-3339)<br/>This allows you to invert the meaning of a group filter to include all nodes except the ones in specified group(s).|
-| BDR       | 5.1.0   | Feature         | Added bdr.drop_node_group (BDR-3313)<br/>You can now  drop empty node groups.|
-| BDR       | 5.1.0   | Feature         | Added SYNCHRONOUS_COMMIT to Commit Scopes (BDR-3340)<br/>This allows dynamic synchronous_commit-like behavior for replication.|
-| BDR       | 5.1.0   | Feature         | Added "event_node_name" column to bdr.event_summary (BDR-3317) |
-| BDR       | 5.1.0   | Feature         | Added write leader election to event history (BDR-3350)<br/>Added information about the node which is elected as a write leader for each group in the event_history catalog. Also improved the reporting of raft instance ids in the event_detail of event_history.|
+| BDR       | 5.1.0   | Feature         | Added pid to the log message emitted upon writer process death. |
+| BDR       | 5.1.0   | Feature         | Added group name in the bdr.event_summary view. |
+| BDR       | 5.1.0   | Feature         | Added SLES support<br/>SLES 15sp4 is now supported. |
+| BDR       | 5.1.0   | Feature         | Added subscription status column to the group subscription summary view.<br/>This will allow you to distinguish whether NULL values are due to a node being down or a subscription being disabled. |
+| BDR       | 5.1.0   | Feature         | Added NOT group filter to Group Commit (BDR-3339)<br/>This allows you to invert the meaning of a group filter to include all nodes except the ones in specified group(s). |
+| BDR       | 5.1.0   | Feature         | Added bdr.drop_node_group<br/>You can now  drop empty node groups. |
+| BDR       | 5.1.0   | Feature         | Added SYNCHRONOUS_COMMIT to Commit Scopes<br/>This allows dynamic synchronous_commit-like behavior for replication. |
+| BDR       | 5.1.0   | Feature         | Added "event_node_name" column to bdr.event_summary. |
+| BDR       | 5.1.0   | Feature         | Added write leader election to event history<br/>Added information about the node which is elected as a write leader for each group in the event_history catalog. Also improved the reporting of raft instance ids in the event_detail of event_history.|
 | BDR       | 5.1.0   | Feature         | Allow exporting and importing other instances' Raft snapshots.<br/>Allow exporting and importing snapshots also for other instances and not only top raft instances.|
-| BDR       | 5.1.0   | Bug fix         | Fixed memory leak in consensus process (BDR-3409, RT91830)  |
+| BDR       | 5.1.0   | Bug fix         | Fixed memory leak in consensus process. (RT91830)  |
 | BDR       | 5.1.0   | Bug fix         | Fixed issue where a node can be inconsistent with the group after rejoining<br/>If a node had been part of a sub-group, then parted and then rejoined to the group, it could be inconsistent with the group. The changes from some nodes of the group would be replayed from a wrong starting point, resulting in potential data-loss. |
-| BDR       | 5.1.0   | Bug fix         | Fixed join and replication when SDW and standby_slot_names are set (BDR-3176, RT89702, RT89536) |
-| BDR       | 5.1.0   | Bug fix         | Fixed spurious warnings when processing sequence options (BDR-3295, RT90668) |
-| BDR       | 5.1.0   | Bug fix         | Fixed upgrades for nodes with CRDTs (BDR-3302) |
-| BDR       | 5.1.0   | Bug fix         | Adjusted lag tracking parameters for LCRs from pg_stat_replication (BDR-3040) |
-| BDR       | 5.1.0   | Bug fix         | Adjusted node routing options defaults based on node kind (BDR-3029)<br/>This change is only related to the display of the information and not the behavior, for example witness nodes are not marked as candidates for receiving writes |
-| BDR       | 5.1.0   | Bug fix         | All sequences are now converted to "distributed" during create node (BDR-2890) |
-| BDR       | 5.1.0   | Bug fix         | Fixed streaming transactions with standby_slot_names (BDR-3248)<br/>This could have led to a subscriber-only node get ahead of a data-node. |
-| BDR       | 5.1.0   | Bug fix         | Made priority work properly for routing selection (BDR-3385)<br/>Previously, node priority was only working if there wasn't previous leader which is never the case on failover so it was pretty much useless.|
-| BDR       | 5.1.0   | Bug fix         | Fixed the recording of its join as complete for the first node (BDR-3458) |
+| BDR       | 5.1.0   | Bug fix         | Fixed join and replication when SDW and standby_slot_names are set. (RT89702, RT89536) |
+| BDR       | 5.1.0   | Bug fix         | Fixed spurious warnings when processing sequence options. (RT90668) |
+| BDR       | 5.1.0   | Bug fix         | Fixed upgrades for nodes with CRDTs. |
+| BDR       | 5.1.0   | Bug fix         | Adjusted lag tracking parameters for LCRs from pg_stat_replication. |
+| BDR       | 5.1.0   | Bug fix         | Adjusted node routing options defaults based on node kind<br/>This change is only related to the display of the information and not the behavior, for example witness nodes are not marked as candidates for receiving writes. |
+| BDR       | 5.1.0   | Bug fix         | All sequences are now converted to "distributed" during create node. |
+| BDR       | 5.1.0   | Bug fix         | Fixed streaming transactions with standby_slot_names<br/>This could have led to a subscriber-only node get ahead of a data-node. |
+| BDR       | 5.1.0   | Bug fix         | Made priority work properly for routing selection<br/>Previously, node priority was only working if there wasn't previous leader which is never the case on failover so it was pretty much useless.|
+| BDR       | 5.1.0   | Bug fix         | Fixed the recording of its join as complete for the first node. |
 | BDR       | 5.1.0   | Bug fix         | Disabled tracing by default.<br/>This was only enabled for initial debugging and was supposed to be disabled before 5.0 release. |
-| BDR       | 5.1.0   | Bug fix         | Added support for reload configuration for the pglogical receiver (BDR-2337)<br/>When the server receives a reload signal, the pglogical receiver will reload and apply the configuration changes |
-| BDR       | 5.1.0   | Bug fix         | Improved missing instance error message in `bdr.monitor_group_raft()` (BDR-3393) |
-| BDR       | 5.1.0   | Bug fix         | Implemented consistent use of tcp keepalives across all BDR connections (BDR-3355, BDR-3463)<br/>This change added the following GUCs:<br/>`bdr.global_connection_timeout`<br/>`bdr.global_keepalives`<br/>`bdr.global_keepalives_idle`<br/>`bdr.global_keepalives_interval`<br/>`bdr.global_keepalives_count`<br/>`bdr.global_tcp_user_timeout`<br/>The defaults are set to fairly conservative values and are subject to adjustments in the future patches. |
+| BDR       | 5.1.0   | Bug fix         | Added support for reload configuration for the pglogical receiver<br/>When the server receives a reload signal, the pglogical receiver will reload and apply the configuration changes. |
+| BDR       | 5.1.0   | Bug fix         | Improved missing instance error message in `bdr.monitor_group_raft()`. |
+| BDR       | 5.1.0   | Bug fix         | Implemented consistent use of tcp keepalives across all BDR connections<br/>This change added the following GUCs:<br/>`bdr.global_connection_timeout`<br/>`bdr.global_keepalives`<br/>`bdr.global_keepalives_idle`<br/>`bdr.global_keepalives_interval`<br/>`bdr.global_keepalives_count`<br/>`bdr.global_tcp_user_timeout`<br/>The defaults are set to fairly conservative values and are subject to adjustments in the future patches. |
 | BDR       | 5.1.0   | Bug fix         | Closed Raft connections on no activity after a timeout<br/>This uses wal_sender_timeout/wal_receiver_timeout underneath. |
 | BDR       | 5.1.0   | Bug fix         | Made backends that receive Raft messages easily identifiable<br/>Added more information in the log message related to Raft backends. |
-| BDR       | 5.1.0   | Bug fix         | Parallel Apply could slow down under heavy load (BDR-3474)
-| BDR       | 5.1.0   | Enhancement     | Restarting sync workers is now avoided.(BDR-3415)<br/>This is to prevent the node join from failing when config changes are made that signal the restart of subscription workers. |
-| Proxy     | 5.1.0   | Enhancement     | Setting `application_name` to proxy name if it has not set by the user in connection string for internal db connections (BDR-2922) |
-| Proxy     | 5.1.0   | Enhancement     | Implemented the new `consensus_grace_period` proxy option which is the duration for which a proxy will continue to route to the current write leader (if it is available) upon loss of a Raft leader. If the new Raft leader is not elected during this period the proxy will stop routing. If set to `0s` the proxy will stop routing immediately. (BDR-3427) |
-| Proxy     | 5.1.0   | Bug fix         | Changed from blocking when write leader is unavailable to closing the new client connections. (BDR-3545) |
-| CLI       | 5.1.0   | Enhancement     | Enhanced the `show-events` command to show Raft events, event source and subtype (BDR-2339) |
-| CLI       | 5.1.0   | Enhancement     | Improved clockskew estimation in `show-clockskew` and `check-health` commands (BDR-2157) |
-| CLI       | 5.1.0   | Feature         | Added support to view and set `consensus_grace_period` proxy option |
-| Utilities | 1.1.0   | Bug fix         | Implemented handling of uninitialized physical replication slots issue (BDR-3303) |
+| BDR       | 5.1.0   | Bug fix         | Parallel Apply could slow down under heavy load. |
+| BDR       | 5.1.0   | Enhancement     | Restarting sync workers is now avoided.<br/>This is to prevent the node join from failing when config changes are made that signal the restart of subscription workers. |
+| Proxy     | 5.1.0   | Enhancement     | Setting `application_name` to proxy name if it has not set by the user in connection string for internal db connections. |
+| Proxy     | 5.1.0   | Enhancement     | Implemented the new `consensus_grace_period` proxy option which is the duration for which a proxy will continue to route to the current write leader (if it is available) upon loss of a Raft leader. If the new Raft leader is not elected during this period the proxy will stop routing. If set to `0s` the proxy will stop routing immediately. |
+| Proxy     | 5.1.0   | Bug fix         | Changed from blocking when write leader is unavailable to closing the new client connections. |
+| CLI       | 5.1.0   | Enhancement     | Enhanced the `show-events` command to show Raft events, event source and subtype. |
+| CLI       | 5.1.0   | Enhancement     | Improved clockskew estimation in `show-clockskew` and `check-health` commands. |
+| CLI       | 5.1.0   | Feature         | Added support to view and set `consensus_grace_period` proxy option. |
+| Utilities | 1.1.0   | Bug fix         | Implemented handling of uninitialized physical replication slots issue. |


### PR DESCRIPTION
## What Changed?

JIRA refs removed (after checking that there weren't any related support tickets associated).