### PR TITLE
Explicitly call out psql -U for OpenShift

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
@@ -890,10 +890,14 @@ This command will start `kubectl exec`, and the `kubectl` executable must be
 reachable in your `PATH` variable to correctly work.
 
 !!! Note
-    Mind that when connecting to instances running on OpenShift, one has to explicitly
-    pass a username to the `psql` command, because of a [security measure built into
-    OpenShift](https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids):
-    `kubectl cnp psql cluster-example -- -U postgres`.
+When connecting to instances running on OpenShift, you must explicitly
+pass a username to the `psql` command, because of a [security measure built into
+OpenShift](https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids):
+
+```shell
+kubectl cnp psql cluster-example -- -U postgres
+```
+!!!
 
 ### Snapshotting a Postgres cluster
 

--- a/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
@@ -889,6 +889,12 @@ postgres=# \q
 This command will start `kubectl exec`, and the `kubectl` executable must be
 reachable in your `PATH` variable to correctly work.
 
+!!! Note
+    Mind that when connecting to instances running on OpenShift, one has to explicitly
+    pass a username to the `psql` command, because of a [security measure built into
+    OpenShift](https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids):
+    `kubectl cnp psql cluster-example -- -U postgres`.
+
 ### Snapshotting a Postgres cluster
 
 The `kubectl cnp snapshot` creates consistent snapshots of a Postgres


### PR DESCRIPTION
Update docs so it is clear users need to call the `kubectl cnp psql` command explicitly with a user on OpenShift due to the fact that OpenShift randomly assigns UID to users in containers.

## What Changed?

Added a Note to clarify the above under the block of text about the `kubectl cnp psql` command.