### PR TITLE
Speed up Netlify deploys

### DIFF
--- a/src/components/feedback-dropdown.js
+++ b/src/components/feedback-dropdown.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import { Dropdown, DropdownButton } from "react-bootstrap";
+import { useStaticQuery, graphql } from "gatsby";
+import Icon, { iconNames } from "./icon";
+
+export const FeedbackDropdown = ({ githubIssuesLink }) => {
+  const data = useStaticQuery(graphql`
+    {
+      edbGit {
+        docsRepoUrl
+        branch
+        sha
+      }
+    }
+  `);
+
+  // add the last commit SHA to paths dynamically to minimize page changes
+  const [url, setUrl] = useState(githubIssuesLink);
+  useEffect(() => {
+    if (githubIssuesLink)
+      setUrl(
+        githubIssuesLink.replace(
+          encodeURIComponent(
+            `${data.edbGit.docsRepoUrl}/commits/${data.edbGit.branch}/`,
+          ),
+          encodeURIComponent(
+            `${data.edbGit.docsRepoUrl}/commits/${data.edbGit.sha}/`,
+          ),
+        ),
+      );
+  });
+
+  return (
+    <DropdownButton
+      className="ml-3"
+      size="sm"
+      variant="outline-info"
+      id="page-actions-button"
+      title={
+        //this seems absolutely buck wild to me, but it's what StackOverflow suggests 🤷🏻‍♂️
+        <Icon
+          iconName={iconNames.ELLIPSIS}
+          className="fill-orange mr-2"
+          width="15"
+          height="15"
+        />
+      }
+    >
+      <Dropdown.Item
+        href={url + "&template=problem-with-topic.yaml"}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Report a problem
+      </Dropdown.Item>
+      <Dropdown.Item
+        href={url + "&template=product-feedback.yaml&labels=feedback"}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Give product feedback
+      </Dropdown.Item>
+    </DropdownButton>
+  );
+};

