### PR TITLE
Fix notes for bdr.run_on_nodes and bdr.run_on_group

### DIFF
--- a/product_docs/docs/pgd/5/reference/functions.mdx
+++ b/product_docs/docs/pgd/5/reference/functions.mdx
@@ -529,7 +529,7 @@ with `bdr.ddl_replication = off`, to avoid replication issues when the same
 replicated DDL command is sent to multiple nodes.
 
 Be careful when using this function since you risk breaking replication
-and causing inconsistencies between nodes. For global schema changes, use
+and causing inconsistencies between nodes in the group. For global schema changes, use
 either transparent DDL replication or `bdr.replicate_ddl_command()` to
 replicate DDL.
 

--- a/product_docs/docs/pgd/5/reference/functions.mdx
+++ b/product_docs/docs/pgd/5/reference/functions.mdx
@@ -486,13 +486,13 @@ defaults are used.
 
 This function doesn't go through normal replication. It uses direct client
 connection to all known nodes. By default, the connection is created
-with `bdr.ddl_replication = off`, since the commands are already being sent
-to all of the nodes in the cluster.
+with `bdr.ddl_replication = off`, to avoid replication issues when the same
+replicated DDL command is sent to multiple nodes.
 
 Be careful when using this function since you risk breaking replication
-and causing inconsistencies between nodes. Use either transparent DDL
-replication or `bdr.replicate_ddl_command()` to replicate DDL.
-DDL might be blocked in a future release.
+and causing inconsistencies between nodes. For global schema changes, use
+either transparent DDL replication or `bdr.replicate_ddl_command()` to
+replicate DDL.
 
 ### `bdr.run_on_group`
 
@@ -525,13 +525,13 @@ defaults are used.
 
 This function doesn't go through normal replication. It uses direct client
 connection to all known nodes. By default, the connection is created
-with `bdr.ddl_replication = off`, since the commands are already being sent
-to all of the nodes in the cluster.
+with `bdr.ddl_replication = off`, to avoid replication issues when the same
+replicated DDL command is sent to multiple nodes.
 
 Be careful when using this function since you risk breaking replication
-and causing inconsistencies between nodes. Use either transparent DDL
-replication or `bdr.replicate_ddl_command()` to replicate DDL.
-DDL might be blocked in a future release.
+and causing inconsistencies between nodes. For global schema changes, use
+either transparent DDL replication or `bdr.replicate_ddl_command()` to
+replicate DDL.
 
 ### `bdr.global_lock_table`
 


### PR DESCRIPTION
The text was copy pasted from `bdr.run_on_all_nodes` and the wording and warnings need to be somewhat different for these two functions

## What Changed?

