### PR TITLE
Security version number fixes

### DIFF
--- a/advocacy_docs/security/advisories/cve2023xxxxx1.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx1.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain packages, standalone packages and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain packages, standalone packages and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks. 
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 
@@ -38,7 +38,7 @@ EnterpriseDB Postgres Advanced Server (EPAS)
 |---------|------|-----------------------|
 | EPAS | All versions prior to 11.21.32 | Update to latest supported version <br/> (at least [11.21.32](/epas/11/epas_rel_notes/epas11_21_32_rel_notes/)) 
 | EPAS | All versions prior to 12.16.20 | Update to latest supported version <br/> (at least [12.16.20](/epas/12/epas_rel_notes/epas12_16_20_rel_notes/)) |
-| EPAS | All versions prior to 13.12.16 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
+| EPAS | All versions prior to 13.12.17 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
 | EPAS | All versions prior to 14.9.0 | Update to latest supported version <br/> (at least [14.9.0](/epas/14/epas_rel_notes/epas14_9_0_rel_notes/))
 | EPAS | All versions prior to 15.4.0 | Update to latest supported version <br/> (at least [15.4.0](/epas/15/epas_rel_notes/epas15_4_0_rel_notes/))
 

--- a/advocacy_docs/security/advisories/cve2023xxxxx2.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx2.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain the function _dbms_aq_move_to_exception_queue which may be used to elevate a user’s privileges to superuser. This function accepts the OID of a table, then accesses that table as the superuser using SELECT and DML commands. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain the function _dbms_aq_move_to_exception_queue which may be used to elevate a user’s privileges to superuser. This function accepts the OID of a table, then accesses that table as the superuser using SELECT and DML commands. 
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 
@@ -38,7 +38,7 @@ EnterpriseDB Postgres Advanced Server (EPAS)
 |---------|------|-----------------------|
 | EPAS | All versions prior to 11.21.32 | Update to latest supported version <br/> (at least [11.21.32](/epas/11/epas_rel_notes/epas11_21_32_rel_notes/)) 
 | EPAS | All versions prior to 12.16.20 | Update to latest supported version <br/> (at least [12.16.20](/epas/12/epas_rel_notes/epas12_16_20_rel_notes/)) |
-| EPAS | All versions prior to 13.12.16 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
+| EPAS | All versions prior to 13.12.17 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
 | EPAS | All versions prior to 14.9.0 | Update to latest supported version <br/> (at least [14.9.0](/epas/14/epas_rel_notes/epas14_9_0_rel_notes/))
 | EPAS | All versions prior to 15.4.0 | Update to latest supported version <br/> (at least [15.4.0](/epas/15/epas_rel_notes/epas15_4_0_rel_notes/))
 

--- a/advocacy_docs/security/advisories/cve2023xxxxx3.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx3.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 allow an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents regardless of permissions. This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 allow an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents regardless of permissions. This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections. 
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 
@@ -40,7 +40,7 @@ Impacted users must upgrade to a fixed version of EPAS and then patch existing d
 |---------|------|-----------------------|
 | EPAS | All versions prior to 11.21.32 | Update to latest supported version <br/> (at least [11.21.32](/epas/11/epas_rel_notes/epas11_21_32_rel_notes/)) 
 | EPAS | All versions prior to 12.16.20 | Update to latest supported version <br/> (at least [12.16.20](/epas/12/epas_rel_notes/epas12_16_20_rel_notes/)) |
-| EPAS | All versions prior to 13.12.16 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
+| EPAS | All versions prior to 13.12.17 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
 | EPAS | All versions prior to 14.9.0 | Update to latest supported version <br/> (at least [14.9.0](/epas/14/epas_rel_notes/epas14_9_0_rel_notes/))
 | EPAS | All versions prior to 15.4.0 | Update to latest supported version <br/> (at least [15.4.0](/epas/15/epas_rel_notes/epas15_4_0_rel_notes/))
 

--- a/advocacy_docs/security/advisories/cve2023xxxxx4.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx4.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete. 
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 
@@ -40,7 +40,7 @@ Impacted users must upgrade to a fixed version of EPAS and then patch existing d
 |---------|------|-----------------------|
 | EPAS | All versions prior to 11.21.32 | Update to latest supported version <br/> (at least [11.21.32](/epas/11/epas_rel_notes/epas11_21_32_rel_notes/)) 
 | EPAS | All versions prior to 12.16.20 | Update to latest supported version <br/> (at least [12.16.20](/epas/12/epas_rel_notes/epas12_16_20_rel_notes/)) |
