### PR TITLE
Update preparing_the_pem_database_server.mdx

### DIFF
--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/preparing_the_pem_database_server.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/preparing_the_pem_database_server.mdx
@@ -19,7 +19,7 @@ You must configure the PEM database server to work with PgBouncer. This example 
 2.  Create a user named pem_admin1 (not a superuser) with `pem_admin` and `pem_agent_pool role` membership on the PEM database server:
 
     ```ini
-    pem=# CREATE USER pem_admin1 PASSWORD 'ANY_PASSWORD' LOGIN
+    pem=# CREATE USER pem_admin1 PASSWORD 'ANY_PASSWORD' LOGIN CREATEROLE;
     CREATEROLE;
     CREATE ROLE
     pem=# GRANT pem_admin, pem_agent_pool TO pem_admin1;

--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/preparing_the_pem_database_server.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/preparing_the_pem_database_server.mdx
@@ -20,7 +20,6 @@ You must configure the PEM database server to work with PgBouncer. This example 
 
     ```ini
     pem=# CREATE USER pem_admin1 PASSWORD 'ANY_PASSWORD' LOGIN CREATEROLE;
-    CREATEROLE;
     CREATE ROLE
     pem=# GRANT pem_admin, pem_agent_pool TO pem_admin1;
     GRANT ROLE


### PR DESCRIPTION
pem_admin1 needs create role permission:

```
[root@pemssl edb]# PEM_SERVER_PASSWORD=pass /usr/edb/pem/agent/bin/pemworker --register-agent --pem-server 192.168.102.14 --pem-port 6432 --pem-user pem_admin1 --pem-agent-user pem_agent_user1 --display-name pem_server_pgbouncer
Sun Jul 23 21:50:24 2023 ERROR: ERROR:  permission denied to create role
CONTEXT:  SQL statement "CREATE ROLE agent5 WITH LOGIN"
PL/pgSQL function pem.create_agent(character varying,integer,boolean) line 48 at EXECUTE
```

## What Changed?

