### PR TITLE
Edits to installs and consistent nomenclature for versions

### DIFF
--- a/product_docs/docs/epas/15/application_programming/12_debugger/configuring_debugger.mdx
+++ b/product_docs/docs/epas/15/application_programming/12_debugger/configuring_debugger.mdx
@@ -20,7 +20,7 @@ If your EDB Postgres Advanced Server host is on a CentOS or Linux system, you ca
 yum install edb-pgadmin4*
 ```
 
-On Linux, you must also install the `edb-asxx-server-pldebugger` RPM package, where `xx` is the EDB Postgres Advanced Server version number. Information about pgAdmin 4 is available at the [pgAdmin website](https://www.pgadmin.org/).
+On Linux, you must also install the `edb-as<xx>-server-pldebugger` RPM package, where `<xx>` is the EDB Postgres Advanced Server version number. Information about pgAdmin 4 is available at the [pgAdmin website](https://www.pgadmin.org/).
 
 The RPM installation adds the pgAdmin4 icon to your Applications menu.
 
@@ -30,9 +30,9 @@ Before using the debugger, edit the `postgresql.conf` file (located in the `data
 shared_preload_libraries = '$libdir/dbms_pipe,$libdir/edb_gen,$libdir/plugin_debugger'
 ```
 
--   On Linux, the `postgresql.conf` file is located in: `/var/lib/edb/asxx/data`
--   On Windows, the `postgresql.conf` file is located in: `C:\Program Files\edb\asxx\data`
+-   On Linux, the `postgresql.conf` file is located in: `/var/lib/edb/as<xx>/data`
+-   On Windows, the `postgresql.conf` file is located in: `C:\Program Files\edb\as<xx>\data`
 
-Where `xx` is the version of EDB Postgres Advanced Server.
+Where `<xx>` is the version of EDB Postgres Advanced Server.
 
 After modifying the `shared_preload_libraries` parameter, restart the database server.

--- a/product_docs/docs/epas/15/application_programming/ecpgplus_guide/installing_ecpgplus.mdx
+++ b/product_docs/docs/epas/15/application_programming/ecpgplus_guide/installing_ecpgplus.mdx
@@ -7,7 +7,7 @@ On Windows, ECPGPlus is installed by the EDB Postgres Advanced Server installati
 
 ## Installing ECPGPlus
 
-On Linux, install with the `edb-asxx-server-devel` RPM package, where `xx` is the EDB Postgres Advanced Server version number. On Linux, the executable is located in:
+On Linux, install with the `edb-as<xx>-server-devel` RPM package, where `<xx>` is the EDB Postgres Advanced Server version number. On Linux, the executable is located in:
 
 ```text
 /usr/edb/as14/bin

--- a/product_docs/docs/epas/15/database_administration/14_edb_clone_schema/setting_up_edb_clone_schema.mdx
+++ b/product_docs/docs/epas/15/database_administration/14_edb_clone_schema/setting_up_edb_clone_schema.mdx
@@ -12,7 +12,7 @@ In addition, it might help to modify some configuration parameters in the `postg
 Perform this installation on any database to be used as the source or target database by an EDB Clone Schema function.
 
 1. Install the following extensions on the database: `postgres_fdw`, `dblink`, `adminpack` and `pgagent`.
-1. Ensure that pgAgent is installed before creating the `pgagent` extension. On Linux, you can use the `edb-asxx-pgagent` RPM package, where `xx` is the EDB Postgres Advanced Server version number to install pgAgent. On Windows, use StackBuilder Plus to download and install pgAgent.
+1. Ensure that pgAgent is installed before creating the `pgagent` extension. On Linux, you can use the `edb-as<xx>-pgagent` RPM package, where `<xx>` is the EDB Postgres Advanced Server version number to install pgAgent. On Windows, use StackBuilder Plus to download and install pgAgent.
 
   Install the extensions:
 
@@ -35,7 +35,7 @@ Modify the `postgresql.conf` file by adding `$libdir/parallel_clone` to the `sha
 
 ## Installing PL/Perl
 
-1.  Install the Perl procedural language (PL/Perl) on the database, and run the `CREATE TRUSTED LANGUAGE plperl` command. For Linux, install PL/Perl using the `edb-asxx-server-plperl` RPM package, where `xx` is the EDB Postgres Advanced Server version number. For Windows, use the EDB Postgres Language Pack. For information on EDB Language Pack, see the [EDB Postgres Language Pack](/language_pack/latest).
+1.  Install the Perl procedural language (PL/Perl) on the database, and run the `CREATE TRUSTED LANGUAGE plperl` command. For Linux, install PL/Perl using the `edb-as<xx>-server-plperl` RPM package, where `<xx>` is the EDB Postgres Advanced Server version number. For Windows, use the EDB Postgres Language Pack. For information on EDB Language Pack, see the [EDB Postgres Language Pack](/language_pack/latest).
 
 1. Connect to the database as a superuser and run the following command:
 

--- a/product_docs/docs/epas/15/epas_security_guide/02_protecting_against_sql_injection_attacks/02_configuring_sql_protect.mdx
+++ b/product_docs/docs/epas/15/epas_security_guide/02_protecting_against_sql_injection_attacks/02_configuring_sql_protect.mdx
@@ -15,7 +15,7 @@ You can configure how SQL/Protect operates.
 
 Meet the following prerequisites before configuring SQL/Protect:
 
--   The library file (`sqlprotect.so` on Linux, `sqlprotect.dll` on Windows) needed to run SQL/Protect is installed in the `lib` subdirectory of your EDB Postgres Advanced Server home directory. For Windows, the EDB Postgres Advanced Server installer does this. For Linux, install the `edb-asxx-server-sqlprotect` RPM package, where `xx` is the EDB Postgres Advanced Server version number.
+-   The library file (`sqlprotect.so` on Linux, `sqlprotect.dll` on Windows) needed to run SQL/Protect is installed in the `lib` subdirectory of your EDB Postgres Advanced Server home directory. For Windows, the EDB Postgres Advanced Server installer does this. For Linux, install the `edb-as<xx>-server-sqlprotect` RPM package, where `<xx>` is the EDB Postgres Advanced Server version number.
 
 -   You need the SQL script file `sqlprotect.sql` located in the `share/contrib` subdirectory of your EDB Postgres Advanced Server home directory.
 

--- a/product_docs/docs/epas/15/epas_security_guide/04_sslutils.mdx
+++ b/product_docs/docs/epas/15/epas_security_guide/04_sslutils.mdx
@@ -9,7 +9,7 @@ description: "The sslutils Postgres extension provides SSL certificate generatio
 
 ## Installing the extension
 
-You install `sslutils` by using the `edb-asxx-server-sslutils` RPM package, where `xx` is the EDB Postgres Advanced Server version number.
+You install `sslutils` by using the `edb-as<xx>-server-sslutils` RPM package, where `<xx>` is the EDB Postgres Advanced Server version number.
 
 Each parameter in the function’s parameter list is described by `parameter n`, where `n` refers to the `nth` ordinal position (for example, first, second, or third) in the function’s parameter list.
 

--- a/product_docs/docs/epas/15/epas_security_guide/tde_feature.mdx
+++ b/product_docs/docs/epas/15/epas_security_guide/tde_feature.mdx
@@ -5,8 +5,8 @@ description: "Provides an overview of the benefits of the Transparent Data Encry
 
 Transparent Data Encryption (TDE) is an optional encryption method that protects data in the database by encrypting the underlying files.
 
-TDE is transparent to authorized users of the database, as no change is required in the applications or existing access policies. It is supported by version 15 of EDB Postgres Advanced Server and EDB Postgres Extended Server with high availability.
+TDE is transparent to authorized users of the database, as no change is required in the applications or existing access policies. It's supported by version 15 of EDB Postgres Advanced Server and EDB Postgres Extended Server with high availability.
 
-TDE hardens your organization’s data security with minimum performance overhead and does not require additional storage. TDE also enables developers to secure their data using secure encryption algorithms without changing their applications. The feature securely stores individual tablespaces and logs encrypted with their own encryption keys, ensuring security of user data while preserving ease of management for database administrators.
+TDE hardens your organization’s data security with minimum performance overhead and doesn't require additional storage. TDE also enables developers to secure their data using secure encryption algorithms without changing their applications. The feature securely stores individual tablespaces and logs encrypted with their own encryption keys, ensuring security of user data while preserving ease of management for database administrators.
 
