### PR TITLE
Update README.md - fix develop instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ These instructions are for members of the EnterpriseDB Github Org only. The icon
 
 1. In order to ensure environmental variables are properly set, [install direnv](https://direnv.net/#getting-started) and run `direnv allow .`
 
-1. Configure npm by running `npm setup`
-
-1. Install all required packages by running `npm install`
+1. Configure npm by running `npm run setup`. This will copy your NPM_TOKEN into .npmrc and then install all required files.
 
 1. And finally, you can start up the site locally with `npm run develop`, which should make it live at `http://localhost:8000/`. Huzzah!
 


### PR DESCRIPTION
Found I had been skipping a step because the instructions gave a non-existent command. Looked into it and found you can lose a step because the setup script also installs all the packages. This update reflects that.

## What Changed?

