### PR TITLE
docs(UPM-23204): Remove bdr_raft_mon metrics

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
@@ -11,7 +11,7 @@ Some data from Postgres monitoring system views, tables, and functions is transf
 The number of tables in your database affects the number of metrics in your cloud logging platform, thus
 affecting your cloud provider costs for storing these metrics. To ensure stability of the metrics pipeline, metrics might be dropped when the number of tables in your database exceeds 2500.
 
-Prometheus [labels](https://prometheus.io/docs/practices/naming/#labels) are included in the `$.Message.labels` JSON object. Dimensions vary depending on the individual metric and are documented separately for each group of related metrics.
+For metrics streamed to a customer-accessible endpoint, Prometheus [labels](https://prometheus.io/docs/practices/naming/#labels) are included in the `$.Message.labels` JSON object. Dimensions vary depending on the individual metric and are documented separately for each group of related metrics.
 
 The available set of metrics is subject to change. Metrics might be added, removed, or renamed. Where possible, we change the metric name when changing the meaning or type of existing metrics.
 
@@ -412,14 +412,6 @@ instances' replication replay positions in monitoring.
 |----------|-------|-------------|
 | `cnp_xlog_insert_lsn` | GAUGE | Node xlog insert position (lsn) |
 
-## `cnp_bdr_raft_mon`
-
-Expose the raft status per CNP node of a BDR cluster
-
-| Metric   | Usage | Description |
-|----------|-------|-------------|
-| `cnp_bdr_raft_mon_raftstatus` | GAUGE | Raft health status; 0 for unhealthy, 1 for healthy |
-
 ## `cnp_bdr_rep_slot_stats`
 
 Metrics from pg_catalog.pg_stat_replication_slots for each BDR replication slot.
@@ -516,21 +508,28 @@ The metrics in this group can have these labels:
 |-------|-------------|
 | `lock_type` | lock\_type |
 
+
+## Disabled: `cnp_bdr_raft_mon`
+
+This metric has been disabled for performance and reliability reasons. It will no longer be generated after 2023-08-16. It was used to report on the health of the Raft distributed consensus layer on PGD nodes. Please see the EDB Postgres Distributed monitoring documentation for other methods to monitor Raft health on PGD clusters.
+
+| Metric   | Usage | Description |
+|----------|-------|-------------|
+| ~~`cnp_bdr_raft_mon_raftstatus`~~ | GAUGE | Raft health status; 0 for unhealthy, 1 for healthy |
+
+
 [comment2]: # "End generated content"
 
 
 ## Other metrics streams
 
 In addition to Postgres metrics from the Cloud Native PostgreSQL operator that
-manages databases in BigAnimal, you can stream metrics about Kubernetes cluster
-state and other details to your cloud platform. Any such metrics
-are generally well-known metrics from widely used tools, documented by the
-upstream vendor of the component.
-
-Refer to the documentation of the tool or project that defines the
-metrics for details on individual metrics.
+manages databases in BigAnimal, additional metrics on Kubernetes workload health
+etc are available from the BigAnimal metrics endpoints. Specific metrics exposed
+may vary depending on Kubernetes version, BigAnimal deployment model and more.
+Any such metrics are generally well-known metrics from widely used tools,
+documented by the upstream vendor of the component. The BigAnimal platform makes
+no guarantees about the availability or stability of these metrics unless explicitly
+documented otherwise.
 
 See also [Kubernetes cluster metrics](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/).
-
-The cloud platform can supply additional streams of metrics
-directly to your metrics, analytics, and dashboarding endpoint.

--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx
@@ -11,7 +11,7 @@ Some data from Postgres monitoring system views, tables, and functions is transf
 The number of tables in your database affects the number of metrics in your cloud logging platform, thus
 affecting your cloud provider costs for storing these metrics. To ensure stability of the metrics pipeline, metrics might be dropped when the number of tables in your database exceeds 2500.
 
-For metrics streamed to a customer-accessible endpoint, Prometheus [labels](https://prometheus.io/docs/practices/naming/#labels) are included in the `$.Message.labels` JSON object. Dimensions vary depending on the individual metric and are documented separately for each group of related metrics.
+Prometheus [labels](https://prometheus.io/docs/practices/naming/#labels) are included in the exposed metrics. These will be in the `$.Message.labels` JSON object when consuming a metrics stream, or in a cloud-provider-specific format for metrics ingested into cloud provider monitoring platforms. Dimensions vary depending on the individual metric and are documented separately for each group of related metrics.
 
 The available set of metrics is subject to change. Metrics might be added, removed, or renamed. Where possible, we change the metric name when changing the meaning or type of existing metrics.
 


### PR DESCRIPTION
## What Changed?

The `bdr_raft_mon` metric is being retired for performance and stability reasons. Update the documentation accordingly.

Includes a few other minor docs fixes for metrics docs.