### PR TITLE
Faster builds: bigger machines, smaller tables

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    runs-on: docs-16c-64gb-600gb
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deploy-draft.yml
+++ b/.github/workflows/deploy-draft.yml
@@ -13,7 +13,7 @@ jobs:
     if: |
       (github.event.action == 'labeled' && github.event.label.name == 'deploy') ||
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'deploy'))
-    runs-on: ubuntu-latest
+    runs-on: docs-16c-64gb-600gb
     steps:
       - name: inject slug/short variables
         uses: rlespinasse/github-slug-action@v4

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    runs-on: docs-16c-64gb-600gb
     steps:
       - uses: actions/checkout@v3
         with:

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -2,6 +2,8 @@ const fs = require("fs");
 const asyncFs = require("fs/promises");
 const path = require("path");
 
+const IS_CI_BUILD = process.env.GITHUB_ACTIONS;
+
 const sortVersionArray = (versions) => {
   return versions.sort((a, b) =>
     b.localeCompare(a, undefined, { numeric: true }),
@@ -330,7 +332,7 @@ const configureRedirects = (
     actions.createRedirect({
       fromPath: toPath,
       toPath: replacePathVersion(toPath),
-      redirectInBrowser: true,
+      redirectInBrowser: !IS_CI_BUILD,
       isPermanent: false,
       force: true,
     });
@@ -344,7 +346,7 @@ const configureRedirects = (
     actions.createRedirect({
       fromPath: replacePathVersion(toPath),
       toPath,
-      redirectInBrowser: true,
+      redirectInBrowser: !IS_CI_BUILD,
       isPermanent: false,
     });
   }
@@ -361,7 +363,7 @@ const configureRedirects = (
       actions.createRedirect({
         fromPath,
         toPath,
-        redirectInBrowser: true,
+        redirectInBrowser: !IS_CI_BUILD,
         isPermanent,
       });
     }
@@ -406,7 +408,7 @@ const configureRedirects = (
         actions.createRedirect({
           fromPath,
           toPath,
-          redirectInBrowser: true,
+          redirectInBrowser: !IS_CI_BUILD,
           isPermanent: false,
         });
     }


### PR DESCRIPTION
## What Changed?

Aim to speed up deployment via two angles:

1. Use faster build environments: 16 cores is better than 2
2. Allow fewer file changes on builds by eliminating client-side redirects (and the huge array shared by every single page that changed every time a new file was added / redirect was changed)