-For information about how to enable transparent data encryption and work with the encrypted files, see the [Transparent Data Encryption](https://www.enterprisedb.com/docs/tde/latest/) documentation.
+For information about how to enable transparent data encryption and work with the encrypted files, see the [Transparent Data Encryption](/tde/latest/) documentation.

--- a/product_docs/docs/epas/15/fundamentals/sql_fundamentals/02_conventions.mdx
+++ b/product_docs/docs/epas/15/fundamentals/sql_fundamentals/02_conventions.mdx
@@ -16,5 +16,5 @@ Some of this information might apply interchangeably to the PostgreSQL and EDB P
 The installation directory path of the PostgreSQL or EDB Postgres Advanced Server products is referred to as *POSTGRES_INSTALL_HOME*.
 
 -   For EDB Postgres Advanced Server Linux installations performed using the interactive installer for version 10 and earlier, the default is `/opt/edb/asx.x`.
--   For EDB Postgres Advanced Server Linux installations performed using an RPM package, the default is `/usr/edb/asxx`.
--   For EDB Postgres Advanced Server Windows installations, the default is `C:\Program Files\edb\asxx`. The product version number is represented by `x.x` or by `xx` for version 10 and later.
+-   For EDB Postgres Advanced Server Linux installations performed using an RPM package, the default is `/usr/edb/as<xx>` where <xx> is the EDB Postgres Advanced Server version number.
+-   For EDB Postgres Advanced Server Windows installations, the default is `C:\Program Files\edb\as<xx>`. The product version number is represented by `x.x` or by `xx` for version 10 and later.

--- a/product_docs/docs/epas/15/fundamentals/sql_fundamentals/02_conventions.mdx
+++ b/product_docs/docs/epas/15/fundamentals/sql_fundamentals/02_conventions.mdx
@@ -16,5 +16,5 @@ Some of this information might apply interchangeably to the PostgreSQL and EDB P
 The installation directory path of the PostgreSQL or EDB Postgres Advanced Server products is referred to as *POSTGRES_INSTALL_HOME*.
 
 -   For EDB Postgres Advanced Server Linux installations performed using the interactive installer for version 10 and earlier, the default is `/opt/edb/asx.x`.
--   For EDB Postgres Advanced Server Linux installations performed using an RPM package, the default is `/usr/edb/as<xx>` where <xx> is the EDB Postgres Advanced Server version number.
+-   For EDB Postgres Advanced Server Linux installations performed using an RPM package, the default is `/usr/edb/as<xx>` where `<xx>` is the EDB Postgres Advanced Server version number.
 -   For EDB Postgres Advanced Server Windows installations, the default is `C:\Program Files\edb\as<xx>`. The product version number is represented by `x.x` or by `xx` for version 10 and later.

--- a/product_docs/docs/epas/15/fundamentals/sql_fundamentals/03_examples_used.mdx
+++ b/product_docs/docs/epas/15/fundamentals/sql_fundamentals/03_examples_used.mdx
@@ -18,10 +18,10 @@ The examples in the documentation use the sample tables `dept`, `emp`, and `jobh
 You can re-create the tables and programs in the sample database at any time by executing the following script:
 
 ```sql
-/usr/edb/asxx/share/pg-sample.sql
+/usr/edb/as<xx>/share/pg-sample.sql
 ```
 
-Where `xx` is the EDB Postgres Advanced Server version number.
+Where `<xx>` is the EDB Postgres Advanced Server version number.
 
 In addition, a script in the same directory contains the database objects created using syntax compatible with Oracle databases. This script file is `edb-sample.sql`. The script:
 

--- a/product_docs/docs/epas/15/installing/uninstalling/linux_uninstall.mdx
+++ b/product_docs/docs/epas/15/installing/uninstalling/linux_uninstall.mdx
@@ -53,7 +53,7 @@ To uninstall EDB Postgres Advanced Server and its dependent packages, use the ap
     ```text
     yum remove edb-as<xx>-server*
     ```
-Where `<xx>` is EDB Postgres Advanced Server version number.
+Where `<xx>` is the EDB Postgres Advanced Server version number.
 
 -   On RHEL or Rocky Linux or AlmaLinux 8:
 

--- a/product_docs/docs/epas/15/installing/uninstalling/linux_uninstall.mdx
+++ b/product_docs/docs/epas/15/installing/uninstalling/linux_uninstall.mdx
@@ -53,7 +53,7 @@ To uninstall EDB Postgres Advanced Server and its dependent packages, use the ap
     ```text
     yum remove edb-as<xx>-server*
     ```
-Where `<xx>` represents the EDB Postgres Advanced Server version.
+Where `<xx>` is EDB Postgres Advanced Server version number.
 
 -   On RHEL or Rocky Linux or AlmaLinux 8:
 

--- a/product_docs/docs/epas/15/installing/uninstalling/windows_uninstall.mdx
+++ b/product_docs/docs/epas/15/installing/uninstalling/windows_uninstall.mdx
@@ -20,7 +20,7 @@ The EDB Postgres Advanced Server interactive installer creates an uninstaller th
     ```text
     uninstall-edb-as<xx>-server.exe
     ```
-    Where `<xx>` represents the EDB Postgres Advanced Server version.
+    Where `<xx>` is the EDB Postgres Advanced Server version number.
 
     The uninstaller opens.
 

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/index.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/index.mdx
@@ -18,13 +18,13 @@ You can use the EDB Postgres Advanced Server interactive installer to install ED
 
 You can invoke the graphical installer in different installation modes to perform an EDB Postgres Advanced Server installation.
 
-During the installation, the graphical installer copies a number of temporary files to the location specified by the `TEMP` environment variable. You can optionally specify an alternate location for the temporary files by modifying the value of the `TEMP` environment variable on the command line:
+During the installation, the graphical installer copies a number of temporary files to the location specified by the `TEMP` environment variable. You can optionally specify an alternative location for the temporary files by modifying the value of the `TEMP` environment variable at the command line:
 
 ```text
-SET TEMP=temp_file_location
+SET TEMP=<temp_file_location>
 ```
 
-Where `temp_file_location` specifies the alternate location for the temporary files and must match the permissions with the `TEMP` environment variable.
+Where `<temp_file_location>` specifies the alternative location for the temporary files and must match the permissions with the `TEMP` environment variable.
 
 !!! Note
-    If you are invoking the installer to perform a system upgrade, the installer preserves the configuration options specified during the previous installation.
+    If you're invoking the installer to perform a system upgrade, the installer preserves the configuration options specified during the previous installation.

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/index.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/index.mdx
@@ -12,7 +12,7 @@ navigation:
 
 <div id="invoking_the_graphical_installer_from_the_command_line" class="registered_link"></div>
 
-The command line options of the EDB Postgres Advanced Server installer offer functionality for Windows systems that reside in situations where a graphical installation may not work because of limited resources or privileges. You can:
+The command line options of the EDB Postgres Advanced Server installer offer functionality for Windows systems that reside in situations where a graphical installation might not work because of limited resources or privileges. You can:
 
 -   Include the `--mode unattended` option when invoking the installer to perform an installation without user input.
 -   Invoke the installer with the `--extract-only` option to perform a minimal installation when you don’t hold the privileges required to perform a complete installation.
@@ -20,7 +20,7 @@ The command line options of the EDB Postgres Advanced Server installer offer fun
 Not all command line options are suitable for all situations. For a complete reference guide to the command line options, see [Reference - Command Line Options](reference_command_line_options/#reference_command_line_options).
 
 !!! Note
-    If you are invoking the installer from the command line to perform a system upgrade, the installer ignores command line options and preserves the configuration of the previous installation.
+    If you're invoking the installer from the command line to perform a system upgrade, the installer ignores command line options and preserves the configuration of the previous installation.
 
 <div class="toctree" maxdepth="3">
 

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_installation_with_limited_privileges.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_installation_with_limited_privileges.mdx
@@ -29,7 +29,7 @@ The scripted EDB Postgres Advanced Server installation doesn't create menu short
 
 To perform a limited installation and generate an installation script: 
 
-1. download and unpack the EDB Postgres Advanced Server installer. 
+1. Download and unpack the EDB Postgres Advanced Server installer. 
 
 1. Navigate to the directory that contains the installer, and invoke the installer:
 

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_installation_with_limited_privileges.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_installation_with_limited_privileges.mdx
@@ -11,62 +11,50 @@ To perform an abbreviated installation of EDB Postgres Advanced Server without a
 
 If you invoke the installer with the `--extract-only` options, you can either manually create a cluster and start the service, or run the installation script. To manually create the cluster, you must:
 
--   Use `initdb` to initialize the cluster
+-   Use initdb to initialize the cluster
 -   Configure the cluster
--   Use `pg_ctl` to start the service
+-   Use pg_ctl to start the service
 
-For more information about the `initdb` and `pg_ctl` commands, see the PostgreSQL Core Documentation for [initdb](https://www.postgresql.org/docs/current/static/app-initdb.html) and [pg_ctl](https://www.postgresql.org/docs/current/static/app-pg-ctl.html).
+For more information about initdb and pg_ctl, see the PostgreSQL core documentation for [initdb](https://www.postgresql.org/docs/current/static/app-initdb.html) and [pg_ctl](https://www.postgresql.org/docs/current/static/app-pg-ctl.html).
 
-If you include the `--extract-only` option, the installer steps through a shortened form of the `Setup` wizard. During the brief installation process, the installer generates an installation script that can be later used to complete a more complete installation. You must have administrative privileges to invoke the installation script.
+If you include the `--extract-only` option, the installer steps through a shortened form of the setup wizard. During the brief installation process, the installer generates an installation script that can be later used to complete a more complete installation. You must have administrative privileges to invoke the installation script.
 
 The installation script:
 
 -   Initializes the database cluster if the cluster is empty.
--   Configures the server to start at boot-time.
+-   Configures the server to start at boot time.
 -   Establishes initial values for Dynatune (dynamic tuning) variables.
 
-The scripted EDB Postgres Advanced Server installation does not create menu shortcuts or provide access to EDB Postgres StackBuilder Plus, and no modifications are made to registry files.
+The scripted EDB Postgres Advanced Server installation doesn't create menu shortcuts or provide access to EDB Postgres StackBuilder Plus, and it doesn't make changes to registry files.
 
-To perform a limited installation and generate an installation script, download and unpack the EDB Postgres Advanced Server installer. Navigate into the directory that contains the installer, and invoke the installer with the command:
-
-```text
-edb-asxx-server-xx.x.x-x-windows.exe --extract-only yes
-```
-
-Where `<xx>` represents the EDB Postgres Advanced Server version.
-
-A dialog opens, prompting you to choose an installation language. Select a language for the installation from the drop-down listbox, and click `OK` to continue. The `Setup Wizard` opens.
-
-![The Welcome window](../../../../images/advanced_server_installer_welcome.png)
-
-<div style="text-align: center"> Fig. 15: The Welcome window </div>
-
-Click `Next` to continue.
-
-![Specify an installation directory](../../../../images/installation_directory.png)
-
-<div style="text-align: center"> Fig. 16: Specify an installation directory </div>
-
-On Windows, the default EDB Postgres Advanced Server installation directory is:
+To perform a limited installation and generate an installation script, download and unpack the EDB Postgres Advanced Server installer. 1. Navigate to the directory that contains the installer, and invoke the installer:
 
 ```text
-C:\Program Files\edb\as<xx>
+edb-as<xx>-server-xx.x.x-x-windows.exe --extract-only yes
 ```
 
-You can accept the default installation location and click `Next` to continue to the `Ready to Install` window, or optionally click the `File Browser` icon to choose an alternate installation directory.
+Where `<xx>` is the EDB Postgres Advanced Server version number.
 
-![The Setup wizard is ready to install EDB Postgres Advanced Server](../../../../images/ready_to_install.png)
+    A dialog box opens, prompting you to choose an installation language. 
+    
+1. Select a language for the installation, and select **OK**. The setup wizard opens.
 
-<div style="text-align: center"> Fig. 17: The Setup wizard is ready to install EDB Postgres Advanced Server </div>
+    ![The Welcome window](../../../../images/advanced_server_installer_welcome.png)
 
-Click `Next` to proceed with the EDB Postgres Advanced Server installation. During the installation, progress bars and popups mark the installation progress. The installer notifies you when the installation is complete.
+1. Select **Next**.
 
-![The EDB Postgres Advanced Server installation is complete](../../../../images/advanced_server_installation_completion.png)
+    ![Specify an installation directory](../../../../images/installation_directory.png)
 
-<div style="text-align: center"> Fig. 18: The EDB Postgres Advanced Server installation is complete </div>
+    On Windows, the default EDB Postgres Advanced Server installation directory is `C:\Program Files\edb\as15`.
 
-After completing the minimal installation, you can execute a script to initialize a cluster and start the service. The script is (by default) located in:
+1. Accept the default installation location and select **Next** to continue to the Ready to Install window. Alternatively,you can select the file browser to choose a different installation directory.
 
-```text
-C:\Program Files\edb
-```
+    ![The Setup wizard is ready to install EDB Postgres Advanced Server](../../../../images/ready_to_install.png)
+
+1. To proceed with the EDB Postgres Advanced Server installation, select **Next**. 
+
+    During the installation, progress bars and popups mark the installation progress. The installer notifies you when the installation is complete.
+
+    ![The EDB Postgres Advanced Server installation is complete](../../../../images/advanced_server_installation_completion.png)
+
+After completing the minimal installation, you can execute a script to initialize a cluster and start the service. The script is by default located in `C:\Program Files\edb`.

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_installation_with_limited_privileges.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_installation_with_limited_privileges.mdx
@@ -27,15 +27,19 @@ The installation script:
 
 The scripted EDB Postgres Advanced Server installation doesn't create menu shortcuts or provide access to EDB Postgres StackBuilder Plus, and it doesn't make changes to registry files.
 
-To perform a limited installation and generate an installation script, download and unpack the EDB Postgres Advanced Server installer. 1. Navigate to the directory that contains the installer, and invoke the installer:
+To perform a limited installation and generate an installation script: 
 
-```text
-edb-as<xx>-server-xx.x.x-x-windows.exe --extract-only yes
-```
+1. download and unpack the EDB Postgres Advanced Server installer. 
 
-Where `<xx>` is the EDB Postgres Advanced Server version number.
+1. Navigate to the directory that contains the installer, and invoke the installer:
 
-    A dialog box opens, prompting you to choose an installation language. 
+  ```text
+  edb-as<xx>-server-xx.x.x-x-windows.exe --extract-only yes
+  ```
+
+  Where `<xx>` is the EDB Postgres Advanced Server version number.
+
+  A dialog box opens, prompting you to choose an installation language. 
     
 1. Select a language for the installation, and select **OK**. The setup wizard opens.
 

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_unattended_installation.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/performing_an_unattended_installation.mdx
@@ -20,11 +20,11 @@ You must have administrative privileges to install EDB Postgres Advanced Server 
 To start the installer in unattended mode, navigate to the directory that contains the executable file, and enter:
 
 ```text
-edb-asxx-server-xx.x.x-x-windows-x64.exe --mode unattended --superpassword
+edb-as<xx>-server-xx.x.x-x-windows-x64.exe --mode unattended --superpassword
 database_superuser_password --servicepassword system_password
 ```
 
-Where `<xx>` represents the EDB Postgres Advanced Server version.
+Where `<xx>` is the EDB Postgres Advanced Server version number.
 
 When invoking the installer, include the `--servicepassword` option to specify an operating system password for the user installing EDB Postgres Advanced Server.
 

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/reference_command_line_options.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/invoking_the_graphical_installer_from_the_command_line/reference_command_line_options.mdx
@@ -7,11 +7,11 @@ redirects:
 
 <div id="reference_command_line_options" class="registered_link"></div>
 
-You can optionally include the following parameters for an EDB Postgres Advanced Server installation on the command line or in a configuration file when invoking the EDB Postgres Advanced Server installer.
+When invoking the EDB Postgres Advanced Server installer, you can optionally include the following parameters for an EDB Postgres Advanced Server installation on the command line or in a configuration file.
 
 `--create_samples { yes | no }`
 
-Specifies whether the installer creates the sample tables and procedures for the database dialect specified with the `--databasemode` parameter. The default is `yes`.
+Specifies whether to create the sample tables and procedures for the database dialect specified with the `--databasemode` parameter. The default is `yes`.
 
 `--databasemode { oracle | postgresql }`
 
@@ -39,20 +39,20 @@ Specifies a list of EDB Postgres Advanced Server components to exclude from the 
 
 `--enable_acledit { 1 | 0 }`
 
-The `--enable_acledit 1` option instructs the installer to grant permission to the user specified by the `--serviceaccount` option to access the EDB Postgres Advanced Server binaries and `data` directory. By default, this option is disabled if `--enable_acledit 0` is specified or if the `--enable_acledit` option is completely omitted.
+The `--enable_acledit 1` option grants permission to the user specified by the `--serviceaccount` option to access the EDB Postgres Advanced Server binaries and `data` directory. By default, this option is disabled if `--enable_acledit 0` is specified or if the `--enable_acledit` option is completely omitted.
 
 !!! Note
     Specifying this option is valid only when installing on Windows. Specify the `--enable_acledit 1` option when a discretionary access control list (DACL) needs to be set for allowing access to objects on which to install EDB Postgres Advanced Server. For information on a DACL, see [DACLs and ACEs](https://msdn.microsoft.com/en-us/library/windows/desktop/aa446597(v=vs.85).aspx) in the Microsoft documentation.
 
-To perform future operations, such as upgrading EDB Postgres Advanced Server, access to the `data` directory must exist for the service account user specified by the `--serviceaccount` option. By specifying the `--enable_acledit 1` option, access to the `data` directory by the service account user is provided.
+To perform future operations, such as upgrading EDB Postgres Advanced Server, the service account user specified by the `--serviceaccount` option must have access to the `data` directory. The `--enable_acledit 1` option provides access to the `data` directory by the service account user.
 
 `--enable-components component_list`
 
-Although this option is listed when you run the installer with the `--help` option, the `--enable-components` parameter has no effect on which components are installed. All components are installed regardless of what is specified in `component_list`. To install only specific selected components, use the `--disable-components` parameter previously described to list the components you don't want to install.
+Although this option is listed when you run the installer with the `--help` option, the `--enable-components` parameter has no effect on the components installed. All components are installed regardless of this setting. To install only specific selected components, use the `--disable-components` parameter to list the components you don't want to install.
 
 `--extract-only { yes | no }`
 
-Include the `--extract-only` parameter to indicate that the installer should extract the EDB Postgres Advanced Server binaries without performing a complete installation. Superuser privileges aren't required for the `--extract-only` option. The default value is `no`.
+Include the `--extract-only` parameter to extract the EDB Postgres Advanced Server binaries without performing a complete installation. Superuser privileges aren't required for the `--extract-only` option. The default value is `no`.
 
 `--help`
 
@@ -60,21 +60,21 @@ Displays a list of the optional parameters.
 
 `--installer-language { en | ja | zh_CN | zh_TW | ko }`
 
-Specifies an installation language for EDB Postgres Advanced Server. The default is `en`.
+Specifies an installation language for EDB Postgres Advanced Server.
 
-`en` specifies English.
+- `en` specifies English. This is the default.
 
-`ja` specifies Japanese
+- `ja` specifies Japanese
 
-`zh_CN` specifies Chinese Simplified.
+- `zh_CN` specifies Chinese Simplified.
 
-`zh_TW` specifies Traditional Chinese.
+- `zh_TW` specifies Traditional Chinese.
 
-`ko` specifies Korean.
+- `ko` specifies Korean.
 
 `--install_runtimes { yes | no }`
 
-Specifies whether to install the Microsoft Visual C++ runtime libraries. Default is `yes`.
+Specifies whether to install the Microsoft Visual C++ runtime libraries. The default is `yes`.
 
 `--locale locale`
 
@@ -82,7 +82,7 @@ Specifies the locale for the EDB Postgres Advanced Server cluster. By default, t
 
 `--mode { unattended }`
 
-Specifies for the installer to perform an installation that requires no user input during the installation process.
+Specifies to perform an installation that requires no user input during the installation process.
 
 `--optionfile config_file`
 
@@ -107,7 +107,7 @@ If you're installing EDB Postgres Advanced Server in unattended mode and don't s
 Specifies a value for the `edb_dynatune` configuration parameter. The `edb_dynatune` configuration parameter determines how EDB Postgres Advanced Server allocates system resources.
 
 -   A value of `33` is appropriate for a system used for development. A low value dedicates the least amount of the host machine’s resources to the database server.
--   A value of `66` is appropriate for an application server with a fixed number of applications. A midrange value dedicates a moderate amount of system resources to the database server. The default value is 66.
+-   A value of `66` is appropriate for an application server with a fixed number of applications. A midrange value dedicates a moderate amount of system resources to the database server. This is the default value.
 -   A value of `100` is appropriate for a host machine that's dedicated to running EDB Postgres Advanced Server. A high value dedicates most of the system resources to the database server.
 
 When the installation is complete, you can adjust the value of `edb_dynatune` by editing the `postgresql.conf` file, located in the `data` directory of your EDB Postgres Advanced Server installation. After editing the `postgresql.conf` file, you must restart the server for the changes to take effect.
@@ -117,14 +117,14 @@ When the installation is complete, you can adjust the value of `edb_dynatune` by
 Specifies the name of the user account that owns the server process.
 
 -   If `--databasemode` is set to `oracle` (the default), the default value of `--serviceaccount` is `enterprisedb`.
--   If `--databasemode` is `postgresql`, the default value of `--serviceaccount` is set to `postgres`.
+-   If `--databasemode` is `postgresql`, the default value of `--serviceaccount` is `postgres`.
 
 For security reasons, the `--serviceaccount` parameter must specify the name of an account that doesn't hold administrator privileges.
 
-If you specify both the `--serviceaccount` option and the `--enable_acledit 1` option when invoking the installer, the database service and pgAgent uses the same service account. They therefore have the required permissions to access the EDB Postgres Advanced Server binaries and `data` directory.
+If you specify both the `--serviceaccount` option and the `--enable_acledit 1` option when invoking the installer, the database service and pgAgent uses the same service account. They therefore have the permissions required to access the EDB Postgres Advanced Server binaries and `data` directory.
 
 !!! Note
-    If you don't include the `--serviceaccount` option when invoking the installer, the `NetworkService` account owns the database service, and the pgAgent service is owned by either `enterprisedb` or `postgres` (depending on the installation mode).
+    If you don't include the `--serviceaccount` option when invoking the installer, the NetworkService account owns the database service, and the pgAgent service is owned by either enterprisedb or postgres, depending on the installation mode.
 
 `--servicename service_name`
 
@@ -139,7 +139,7 @@ Specifies the OS system password. If unspecified, the value of `--servicepasswor
 Specifies the user name of the database superuser.
 
 -   If `--databasemode` is set to `oracle` (the default), the default value of `--superaccount` is `enterprisedb`.
--   If `--databasemode` is set to `postgresql`, the default value of `--superaccount` is set to `postgres`.
+-   If `--databasemode` is set to `postgresql`, the default value of `--superaccount` is `postgres`.
 
 `--superpassword superuser_password`
 
@@ -149,11 +149,11 @@ Specifies the database superuser password. If you're installing in non-interacti
 
 Specifies installer behavior during an unattended installation.
 
-Include `--unattendedmodeui none` to specify for the installer not to display progress bars during the EDB Postgres Advanced Server installation.
+Include `--unattendedmodeui none` if you don't want to display progress bars during the EDB Postgres Advanced Server installation.
 
-Include `--unattendedmodeui minimal` to specify for the installer to display progress bars during the installation process. This is the default behavior.
+Include `--unattendedmodeui minimal` to display progress bars during the installation process. This is the default behavior.
 
-Include `--unattendedmodeui minimalWithDialogs` to specify for the installer to display progress bars and report any errors encountered during the installation process in additional dialog boxes.
+Include `--unattendedmodeui minimalWithDialogs` to display progress bars and report any errors encountered during the installation process in additional dialog boxes.
 
 `--version`
 
@@ -163,8 +163,7 @@ Retrieves version information about the installer.
 
 Specifies an initial value for the `edb_dynatune_profile` configuration parameter. `edb_dynatune_profile` controls aspects of performance-tuning based on the type of work that the server performs.
 
--   Specify `oltp` if the EDB Postgres Advanced Server installation is used to support heavy online transaction processing workloads.
--   The default value is `oltp`.
+-   Specify `oltp` if the EDB Postgres Advanced Server installation is used to support heavy online transaction processing workloads. This is the default value.
 -   Specify `mixed` if EDB Postgres Advanced Server provides a mix of transaction processing and data reporting.
 -   Specify `reporting` if EDB Postgres Advanced Server is used for heavy data reporting.
 

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/performing_a_graphical_installation_on_windows.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/performing_a_graphical_installation_on_windows.mdx
@@ -7,240 +7,201 @@ redirects:
 
 <div id="performing_a_graphical_installation_on_windows" class="registered_link"></div>
 
-A graphical installation is a quick and easy way to install EDB Postgres Advanced Server on a Windows system. Use the wizard's dialogs to specify information about your system and system usage; when you have completed the dialogs, the installer performs an installation based on the selections made during the setup process.
+A graphical installation is a quick and easy way to install EDB Postgres Advanced Server on a Windows system. Use the wizard's screens to specify information about your system and system usage;.when you have completed the dialogs, the installer performs an installation based on the selections made during the setup process.
 
-To invoke the wizard, you must have administrator privileges. Assume administrator privileges, and double-click the `edb-as<xx>-server-xx.x.x-x-windows-x64` executable file.
+1. Assume administrator privileges, and double-click the `edb-as<xx>-server-xx.x.x-x-windows-x64` executable file, where `<xx>` is the EDB Postgres Advanced Server version number.
 
-Where `<xx>` represents the EDB Postgres Advanced Server version.
+    !!! Note
+        To install EDB Postgres Advanced Server on some versions of Windows, you might need to right-click the file and select **Run as Administrator** from the context menu to invoke the installer with administrator privileges.
 
-!!! Note
-    To install EDB Postgres Advanced Server on some versions of Windows, you may be required to right click on the file icon and select `Run as Administrator` from the context menu to invoke the installer with `Administrator` privileges.
+    ![The EDB Postgres Advanced Server installer Welcome window](../../../images/advanced_server_installer_welcome.png)
 
-![The EDB Postgres Advanced Server installer Welcome window](../../../images/advanced_server_installer_welcome.png)
+1. Select **Next**. The EnterpriseDB license agreement opens.
 
-<div style="text-align: center"> Fig. 1: The EDB Postgres Advanced Server installer Welcome window </div>
+    ![The EnterpriseDB License Agreement](../../../images/enterprisedb_license_agreement.png)
 
-Click `Next` to continue.
+1. Carefully review the license agreement before selecting the appropriate option. Select **Next**. 
 
-The EnterpriseDB `License Agreement` opens.
+    The Installation Directory window opens.
 
-![The EnterpriseDB License Agreement](../../../images/enterprisedb_license_agreement.png)
+    ![The Installation Directory window](../../../images/installation_directory.png)
 
-<div style="text-align: center"> Fig. 2: The EnterpriseDB License Agreement </div>
+    By default, the EDB Postgres Advanced Server installation directory is:
 
-Carefully review the license agreement before highlighting the appropriate radio button; click `Next` to continue.
+    ```text
+    C:\Program Files\edb\as<xx>
+    ```
 
-The `Installation Directory` window opens.
+    Where `<xx>` is the EDB Postgres Advanced Server version number.
 
-![The Installation Directory window](../../../images/installation_directory.png)
+1.  Accept the default installation location and select **Next**. Alternatively, select the file browser icon to open the Browse For Folder dialog box to choose a different installation directory.
 
-<div style="text-align: center"> Fig. 3: The Installation Directory window </div>
+    !!! Note
+        Don't store the `data` directory of a production database on an NFS file system.
 
-By default, the EDB Postgres Advanced Server installation directory is:
+    The Select Components window opens, which contains a list of optional components that you can install with the EDB Postgres Advanced Server setup wizard. You can omit a component from the EDB Postgres Advanced Server installation by clearing the check box next to its name.
+    
+    ![The Select Components window](../../../images/select_components.png)
 
-```text
-C:\Program Files\edb\as<xx>
-```
-Where `<xx>` represents the EDB Postgres Advanced Server version.
+    The setup wizard can install the following components while installing EDB Postgres Advanced Server 15:
 
-You can accept the default installation location, and click `Next` to continue, or optionally click the `File Browser` icon to open the `Browse For Folder` dialog to choose an alternate installation directory.
+    -  Select **EDB Postgres Advanced Server** to install EDB Postgres Advanced Server 15.
 
-!!! Note
-    The `data` directory of a production database should not be stored on an NFS file system.
+    -  Select **StackBuilder Plus** to install that utility. The StackBuilder Plus utility is a graphical tool that can update installed products or download and add supporting modules (and the resulting dependencies) after your EDB Postgres Advanced Server setup and installation completes. See [Using StackBuilder Plus](using_stackbuilder_plus/) for more information.
 
-![The Select Components window](../../../images/select_components.png)
+    - The **Command Line Tools** option installs command line tools and supporting client libraries including these and others:
 
-<div style="text-align: center"> Fig. 4: The Select Components window </div>
+        -   libpq
+        -   psql
+        -   EDB\*Loader
+        -   ecpgPlus
+        -   pg_basebackup, pg_dump, and pg_restore 
+        -   pg_bench
 
-The `Select Components` window contains a list of optional components that you can install with the EDB Postgres Advanced Server `Setup` wizard. You can omit a module from the EDB Postgres Advanced Server installation by deselecting the box next to the components name.
+    !!! Note
+        The command line tools are required if you're installing EDB Postgres Advanced Server or pgAdmin 4.
 
-The `Setup` wizard can install the following components while installing EDB Postgres Advanced Server:
+1. After selecting the components you want to install, select **Next**. The Additional Directories window opens.
 
-**EDB Postgres Advanced Server**
+    ![The Additional Directories window](../../../images/additional_directories.png)
 
-Select the `EDB Postgres Advanced Server` option to install EDB Postgres Advanced Server.
-
-**StackBuilder Plus**
-
-The `StackBuilder Plus` utility is a graphical tool that can update installed products, or download and add supporting modules (and the resulting dependencies) after your EDB Postgres Advanced Server setup and installation completes. See [Using StackBuilder Plus](using_stackbuilder_plus/) for more information about StackBuilder Plus.
-
-**Command Line Tools**
-
-The `Command Line Tools` option installs command line tools and supporting client libraries including:
-
--   libpq
--   psql
--   EDB\*Loader
--   ecpgPlus
--   pg_basebackup, pg_dump, and pg_restore
--   pg_bench
--   and more.
-
-!!! Note
-    The `Command Line Tools` are required if you are installing EDB Postgres Advanced Server or pgAdmin 4.
-
-After selecting the components you wish to install, click `Next` to open the `Additional Directories` window.
-
-![The Additional Directories window](../../../images/additional_directories.png)
-
-<div style="text-align: center"> Fig. 5: The Additional Directories window </div>
-
-By default, the EDB Postgres Advanced Server `data` files are saved to:
+    By default, the EDB Postgres Advanced Server data files are saved to:
 
 ```text
 C:\Program Files\edb<xx>\data
 ```
-Where `<xx>` represents the EDB Postgres Advanced Server version.
+Where `<xx>` is the EDB Postgres Advanced Server version number.
 
 The default location of the EDB Postgres Advanced Server `Write-Ahead Log (WAL) Directory` is:
 
 ```text
 C:\Program Files\edb\as<xx>\data\pg_wal
 ```
+    
+EDB Postgres Advanced Server uses write-ahead logs to promote transaction safety and speed transaction processing. When you make a change to a table, the change is stored in shared memory, and a record of the change is written to the write-ahead log. When you perform a COMMIT, EDB Postgres Advanced Server writes contents of the write-ahead log to disk.
 
-EDB Postgres Advanced Server uses write-ahead logs to promote transaction safety and speed transaction processing; when you make a change to a table, the change is stored in shared memory and a record of the change is written to the write-ahead log. When you perform a `COMMIT`, EDB Postgres Advanced Server writes contents of the write-ahead log to disk.
+1. Accept the default file locations, or use the file browser to select a different location. Select **Next**. 
 
-Accept the default file locations, or use the `File Browser` icon to select an alternate location; click `Next` to continue to the `EPAS Dialect` window.
+    The EDB Postgres Advanced Server Dialect window opens. The server dialect specifies the compatibility features supported by EDB Postgres Advanced Server.
 
-![The EDB Postgres Advanced Server Dialect window](../../../images/advanced_server_dialect.png)
+    ![The EDB Postgres Advanced Server Dialect window](../../../images/advanced_server_dialect.png)
 
-<div style="text-align: center"> Fig. 6: The EDB Postgres Advanced Server Dialect window </div>
+1. From the list, select a server dialect. 
 
-Use the drop-down listbox on the `EDB Postgres Advanced Server Dialect` window to choose a server dialect. The server dialect specifies the compatibility features supported by EDB Postgres Advanced Server.
+    By default, EDB Postgres Advanced Server installs in Compatible with Oracle mode. You can choose between Compatible with Oracle and Compatible with PostgreSQL installation modes.
 
-By default, EDB Postgres Advanced Server installs in `Compatible with Oracle` mode; you can choose between `Compatible with Oracle` and `Compatible with PostgreSQL` installation modes.
+    If you select **Compatible with Oracle**, the installation includes the following features:
 
-**Compatible with Oracle**
+    -   Data dictionary views that are compatible with Oracle databases.
+    -   Oracle data type conversions.
+    -   Date values displayed in a format compatible with Oracle syntax.
+    -   Support for Oracle-styled concatenation rules. (If you concatenate a string value with a `NULL` value, the returned value is the value of the string.)
+    -   Schemas (`dbo` and `sys`) compatible with Oracle databases added to the `SEARCH_PATH`.
+    -   Support for the following Oracle built-in packages.
 
-If you select `Compatible with Oracle`, the installation includes the following features:
+    | Package          | Functionality compatible with Oracle databases                                                                                                                               |
+    | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | `dbms_alert`     | Provides the capability to register for, send, and receive alerts.                                                                                                           |
+    | `dbms_job`       | Provides the capability for creating, scheduling, and managing jobs.                                                                                                  |
+    | `dbms_lob`       | Provides the capability to manage on large objects.                                                                                                                          |
+    | `dbms_output`    | Provides the capability to send messages to a message buffer or get messages from the message buffer.                                                                       |
+    | `dbms_pipe`      | Provides the capability to send messages through a pipe within or between sessions connected to the same database cluster.                                                   |
+   | `dbms_rls`       | Enables the implementation of Virtual Private Database on certain EDB Postgres Advanced Server database objects.                                                                          |
+    | `dbms_sql`       | Provides an application interface to the EDB dynamic SQL functionality.                                                                                                      |
+    | `dbms_utility`   | Provides various utility programs.                                                                                                                                           |
+    | `dbms_aqadm`     | Provides supporting procedures for Advanced Queueing functionality.                                                                                                          |
+    | `dbms_aq`        | Provides message queueing and processing for EDB Postgres Advanced Server.                                                                                                                |
+    | `dbms_profiler`  | Collects and stores performance information about the PL/pgSQL and SPL statements that are executed during a performance profiling session.                                  |
+    | `dbms_random`    | Provides a number of methods to generate random values.                                                                                                                      |
+    | `dbms_redact`    | Enables redacting or masking of data that's returned by a query.                                                                                                        |
+    | `dbms_lock`      | Provides support for the `DBMS_LOCK.SLEEP` procedure.                                                                                                                        |
+    | `dbms_scheduler` | Provides a way to create and manage jobs, programs, and job schedules.                                                                                                       |
+    | `dbms_crypto`    | Provides functions and procedures to encrypt or decrypt RAW, BLOB, or CLOB data. You can also use `DBMS_CRYPTO` functions to generate cryptographically strong random values. |
+    | `dbms_mview`     | Provides a way to manage and refresh materialized views and their dependencies.                                                                                              |
+    | `dbms_session`   | Provides support for the `DBMS_SESSION.SET_ROLE` procedure.                                                                                                                  |
+    | `utl_encode`     | Provides a way to encode and decode data.                                                                                                                                    |
+    | `utl_http`       | Provides a way to use the HTTP or HTTPS protocol to retrieve information found at a URL.                                                                                    |
+    | `utl_file`       | Provides the capability to read from and write to files on the operating system’s file system.                                                                              |
+    | `utl_smtp`       | Provides the capability to send emails over the simple mail transfer protocol (SMTP).                                                                                       |
+    | `utl_mail`       | Provides the capability to manage email.                                                                                                                                    |
+    | `utl_url`        | Provides a way to escape illegal and reserved characters in a URL.                                                                                                      |
+    | `utl_raw`        | Provides a way to manipulate or retrieve the length of raw data types.                                                                                                       |
 
--   Data dictionary views that is compatible with Oracle databases.
--   Oracle data type conversions.
--   Date values displayed in a format compatible with Oracle syntax.
--   Support for Oracle-styled concatenation rules (if you concatenate a string value with a `NULL` value, the returned value is the value of the string).
--   Schemas (`dbo` and `sys`) compatible with Oracle databases added to the `SEARCH_PATH`.
--   Support for the following Oracle built-in packages:
+    This isn't a comprehensive list of the compatibility features for Oracle included when EDB Postgres Advanced Server is installed in Compatible with Oracle mode. For more information, see the [Database compatibility for Oracle developers built-in package](../../../reference/oracle_compatibility_reference/epas_compat_bip_guide/).
 
-| Package          | Functionality compatible with Oracle databases                                                                                                                               |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dbms_alert`     | Provides the capability to register for, send, and receive alerts.                                                                                                           |
-| `dbms_job`       | Provides the capability for the creation, scheduling, and managing of jobs.                                                                                                  |
-| `dbms_lob`       | Provides the capability to manage on large objects.                                                                                                                          |
-| `dbms_output`    | Provides the capability to send messages to a message buffer, or get messages from the message buffer.                                                                       |
-| `dbms_pipe`      | Provides the capability to send messages through a pipe within or between sessions connected to the same database cluster.                                                   |
-| `dbms_rls`       | Enables the implementation of Virtual Private Database on certain EDB Postgres Advanced Server database objects.                                                                          |
-| `dbms_sql`       | Provides an application interface to the EDB dynamic SQL functionality.                                                                                                      |
-| `dbms_utility`   | Provides various utility programs.                                                                                                                                           |
-| `dbms_aqadm`     | Provides supporting procedures for Advanced Queueing functionality.                                                                                                          |
-| `dbms_aq`        | Provides message queueing and processing for EDB Postgres Advanced Server.                                                                                                                |
-| `dbms_profiler`  | Collects and stores performance information about the PL/pgSQL and SPL statements that are executed during a performance profiling session.                                  |
-| `dbms_random`    | Provides a number of methods to generate random values.                                                                                                                      |
-| `dbms_redact`    | Enables the redacting or masking of data that is returned by a query.                                                                                                        |
-| `dbms_lock`      | Provides support for the `DBMS_LOCK.SLEEP` procedure.                                                                                                                        |
-| `dbms_scheduler` | Provides a way to create and manage jobs, programs, and job schedules.                                                                                                       |
-| `dbms_crypto`    | Provides functions and procedures to encrypt or decrypt RAW, BLOB or CLOB data. You can also use `DBMS_CRYPTO` functions to generate cryptographically strong random values. |
-| `dbms_mview`     | Provides a way to manage and refresh materialized views and their dependencies.                                                                                              |
-| `dbms_session`   | Provides support for the `DBMS_SESSION.SET_ROLE` procedure.                                                                                                                  |
-| `utl_encode`     | Provides a way to encode and decode data.                                                                                                                                    |
-| `utl_http`       | Provides a way to use the HTTP or HTTPS protocol to retrieve information found at an URL.                                                                                    |
-| `utl_file`       | Provides the capability to read from, and write to files on the operating system’s file system.                                                                              |
-| `utl_smtp`       | Provides the capability to send e-mails over the Simple Mail Transfer Protocol (SMTP).                                                                                       |
-| `utl_mail`       | Provides the capability to manage e-mail.                                                                                                                                    |
-| `utl_url`        | Provides a way to escape illegal and reserved characters within an URL.                                                                                                      |
-| `utl_raw`        | Provides a way to manipulate or retrieve the length of raw data types.                                                                                                       |
+    If you choose to install in Compatible with Oracle mode, the EDB Postgres Advanced Server superuser name is enterprisedb.
 
-This is not a comprehensive list of the compatibility features for Oracle included when EDB Postgres Advanced Server is installed in `Compatible with Oracle` mode. For more information, see the [Database compatibility for Oracle developers built-in package](../../../reference/oracle_compatibility_reference/epas_compat_bip_guide/).
+    If you select **Compatible with PostgreSQL**, EDB Postgres Advanced Server exhibits compatibility with PostgreSQL version 15. If you choose to install in Compatible with PostgreSQL mode, the default EDB Postgres Advanced Server superuser name is postgres. For detailed information about PostgreSQL functionality, visit the [PostgreSQL website](http://www.postgresql.org).
 
-If you choose to install in `Compatible with Oracle` mode, the EDB Postgres Advanced Server superuser name is `enterprisedb`.
+1. After specifying a configuration mode, select **Next**. The Password window opens.
 
-**Compatible with PostgreSQL**
+    ![The Password window](../../../images/password_window.png)
 
-If you select `Compatible with PostgreSQL`, EDB Postgres Advanced Server exhibits compatibility with PostgreSQL. If you choose to install in `Compatible with PostgreSQL` mode, the default EDB Postgres Advanced Server superuser name is `postgres`.
+    EDB Postgres Advanced Server uses the password specified on the Password window for the database superuser. The specified password must conform to any security policies on the EDB Postgres Advanced Server host.
 
-For detailed information about PostgreSQL functionality, visit the official [PostgreSQL website](http://www.postgresql.org).
+1. After you enter a password in the **Password** field and confirm the password in the **Retype Password** field, select **Next**. The Additional Configuration window opens.
 
-After specifying a configuration mode, click `Next` to continue to the `Password` window.
+    ![The Additional Configuration window](../../../images/additional_configuration.png)
 
-![The Password window](../../../images/password_window.png)
+1. Use the fields on the Additional Configuration window to specify installation details:
 
-<div style="text-align: center"> Fig. 7: The Password window </div>
+    -   Use the **Port** field to specify the port number for EDB Postgres Advanced Server to listen to for connection requests from client applications. The default is `5444`.
+    -   If the **Locale** field is set to **[Default locale]**, EDB Postgres Advanced Server uses the system locale as the working locale. From the list, select an alternative locale for EDB Postgres Advanced Server.
+    -   By default, the setup wizard installs corresponding sample data for the server dialect specified by the compatibility mode (Oracle or PostgreSQL). If you don't want to install sample data, clear the check box next to **Install sample tables and procedures**.
 
-EDB Postgres Advanced Server uses the password specified on the `Password` window for the database superuser. The specified password must conform to any security policies existing on the EDB Postgres Advanced Server host.
+1. After verifying the information on the Additional Configuration window, select **Next**. The Dynatune Dynamic Tuning: Server Utilization window opens.
 
-After you enter a password in the `Password` field, confirm the password in the `Retype Password` field, and click `Next` to continue.
+    ![The Dynatune Dynamic Tuning: Server Utilization window](../../../images/dynatune_dynamic_tuning_server_utilization.png)
 
-The `Additional Configuration` window opens.
+    The setup wizard helps with performance tuning by way of the Dynatune Dynamic Tuning feature. Dynatune functionality allows EDB Postgres Advanced Server to make optimal use of the system resources available on the host machine on which it's installed.
 
-![The Additional Configuration window](../../../images/additional_configuration.png)
+1. Use the options on the Server Utilization window to set the initial value of the `edb_dynatune` configuration parameter. The `edb_dynatune` configuration parameter determines how EDB Postgres Advanced Server allocates system resources.
 
-<div style="text-align: center"> Fig. 8: The Additional Configuration window </div>
+    -   Select **Development** to set the value of `edb_dynatune` to `33`. A low value dedicates the least amount of the host machine’s resources to the database server. This seletion is a good choice for a development machine.
+    -   Select **General Purpose** to set the value of `edb_dynatune` to `66`. A mid-range value dedicates a moderate amount of system resources to the database server. This setting is good for an application server with a fixed number of applications running on the same host as EDB Postgres Advanced Server.
+    -   Select **Dedicated** to set the value of `edb_dynatune` to `100`. A high value dedicates most of the system resources to the database server. This setting is a good choice for a dedicated server host.
 
-Use the fields on the `Additional Configuration` window to specify installation details:
+    (After the installation is complete, you can adjust the value of `edb_dynatune` by editing the `postgresql.conf` file, located in the `data` directory of your EDB Postgres Advanced Server installation. After editing the `postgresql.conf` file, you must restart the server for your changes to take effect.)
 
--   Use the `Port` field to specify the port number that EDB Postgres Advanced Server should listen to for connection requests from client applications. The default is `5444`.
--   If the `Locale` field is set to `[Default locale]`, EDB Postgres Advanced Server uses the system locale as the working locale. Use the drop-down listbox next to `Locale` to specify an alternate locale for EDB Postgres Advanced Server.
--   By default, the `Setup` wizard installs corresponding sample data for the server dialect specified by the compatibility mode `(Oracle` or `PostgreSQL)`. Clear the check box next to `Install sample tables and procedures` if you don't wish to have sample data installed.
+    Select the appropriate setting for your system, and select **Next**. The Dynatune Dynamic Tuning: Workload Profile window opens.
 
-After verifying the information on the `Additional Configuration` window, click `Next` to open the `Dynatune Dynamic Tuning: Server Utilization` window.
+    ![The Dynatune Dynamic Tuning: Workload Profile window](../../../images/dynatune_dynamic_tuning_workload_profile.png)
 
-The graphical `Setup` wizard facilitates performance tuning via the Dynatune Dynamic Tuning feature. Dynatune functionality allows EDB Postgres Advanced Server to make optimal usage of the system resources available on the host machine on which it is installed.
+1. Use the options on the Workload Profile window to specify the initial value of the `edb_dynatune_profile` configuration parameter. The `edb_dynatune_profile` parameter controls performance-tuning aspects based on the type of work that the server performs.
 
-![The Dynatune Dynamic Tuning: Server Utilization window](../../../images/dynatune_dynamic_tuning_server_utilization.png)
+    -   Select **Transaction Processing (OLTP systems)** to specify an `edb_dynatune_profile` value of `oltp`. Recommended when EDB Postgres Advanced Server is supporting heavy online transaction processing.
+    -   Select **General Purpose (OLTP and reporting workloads)** to specify an `edb_dynatune_profile` value of `mixed`. Recommended for servers that provide a mix of transaction processing and data reporting.
+    -   Select **Reporting (Complex queries or OLAP workloads)** to specify an `edb_dynatune_profile` value of `reporting`. Recommended for database servers used for heavy data reporting.
 
-<div style="text-align: center"> Fig. 9: The Dynatune Dynamic Tuning: Server Utilization window </div>
+    After the installation is complete, you can adjust the value of `edb_dynatune_profile` by editing the `postgresql.conf` file, located in the `data` directory of your EDB Postgres Advanced Server installation. After editing the `postgresql.conf` file, you must restart the server for your changes to take effect.
 
-The `edb_dynatune` configuration parameter determines how EDB Postgres Advanced Server allocates system resources. Use the radio buttons on the `Server Utilization` window to set the initial value of the `edb_dynatune` configuration parameter:
+    For more information about `edb_dynatune` and other performance-related topics, see the [Dynatune](../../../managing_performance/using_dynatune).
 
--   Select `Development` to set the value of `edb_dynatune` to `33`. A low value dedicates the least amount of the host machine’s resources to the database server. This is a good choice for a development machine.
--   Select `General Purpose` to set the value of `edb_dynatune` to `66`. A mid-range value dedicates a moderate amount of system resources to the database server. This would be a good setting for an application server with a fixed number of applications running on the same host as EDB Postgres Advanced Server.
--   Select `Dedicated` to set the value of `edb_dynatune` to `100`. A high value dedicates most of the system resources to the database server. This is a good choice for a dedicated server host.
+1.  Select **Next**.
 
-After the installation is complete, you can adjust the value of `edb_dynatune` by editing the `postgresql.conf` file, located in the `data` directory of your EDB Postgres Advanced Server installation. After editing the `postgresql.conf` file, you must restart the server for your changes to take effect.
+    By default, EDB Postgres Advanced Server is configured to start the service when the system boots. The Pre Installation Summary opens.
 
-Select the appropriate setting for your system, and click `Next` to continue to the `Dynatune Dynamic Tuning: Workload Profile` window.
+    ![The Pre Installation Summary](../../../images/pre_installation_summary.png)
 
-![The Dynatune Dynamic Tuning: Workload Profile window](../../../images/dynatune_dynamic_tuning_workload_profile.png)
+    The Pre Installation Summary provides an overview of the options specified during the setup process. 
+    
+1. Review the options before selecting **Next**. (Use **Back** to navigate back through the screens and update any options.)
 
-<div style="text-align: center"> Fig. 10: The Dynatune Dynamic Tuning: Workload Profile window </div>
+    The Ready to Install window confirms that the installer has the information it needs about your configuration preferences to install EDB Postgres Advanced Server. 
 
-Use the radio buttons on the `Workload Profile` window to specify the initial value of the `edb_dynatune_profile` configuration parameter. The `edb_dynatune_profile` parameter controls performance-tuning aspects based on the type of work that the server performs.
+1. Select **Next**.
 
--   Select `Transaction Processing (OLTP systems)` to specify an `edb_dynatune_profile` value of `oltp`. Recommended when EDB Postgres Advanced Server is supporting heavy online transaction processing.
--   Select `General Purpose (OLTP and reporting workloads)` to specify an `edb_dynatune_profile` value of `mixed`. Recommended for servers that provide a mix of transaction processing and data reporting.
--   Select `Reporting (Complex queries or OLAP workloads)` to specify an `edb_dynatune_profile` value of `reporting`. Recommended for database servers used for heavy data reporting.
+    ![The Ready to Install window](../../../images/ready_to_install.png)
 
-After the installation is complete, you can adjust the value of `edb_dynatune_profile` by editing the `postgresql.conf` file, located in the `data` directory of your EDB Postgres Advanced Server installation. After editing the `postgresql.conf` file, you must restart the server for your changes to take effect.
+    ![Installing EDB Postgres Advanced Server](../../../images/installing_advanced_server.png)
 
-For more information about `edb_dynatune` and other performance-related topics, see the [Dynatune](../../../managing_performance/using_dynatune).
+    As each supporting module is unpacked and installed, the module’s installation is confirmed with a progress bar.
 
-Click `Next` to continue.
+    Before the setup wizard completes the EDB Postgres Advanced Server installation, it prompts: `Launch StackBuilder Plus at exit?`
 
-By default, EDB Postgres Advanced Server is configured to start the service when the system boots. The `Pre Installation Summary` opens.
+    ![The Setup wizard offers to Launch StackBuilder Plus at exit](../../../images/setup_wizard.png)
 
-![The Pre Installation Summary](../../../images/pre_installation_summary.png)
+    EDB Postgres StackBuilder Plus is included with the installation of EDB Postgres Advanced Server and its core supporting components. StackBuilder Plus is a graphical tool that can update installed products or download and add supporting modules and the resulting dependencies after your EDB Postgres Advanced Server setup and installation completes. See [Using StackBuilder Plus](using_stackbuilder_plus/) for more information.
 
-<div style="text-align: center"> Fig. 11: The Pre Installation Summary </div>
+1. To complete the EDB Postgres Advanced Server installation, clear the **StackBuilder Plus** check box and select **Finish**. Alternatively, accept the default and proceed to StackBuilder Plus.
 
-The `Pre Installation Summary` provides an overview of the options specified during the `Setup` process. Review the options before clicking `Next`; click `Back` to navigate back through the dialogs and update any options.
-
-The `Ready to Install` window confirms that the installer has the information it needs about your configuration preferences to install EDB Postgres Advanced Server. Click `Next` to continue.
-
-![The Ready to Install window](../../../images/ready_to_install.png)
-
-<div style="text-align: center"> Fig. 12: The Ready to Install window </div>
-
-![Installing EDB Postgres Advanced Server](../../../images/installing_advanced_server.png)
-
-<div style="text-align: center"> Fig. 13: Installing EDB Postgres Advanced Server </div>
-
-As each supporting module is unpacked and installed, the module’s installation is confirmed with a progress bar.
-
-Before the `Setup` wizard completes the EDB Postgres Advanced Server installation, it offers to `Launch StackBuilder Plus at exit?`
-
-![The Setup wizard offers to Launch StackBuilder Plus at exit](../../../images/setup_wizard.png)
-
-<div style="text-align: center"> Fig. 14: The Setup wizard offers to Launch StackBuilder Plus at exit </div>
-
-You can clear the `StackBuilder Plus` check box and click `Finish` to complete the EDB Postgres Advanced Server installation, or accept the default and proceed to StackBuilder Plus.
-
-EDB Postgres StackBuilder Plus is included with the installation of EDB Postgres Advanced Server and its core supporting components. StackBuilder Plus is a graphical tool that can update installed products, or download and add supporting modules (and the resulting dependencies) after your EDB Postgres Advanced Server setup and installation completes. See [Using StackBuilder Plus](using_stackbuilder_plus/) for more information about StackBuilder Plus.

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/performing_a_graphical_installation_on_windows.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/performing_a_graphical_installation_on_windows.mdx
@@ -137,7 +137,7 @@ A graphical installation is a quick and easy way to install EDB Postgres Advance
 
     ![The Password window](../../../images/password_window.png)
 
-    EDB Postgres Advanced Server uses the password specified on the Password window for the database superuser. The specified password must conform to any security policies on the EDB Postgres Advanced Server host.
+    EDB Postgres Advanced Server uses the password specified on the Password window for the database superuser. The specified password must confirm to any security policies on the EDB Postgres Advanced Server host.
 
 1. After you enter a password in the **Password** field and confirm the password in the **Retype Password** field, select **Next**. The Additional Configuration window opens.
 

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/performing_a_graphical_installation_on_windows.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/performing_a_graphical_installation_on_windows.mdx
@@ -7,7 +7,7 @@ redirects:
 
 <div id="performing_a_graphical_installation_on_windows" class="registered_link"></div>
 
-A graphical installation is a quick and easy way to install EDB Postgres Advanced Server on a Windows system. Use the wizard's screens to specify information about your system and system usage;.when you have completed the dialogs, the installer performs an installation based on the selections made during the setup process.
+A graphical installation is a quick and easy way to install EDB Postgres Advanced Server on a Windows system. Use the wizard's screens to specify information about your system and system usage. After you complete the screens, the installer performs an installation based on the selections made during the setup process.
 
 1. Assume administrator privileges, and double-click the `edb-as<xx>-server-xx.x.x-x-windows-x64` executable file, where `<xx>` is the EDB Postgres Advanced Server version number.
 
@@ -43,9 +43,9 @@ A graphical installation is a quick and easy way to install EDB Postgres Advance
     
     ![The Select Components window](../../../images/select_components.png)
 
-    The setup wizard can install the following components while installing EDB Postgres Advanced Server 15:
+    The setup wizard can install the following components while installing EDB Postgres Advanced Server:
 
-    -  Select **EDB Postgres Advanced Server** to install EDB Postgres Advanced Server 15.
+    -  Select **EDB Postgres Advanced Server** to install EDB Postgres Advanced Server.
 
     -  Select **StackBuilder Plus** to install that utility. The StackBuilder Plus utility is a graphical tool that can update installed products or download and add supporting modules (and the resulting dependencies) after your EDB Postgres Advanced Server setup and installation completes. See [Using StackBuilder Plus](using_stackbuilder_plus/) for more information.
 
@@ -67,18 +67,18 @@ A graphical installation is a quick and easy way to install EDB Postgres Advance
 
     By default, the EDB Postgres Advanced Server data files are saved to:
 
-```text
-C:\Program Files\edb<xx>\data
-```
-Where `<xx>` is the EDB Postgres Advanced Server version number.
+  ```text
+  C:\Program Files\edb<xx>\data
+  ```
+  Where `<xx>` is the EDB Postgres Advanced Server version number.
 
-The default location of the EDB Postgres Advanced Server `Write-Ahead Log (WAL) Directory` is:
+  The default location of the EDB Postgres Advanced Server `Write-Ahead Log (WAL) Directory` is:
 
-```text
-C:\Program Files\edb\as<xx>\data\pg_wal
-```
+  ```text
+  C:\Program Files\edb\as<xx>\data\pg_wal
+  ```
     
-EDB Postgres Advanced Server uses write-ahead logs to promote transaction safety and speed transaction processing. When you make a change to a table, the change is stored in shared memory, and a record of the change is written to the write-ahead log. When you perform a COMMIT, EDB Postgres Advanced Server writes contents of the write-ahead log to disk.
+  EDB Postgres Advanced Server uses write-ahead logs to promote transaction safety and speed transaction processing. When you make a change to a table, the change is stored in shared memory, and a record of the change is written to the write-ahead log. When you perform a COMMIT, EDB Postgres Advanced Server writes contents of the write-ahead log to disk.
 
 1. Accept the default file locations, or use the file browser to select a different location. Select **Next**. 
 
@@ -131,7 +131,7 @@ EDB Postgres Advanced Server uses write-ahead logs to promote transaction safety
 
     If you choose to install in Compatible with Oracle mode, the EDB Postgres Advanced Server superuser name is enterprisedb.
 
-    If you select **Compatible with PostgreSQL**, EDB Postgres Advanced Server exhibits compatibility with PostgreSQL version 15. If you choose to install in Compatible with PostgreSQL mode, the default EDB Postgres Advanced Server superuser name is postgres. For detailed information about PostgreSQL functionality, visit the [PostgreSQL website](http://www.postgresql.org).
+    If you select **Compatible with PostgreSQL**, EDB Postgres Advanced Server exhibits compatibility with PostgreSQL version 15. If you choose to install in Compatible with PostgreSQL mode, the default EDB Postgres Advanced Server superuser name is postgres. For detailed information about PostgreSQL functionality, see the [PostgreSQL website](http://www.postgresql.org).
 
 1. After specifying a configuration mode, select **Next**. The Password window opens.
 
@@ -175,7 +175,7 @@ EDB Postgres Advanced Server uses write-ahead logs to promote transaction safety
 
     After the installation is complete, you can adjust the value of `edb_dynatune_profile` by editing the `postgresql.conf` file, located in the `data` directory of your EDB Postgres Advanced Server installation. After editing the `postgresql.conf` file, you must restart the server for your changes to take effect.
 
-    For more information about `edb_dynatune` and other performance-related topics, see the [Dynatune](../../../managing_performance/using_dynatune).
+    For more information about edb_dynatune and other performance-related topics, see the [Dynatune](../../../managing_performance/using_dynatune).
 
 1.  Select **Next**.
 
@@ -204,4 +204,3 @@ EDB Postgres Advanced Server uses write-ahead logs to promote transaction safety
     EDB Postgres StackBuilder Plus is included with the installation of EDB Postgres Advanced Server and its core supporting components. StackBuilder Plus is a graphical tool that can update installed products or download and add supporting modules and the resulting dependencies after your EDB Postgres Advanced Server setup and installation completes. See [Using StackBuilder Plus](using_stackbuilder_plus/) for more information.
 
 1. To complete the EDB Postgres Advanced Server installation, clear the **StackBuilder Plus** check box and select **Finish**. Alternatively, accept the default and proceed to StackBuilder Plus.
-

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus.mdx
@@ -7,58 +7,46 @@ redirects:
 
 <div id="using_stackbuilder_plus" class="registered_link"></div>
 
-The StackBuilder Plus utility provides a graphical interface that simplifies the process of updating, downloading, and installing modules that complement your EDB Postgres Advanced Server installation. When you install a module with StackBuilder Plus, StackBuilder Plus automatically resolves any software dependencies.
+The StackBuilder Plus utility provides a graphical interface that simplifies the process of updating, downloading, and installing modules that complement your EDB Postgres Advanced Server installation. When you install a module with StackBuilder Plus, StackBuilder Plus resolves any software dependencies.
 
-You can invoke StackBuilder Plus at any time after the installation has completed by selecting the `StackBuilder Plus` menu option from the `Apps` menu. Enter your system password (if prompted), and the StackBuilder Plus welcome window opens.
+You can invoke StackBuilder Plus at any time after the installation is complete by selecting **Apps >`StackBuilder Plus**. If prompted, enter your system password, and the StackBuilder Plus welcome window opens.
 
 ![The StackBuilder Plus welcome window](../../../images/stackbuilder_plus_welcome.png)
 
-<div style="text-align: center"> Fig. 19: The StackBuilder Plus welcome window </div>
+From the list, select your EDB Postgres Advanced Server installation.
 
-Use the drop-down listbox on the welcome window to select your EDB Postgres Advanced Server installation.
+StackBuilder Plus requires Internet access. If your installation of EDB Postgres Advanced Server resides behind a firewall with restricted Internet access, StackBuilder Plus can download program installers through a proxy server. The module provider determines if the module can be accessed through an HTTP proxy or an FTP proxy. Currently, all updates are transferred by way of an HTTP proxy. The FTP proxy information isn't used.
 
-StackBuilder Plus requires Internet access; if your installation of EDB Postgres Advanced Server resides behind a firewall (with restricted Internet access), StackBuilder Plus can download program installers through a proxy server. The module provider determines if the module can be accessed through an HTTP proxy or an FTP proxy; currently, all updates are transferred via an HTTP proxy and the FTP proxy information is not used.
+If the selected EDB Postgres Advanced Server installation has restricted Internet access, on the welcome window, select **Proxy Servers** to open the Proxy Servers dialog box.
 
-If the selected EDB Postgres Advanced Server installation has restricted Internet access, use the `Proxy Servers` on the `Welcome` window to open the `Proxy servers` dialog.
+![The Proxy Servers dialog box](../../../images/proxy_servers.png)
 
-![The Proxy Servers dialog](../../../images/proxy_servers.png)
-
-<div style="text-align: center"> Fig. 20: The Proxy Servers dialog </div>
-
-Enter the IP address and port number of the proxy server in the `HTTP proxy` on the `Proxy Servers` dialog. Currently, all StackBuilder Plus modules are distributed via HTTP proxy (FTP proxy information is ignored). Click `OK` to continue.
+In the Proxy Servers dialog box, enter the IP address and port number of the proxy server in the **HTTP proxy** field. Currently, all StackBuilder Plus modules are distributed via HTTP proxy, and FTP proxy information is ignored. Select **OK**.
 
 ![The StackBuilder Plus module selection window](../../../images/stackbuilder_plus_module_selection.png)
 
-<div style="text-align: center"> Fig. 21: The StackBuilder Plus module selection window </div>
-
 The tree control on the StackBuilder Plus module selection window displays a node for each module category.
 
-Expand a module, and highlight a component name in the tree control to review a detailed description of the component. To add one or more components to the installation or to upgrade a component, check the box to the left of a module name and click `Next`.
+To review a detailed description of the component, expand a module and select a component name in the tree control. To add components to the installation or to upgrade a component, select the check box to the left of a module name and select **Next**.
 
 StackBuilder Plus confirms the packages selected.
 
 ![A summary window displays a list of selected packages](../../../images/summary_window_displaying_selected_packages.png)
 
-<div style="text-align: center"> Fig. 22: A summary window displays a list of selected packages </div>
+Use the browse icon (...) to the right of the **Download directory** field to open a file selector, and choose an alternativee location to store the downloaded installers. Select **Next** to connect to the server and download the required installation files.
 
-Use the browse icon (...) to the right of the `Download directory` field to open a file selector, and choose an alternate location to store the downloaded installers. Click `Next` to connect to the server and download the required installation files.
-
-When the download completes, a window opens that confirms the installation files have been downloaded and are ready for installation.
+When the download completes, a window opens that confirms the installation files were downloaded and are ready for installation.
 
 ![Confirmation that the download process is complete](../../../images/download_complete.png)
 
-<div style="text-align: center"> Fig. 23: Confirmation that the download process is complete </div>
+To exit StackBuilder Plus without installing the downloaded files, select the **Skip Installation** check box and select **Next**. To start the installation process, leave the box cleared and select **Next**.
 
-You can check the box next to `Skip Installation`, and select `Next` to exit StackBuilder Plus without installing the downloaded files, or leave the box unchecked and click `Next` to start the installation process.
+Each downloaded installer has different requirements. As the installers execute, they might prompt you to confirm acceptance of license agreements, enter passwords, and provide configuration information.
 
-Each downloaded installer has different requirements. As the installers execute, they may prompt you to confirm acceptance of license agreements, to enter passwords, and provide configuration information.
+During the installation process, you might be prompted by one or more of the installers to restart your system. Select **No** or **Restart Later** until all installations are completed. When the last installation has completed, restart the system to apply all of the updates.
 
-During the installation process, you may be prompted by one (or more) of the installers to restart your system. Select `No` or `Restart Later` until all installations are completed. When the last installation has completed, reboot the system to apply all of the updates.
+You might occasionally encounter packages that don’t install successfully. If a package fails to install, StackBuilder Plus alerts you to the installation error and writes a message to the log file at `%TEMP%`.
 
-You may occasionally encounter packages that don’t install successfully. If a package fails to install, StackBuilder Plus will alert you to the installation error with a popup dialog, and write a message to the log file at `%TEMP%`.
+When the installation is complete, StackBuilder Plus alerts you to the success or failure of the installations of the requested packages. If you were prompted by an installer to restart your computer, restart now.
 
 ![StackBuilder Plus confirms the completed installation](../../../images/stackbuilder_plus_completed_installation.png)
-
-<div style="text-align: center"> Fig. 24: StackBuilder Plus confirms the completed installation </div>
-
-When the installation is complete, StackBuilder Plus will alert you to the success or failure of the installations of the requested packages. If you were prompted by an installer to restart your computer, reboot now.

--- a/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus.mdx
+++ b/product_docs/docs/epas/15/installing/windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus.mdx
@@ -9,19 +9,19 @@ redirects:
 
 The StackBuilder Plus utility provides a graphical interface that simplifies the process of updating, downloading, and installing modules that complement your EDB Postgres Advanced Server installation. When you install a module with StackBuilder Plus, StackBuilder Plus resolves any software dependencies.
 
-You can invoke StackBuilder Plus at any time after the installation is complete by selecting **Apps >`StackBuilder Plus**. If prompted, enter your system password, and the StackBuilder Plus welcome window opens.
+You can invoke StackBuilder Plus any time after the installation is complete by selecting **Apps > StackBuilder Plus**. If prompted, enter your system password, and the StackBuilder Plus welcome window opens.
 
 ![The StackBuilder Plus welcome window](../../../images/stackbuilder_plus_welcome.png)
 
 From the list, select your EDB Postgres Advanced Server installation.
 
-StackBuilder Plus requires Internet access. If your installation of EDB Postgres Advanced Server resides behind a firewall with restricted Internet access, StackBuilder Plus can download program installers through a proxy server. The module provider determines if the module can be accessed through an HTTP proxy or an FTP proxy. Currently, all updates are transferred by way of an HTTP proxy. The FTP proxy information isn't used.
+StackBuilder Plus requires Internet access. If your installation of EDB Postgres Advanced Server is behind a firewall with restricted Internet access, StackBuilder Plus can download program installers through a proxy server. The module provider determines if the module can be accessed through an HTTP proxy or an FTP proxy. Currently, all updates are transferred by way of an HTTP proxy. The FTP proxy information isn't used.
 
 If the selected EDB Postgres Advanced Server installation has restricted Internet access, on the welcome window, select **Proxy Servers** to open the Proxy Servers dialog box.
 
 ![The Proxy Servers dialog box](../../../images/proxy_servers.png)
 
-In the Proxy Servers dialog box, enter the IP address and port number of the proxy server in the **HTTP proxy** field. Currently, all StackBuilder Plus modules are distributed via HTTP proxy, and FTP proxy information is ignored. Select **OK**.
+In the Proxy Servers dialog box, in the **HTTP proxy** fieldm enter the IP address and port number of the proxy server. Currently, all StackBuilder Plus modules are distributed by way of HTTP proxy, and FTP proxy information is ignored. Select **OK**.
 
 ![The StackBuilder Plus module selection window](../../../images/stackbuilder_plus_module_selection.png)
 
@@ -33,13 +33,13 @@ StackBuilder Plus confirms the packages selected.
 
 ![A summary window displays a list of selected packages](../../../images/summary_window_displaying_selected_packages.png)
 
-Use the browse icon (...) to the right of the **Download directory** field to open a file selector, and choose an alternativee location to store the downloaded installers. Select **Next** to connect to the server and download the required installation files.
+Use the browse icon (...) to the right of the **Download directory** field to open a file selector and choose an alternativee location to store the downloaded installers. Select **Next** to connect to the server and download the required installation files.
 
 When the download completes, a window opens that confirms the installation files were downloaded and are ready for installation.
 
 ![Confirmation that the download process is complete](../../../images/download_complete.png)
 
-To exit StackBuilder Plus without installing the downloaded files, select the **Skip Installation** check box and select **Next**. To start the installation process, leave the box cleared and select **Next**.
+To start the installation process, leave the **Skip Installation** box cleared and select **Next**. To exit StackBuilder Plus without installing the downloaded files, select the check box, and select **Next**.
 
 Each downloaded installer has different requirements. As the installers execute, they might prompt you to confirm acceptance of license agreements, enter passwords, and provide configuration information.
 

--- a/product_docs/docs/epas/15/installing/windows/managing_an_advanced_server_installation/configuring_epas.mdx
+++ b/product_docs/docs/epas/15/installing/windows/managing_an_advanced_server_installation/configuring_epas.mdx
@@ -15,19 +15,17 @@ You can easily update parameters that determine the behavior of EDB Postgres Adv
 -   The `pg_hba.conf` file specifies your preferences for network authentication and authorization.
 -   The `pg_ident.conf` file maps operating system identities (user names) to EDB Postgres Advanced Server identities (roles) when using `ident`-based authentication.
 
-For more information about Modifying the postgresql.conf file and Modifying the pg_hba.conf file, see [Setting parameters](../../../../database_administration/01_configuration_parameters/01_setting_new_parameters).
+For more information about modifying the `postgresql.conf` and `pg_hba.conf` files, see [Setting parameters](../../../../database_administration/01_configuration_parameters/01_setting_new_parameters).
 
-You can use your editor of choice to open a configuration file, or on Windows navigate through the `EDB Postgres` menu to open a file.
+You can use your editor of choice to open a configuration file. On Windows, you can navigate through the **EDB Postgres** menu to open a file.
 
 ![Accessing the configuration files through the Windows system menu](../../../images/accessing_configuration_files.png)
 
-<div style="text-align: center"> Fig. 1: Accessing the configuration files through the Windows system menu </div>
-
 ## Setting EDB Postgres Advanced Server environment variables
 
-The graphical installer provides a script that simplifies the task of setting environment variables for Windows users. The script sets the environment variables for your current shell session; when your shell session ends, the environment variables are destroyed. You may wish to invoke `pgplus_env.bat` from your system-wide shell startup script, so that environment variables are automatically defined for each shell session.
+The graphical installer provides a script that simplifies the task of setting environment variables for Windows users. The script sets the environment variables for your current shell session. When your shell session ends, the environment variables are destroyed. You might want to invoke `pgplus_env.bat` from your system-wide shell startup script, which definies environment variables for each shell session.
 
-The `pgplus_env` script is created during the EDB Postgres Advanced Server installation process and reflects the choices made during installation. To invoke the script, open a command line and enter:
+The `pgplus_env` script is created during the EDB Postgres Advanced Server installation process and reflects the choices made during installation. To invoke the script, at the command line, enter:
 
 ```text
 C:\Program Files\edb\as14\pgplus_env.bat
@@ -45,7 +43,7 @@ PGPORT=5444
 PGLOCALEDIR=C:\Program Files\edb\as14\share\locale
 ```
 
-If you have used an installer created by EDB to install PostgreSQL, the `pg_env` script performs the same function:
+If you used an installer created by EDB to install PostgreSQL, the `pg_env` script performs the same function:
 
 ```text
 C:\Progra~1\PostgreSQL\14\pg_env.bat
@@ -64,9 +62,9 @@ PGLOCALEDIR=C:\Program Files\PostgreSQL\14\share\locale
 
 ## Connecting to EDB Postgres Advanced Server with edb-psql
 
-`edb-psql` is a command line client application that allows you to execute SQL commands and view the results. To open the `edb-psql` client, the client must be in your search path. The executable resides in the `bin` directory, under your EDB Postgres Advanced Server installation.
+edb-psql is a command-line client application that allows you to execute SQL commands and view the results. To open the edb-psql client, make sure the client is in your search path. The executable resides in the `bin` directory under your EDB Postgres Advanced Server installation.
 
-Use the following command and options to start the `edb-psql` client:
+Use the following command and options to start the edb-psql client:
 
 ```text
 psql -d edb -U enterprisedb
@@ -74,38 +72,30 @@ psql -d edb -U enterprisedb
 
 ![Connecting to the server](../../../images/connecting_to_server.png)
 
-<div style="text-align: center"> Fig. 2: Connecting to the server </div>
-
 Where:
 
-`-d` specifies the database to which `edb-psql` will connect.
+`-d` specifies the database to which edb-psql connects.
 
-`-U` specifies the identity of the database user that will be used for the session.
+`-U` specifies the identity of the database user to use for the session.
 
-If you have performed an installation with the interactive installer, you can access the `edb-psql` client by selecting `EDB-PSQL` from the `EDB Postgres` menu. When the client opens, provide connection information for your session.
+If you performed an installation with the interactive installer, you can access the edb-psql client by selecting **EDB Postgres > EDB-PSQL**. When the client opens, provide connection information for your session.
 
-`edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. For more information about using the command line client, see the [PostgreSQL Core Documentation](https://www.postgresql.org/docs/current/static/app-psql.html).
+The `edb-psql` file is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community psql, with added support for EDB Postgres Advanced Server features. For more information about using the command-line client, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/app-psql.html).
 
 ## Connecting to EDB Postgres Advanced Server with the pgAdmin 4 client
 
-pgAdmin 4 provides an interactive graphical interface that you can use to manage your database and database objects. Easy-to-use dialogs and online help simplify tasks such as object creation, role management, and granting or revoking privileges. The tabbed browser panel provides quick access to information about the object currently selected in the pgAdmin tree control.
+pgAdmin 4 provides a graphical interface that you can use to manage your database and database objects. Dialog boxes and online help simplify tasks such as object creation, role management, and granting or revoking privileges. The tabbed browser panel provides quick access to information about the object currently selected in the pgAdmin tree control.
 
-The client is distributed with the graphical installer. To open pgAdmin, select pgAdmin4 from the `EDB Postgres` menu. The client opens in your default browser.
+The client is distributed with the graphical installer. To open pgAdmin, select **EDB Postgres > pgAdmin4**`. The client opens in your default browser.
 
-![The pgAdmin 4 client Dashboard](../../../images/pgadmin4_client_dashboard.png)
+![The pgAdmin 4 client dashboard](../../../images/pgadmin4_client_dashboard.png)
 
-<div style="text-align: center"> Fig. 1: The pgAdmin 4 client Dashboard </div>
-
-To connect to the EDB Postgres Advanced Server database server, expand the `Servers` node of the `Browser` tree control, and right click on the `EDB Postgres Advanced Server` node. When the context menu opens, select `Connect Server`. The `Connect to Server` dialog opens.
+To connect to the EDB Postgres Advanced Server database server, expand the Servers node of the Browser tree control, and right-click on the EDB Postgres Advanced Server node. From the context menu, select **Connect Server**. The Connect to Server dialog box opens.
 
 ![The Connect to Server dialog](../../../images/connecting_server.png)
 
-<div style="text-align: center"> Fig. 2: The Connect to Server dialog </div>
-
-Provide the password associated with the database superuser in the `Password` field, and click `OK` to connect.
+To connect, in the **Password** field, provide the password associated with the database superuser, and select **OK**.
 
 ![Connecting to an EDB Postgres Advanced Server database](../../../images/connecting_to_advanced_server_database.png)
 
-<div style="text-align: center"> Fig. 3: Connecting to an EDB Postgres Advanced Server database </div>
-
-When the client connects, you can use the `Browser` tree control to retrieve information about existing database objects, or to create new objects. For more information about using the pgAdmin client, use the `Help` drop-down menu to access the online help files.
+When the client connects, you can use the Browser tree control to retrieve information about existing database objects or to create new objects. For more information about using the pgAdmin client, use the **Help** menu.

--- a/product_docs/docs/epas/15/managing_performance/02_index_advisor/02_index_advisor_configuration.mdx
+++ b/product_docs/docs/epas/15/managing_performance/02_index_advisor/02_index_advisor_configuration.mdx
@@ -9,7 +9,7 @@ redirects:
 
 Index Advisor doesn't require configuration to generate recommendations that are available only for the rest of the current session. To store the results of multiple sessions, you must create the `index_advisor_log` table, where EDB Postgres Advanced Server stores Index Advisor recommendations. To create the `index_advisor_log` table, create the extension `index_advisor`.
 
-When selecting a storage schema for the Index Advisor table, function, and view, keep in mind that all users that invoke Index Advisor and query the result set must have `USAGE` privileges on the schema. The schema must be in the search path of all users that are interacting with Index Advisor.
+When selecting a storage schema for the Index Advisor table, function, and view, keep in mind that all users that invoke Index Advisor and query the result set must have USAGE privileges on the schema. The schema must be in the search path of all users that are interacting with Index Advisor.
 
 ## Storing the results of multiple sessions
 
@@ -33,14 +33,14 @@ When selecting a storage schema for the Index Advisor table, function, and view,
     ```
 
     !!! Note
-        If you're using Index Advisor in earlier version of EDB Postgres Advanced Server and upgrading to version 15, then use this command to create the index_advisor extension:
+        If you're using Index Advisor in an earlier version of EDB Postgres Advanced Server and upgrading to version 15, then use this command to create the index_advisor extension:
 
         ```sql
         # running as the database superuser using psql
         create extension index_advisor version 1.1;
         ```
 
-    This command creates the extension and links any of the old database objects to it.
+        This command creates the extension and links any of the old database objects to it.
     
 3.  Grant privileges on the `index_advisor_log` table to all Index Advisor users. This step isn't necessary if the Index Advisor user is a superuser or the owner of these database objects.
 

--- a/product_docs/docs/epas/15/reference/database_administrator_reference/01_index_advisor_components.mdx
+++ b/product_docs/docs/epas/15/reference/database_administrator_reference/01_index_advisor_components.mdx
@@ -14,7 +14,7 @@ On Windows, the EDB Postgres Advanced Server installer creates the shared librar
 
 `index_advisor.dll`
 
-For Linux, install the `edb-asxx-server-indexadvisor` RPM package, where `xx` is the EDB Postgres Advanced Server version number. The shared library is:
+For Linux, install the `edb-as<xx>-server-indexadvisor` RPM package, where `<xx>` is the EDB Postgres Advanced Server version number. The shared library is:
 
 `index_advisor.so`
 


### PR DESCRIPTION
Part I of install topics transferred from outdated branch.

Also made xx nomenclature consistent throughout the doc, as it was using three different styles of wording.

