### PR TITLE
Switched to ticks and unified ordering as most current upgrade first

### DIFF
--- a/product_docs/docs/pgd/3.7/bdr/upgrades/supported_paths.mdx
+++ b/product_docs/docs/pgd/3.7/bdr/upgrades/supported_paths.mdx
@@ -1,13 +1,13 @@
 ---
 title: Supported BDR upgrade paths
 ---
-### Upgrading from version 3.6 to version 3.7
-
-We recommend you upgrade your cluster to the latest version of 3.6 before upgrading your cluster to 3.7.  You will then be able to upgrade to a version of 3.7 released on the same date or later. 
-
 
 ### Upgrading within version 3.7
 
-BDR 3.7 does not follow semantic versioning. Instead, it uses 2 position majors similar to PostgreSQL releases prior to version 10 (e.g. 9.6).  BDR 3.7 also considered releases prior to 3.7.9 as beta releases and they could include breaking changes.  BDR 3.7.9 was declared a Long Term Sppoort version under the previous versioning nomenclature.  All releses 3.7.9 and later maintain backward compatibility allowing upgrades to later versions.
+BDR 3.7 does not follow semantic versioning. Instead, it uses 2 position majors similar to PostgreSQL releases prior to version 10 (e.g. 9.6).  BDR 3.7 also considered releases prior to 3.7.9 as beta releases and they could include breaking changes. BDR 3.7.9 was declared a Long Term Support version under the previous versioning nomenclature. All releases 3.7.9 and later maintain backward compatibility allowing upgrades to later versions.
 
+
+### Upgrading from version 3.6 to version 3.7
+
+We recommend you upgrade your cluster to the latest version of 3.6 before upgrading your cluster to 3.7.  You will then be able to upgrade to a version of 3.7 released on the same date or later. 
 

--- a/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
@@ -2,9 +2,17 @@
 title: Supported BDR upgrade paths
 ---
 
-## Upgrading from version 3.6 to version 4
+## Upgrading within version 4
 
-Currently there are no direct upgrade paths from 3.6 to 4.  You must first upgrade your cluster to 3.7 before upgrading to 4.  See [Upgrading from 3.6](/pgd/3.7/bdr/upgrades/supported_paths/#upgrading-from-version-36) in the 3.7 documentation for more information.
+Beginning with version 4, EDB Postgres Distributed has adopted semantic versioning. All changes within the same major will be backward compatible lowering the risk when upgrading and allowing you to choose any later minor or patch release as the upgrade target. 
+
+| 4.0.0 | 4.0.1 | 4.0.2 | 4.1.0 | 4.1.1 | Target BDR version |
+|-------|-------|-------|--------|------|--------------------|
+| ✓     | ✓     | ✓     | ✓      | ✓    | 4.2.0              |
+| ✓     | ✓     | ✓     | ✓      |      | 4.1.1              |
+| ✓     | ✓     | ✓     |        |      | 4.1.0              |
+| ✓     | ✓     |       |        |      | 4.0.2              |
+| ✓     |       |       |        |      | 4.0.1              |
 
 ## Upgrading from version 3.7 to version 4
 
@@ -12,21 +20,15 @@ Currently it is recommended that you are using 3.7.15 or later before upgrading 
 
 | 3.7.15 | 3.7.16 | 3.7.17 | Target BDR version |
 |--------|--------|--------|--------------------|
-| X      | X      | X      | 4.2.0              |
-| X      | X      |        | 4.1.1              |
-| X      | X      |        | 4.1.0              |
-| X      |        |        | 4.0.2              |
+| ✓      | ✓      | ✓      | 4.2.0              |
+| ✓      | ✓      |        | 4.1.1              |
+| ✓      | ✓      |        | 4.1.0              |
+| ✓      |        |        | 4.0.2              |
 
-## Upgrading within version 4
+## Upgrading from version 3.6 to version 4
 
-Beginning with version 4, EDB Postgres Distributed has adopted semantic versioning. All changes within the same major will be backward compatible lowering the risk when upgrading and allowing you to choose any later minor or patch release as the upgrade target. 
+Currently there are no direct upgrade paths from 3.6 to 4.  You must first upgrade your cluster to 3.7 before upgrading to 4.  See [Upgrading from 3.6](/pgd/3.7/bdr/upgrades/supported_paths/#upgrading-from-version-36) in the 3.7 documentation for more information.
 
-| 4.0.0 | 4.0.1 | 4.0.2 | 4.1.0 | 4.1.1 | Target BDR version |
-|-------|-------|-------|--------|------|--------------------|
-| X     | X     | X     | X      | X    | 4.2.0              |
-| X     | X     | X     | X      |      | 4.1.1              |
-| X     | X     | X     |        |      | 4.1.0              |
-| X     | X     |       |        |      | 4.0.2              |
-| X     |       |       |        |      | 4.0.1              |
+
 
 

--- a/product_docs/docs/pgd/5/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/5/upgrades/upgrade_paths.mdx
@@ -7,9 +7,9 @@ title: Supported PGD upgrade paths
 
 | 5.0.0 | 5.0.1 | 5.1.0 | Target PGD version |
 |-------|-------|-------|--------------------|
-| X     | X     | X     | 5.2.0              |
-| X     | X     |       | 5.1.0              |
-| X     |       |       | 5.0.1              |
+| ✓     | ✓     | ✓     | 5.2.0              |
+| ✓     | ✓     |       | 5.1.0              |
+| ✓     |       |       | 5.0.1              |
 
 
 ## Upgrading from version 4 to version 5
@@ -18,10 +18,10 @@ Upgrades from PGD 4 to PGD 5 are supported from version 4.3.0. For older version
 
 | 4.3.0 | 4.3.0-1 | 4.3.1 | 4.3.1-1 | Target PGD version |
 |-------|---------|-------|---------|--------------------|
-| X     |  X      |   X   |    X    | 5.2.0              |
-| X     |  X      |   X   |         | 5.1.0              |
-| X     |  X      |       |         | 5.0.1              |
-| X     |         |       |         | 5.0.0              |
+| ✓     |  ✓      |   ✓   |    ✓    | 5.2.0              |
+| ✓     |  ✓      |   ✓   |         | 5.1.0              |
+| ✓     |  ✓      |       |         | 5.0.1              |
+| ✓     |         |       |         | 5.0.0              |
 
 
 


### PR DESCRIPTION
## What Changed?

Orders are all most current upgrades first (as in the life of any edition the most likely upgrade will be within that version - other older version upgrades will be likely consulted once and never again).

X changed to ✓ to indicate a positive upgrade path.

Typos fixed in old 3.7 docs.