### PR TITLE
Fix formatting of lists

### DIFF
--- a/product_docs/docs/epas/15/epas_guide/03_database_administration/05_edb_audit_logging/01_audit_logging_configuration_parameters.mdx
+++ b/product_docs/docs/epas/15/epas_guide/03_database_administration/05_edb_audit_logging/01_audit_logging_configuration_parameters.mdx
@@ -30,8 +30,9 @@ Use the following configuration parameters to control database auditing. See [Su
 `edb_audit_archiver_compress_time_limit`
 
  Specifies the time in seconds after which audit logs are eligible for compression. The possible values are: 
-    - `0` &mdash; Compression starts as soon as the log file isn't a current file. 
-    - `-1` &mdash; Compression of the log file on a timely basis doesn't occur.
+ 
+ - `0` &mdash; Compression starts as soon as the log file isn't a current file. 
+ - `-1` &mdash; Compression of the log file on a timely basis doesn't occur.
 
 `edb_audit_archiver_compress_size_limit`
 
@@ -50,8 +51,9 @@ If the parameter is set to `-1`, compression of the log file on a size basis doe
 `edb_audit_archiver_expire_time_limit`
 
  Specifies the time, in seconds, after which audit logs are eligible to expire. The possible values to set this parameter are: 
-    - `0` &mdash; Expiration starts as soon as the log file isn't a current file. 
-    - `-1` &mdash; Expiration of the log file on a timely basis doesn't occur.
+ 
+ - `0` &mdash; Expiration starts as soon as the log file isn't a current file. 
+ - `-1` &mdash; Expiration of the log file on a timely basis doesn't occur.
 
 `edb_audit_archiver_expire_size_limit` 
 


### PR DESCRIPTION
01_audit_logging_configuration_parameters.mdx

Unnecessary indentation of the bulleted lists messes up inline formatting.

## What Changed?

Bulleted lists for the `edb_audit_archiver_compress_time_limit` and `edb_audit_archiver_compress_size_limit` values were incorrectly formatted. 