### PR TITLE
Replication Server: super user permissions not required 

### DIFF
--- a/product_docs/docs/eprs/7/05_smr_operation/01_prerequisites/05_preparing_sub_database.mdx
+++ b/product_docs/docs/eprs/7/05_smr_operation/01_prerequisites/05_preparing_sub_database.mdx
@@ -20,11 +20,6 @@ Choose or create a database passworded user name to serve as the subscription da
 
 When creating the subscription database definition, enter the subscription database user name in the Subscription Service – Add Database dialog box (see [Adding a subscription database](../03_creating_subscription/02_adding_subscription_database/#adding_subscription_database)).
 
-The subscription database user must also be able to run the `TRUNCATE` command on the subscription tables. This requires the following:
-
--   Superuser privileges.
--   The ability to modify the system catalog tables to disable foreign key constraints on subscription tables. See [Disabling foreign key constraints for snapshot replications](../../10_appendix/03_miscellaneous_xdb_processing_topics/04_disable_foreign_key_constraints_for_snapshot_replication/#disable_foreign_key_constraints_for_snapshot_replication) for more information on this requirement.
-
 When choosing the subscription database user name, you can either:
 
 -   For the subscription database user name, use the Postgres user name postgres created when you installed PostgreSQL (enterprisedb for EDB Postgres Advanced Server installed in Oracle-compatible configuration mode). If you choose this option, skip Step 1 and proceed to Step 2.


### PR DESCRIPTION

## What Changed?

super user permissions not required for a Subscription database user

https://enterprisedb.atlassian.net/browse/XDB-1753

Fixes https://github.com/EnterpriseDB/docs/issues/2702
