### PR TITLE
BigAnimal: fix to pricing

### DIFF
--- a/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
+++ b/product_docs/docs/biganimal/release/pricing_and_billing/index.mdx
@@ -13,7 +13,6 @@ Pricing is based on the number of virtual central processing units (vCPUs) provi
 | Database type                | Hourly price   | Monthly price\* | 
 | ---------------------------- | -------------- | --------------- | 
 | PostgreSQL                   | $0.0856 / vCPU | $62.49 / vCPU  | 
-| PostgreSQL                   | $0.1655 / vCPU | $120.82 / vCPU  | 
 | EDB Postgres Advanced Server | $0.2568 / vCPU | $187.46 / vCPU  | 
 
 Extreme high availability powered by EDB Postgres Distributed is now available in preview! Contact Sales for more information about pricing.


### PR DESCRIPTION
## What Changed?

Per Slack message, Natalia says we don't need the 2nd PostgreSQL line in the pricing table