### PR TITLE
Fixing conflicts docs to reflect actual update/delete behavior

### DIFF
--- a/product_docs/docs/pgd/5/consistency/conflicts.mdx
+++ b/product_docs/docs/pgd/5/consistency/conflicts.mdx
@@ -212,7 +212,7 @@ The database can clean up the deleted row by the time the `UPDATE` is received i
 
 Another type of `UPDATE`/`DELETE` conflict is when a `DELETE` for a row comes after that row was updated locally. In this situation, the outcome depends on the type of conflict detection used and the replication identity in use. 
 
-When using the default, [origin conflict detection](#origin-conflict-detection) and only primary keys for replication, no conflict is detected, leading to the `DELETE` being applied and the row being removed. 
+When using [origin conflict detection](#origin-conflict-detection) (the default) and only primary keys for replication, no conflict is detected, leading to the `DELETE` being applied and the row being removed. 
 
 If `REPLICA IDENTITY FULL` is being used for replication, the conflict will be detected and a `delete_recently_updated` conflict is generated.
 

--- a/product_docs/docs/pgd/5/consistency/conflicts.mdx
+++ b/product_docs/docs/pgd/5/consistency/conflicts.mdx
@@ -210,8 +210,15 @@ If the deleted row is still detectable (the deleted row wasn't removed by `VACUU
 
 The database can clean up the deleted row by the time the `UPDATE` is received in case the local node is lagging behind in replication. In this case, PGD can't differentiate between `UPDATE`/`DELETE` conflicts and [INSERT/UPDATE conflicts](#insertupdate-conflicts). It generates the `update_missing` conflict.
 
-Another type of conflicting `DELETE` and `UPDATE` is a `DELETE` that comes after the row was updated locally. In this situation, the outcome depends on the type of conflict detection used. When using the
-default, [origin conflict detection](#origin-conflict-detection), no conflict is detected, leading to the `DELETE` being applied and the row removed. If you enable [row version conflict detection](#row-version-conflict-detection), a `delete_recently_updated` conflict is generated. The default resolution for this conflict type is to apply the `DELETE` and remove the row. However, you can configure this or a conflict trigger can handled it.
+Another type of `UPDATE`/`DELETE` conflict is when a `DELETE` for a row comes after that row was updated locally. In this situation, the outcome depends on the type of conflict detection used and the replication identity in use. 
+
+When using the default, [origin conflict detection](https://www.enterprisedb.com/docs/pgd/latest/consistency/conflicts/#origin-conflict-detection) and only primary keys for replication, no conflict is detected, leading to the `DELETE` being applied and the row being removed. 
+
+If `REPLICA IDENTITY FULL` is being used for replication, the conflict will be detected and a `delete_recently_updated` conflict is generated.
+
+Similarly, if [row version conflict detection](https://www.enterprisedb.com/docs/pgd/latest/consistency/conflicts/#row-version-conflict-detection) is enabled, a `delete_recently_updated` conflict is also generated in this scenario. 
+
+The default resolution for `delete_recently_updated` is to `skip` the operation,  so the `DELETE` will not be applied.  You can configure this default resolution, using `bdr.alter_node_set_conflict_resolver` to update to apply the `DELETE` or set up a conflict trigger to handle it.
 
 #### INSERT/UPDATE conflicts
 

--- a/product_docs/docs/pgd/5/consistency/conflicts.mdx
+++ b/product_docs/docs/pgd/5/consistency/conflicts.mdx
@@ -212,11 +212,11 @@ The database can clean up the deleted row by the time the `UPDATE` is received i
 
 Another type of `UPDATE`/`DELETE` conflict is when a `DELETE` for a row comes after that row was updated locally. In this situation, the outcome depends on the type of conflict detection used and the replication identity in use. 
 
-When using the default, [origin conflict detection](https://www.enterprisedb.com/docs/pgd/latest/consistency/conflicts/#origin-conflict-detection) and only primary keys for replication, no conflict is detected, leading to the `DELETE` being applied and the row being removed. 
+When using the default, [origin conflict detection](#origin-conflict-detection) and only primary keys for replication, no conflict is detected, leading to the `DELETE` being applied and the row being removed. 
 
 If `REPLICA IDENTITY FULL` is being used for replication, the conflict will be detected and a `delete_recently_updated` conflict is generated.
 
-Similarly, if [row version conflict detection](https://www.enterprisedb.com/docs/pgd/latest/consistency/conflicts/#row-version-conflict-detection) is enabled, a `delete_recently_updated` conflict is also generated in this scenario. 
+Similarly, if [row version conflict detection](#row-version-conflict-detection) is enabled, a `delete_recently_updated` conflict is also generated in this scenario. 
 
 The default resolution for `delete_recently_updated` is to `skip` the operation,  so the `DELETE` will not be applied.  You can configure this default resolution, using `bdr.alter_node_set_conflict_resolver` to update to apply the `DELETE` or set up a conflict trigger to handle it.
 


### PR DESCRIPTION
## What Changed?

After viewing the code path, I have determined this is the current behaviour (line 213-221).

Discussion about whether this behaviour is good is out of scope for this change. This just seeks to match observed functionality.

For reference - JIRA ticket - https://enterprisedb.atlassian.net/browse/BDR-3876
