### PR TITLE
Removing references to clusters running on Debian.

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
@@ -862,7 +862,7 @@ it from the actual pod. This means that you will be using the `postgres` user.
 ```shell
 kubectl cnp psql cluster-example
 
-psql (15.3 (Debian 15.3-1.pgdg110+1))
+psql (15.3)
 Type "help" for help.
 
 postgres=#
@@ -873,7 +873,7 @@ select to work against a replica by using the `--replica` option:
 
 ```shell
 kubectl cnp psql --replica cluster-example
-psql (15.3 (Debian 15.3-1.pgdg110+1))
+psql (15.3)
 
 Type "help" for help.
 


### PR DESCRIPTION
Don't know if this is easy to do, as this would make these docs diverge from the upstream ones, but referencing Debian here (`psql` output showing the Postgres cluster is running on Debian images), is quite confusing, and should probably be avoided.


