### PR TITLE
Update index.mdx

### DIFF
--- a/product_docs/docs/tde/15/index.mdx
+++ b/product_docs/docs/tde/15/index.mdx
@@ -19,7 +19,7 @@ navigation:
 ---
 
 
-Transparent data encryption (TDE) is an optional feature supported by version 15 of EDB Postgres Advanced Server and EDB Postgres Extended Server with high availability. 
+Transparent data encryption (TDE) is an optional feature supported by version 15 of EDB Postgres Advanced Server and EDB Postgres Extended Server. 
 
 It encrypts any user data stored in the database system. This encryption is transparent to the user. User data includes the actual data stored in tables and other objects as well as system catalog data such as the names of objects.
 


### PR DESCRIPTION
Customers don't need to use the HA features of EDB Postgres Extended Server to get TDE. In fact, we decided to put Extended in Standard so customers didn't need to unnecessarily pay for an Extreme HA Add-On just to get TDE. Let's remove the 'with high availability' mention.

## What Changed?
Removed 'with high availability'. 

Before: Transparent data encryption (TDE) is an optional feature supported by version 15 of EDB Postgres Advanced Server and EDB Postgres Extended Server with high availability. 

After: 
 Before: Transparent data encryption (TDE) is an optional feature supported by version 15 of EDB Postgres Advanced Server and EDB Postgres Extended Server. 
