### PR TITLE
Added link in OTEL to SQL info

### DIFF
--- a/product_docs/docs/pgd/5/monitoring/otel.mdx
+++ b/product_docs/docs/pgd/5/monitoring/otel.mdx
@@ -47,6 +47,8 @@ Different kinds of metrics are collected as shown in the tables that follow.
 
 ### Consensus metric
 
+See also [Monitoring Raft Consensus](sql/#monitoring-raft-consensus)
+
 | Metric name | Type | Labels | Description
 | ----------- | ---- | ------ | -----------
 | bdr_raft_state | gauge | state_str - RAFT_FOLLOWER, RAFT_CANDIDATE, RAFT_LEADER, RAFT_STOPPED | Raft state of the consensus on this node


### PR DESCRIPTION
## What Changed?

Added link in OTEL for Consensus metrics directing reader to SQL monitoring info on same metrics.

At suggestion of @irionr 