### PR TITLE
Add release notes for TPA 23.19

### DIFF
--- a/product_docs/docs/tpa/23/rel_notes/index.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/index.mdx
@@ -2,6 +2,7 @@
 title: Trusted Postgres Architect release notes
 navTitle: "Release notes"
 navigation:
+ - tpa_23.19_rel_notes
  - tpa_23.18_rel_notes
  - tpa_23.17_rel_notes
  - tpa_23.16_rel_notes
@@ -15,6 +16,7 @@ The Trusted Postgres Architect documentation describes the latest version of Tru
 
 |           Version            | Release date |
 | ---------------------------- | ------------ |
+| [23.12](tpa_23.19_rel_notes) | 12 Jul 2023  |
 | [23.18](tpa_23.18_rel_notes) | 23 May 2023  |
 | [23.17](tpa_23.17_rel_notes) | 10 May 2023  |
 | [23.16](tpa_23.16_rel_notes) | 21 Mar 2023  |

--- a/product_docs/docs/tpa/23/rel_notes/tpa_23.17_rel_notes.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/tpa_23.17_rel_notes.mdx
@@ -4,7 +4,7 @@ navTitle: "Version 23.17"
 ---
 
 
-New features, enhancements, bug fixes, and other changes in Trusted Postgres Architect 23.16 include the following:
+New features, enhancements, bug fixes, and other changes in Trusted Postgres Architect 23.17 include the following:
 
 | Type | Description |
 | ---- |------------ |

--- a/product_docs/docs/tpa/23/rel_notes/tpa_23.18_rel_notes.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/tpa_23.18_rel_notes.mdx
@@ -4,7 +4,7 @@ navTitle: "Version 23.18"
 ---
 
 
-New features, enhancements, bug fixes, and other changes in Trusted Postgres Architect 23.16 include the following:
+New features, enhancements, bug fixes, and other changes in Trusted Postgres Architect 23.18 include the following:
 
 | Type | Description |
 | ---- |------------ |

--- a/product_docs/docs/tpa/23/rel_notes/tpa_23.19_rel_notes.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/tpa_23.19_rel_notes.mdx
@@ -1,0 +1,24 @@
+---
+title: Trusted Postgres Architect 23.19 release notes 
+navTitle: "Version 23.19"
+---
+
+
+New features, enhancements, bug fixes, and other changes in Trusted Postgres Architect 23.19 include the following:
+
+| Type | Description |
+| ---- |------------ |
+| Enhancement | TPA now allows the creation of physical replicas of subscriber-only PGD nodes. |
+| Enhancement | TPA now supports the configuration of HTTP(S) HARP and PGD Proxy health probes. |
+| Enhancement | TPA now allows you to select Patroni as a failover manager with the M1 architecture. This support is experimental and not yet recommended for use in production. |
+| Enhancement | TPA now allows you to set specific versions for edb-pgd-proxy and edb-bdr-utilities rather than always using the latest version. |
+| Change | On Debian-like systems, the package selection code now uses -dbg rather than -dbgsym for certain packages where applicable. |
+| Change | When configuring replication slots, TPA will now ensure that only valid characters are used in the primary_slot_name. Previously TPA would use the inventory_hostname as a default, which could contain hyphens; these are now replaced with underscores|
+| Change | The default Failover Manager version is now 4.7. |
+| Bug fix | Fixed an issue whereby PGD 3.7 to 4 upgrades would fail in TPA 23.18. |
+| Bug fix | Fixed an issue whereby TPA would include underscores in TLS certificate Common Names when deploying PEM. This is invalid and would result in failure on some platforms. |
+| Bug fix | Fixed an issue whereby an incorrect etcd service name would be used on Debian-like platforms, preventing TPA from starting etcd. |
+| Bug fix | Fixed an issue whereby TPA could not instal etcd packages on RHEL 8. |
+| Bug fix | Fixed an issue whereby the message `Failed to commit files to git: b''` would be displayed during configure. |
+| Bug fix | Fixed an issue whereby TPA would erroneously generate and overwrite Postgres user passwords when `generate_password: false`. |
+| Bug fix | Fixed an issue whereby volume map creation on AWS failed to take account of region resulting in failures when using regions other than eu-west-1. |

