### PR TITLE
dirty links change to make link to index work

### DIFF
--- a/product_docs/docs/pgd/5/routing/installing_proxy.mdx
+++ b/product_docs/docs/pgd/5/routing/installing_proxy.mdx
@@ -82,7 +82,7 @@ The API can be enabled by adding the config `cluster.proxy.http.enable: true`. W
 
 To enable HTTPS set the config parameter `cluster.proxy.http.secure: true`. If it is set to `true`, the `cert_file` and `key_file` must also be set.
 
-The `cluster.proxy.endpoint` is an endpoint used by the proxy to connect to the current write leader as part of its checks. When `cluster.proxy.http.enable` is `true`, `cluster.proxy.endpoint` must also be set. It could be same as BDR node [routing_dsn](index#configuration) where host will be `listen_address` and port will be `listen_port` [proxy options](index#configuration). If required, user can add additional connection string parameters in this endpoint, like `sslmode`, `sslrootcert`, `user`, etc.
+The `cluster.proxy.endpoint` is an endpoint used by the proxy to connect to the current write leader as part of its checks. When `cluster.proxy.http.enable` is `true`, `cluster.proxy.endpoint` must also be set. It could be same as BDR node [routing_dsn](../routing#configuration) where host will be `listen_address` and port will be `listen_port` [proxy options](../routing#configuration). If required, user can add additional connection string parameters in this endpoint, like `sslmode`, `sslrootcert`, `user`, etc.
 
 #### PGD Proxy user
 


### PR DESCRIPTION
## What Changed?

Links inside routing pointed at index, but a reference to [index#configuration] is misread and comes out as index/#configuration which fails to resolve. Only two links in the codebase like this, so changed here to [../routing#configuration] which does resolve to the index page.

May need to raise issue as bug or as wider discussion of why don't we have a more classical folder/files hierarchy. 

Should close #4596.
