### PR TITLE
BDR-3735 - Add release notes for HARP 2.3.0

### DIFF
--- a/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.3.0_rel_notes.mdx
@@ -1,0 +1,12 @@
+---
+title: "Version 2.3.0"
+---
+
+This is a patch release of HARP 2 that includes enhancements and fixes for issues identified
+in previous versions.
+
+| Type | Description |
+| ---- |------------ |
+| Bug fix     | Fix the CAMO lag computation issue - (BDR-3341) |
+| Bug fix     | Add SSL support for DCS ETCD - (BDR-3582)       |
+| Enhancement | Add HTTPS support for HARP probes - (BDR-3548)  |

--- a/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/3.7/harp/01_release_notes/harp2.3.0_rel_notes.mdx
@@ -7,6 +7,6 @@ in previous versions.
 
 | Type | Description |
 | ---- |------------ |
-| Bug fix     | Fix the CAMO lag computation issue - (BDR-3341) |
-| Bug fix     | Add SSL support for DCS ETCD - (BDR-3582)       |
-| Enhancement | Add HTTPS support for HARP probes - (BDR-3548)  |
+| Bug fix     | Fix the CAMO lag computation issue - (BDR-3341).                    |
+| Bug fix     | Fix the Etcd TLS issue when only `ssl_ca_file` is set - (BDR-3582). |
+| Feature     | Add HTTP(S) health check probes for HARP.                           |

--- a/product_docs/docs/pgd/3.7/harp/01_release_notes/index.mdx
+++ b/product_docs/docs/pgd/3.7/harp/01_release_notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release Notes
 navigation:
+- harp2.3.0_rel_notes
 - harp2.2.3_rel_notes
 - harp2.2.2_rel_notes
 - harp2.2.1_rel_notes
@@ -23,6 +24,7 @@ The release notes in this section provide information on what was new in each re
 
 | Version                  | Release Date |
 | -----------------------  | ------------ |
+| [2.3.0](harp2.3.0_rel_notes)  | 2023 Jul 12  |
 | [2.2.3](harp2.2.3_rel_notes)  | 2023 May 16  |
 | [2.2.2](harp2.2.2_rel_notes)  | 2023 Mar 30  |
 | [2.2.1](harp2.2.1_rel_notes)  | 2022 Nov 16  |

--- a/product_docs/docs/pgd/4/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/index.mdx
@@ -32,6 +32,7 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 
 | Release Date | EDB Postgres Distributed     | BDR   | HARP  |  CLI  | TPAexec                                                                          |
 | ------------ | ---------------------------- | ----- | ----- | ----- | -------------------------------------------------------------------------------- |
+| 2023 May 17  | [4.3.1](pgd_4.3.1_rel_notes) | 4.3.1 | 2.3.0[^*] | 1.1.1 | [23.17](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2023 May 17  | [4.3.1](pgd_4.3.1_rel_notes) | 4.3.1 | 2.2.3 | 1.1.1 | [23.17](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2023 Feb 14  | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.2[^*] | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
 | 2023 Feb 14  | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
@@ -46,4 +47,5 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 | 2021 Dec 01  | [4.0.0](pgd_4.0.0_rel_notes) | 4.0.0 | 2.0.0 | -     | [22.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/2106/)  |
 
 
+[^*] We released a patch to HARP 2.2.3 with few bug fixes and enhancement. If using 2.2.3 or below with an earlier version of EDB Postgres Distributed, we recommend that you upgrade to 2.3.0.
 [^*] We released a patch to HARP 2.2.1 to address a security vulnerability. If using 2.2.1 with an earlier version of EDB Postgres Distributed, we recommend that you upgrade to 2.2.2.

--- a/product_docs/docs/pgd/4/rel_notes/pgd_4.3.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/pgd_4.3.1_rel_notes.mdx
@@ -24,5 +24,8 @@ EDB Postgres Distributed version 4.3.1 is a minor release of EDB Postgres Distri
 | BDR       | 4.3.1   | Bug fix         | Reload configuration for the pglogical receiver. Reload and apply the configuration changes when the server receives reload signal. |
 | BDR       | 4.3.1   | Enhancement     | Avoid restarting sync workers. This enhancement is to prevent the node join from failing when config changes are made that signal the restart of subscription workers. |
 | CLI       | 1.1.1   | Change          | Upgraded third-party dependencies to fix Github dependabot alerts. |
+| HARP      | 2.3.0   | Bug fix         | Fix the CAMO lag computation issue - (BDR-3341) |
+| HARP      | 2.3.0   | Bug fix         | Add SSL support for DCS ETCD - (BDR-3582)       |
+| HARP      | 2.3.0   | Enhancement     | Add HTTPS support for HARP probes - (BDR-3548)  |
 | HARP      | 2.2.3   | Bug fix         | Updated consensus check to use `bdr.get_raft_status` instead of `bdr.monitor_group_raft`. |
 | Utilities | 1.1.0   | Bug fix         | Fixed handle uninitialized physical replication slots issue.  |

--- a/product_docs/docs/pgd/4/rel_notes/pgd_4.3.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/pgd_4.3.1_rel_notes.mdx
@@ -24,8 +24,8 @@ EDB Postgres Distributed version 4.3.1 is a minor release of EDB Postgres Distri
 | BDR       | 4.3.1   | Bug fix         | Reload configuration for the pglogical receiver. Reload and apply the configuration changes when the server receives reload signal. |
 | BDR       | 4.3.1   | Enhancement     | Avoid restarting sync workers. This enhancement is to prevent the node join from failing when config changes are made that signal the restart of subscription workers. |
 | CLI       | 1.1.1   | Change          | Upgraded third-party dependencies to fix Github dependabot alerts. |
-| HARP      | 2.3.0   | Bug fix         | Fix the CAMO lag computation issue - (BDR-3341) |
-| HARP      | 2.3.0   | Bug fix         | Add SSL support for DCS ETCD - (BDR-3582)       |
-| HARP      | 2.3.0   | Enhancement     | Add HTTPS support for HARP probes - (BDR-3548)  |
+| HARP      | 2.3.0   | Bug fix         | Fix the CAMO lag computation issue - (BDR-3341). |
+| HARP      | 2.3.0   | Bug fix         | Fix the Etcd TLS issue when only `ssl_ca_file` is set - (BDR-3582). |
+| HARP      | 2.3.0   | Feature         | Add HTTP(S) health check probes for HARP. |
 | HARP      | 2.2.3   | Bug fix         | Updated consensus check to use `bdr.get_raft_status` instead of `bdr.monitor_group_raft`. |
 | Utilities | 1.1.0   | Bug fix         | Fixed handle uninitialized physical replication slots issue.  |


### PR DESCRIPTION
Add release notes for HARP 2.3.0.
The notes have been added for BDR 3.7 as well as BDR 4.x.

More details about the fixes in this release are mentioned in [BDR-3735](https://enterprisedb.atlassian.net/browse/BDR-3735)

Please do not merge this before the actual release.

[BDR-3735]: https://enterprisedb.atlassian.net/browse/BDR-3735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