--- a/product_docs/docs/tpa/23/rel_notes/tpa_23.19_rel_notes.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/tpa_23.19_rel_notes.mdx
@@ -13,12 +13,12 @@ New features, enhancements, bug fixes, and other changes in Trusted Postgres Arc
 | New feature | TPA now allows you to select Patroni as a failover manager with the M1 architecture. This support is experimental and not yet recommended for use in production. |
 | Enhancement | TPA now allows you to set specific versions for edb-pgd-proxy and edb-bdr-utilities rather than always using the latest version. |
 | Change | On Debian-like systems, the package selection code now uses -dbg rather than -dbgsym for certain packages where applicable. |
-| Change | When configuring replication slots, TPA will now ensure that only valid characters are used in the primary_slot_name. Previously TPA would use the inventory_hostname as a default, which could contain hyphens; these are now replaced with underscores|
+| Change | When configuring replication slots, TPA will now ensure that only valid characters are used in the primary_slot_name. Previously TPA would use the inventory_hostname as a default, which could contain hyphens; these are now replaced with underscores. |
 | Change | The default Failover Manager version is now 4.7. |
 | Bug fix | Fixed an issue whereby PGD 3.7 to 4 upgrades would fail in TPA 23.18. |
 | Bug fix | Fixed an issue whereby TPA would include underscores in TLS certificate Common Names when deploying PEM. This is invalid and would result in failure on some platforms. |
 | Bug fix | Fixed an issue whereby an incorrect etcd service name would be used on Debian-like platforms, preventing TPA from starting etcd. |
-| Bug fix | Fixed an issue whereby TPA could not instal etcd packages on RHEL 8. |
+| Bug fix | Fixed an issue whereby TPA could not install etcd packages on RHEL 8. |
 | Bug fix | Fixed an issue whereby the message `Failed to commit files to git: b''` would be displayed during configure. |
 | Bug fix | Fixed an issue whereby TPA would erroneously generate and overwrite Postgres user passwords when `generate_password: false`. |
 | Bug fix | Fixed an issue whereby volume map creation on AWS failed to take account of region resulting in failures when using regions other than eu-west-1. |

--- a/product_docs/docs/tpa/23/rel_notes/tpa_23.19_rel_notes.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/tpa_23.19_rel_notes.mdx
@@ -8,9 +8,9 @@ New features, enhancements, bug fixes, and other changes in Trusted Postgres Arc
 
 | Type | Description |
 | ---- |------------ |
-| Enhancement | TPA now allows the creation of physical replicas of subscriber-only PGD nodes. |
-| Enhancement | TPA now supports the configuration of HTTP(S) HARP and PGD Proxy health probes. |
-| Enhancement | TPA now allows you to select Patroni as a failover manager with the M1 architecture. This support is experimental and not yet recommended for use in production. |
+| New feature | TPA now allows the creation of physical replicas of subscriber-only PGD nodes. |
+| New feature | TPA now supports the configuration of HTTP(S) HARP and PGD Proxy health probes. |
+| New feature | TPA now allows you to select Patroni as a failover manager with the M1 architecture. This support is experimental and not yet recommended for use in production. |
 | Enhancement | TPA now allows you to set specific versions for edb-pgd-proxy and edb-bdr-utilities rather than always using the latest version. |
 | Change | On Debian-like systems, the package selection code now uses -dbg rather than -dbgsym for certain packages where applicable. |
 | Change | When configuring replication slots, TPA will now ensure that only valid characters are used in the primary_slot_name. Previously TPA would use the inventory_hostname as a default, which could contain hyphens; these are now replaced with underscores|


### PR DESCRIPTION
Add release notes for TPA 23.19
Correct version numbers in previous RNs

A summarized version of detailed 23.19 release notes for the EnterpriseDB docs site.
