### PR TITLE
Internalised links - fixed old TPA version numbers

### DIFF
--- a/product_docs/docs/pgd/4/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/index.mdx
@@ -38,16 +38,16 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 | ------------ | ---------------------------- | ----- | ----- | ----- | -------------------------------------------------------------------------------- |
 | 2023 July 12  | [4.3.1-1 ](pgd_4.3.1-1_rel_notes)| 4.3.1 | 2.3.0 | 1.1.1 | [23.19](/tpa/latest/rel_notes/tpa_23.19_rel_notes)   |
 | 2023 May 17  | [4.3.1](pgd_4.3.1_rel_notes) | 4.3.1 | 2.2.3 | 1.1.1 | [23.17](/tpa/latest/rel_notes/tpa_23.17_rel_notes)   |
-| 2023 Mar 30  | [4.3.0-1](pgd_4.3.0-1_rel_notes) | 4.3.0 | 2.2.2 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
-| 2023 Feb 14  | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
-| 2022 Dec 14  | [4.2.2](pgd_4.2.2_rel_notes) | 4.2.2 | 2.2.1 | 1.1.0 | [23.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/239/)   |
-| 2022 Nov 16  | [4.2.1](pgd_4.2.1_rel_notes) | 4.2.1 | 2.2.1 | 1.1.0 | [23.7](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/237/)   |
-| 2022 Aug 22  | [4.2.0](pgd_4.2.0_rel_notes) | 4.2.0 | 2.2.0 | 1.1.0 | [23.5](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/235/)   |
-| 2022 June 21 | [4.1.1](pgd_4.1.1_rel_notes) | 4.1.1 | 2.1.1 | 1.0.0 | [23.2](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/232/)   |
-| 2022 May 17  | [4.1.0](pgd_4.1.0_rel_notes) | 4.1.0 | 2.1.0 | 1.0.0 | [23.1](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/231/)   |
-| 2022 Mar 31  | [4.0.3](pgd_4.0.3_rel_notes) | -     | 2.0.3 | -     | [22.10](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/2210/) |
-| 2022 Feb 24  | [4.0.2](pgd_4.0.2_rel_notes) | 4.0.2 | 2.0.2 | -     | [22.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/229/)   |
-| 2022 Jan 31  | [4.0.1](pgd_4.0.1_rel_notes) | 4.0.1 | 2.0.1 | -     | [22.6](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/2206/)  |
-| 2021 Dec 01  | [4.0.0](pgd_4.0.0_rel_notes) | 4.0.0 | 2.0.0 | -     | [22.9](https://techsupport.enterprisedb.com/customer_portal/sw/tpa/trunk/2106/)  |
+| 2023 Mar 30  | [4.3.0-1](pgd_4.3.0-1_rel_notes) | 4.3.0 | 2.2.2 | 1.1.0 | [23.9](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-239)   |
+| 2023 Feb 14  | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.1 | 1.1.0 | [23.9](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-239)   |
+| 2022 Dec 14  | [4.2.2](pgd_4.2.2_rel_notes) | 4.2.2 | 2.2.1 | 1.1.0 | [23.9](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-239)   |
+| 2022 Nov 16  | [4.2.1](pgd_4.2.1_rel_notes) | 4.2.1 | 2.2.1 | 1.1.0 | [23.7](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-237)   |
+| 2022 Aug 22  | [4.2.0](pgd_4.2.0_rel_notes) | 4.2.0 | 2.2.0 | 1.1.0 | [23.5](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-235)   |
+| 2022 June 21 | [4.1.1](pgd_4.1.1_rel_notes) | 4.1.1 | 2.1.1 | 1.0.0 | [23.2](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-232)   |
+| 2022 May 17  | [4.1.0](pgd_4.1.0_rel_notes) | 4.1.0 | 2.1.0 | 1.0.0 | [23.1](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-231)   |
+| 2022 Mar 31  | [4.0.3](pgd_4.0.3_rel_notes) | -     | 2.0.3 | -     | 22.10 |
+| 2022 Feb 24  | [4.0.2](pgd_4.0.2_rel_notes) | 4.0.2 | 2.0.2 | -     | 22.9   |
+| 2022 Jan 31  | [4.0.1](pgd_4.0.1_rel_notes) | 4.0.1 | 2.0.1 | -     | 22.6  |
+| 2021 Dec 01  | [4.0.0](pgd_4.0.0_rel_notes) | 4.0.0 | 2.0.0 | -     | 21.9  |
 
 


### PR DESCRIPTION
## What Changed?

Tidied up the links and did some archeology to identify what the correct version numbers were at the bottom end of the list.

Removed the links on the 22.x series for now.