### PR TITLE
OCL - Release notes title fix as per EC-2808

### DIFF
--- a/product_docs/docs/ocl_connector/15/ocl_rel_notes/index.mdx
+++ b/product_docs/docs/ocl_connector/15/ocl_rel_notes/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "EDB ODBC Connector release notes"
+title: "EDB OCL Connector release notes"
 navTitle: Release Notes
 navigation: 
  - 15.2.0.3_ocl_release_notes


### PR DESCRIPTION
## What Changed?
Fixed the title of OCL Release notes as per [EC-2808](https://enterprisedb.atlassian.net/browse/EC-2808)





[EC-2808]: https://enterprisedb.atlassian.net/browse/EC-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