### PR TITLE
Fixed indents carried over from bdr4 docs

### DIFF
--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -144,8 +144,8 @@ bdr.alter_node_group_config(node_group_name text,
                             apply_delay interval DEFAULT NULL,
                             check_constraints boolean DEFAULT NULL,
                             num_writers int DEFAULT NULL,
-							              enable_wal_decoder boolean DEFAULT NULL,
-							              streaming_mode text DEFAULT NULL,
+							enable_wal_decoder boolean DEFAULT NULL,
+							streaming_mode text DEFAULT NULL,
                             default_commit_scope text DEFAULT NULL)
 ```
 


### PR DESCRIPTION
## What Changed?

Removed loose indents in bdr.alter_node_group_config originally reported in BDR4 #3016 

This completes the tab tidy up