### PR TITLE
BigAnimal: update CLI commands for connecting to AWS

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
@@ -23,13 +23,13 @@ To connect your cloud:
 1.  Create a BigAnimal CLI credential:
 
    ```shell
-   biganimal create-credential --name <cred> --address portal.biganimal.com --port 443
+   biganimal credential create --name <cred> 
    ```
 
 1. To set up your cloud provider, run the `setup-csp` command:
 
    ```shell
-   biganimal setup-csp 
+    biganimal cloud-provider setup  
    ```
    The command checks for cloud account readiness and displays the results. 
 
@@ -44,6 +44,6 @@ To connect your cloud:
 1.  Connect your cloud account to BigAnimal:
 
    ```shell
-   biganimal connect-csp --provider aws --project <project-name>
+   biganimal cloud-provider connect --provider aws --project <project-name>
    ```
  After your cloud account is successfully connected to BigAnimal, you and other users with the correct permissions can create clusters.


### PR DESCRIPTION
## What Changed?

Missed updating the CLI commands in the Connecting to your AWS Cloud.

Kyle pointed out the miss in Slack: https://edb.slack.com/archives/CU5QEU5L7/p1689358429868599