### PR TITLE
fix definition of max digits of a snowflake id

### DIFF
--- a/product_docs/docs/pgd/4/bdr/sequences.mdx
+++ b/product_docs/docs/pgd/4/bdr/sequences.mdx
@@ -47,7 +47,7 @@ useful property of recording the timestamp at which the values were
 created.
 
 SnowflakeId sequences have the restriction that they work only for 64-bit BIGINT
-datatypes and produce values 19 digits long, which might be too long for
+datatypes and produce values up to 19 digits long, which might be too long for
 use in some host language datatypes such as Javascript Integer types.
 Globally allocated sequences allocate a local range of values that can
 be replenished as needed by inter-node consensus, making them suitable for
@@ -111,7 +111,7 @@ into the table. Putting the timestamp first ensures this.
 A few limitations and caveats apply to SnowflakeId sequences.
 
 SnowflakeId sequences are 64 bits wide and need a `bigint` or `bigserial`.
-Values generated are at least 19 digits long.
+Values generated are up to 19 digits long.
 There's no practical 32-bit `integer` version, so you can't use it with `serial`
 sequences. Use globally allocated range sequences instead.
 

--- a/product_docs/docs/pgd/5/sequences.mdx
+++ b/product_docs/docs/pgd/5/sequences.mdx
@@ -48,7 +48,7 @@ useful property of recording the timestamp when the values were
 created.
 
 SnowflakeId sequences have the restriction that they work only for 64-bit BIGINT
-datatypes and produce values 19 digits long, which might be too long for
+datatypes and produce values up to 19 digits long, which might be too long for
 use in some host language datatypes, such as Javascript Integer types.
 Globally allocated sequences allocate a local range of values that can
 be replenished as needed by inter-node consensus, making them suitable for
@@ -112,7 +112,7 @@ into the table. Putting the timestamp first ensures this.
 A few limitations and caveats apply to SnowflakeId sequences.
 
 SnowflakeId sequences are 64 bits wide and need a `bigint` or `bigserial`.
-Values generated are at least 19 digits long.
+Values generated are up to 19 digits long.
 There's no practical 32-bit `integer` version, so you can't use it with `serial`
 sequences. Use globally allocated range sequences instead.
 


### PR DESCRIPTION
## What Changed?

Just some definitions from absolute 19 digits to up to 19 digits.