### PR TITLE
Update installation instructions for ASP

### DIFF
--- a/advocacy_docs/pg_extensions/advanced_storage_pack/installing.mdx
+++ b/advocacy_docs/pg_extensions/advanced_storage_pack/installing.mdx
@@ -3,7 +3,7 @@ title: Installing Advanced Storage Pack
 navTitle: Installing
 ---
 
-The Advanced Storage Pack is supported on the same platforms as the Postgres distribution you're using. Support for Advanced Storage Pack starts with Postgres 11. For details, see:
+The Advanced Storage Pack is supported on the same platforms as the Postgres distribution you're using. Support for Advanced Storage Pack starts with Postgres 12. For details, see:
 
 - [EDB Postgres Advanced Server Product Compatibility](https://www.enterprisedb.com/platform-compatibility#epas)
 
@@ -31,16 +31,10 @@ Before you begin the installation process:
 
 ## Install the package
 
-The syntax for the RPM package install command is:
+The syntax for the package install command is:
 
 ```shell
-sudo <package-manager> -y install edb-<postgres><postgres_version>-advanced-storage-pack<major_version>
-```
-
-The syntax for the Debian package install command is:
-
-```shell
-sudo <package-manager> -y install edb-<postgres><postgres_version>-advanced-storage-pack-<major_version>
+sudo <package-manager> -y install edb-<postgres><postgres_version>-advanced-storage-pack
 ```
 
 Where: 
@@ -49,10 +43,10 @@ Where:
 
   | Package manager |             Operating system     |
   | --------------- | -------------------------------- |
-  | dnf             | RHEL 8 and derivatives           |
+  | dnf             | RHEL 8/9 and derivatives         |
   | yum             | RHEL 7 and derivatives, CentOS 7 |
   | zypper          | SLES                             |
-  | apt-get         | Debian and derivatives           |
+  | apt-get         | Debian and Ubuntu                |
 
 - `<postgres>` is the distribution of Postgres you're using:
 
@@ -64,16 +58,14 @@ Where:
 
 - `<postgres_version>` is the version of Postgres you're using.
 
-- `<major_version>` is the major version of Advanced Storage Pack you're installing. 
-
-For example, to install Advanced Storage Pack 1.0.0 for EDB Postgres Advanced Server 14 on a RHEL 8 platform:
+For example, to install Advanced Storage Pack for EDB Postgres Advanced Server 14 on a RHEL 8 platform:
 
 ```shell
-sudo dnf -y install edb-as14-advanced-storage-pack1
+sudo dnf -y install edb-as14-advanced-storage-pack
 ```
 
-To install Advanced Storage Pack 1.0.0 for EDB Postgres Advanced Server 14 on a Debian 11 platform:
+To install Advanced Storage Pack for PostgreSQL 14 on a Debian platform:
 
 ```shell
-sudo apt-get -y install edb-pg14-advanced-storage-pack-1
+sudo apt-get -y install edb-pg14-advanced-storage-pack
 ```


### PR DESCRIPTION
- ASP packages are only available in version 12 onwards. Version 11 was never a possibility for ASP.
- EL 9 is now released, so added to the distro list
- Ubuntu is the only Debian derivative that we support, so mention it instead of letting customers think any other derivative is included
- The 1 and -1 were dropped from the package names a while back, and the packages have been released without them, with appropriate upgrade paths
- Newer versions than 1.0.0 have been out as well, so the installation instructions are not helping anyone by mentioning that past version explicitly
- Also fixing the last example that intends to install for EPAS, but shows the instruction for PostgreSQL