### PR TITLE
EPAS 15 - Log file fix as per DB-2428

### DIFF
--- a/product_docs/docs/epas/11/installing/linux_install_details/component_locations.mdx
+++ b/product_docs/docs/epas/11/installing/linux_install_details/component_locations.mdx
@@ -18,15 +18,12 @@ The RPM installers place EDB Postgres Advanced Server components in the director
 | --------------------------------- | ------------------------------------------ |
 | Executables                       | `/usr/edb/as11/bin`                        |
 | Libraries                         | `/usr/edb/as11/lib`                        |
-| Cluster configuration files       | `/etc/edb/as11`                            |
+| Cluster configuration files       | `/var/lib/edb/as11`                        |
 | Documentation                     | `/usr/edb/as11/share/doc`                  |
 | Contrib                           | `/usr/edb/as11/share/contrib`              |
 | Data                              | `/var/lib/edb/as11/data`                   |
-| Logs                              | `/var/log/as11`                            |
-| Lock files                        | `/var/lock/as11`                           |
-| Log rotation file                 | `/etc/logrotate.d/as11`                    |
-| Sudo configuration file           | `/etc/sudoers.d/as11`                      |
-| Binary to access VIP without sudo | `/usr/edb/as11/bin/secure`                 |
+| Logs                              | `/var/log/edb/as11`                        |
+| Lock files                        | `/var/lock/edb/as11`                       |
 | Backup area                       | `/var/lib/edb/as11/backups`                |
 | Templates                         | `/usr/edb/as11/share`                      |
 | Procedural Languages              | `/usr/edb/as11/lib or /usr/edb/as11/lib64` |

--- a/product_docs/docs/epas/12/installing/linux_install_details/component_locations.mdx
+++ b/product_docs/docs/epas/12/installing/linux_install_details/component_locations.mdx
@@ -18,15 +18,12 @@ The RPM installers place EDB Postgres Advanced Server components in the director
 | --------------------------------- | ------------------------------------------ |
 | Executables                       | `/usr/edb/as12/bin`                        |
 | Libraries                         | `/usr/edb/as12/lib`                        |
-| Cluster configuration files       | `/etc/edb/as12`                            |
+| Cluster configuration files       | `/var/lib/edb/as12`                        |
 | Documentation                     | `/usr/edb/as12/share/doc`                  |
 | Contrib                           | `/usr/edb/as12/share/contrib`              |
 | Data                              | `/var/lib/edb/as12/data`                   |
-| Logs                              | `/var/log/as12`                            |
-| Lock files                        | `/var/lock/as12`                           |
-| Log rotation file                 | `/etc/logrotate.d/as12`                    |
-| Sudo configuration file           | `/etc/sudoers.d/as12`                      |
-| Binary to access VIP without sudo | `/usr/edb/as12/bin/secure`                 |
+| Logs                              | `/var/log/edb/as12`                        |
+| Lock files                        | `/var/lock/edb/as12`                       |
 | Backup area                       | `/var/lib/edb/as12/backups`                |
 | Templates                         | `/usr/edb/as12/share`                      |
 | Procedural Languages              | `/usr/edb/as12/lib or /usr/edb/as12/lib64` |

--- a/product_docs/docs/epas/13/installing/linux_install_details/component_locations.mdx
+++ b/product_docs/docs/epas/13/installing/linux_install_details/component_locations.mdx
@@ -17,15 +17,12 @@ The RPM installers place EDB Postgres Advanced Server components in the director
 | --------------------------------- | ------------------------------------------ |
 | Executables                       | `/usr/edb/as13/bin`                        |
 | Libraries                         | `/usr/edb/as13/lib`                        |
-| Cluster configuration files       | `/etc/edb/as13`                            |
+| Cluster configuration files       | `/var/lib/edb/as13`                        |
 | Documentation                     | `/usr/edb/as13/share/doc`                  |
 | Contrib                           | `/usr/edb/as13/share/contrib`              |
 | Data                              | `/var/lib/edb/as13/data`                   |
-| Logs                              | `/var/log/as13`                            |
-| Lock files                        | `/var/lock/as13`                           |
-| Log rotation file                 | `/etc/logrotate.d/as13`                    |
-| Sudo configuration file           | `/etc/sudoers.d/as13`                      |
-| Binary to access VIP without sudo | `/usr/edb/as13/bin/secure`                 |
+| Logs                              | `/var/log/edb/as13`                        |
+| Lock files                        | `/var/lock/edb/as13`                       |
 | Backup area                       | `/var/lib/edb/as13/backups`                |
 | Templates                         | `/usr/edb/as13/share`                      |
 | Procedural Languages              | `/usr/edb/as13/lib or /usr/edb/as13/lib64` |

