### PR TITLE
Add note about need for pg-force-version to pgbackrest instructions

### DIFF
--- a/advocacy_docs/supported-open-source/pgbackrest/03-quick_start.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/03-quick_start.mdx
@@ -31,6 +31,7 @@ repo1-path=/var/lib/edb/as13/backups
 pg1-path=/var/lib/edb/as13/data
 pg1-user=enterprisedb
 pg1-port=5444
+pg-version-force=15
 ```
 
 For **PostgreSQL**:

--- a/advocacy_docs/supported-open-source/pgbackrest/03-quick_start.mdx
+++ b/advocacy_docs/supported-open-source/pgbackrest/03-quick_start.mdx
@@ -25,23 +25,25 @@ For **EDB Postgres Advanced Server**:
 
 ```ini
 [global]
-repo1-path=/var/lib/edb/as13/backups
+repo1-path=/var/lib/edb/as15/backups
 
 [demo]
-pg1-path=/var/lib/edb/as13/data
+pg1-path=/var/lib/edb/as15/data
 pg1-user=enterprisedb
 pg1-port=5444
 pg-version-force=15
 ```
 
+The `pg-version-force` value should be set to the same major version number as the server reports when using `show server_version_num;` in PSQL. Only the first two digits are the major version. For example, 15000 is major version 15.
+
 For **PostgreSQL**:
 
 ```ini
 [global]
-repo1-path=/var/lib/pgsql/13/backups
+repo1-path=/var/lib/pgsql/15/backups
 
 [demo]
-pg1-path=/var/lib/pgsql/13/data
+pg1-path=/var/lib/pgsql/15/data
 pg1-user=postgres
 pg1-port=5432
 ```


### PR DESCRIPTION
Currently the EPAS newest major release is v15, hence pg-version-force option should be added to pgbackuprest.conf to solve below issue.

https://github.com/pgbackrest/pgbackrest/issues/2032

## What Changed?
pgbackrest.conf sample(EPAS part) changed from:
-------------------------------------------------------
[global]
repo1-path=/var/lib/edb/as13/backups

[demo]
pg1-path=/var/lib/edb/as13/data
pg1-user=enterprisedb
pg1-port=5444
-------------------------------------------------------
to:
-------------------------------------------------------
[global]
repo1-path=/var/lib/edb/as13/backups

[demo]
pg1-path=/var/lib/edb/as13/data
pg1-user=enterprisedb
pg1-port=5444
pg-version-force=15
-------------------------------------------------------