-| EPAS | All versions prior to 13.12.16 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
+| EPAS | All versions prior to 13.12.17 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
 | EPAS | All versions prior to 14.9.0 | Update to latest supported version <br/> (at least [14.9.0](/epas/14/epas_rel_notes/epas14_9_0_rel_notes/))
 | EPAS | All versions prior to 15.4.0 | Update to latest supported version <br/> (at least [15.4.0](/epas/15/epas_rel_notes/epas15_4_0_rel_notes/))
 

--- a/advocacy_docs/security/advisories/cve2023xxxxx5.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx5.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 using DBMS_MVIEW allows an authenticated user to refresh any materialized view, regardless of that user’s permissions. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 using DBMS_MVIEW allows an authenticated user to refresh any materialized view, regardless of that user’s permissions. 
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 

--- a/advocacy_docs/security/advisories/cve2023xxxxx6.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx6.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 10.XX, 11.XX, 12.XX, 13.XX, 14.XX and 15.XX contain the functions get_url_as_text and get_url_as_bytea. These functions are publicly executable, thus permitting an authenticated user to read any file from the local filesystem or remote system regardless of that user's permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain the functions get_url_as_text and get_url_as_bytea. These functions are publicly executable, thus permitting an authenticated user to read any file from the local filesystem or remote system regardless of that user's permissions.
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 
@@ -38,7 +38,7 @@ EnterpriseDB Postgres Advanced Server (EPAS)
 |---------|------|-----------------------|
 | EPAS | All versions prior to 11.21.32 | Update to latest supported version <br/> (at least [11.21.32](/epas/11/epas_rel_notes/epas11_21_32_rel_notes/)) 
 | EPAS | All versions prior to 12.16.20 | Update to latest supported version <br/> (at least [12.16.20](/epas/12/epas_rel_notes/epas12_16_20_rel_notes/)) |
-| EPAS | All versions prior to 13.12.16 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
+| EPAS | All versions prior to 13.12.17 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
 | EPAS | All versions prior to 14.9.0 | Update to latest supported version <br/> (at least [14.9.0](/epas/14/epas_rel_notes/epas14_9_0_rel_notes/))
 | EPAS | All versions prior to 15.4.0 | Update to latest supported version <br/> (at least [15.4.0](/epas/15/epas_rel_notes/epas15_4_0_rel_notes/))
 

--- a/advocacy_docs/security/advisories/cve2023xxxxx7.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx7.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0, using UTL_ENCODE allows an authenticated user to read any large object, regardless of that users permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0, using UTL_ENCODE allows an authenticated user to read any large object, regardless of that users permissions.
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 
@@ -40,7 +40,7 @@ Impacted users must upgrade to a fixed version of EPAS and then patch existing d
 |---------|------|-----------------------|
 | EPAS | All versions prior to 11.21.32 | Update to latest supported version <br/> (at least [11.21.32](/epas/11/epas_rel_notes/epas11_21_32_rel_notes/)) 
 | EPAS | All versions prior to 12.16.20 | Update to latest supported version <br/> (at least [12.16.20](/epas/12/epas_rel_notes/epas12_16_20_rel_notes/)) |
-| EPAS | All versions prior to 13.12.16 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
+| EPAS | All versions prior to 13.12.17 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
 | EPAS | All versions prior to 14.9.0 | Update to latest supported version <br/> (at least [14.9.0](/epas/14/epas_rel_notes/epas14_9_0_rel_notes/))
 | EPAS | All versions prior to 15.4.0 | Update to latest supported version <br/> (at least [15.4.0](/epas/15/epas_rel_notes/epas15_4_0_rel_notes/))
 

--- a/advocacy_docs/security/advisories/cve2023xxxxx8.mdx
+++ b/advocacy_docs/security/advisories/cve2023xxxxx8.mdx
@@ -9,7 +9,7 @@ Last Updated: 2023/08/21
 
 ## Summary 
 
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 permit an authenticated user to use DBMS_PROFILER to remove all accumulated profiling data on a system-wide basis, regardless of that user’s permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 permit an authenticated user to use DBMS_PROFILER to remove all accumulated profiling data on a system-wide basis, regardless of that user’s permissions.
 
 ## Vulnerability details
 