--- a/product_docs/docs/epas/14/installing/linux_install_details/component_locations.mdx
+++ b/product_docs/docs/epas/14/installing/linux_install_details/component_locations.mdx
@@ -17,15 +17,12 @@ The RPM installers place EDB Postgres Advanced Server components in the director
 | --------------------------------- | ------------------------------------------ |
 | Executables                       | `/usr/edb/as14/bin`                        |
 | Libraries                         | `/usr/edb/as14/lib`                        |
-| Cluster configuration files       | `/etc/edb/as14`                            |
+| Cluster configuration files       | `/var/lib/edb/as14`                        |
 | Documentation                     | `/usr/edb/as14/share/doc`                  |
 | Contrib                           | `/usr/edb/as14/share/contrib`              |
 | Data                              | `/var/lib/edb/as14/data`                   |
-| Logs                              | `/var/log/as14`                            |
-| Lock files                        | `/var/lock/as14`                           |
-| Log rotation file                 | `/etc/logrotate.d/as14`                    |
-| Sudo configuration file           | `/etc/sudoers.d/as14`                      |
-| Binary to access VIP without sudo | `/usr/edb/as14/bin/secure`                 |
+| Logs                              | `/var/log/edb/as14`                        |
+| Lock files                        | `/var/lock/edb/as14`                       |
 | Backup area                       | `/var/lib/edb/as14/backups`                |
 | Templates                         | `/usr/edb/as14/share`                      |
 | Procedural Languages              | `/usr/edb/as14/lib or /usr/edb/as14/lib64` |

--- a/product_docs/docs/epas/15/installing/linux_install_details/component_locations.mdx
+++ b/product_docs/docs/epas/15/installing/linux_install_details/component_locations.mdx
@@ -22,10 +22,8 @@ The RPM installers place EDB Postgres Advanced Server components in the director
 | Documentation                     | `/usr/edb/as15/share/doc`                  |
 | Contrib                           | `/usr/edb/as15/share/contrib`              |
 | Data                              | `/var/lib/edb/as15/data`                   |
-| Logs                              | `/var/log/as15`                            |
-| Lock files                        | `/var/lock/as15`                           |
-| Log rotation file                 | `/etc/logrotate.d/as15`                    |
-| Sudo configuration file           | `/etc/sudoers.d/as15`                      |
+| Logs                              | `/var/log/edb/as15`                            |
+| Lock files                        | `/var/lock/edb/as15`                           |
 | Binary to access VIP without sudo | `/usr/edb/as15/bin/secure`                 |
 | Backup area                       | `/var/lib/edb/as15/backups`                |
 | Templates                         | `/usr/edb/as15/share`                      |

--- a/product_docs/docs/epas/15/installing/linux_install_details/component_locations.mdx
+++ b/product_docs/docs/epas/15/installing/linux_install_details/component_locations.mdx
@@ -18,13 +18,12 @@ The RPM installers place EDB Postgres Advanced Server components in the director
 | --------------------------------- | ------------------------------------------ |
 | Executables                       | `/usr/edb/as15/bin`                        |
 | Libraries                         | `/usr/edb/as15/lib`                        |
-| Cluster configuration files       | `/etc/edb/as15`                            |
+| Cluster configuration files       | `/var/lib/edb/as15`                            |
 | Documentation                     | `/usr/edb/as15/share/doc`                  |
 | Contrib                           | `/usr/edb/as15/share/contrib`              |
 | Data                              | `/var/lib/edb/as15/data`                   |
 | Logs                              | `/var/log/edb/as15`                            |
 | Lock files                        | `/var/lock/edb/as15`                           |
-| Binary to access VIP without sudo | `/usr/edb/as15/bin/secure`                 |
 | Backup area                       | `/var/lib/edb/as15/backups`                |
 | Templates                         | `/usr/edb/as15/share`                      |
 | Procedural Languages              | `/usr/edb/as15/lib or /usr/edb/as15/lib64` |


### PR DESCRIPTION
## What Changed?

Removed Log rotation file and Sudo configuration file and updated Logs and Lock files as per [DB-2428](https://enterprisedb.atlassian.net/browse/DB-2428)





[DB-2428]: https://enterprisedb.atlassian.net/browse/DB-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