### PR TITLE
PGD: including "EDB" in product name

### DIFF
--- a/product_docs/docs/pgd/5/quickstart/index.mdx
+++ b/product_docs/docs/pgd/5/quickstart/index.mdx
@@ -17,14 +17,14 @@ navigation:
 
 ## Quick start
 
-Postgres Distributed (PGD) is a multi-master replicating implementation of Postgres designed for high performance and availability. You can create database clusters made up of many bidirectionally synchronizing database nodes. The clusters can have a number of proxy servers that direct your query traffic to the most available nodes, adding further resilience to your cluster configuration.
+EDB Postgres Distributed (PGD) is a multi-master replicating implementation of Postgres designed for high performance and availability. You can create database clusters made up of many bidirectionally synchronizing database nodes. The clusters can have a number of proxy servers that direct your query traffic to the most available nodes, adding further resilience to your cluster configuration.
 
 !!! Note Fully Managed BigAnimal
-    If you would prefer to have a fully managed Postgres Distributed experience, PGD is now available as the Extreme High Availability option on BigAnimal, EDB's cloud platform for Postgres. Read more about [BigAnimal Extreme High Availability](/biganimal/latest/overview/02_high_availability/#extreme-high-availability-preview).
+    If you would prefer to have a fully managed EDB Postgres Distributed experience, PGD is now available as the Extreme High Availability option on BigAnimal, EDB's cloud platform for Postgres. Read more about [BigAnimal Extreme High Availability](/biganimal/latest/overview/02_high_availability/#extreme-high-availability-preview).
  
 PGD is very configurable. To quickly evaluate and deploy PGD, use this quick start. It'll get you up and running with a fully configured PGD cluster using the same tools that you'll use to deploy to production. This quick start includes:
 
-* A short introduction to Trusted Postgres Architect (TPA) and how it helps you configure, deploy, and manage Postgres Distributed
+* A short introduction to Trusted Postgres Architect (TPA) and how it helps you configure, deploy, and manage EDB Postgres Distributed
 * A guide to selecting Docker, Linux hosts, or AWS quick starts
   * The Docker quick start
   * The Linux host quick start


### PR DESCRIPTION
## What Changed?

@djw-m even though the short name suggests otherwise, EDB is part of the product name we should be using in the docs

@ebgitelman can you look for instances of the product name missing EDB in your copyediting passes? Also, CLI should be uppercase. We need to search the docs for Cli and cli and fix the case.