@@ -28,7 +28,7 @@ CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N
 EnterpriseDB Postgres Advanced Server (EPAS)
 * All versions prior to 11.21.32
 * All versions prior to 12.16.20
-* All versions prior to 13.12.16
+* All versions prior to 13.12.17
 * All versions prior to 14.9.0
 * All versions prior to 15.4.0 
 
@@ -40,7 +40,7 @@ Impacted users must upgrade to a fixed version of EPAS and then patch existing d
 |---------|------|-----------------------|
 | EPAS | All versions prior to 11.21.32 | Update to latest supported version <br/> (at least [11.21.32](/epas/11/epas_rel_notes/epas11_21_32_rel_notes/)) 
 | EPAS | All versions prior to 12.16.20 | Update to latest supported version <br/> (at least [12.16.20](/epas/12/epas_rel_notes/epas12_16_20_rel_notes/)) |
-| EPAS | All versions prior to 13.12.16 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
+| EPAS | All versions prior to 13.12.17 | Update to latest supported version <br/> (at least [13.12.17](/epas/13/epas_rel_notes/epas13_12_17_rel_notes/))
 | EPAS | All versions prior to 14.9.0 | Update to latest supported version <br/> (at least [14.9.0](/epas/14/epas_rel_notes/epas14_9_0_rel_notes/))
 | EPAS | All versions prior to 15.4.0 | Update to latest supported version <br/> (at least [15.4.0](/epas/15/epas_rel_notes/epas15_4_0_rel_notes/))
 

--- a/advocacy_docs/security/advisories/index.mdx
+++ b/advocacy_docs/security/advisories/index.mdx
@@ -30,11 +30,11 @@ Advisories with numbers in the format `CVE-YYYY-XXXXX-n` are submitted and pendi
 &nbsp;&nbsp;<a href="cve2023xxxxx1">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain packages, standalone packages and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain packages, standalone packages and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks. 
 <br/>
 <a href="cve2023xxxxx1">Read More...</a>
 </details>
@@ -48,11 +48,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser
 </h4>
-<h5>All EnterpriseDB Postgres Advanced Server (EPAS) versions prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0 </h5>
+<h5>All EnterpriseDB Postgres Advanced Server (EPAS) versions prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0 </h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain the function _dbms_aq_move_to_exception_queue which may be used to elevate a user’s privileges to superuser. This function accepts the OID of a table, then accesses that table as the superuser using SELECT and DML commands. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain the function _dbms_aq_move_to_exception_queue which may be used to elevate a user’s privileges to superuser. This function accepts the OID of a table, then accesses that table as the superuser using SELECT and DML commands. 
 <br/>
 <a href="cve2023xxxxx2">Read More...</a>
 </details>
@@ -67,11 +67,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory() 
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 allow an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents regardless of permissions. This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections.  <br/>
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 allow an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents regardless of permissions. This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections.  <br/>
 <a href="cve2023xxxxx3">Read More...</a>
 </details>
 </td></tr>
@@ -86,10 +86,10 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5></summary>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5></summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete. 
 <br/>
 <a href="cve2023xxxxx4">Read More...</a>
 </details></td></tr>
@@ -101,11 +101,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 using DBMS_MVIEW allows an authenticated user to refresh any materialized view, regardless of that user’s permissions.  
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 using DBMS_MVIEW allows an authenticated user to refresh any materialized view, regardless of that user’s permissions.  
 <br/>
 <a href="cve2023xxxxx5">Read More...</a>
 </details></td></tr>
@@ -117,11 +117,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21,32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain the functions `get_url_as_text` and `get_url_as_bytea`. These functions are publicly executable, thus permitting an authenticated user to read any file from the local filesystem or remote system regardless of that user's permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21,32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain the functions `get_url_as_text` and `get_url_as_bytea`. These functions are publicly executable, thus permitting an authenticated user to read any file from the local filesystem or remote system regardless of that user's permissions.
 <br/>
 <a href="cve2023xxxxx6">Read More...</a>
 </details></td></tr>
@@ -133,11 +133,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21,32, 12.
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0, using UTL_ENCODE allows an authenticated user to read any large object, regardless of that users permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0, using UTL_ENCODE allows an authenticated user to read any large object, regardless of that users permissions.
 <br/>
 <a href="cve2023xxxxx7">Read More...</a>
 </details></td></tr>