--- a/src/components/feedback-dropdown.js
+++ b/src/components/feedback-dropdown.js
@@ -15,7 +15,7 @@ export const FeedbackDropdown = ({ githubIssuesLink }) => {
   `);
 
   // add the last commit SHA to paths dynamically to minimize page changes
-  const [url, setUrl] = useState(githubIssuesLink);
+  const [url, setUrl] = useState();
   useEffect(() => {
     if (githubIssuesLink)
       setUrl(
@@ -28,7 +28,12 @@ export const FeedbackDropdown = ({ githubIssuesLink }) => {
           ),
         ),
       );
-  });
+  }, [
+    githubIssuesLink,
+    data.edbGit.docsRepoUrl,
+    data.edbGit.branch,
+    data.edbGit.sha,
+  ]);
 
   return (
     <DropdownButton

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,26 +1,49 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "./";
+import { useStaticQuery, graphql } from "gatsby";
 
 const TimestampLink = ({ timestamp, githubFileLink }) => {
+  const data = useStaticQuery(graphql`
+    {
+      edbGit {
+        docsRepoUrl
+        branch
+        sha
+      }
+    }
+  `);
+
+  // add the last commit SHA to paths dynamically to minimize page changes
+  const [url, setUrl] = useState(githubFileLink);
+  useEffect(() => {
+    if (githubFileLink)
+      setUrl(
+        githubFileLink.replace(
+          `${data.edbGit.docsRepoUrl}/commits/${data.edbGit.branch}/`,
+          `${data.edbGit.docsRepoUrl}/commits/${data.edbGit.sha}/`,
+        ),
+      );
+  });
+
   if (timestamp) {
     return (
       <>
         ·
         <div className="d-inline-block mx-2">
-          {githubFileLink ? (
-            <a href={githubFileLink}> Modified {timestamp.split("T")[0]} </a>
+          {url ? (
+            <a href={url}> Modified {timestamp.split("T")[0]} </a>
           ) : (
             <span>Modified {timestamp.split("T")[0]}</span>
           )}
         </div>
       </>
     );
-  } else if (githubFileLink) {
+  } else if (url) {
     return (
       <>
         ·
         <div className="d-inline-block mx-2">
-          <a href={githubFileLink}>File History</a>
+          <a href={url}>File History</a>
         </div>
       </>
     );

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -23,7 +23,12 @@ const TimestampLink = ({ timestamp, githubFileLink }) => {
           `${data.edbGit.docsRepoUrl}/commits/${data.edbGit.sha}/`,
         ),
       );
-  });
+  }, [
+    githubFileLink,
+    data.edbGit.docsRepoUrl,
+    data.edbGit.branch,
+    data.edbGit.sha,
+  ]);
 
   if (timestamp) {
     return (

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -96,7 +96,7 @@ const Layout = ({
       Archive,
       AuthenticatedContentPlaceholder,
     }),
-    [katacodaPanelData, meta.path, meta.isIndexPage],
+    [katacodaPanelData, meta.path, meta.isIndexPage, meta.productVersions],
   );
 
   return (

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -53,6 +53,7 @@ const Layout = ({
           to={href}
           pageUrl={meta.path}
           pageIsIndex={meta.isIndexPage}
+          productVersions={meta.productVersions}
           {...rest}
         />
       ),

--- a/src/components/left-nav.js
+++ b/src/components/left-nav.js
@@ -87,7 +87,7 @@ const LeftNav = ({
       {navTree.items.map((node) => (
         <TreeNode
           node={node}
-          path={path}
+          path={pagePath}
           key={node.path + node.title}
           hideIfEmpty={hideEmptySections}
         />

--- a/src/components/prev-next.js
+++ b/src/components/prev-next.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "./";
 
-const PrevNext = ({ prevNext, path, depth, depthLimit = 3 }) => {
+const PrevNext = ({ prevNext, depth, depthLimit = 3 }) => {
   let prevLink = prevNext.prev;
   let nextLink = prevNext.next;
   if (depth <= depthLimit) prevLink = null;

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -294,7 +294,7 @@ const preprocessPathsAndRedirects = (nodes, productVersions) => {
             node.fileAbsolutePath
           },title=Overlapping redirect::Redirect ${redirect} matches another ${
             existingIsRedirect ? "redirect pointing to" : "page at"
-          }: https://github.com/EnterpriseDB/docs/${ghBranch}/blob/${path.relative(
+          }: https://github.com/EnterpriseDB/docs/blob/${ghBranch}/${path.relative(
             process.cwd(),
             existing.filepath,
           )}`);

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -289,16 +289,15 @@ const preprocessPathsAndRedirects = (nodes, productVersions) => {
         const existing = validPaths.get(redirect);
         const existingIsRedirect = existing.urlpath !== redirect;
         if (isGHBuild) {
-          console.warn(
-            `::warning file=${
-              node.fileAbsolutePath
-            },title=Overlapping redirect::Redirect ${redirect} matches another ${
-              existingIsRedirect ? "redirect pointing to" : "page at"
-            }: https://github.com/EnterpriseDB/docs/${ghBranch}/blob/${path.relative(
-              process.cwd(),
-              existing.filepath,
-            )}`,
-          );
+          console.warn(`
+::warning file=${
+            node.fileAbsolutePath
+          },title=Overlapping redirect::Redirect ${redirect} matches another ${
+            existingIsRedirect ? "redirect pointing to" : "page at"
+          }: https://github.com/EnterpriseDB/docs/${ghBranch}/blob/${path.relative(
+            process.cwd(),
+            existing.filepath,
+          )}`);
         } else {
           console.warn(
             `Redirect ${redirect} for page ${nodePath} matches the path of a ${

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -265,12 +265,12 @@ const preprocessPathsAndRedirects = (nodes, productVersions) => {
       productVersions[node.fields.product][0] === node.fields.version;
     const nodePathLatest = isLatest && replacePathVersion(nodePath);
     const addPath = (url) => {
-      let value = validPaths.get(url) || [];
+      let value = validPaths.get(url);
+      if (!value) validPaths.set(url, (value = []));
       value.push({
         urlpath: nodePathLatest || nodePath,
         filepath: node.fileAbsolutePath,
       });
-      if (value.length === 1) validPaths.set(url, value);
     };
 
     addPath(nodePath);
@@ -424,16 +424,16 @@ const configureRedirects = (productVersions, node, validPaths, actions) => {
     //    /epas/latest/B -> /epas/latest/C
     const toIsLatest = isLatest || isLastVersion;
     if (toIsLatest) {
-      fromPath = replacePathVersion(fromPath);
-      if (fromPath !== toPath) {
-        let value = validPaths.get(fromPath) || [];
+      const fromPathLatest = replacePathVersion(fromPath);
+      if (fromPathLatest !== fromPath && fromPathLatest !== toPath) {
+        let value = validPaths.get(fromPathLatest);
+        if (!value) validPaths.set(fromPathLatest, (value = []));
         value.push({
           urlpath: toPath,
           filepath: node.fileAbsolutePath,
         });
-        if (value.length === 1) validPaths.set(fromPath, value);
         actions.createRedirect({
-          fromPath,
+          fromPath: fromPathLatest,
           toPath,
           redirectInBrowser: false,
           isPermanent: false,

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -472,7 +472,7 @@ const reportRedirectCollisions = (validPaths, reporter) => {
         reporter.warn(`
 ::warning file=${
           source.filepath
-        },title=Overlapping redirect found in::Redirect ${urlpath} also matches matches ${(
+        },title=Overlapping redirect found in::Redirect ${urlpath} also matches ${(
           "\n" + list
         )
           .replace(/%/g, "%25")

--- a/src/constants/utils.js
+++ b/src/constants/utils.js
@@ -28,3 +28,6 @@ export const capitalize = (s) => {
 export const getBaseUrl = (path, depth) => {
   return path.split("/").slice(0, depth).join("/");
 };
+
+export const isPathAnIndexPage = (filePath) =>
+  filePath.endsWith("/index.mdx") || filePath === "index.mdx";

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -222,6 +222,7 @@ const DocTemplate = ({ data, pageContext }) => {
   const {
     frontmatter,
     pagePath,
+    productVersions,
     versions,
     githubFileLink,
     githubEditLink,
@@ -230,7 +231,7 @@ const DocTemplate = ({ data, pageContext }) => {
     navTree,
     prevNext,
   } = pageContext;
-  const navRoot = findDescendent(navTree, (n) => n.path === path);
+  const navRoot = findDescendent(navTree, (n) => n.path === pagePath);
   const versionArray = makeVersionArray(
     versions,
     pageContext.pathVersions,
@@ -265,7 +266,8 @@ const DocTemplate = ({ data, pageContext }) => {
     title: title,
     description: description,
     path: pagePath,
-    isIndexPage: isIndexPage,
+    isIndexPage,
+    productVersions,
     canonicalPath: pageContext.pathVersions.filter((p) => !!p)[0],
   };
 
@@ -344,9 +346,7 @@ const DocTemplate = ({ data, pageContext }) => {
             )}
           </ContentRow>
           {sections && <Sections sections={sections} />}
-          {depth > 2 && (
-            <PrevNext prevNext={prevNext} path={path} depth={depth} />
-          )}
+          {depth > 2 && <PrevNext prevNext={prevNext} depth={depth} />}
           <DevFrontmatter frontmatter={frontmatter} />
 
           <Footer timestamp={mtime} githubFileLink={githubFileLink} />

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { Container, Row, Col, Dropdown, DropdownButton } from "react-bootstrap";
+import { Container, Row, Col } from "react-bootstrap";
 import { graphql, Link } from "gatsby";
+import { isPathAnIndexPage } from "../constants/utils";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import {
   CardDecks,
@@ -15,7 +16,7 @@ import {
   TableOfContents,
 } from "../components";
 import { products } from "../constants/products";
-import Icon, { iconNames } from "../components/icon";
+import { FeedbackDropdown } from "../components/feedback-dropdown";
 
 export const query = graphql`
   query ($nodeId: String!) {
@@ -27,6 +28,11 @@ export const query = graphql`
       }
       body
       tableOfContents
+      fileAbsolutePath
+    }
+    edbGit {
+      docsRepoUrl
+      branch
     }
   }
 `;
@@ -181,53 +187,15 @@ const Section = ({ section }) => (
   </div>
 );
 
-const FeedbackDropdown = ({ githubIssuesLink }) => (
-  <DropdownButton
-    className="ml-3"
-    size="sm"
-    variant="outline-info"
-    id="page-actions-button"
-    title={
-      //this seems absolutely buck wild to me, but it's what StackOverflow suggests 🤷🏻‍♂️
-      <Icon
-        iconName={iconNames.ELLIPSIS}
-        className="fill-orange mr-2"
-        width="15"
-        height="15"
-      />
-    }
-  >
-    <Dropdown.Item
-      href={githubIssuesLink + "&template=problem-with-topic.yaml"}
-      target="_blank"
-      rel="noreferrer"
-    >
-      Report a problem
-    </Dropdown.Item>
-    <Dropdown.Item
-      href={
-        githubIssuesLink + "&template=product-feedback.yaml&labels=feedback"
-      }
-      target="_blank"
-      rel="noreferrer"
-    >
-      Give product feedback
-    </Dropdown.Item>
-  </DropdownButton>
-);
-
 const DocTemplate = ({ data, pageContext }) => {
-  const { fields, body, tableOfContents } = data.mdx;
+  const { fields, body, tableOfContents, fileAbsolutePath } = data.mdx;
+  const gitData = data.edbGit;
   const { path, mtime, depth } = fields;
   const {
     frontmatter,
     pagePath,
     productVersions,
     versions,
-    githubFileLink,
-    githubEditLink,
-    githubIssuesLink,
-    isIndexPage,
     navTree,
     prevNext,
   } = pageContext;
@@ -249,6 +217,20 @@ const DocTemplate = ({ data, pageContext }) => {
     deepToC,
   } = frontmatter;
 
+  // don't encourage folks to edit on main - set the edit links to develop in production builds
+  const branch = gitData.branch === "main" ? "develop" : gitData.branch;
+  const fileUrlSegment = fileAbsolutePath.split("/product_docs/docs").slice(1);
+  const githubFileLink = `${gitData.docsRepoUrl}/blob/${gitData.branch}/product_docs/docs${fileUrlSegment}`;
+  const githubFileHistoryLink = `${gitData.docsRepoUrl}/commits/${gitData.branch}/product_docs/docs${fileUrlSegment}`;
+  const githubEditLink = `${gitData.docsRepoUrl}/edit/${branch}/product_docs/docs${fileUrlSegment}`;
+  const githubIssuesLink = `${
+    gitData.docsRepoUrl
+  }/issues/new?title=${encodeURIComponent(
+    `Feedback on ${product} ${version} - "${frontmatter.title}"`,
+  )}&context=${encodeURIComponent(
+    `${githubFileLink}\n`,
+  )}&template=problem-with-topic.yaml`;
+
   const sections = depth === 2 ? buildSections(navTree) : null;
 
   let title = frontmatter.title;
@@ -266,7 +248,7 @@ const DocTemplate = ({ data, pageContext }) => {
     title: title,
     description: description,
     path: pagePath,
-    isIndexPage,
+    isIndexPage: isPathAnIndexPage(fileAbsolutePath),
     productVersions,
     canonicalPath: pageContext.pathVersions.filter((p) => !!p)[0],
   };
@@ -349,7 +331,7 @@ const DocTemplate = ({ data, pageContext }) => {
           {depth > 2 && <PrevNext prevNext={prevNext} depth={depth} />}
           <DevFrontmatter frontmatter={frontmatter} />
 
-          <Footer timestamp={mtime} githubFileLink={githubFileLink} />
+          <Footer timestamp={mtime} githubFileLink={githubFileHistoryLink} />
         </MainContent>
       </Container>
     </Layout>

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -116,6 +116,7 @@ const LearnDocTemplate = ({ data, pageContext }) => {
   const {
     frontmatter,
     pagePath,
+    productVersions,
     navLinks,
     githubFileLink,
     githubEditLink,
@@ -140,6 +141,7 @@ const LearnDocTemplate = ({ data, pageContext }) => {
     description: description,
     path: pagePath,
     isIndexPage: isIndexPage,
+    productVersions,
   };
 
   const showToc = !!mdx.tableOfContents.items && !frontmatter.hideToC;


### PR DESCRIPTION
Key to accomplishing this is reducing the number of files changed from build-to-build to as close as possible to those corresponding to the set of pages actually *changed*. To this end, 

- Eliminates most client-side redirects by actually rewriting current version links to /latest/ instead of depending on a redirect to handle this (a server-side redirect is still created so that versioned URLs will work in production, but there shouldn't be any links *within* docs that use a versioned path to a latest-version page). The goal here is to eliminate the client-side redirects table, which is carried along with every page's data and will tend to change every time a file is added / removed / renamed - thus adding a single file could result in *every* page being re-deployed.
- Stop using the last commit SHA in static links for reporting errors or viewing page history. It was *nice to have this*, but it also meant that every page would change on every commit... So every page had to be redeployed on every commit. To retain the benefits, I've moved to rerendering these links client-side to reintroduce the hash. If JavaScript is disabled, the static version, containing the branch name, will be used - which is good enough in most cases. 
- Strip the webpackCompilationHash value from both generated HTML files and app-data.json. This is another thing that would cause tiny, localized changes to trigger redeployment of every single page. The intent here is to allow pages to recover gracefully when a new deployment lands after they've been loaded... That's cool and all, but I kinda feel like the number of folks likely to be affected by that is somewhere between few and none. It'd be nice if there was a way to make this just... Not change so readily... But right now, it's the difference between small content changes having deploy times measured in tens of minutes vs tens of seconds. Easily the biggest hack in this set of changes though; if we do see ugly errors, will have to revisit.

View the deploy history for this PR to see results.
