### PR TITLE
Add workaround for EFM monitoring

### DIFF
--- a/product_docs/docs/pem/9/monitoring_failover_manager.mdx
+++ b/product_docs/docs/pem/9/monitoring_failover_manager.mdx
@@ -18,10 +18,8 @@ To monitor the status of a Failover Manager cluster on the Streaming Replication
 -   Use the **EFM Installation Path** field to specify the location of the Failover Manager binary file. By default, the Failover Manager binary file is installed in `/usr/efm-<X>/bin`, where `<X>` is the EFM version.
 
 !!! Note
-In order to monitor Failover Manager, the PEM Agent executes the command `efm cluster-status-json <cluster_name>` as the user `efm`.
-If your cluster properties file is not located in the home directory of this user, this will fail.
-In this case, you should create a symlink to the cluster properties files in the home directory of `efm` and ensure that `efm`
-has permission to read and execute the cluster properties file.
+To monitor Failover Manager, the PEM agent executes the `efm cluster-status-json <cluster_name>` command as the user `efm`. This command fails if the cluster properties file isn't in the `efm` user's home directory.
+In this case, create a symlink to the cluster properties files in the home directory of `efm` and ensure that `efm` has permission to read and execute the cluster properties file
 !!!
 
 After registering your servers, the Streaming Replication Analysis dashboard displays status information about your EFM cluster near the bottom of the dashboard.

--- a/product_docs/docs/pem/9/monitoring_failover_manager.mdx
+++ b/product_docs/docs/pem/9/monitoring_failover_manager.mdx
@@ -17,6 +17,13 @@ To monitor the status of a Failover Manager cluster on the Streaming Replication
 
 -   Use the **EFM Installation Path** field to specify the location of the Failover Manager binary file. By default, the Failover Manager binary file is installed in `/usr/efm-<X>/bin`, where `<X>` is the EFM version.
 
+!!! Note
+In order to monitor Failover Manager, the PEM Agent executes the command `efm cluster-status-json <cluster_name>` as the user `efm`.
+If your cluster properties file is not located in the home directory of this user, this will fail.
+In this case, you should create a symlink to the cluster properties files in the home directory of `efm` and ensure that `efm`
+has permission to read and execute the cluster properties file.
+!!!
+
 After registering your servers, the Streaming Replication Analysis dashboard displays status information about your EFM cluster near the bottom of the dashboard.
 
 ![The Failover Manager cluster status report](images/fm_cluster_status.png)


### PR DESCRIPTION
Add workaround for case where the cluster properties file is not in the home directory of the efm user.