@@ -149,11 +149,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 permit an authenticated user to use DBMS_PROFILER to remove all accumulated profiling data on a system-wide basis, regardless of that user’s permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 permit an authenticated user to use DBMS_PROFILER to remove all accumulated profiling data on a system-wide basis, regardless of that user’s permissions.
 <br/>
 <a href="cve2023xxxxx8">Read More...</a>
 </details></td></tr>

--- a/advocacy_docs/security/index.mdx
+++ b/advocacy_docs/security/index.mdx
@@ -33,11 +33,11 @@ Advisories with numbers in the format `CVE-YYYY-XXXXX-n` are submitted and pendi
 &nbsp;&nbsp;<a href="advisories/cve2023xxxxx1">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain packages, standalone packages and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain packages, standalone packages and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks. 
 <br/>
 <a href="advisories/cve2023xxxxx1">Read More...</a>
 </details>
@@ -51,11 +51,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser
 </h4>
-<h5>All EnterpriseDB Postgres Advanced Server (EPAS) versions prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0 </h5>
+<h5>All EnterpriseDB Postgres Advanced Server (EPAS) versions prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0 </h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain the function _dbms_aq_move_to_exception_queue which may be used to elevate a user’s privileges to superuser. This function accepts the OID of a table, then accesses that table as the superuser using SELECT and DML commands. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain the function _dbms_aq_move_to_exception_queue which may be used to elevate a user’s privileges to superuser. This function accepts the OID of a table, then accesses that table as the superuser using SELECT and DML commands. 
 <br/>
 <a href="advisories/cve2023xxxxx2">Read More...</a>
 </details>
@@ -70,11 +70,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory() 
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 allow an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents regardless of permissions. This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections.  <br/>
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 allow an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents regardless of permissions. This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections.  <br/>
 <a href="advisories/cve2023xxxxx3">Read More...</a>
 </details>
 </td></tr>
@@ -89,10 +89,10 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5></summary>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5></summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete. 
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete. 
 <br/>
 <a href="advisories/cve2023xxxxx4">Read More...</a>
 </details></td></tr>
@@ -104,11 +104,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 using DBMS_MVIEW allows an authenticated user to refresh any materialized view, regardless of that user’s permissions.  
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 using DBMS_MVIEW allows an authenticated user to refresh any materialized view, regardless of that user’s permissions.  
 <br/>
 <a href="advisories/cve2023xxxxx5">Read More...</a>
 </details></td></tr>
@@ -120,11 +120,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21.32, 12.
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21,32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 contain the functions `get_url_as_text` and `get_url_as_bytea`. These functions are publicly executable, thus permitting an authenticated user to read any file from the local filesystem or remote system regardless of that user's permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21,32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 contain the functions `get_url_as_text` and `get_url_as_bytea`. These functions are publicly executable, thus permitting an authenticated user to read any file from the local filesystem or remote system regardless of that user's permissions.
 <br/>
 <a href="advisories/cve2023xxxxx6">Read More...</a>
 </details></td></tr>
@@ -136,11 +136,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) up to 11.21,32, 12.
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0, using UTL_ENCODE allows an authenticated user to read any large object, regardless of that users permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0, using UTL_ENCODE allows an authenticated user to read any large object, regardless of that users permissions.
 <br/>
 <a href="advisories/cve2023xxxxx7">Read More...</a>
 </details></td></tr>
@@ -152,11 +152,11 @@ All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 
 &nbsp;&nbsp;Updated: </span><span>2023/08/21</span>
 <h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission
 </h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0, 15.4.0</h5>
+<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.16, 14.9.0 and 15.4.0 permit an authenticated user to use DBMS_PROFILER to remove all accumulated profiling data on a system-wide basis, regardless of that user’s permissions.
+All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0 and 15.4.0 permit an authenticated user to use DBMS_PROFILER to remove all accumulated profiling data on a system-wide basis, regardless of that user’s permissions.
 <br/>
 <a href="advisories/cve2023xxxxx8">Read More...</a>
 </details></td></tr>


### PR DESCRIPTION
## What Changed?

Fix up on all the version numbers to refer to 13.12.17 not 16 *AND* fixed in all indexes and removed the place holder values in the summary for cve2023xxxxx6