### PR TITLE
sample table should use autocluster

### DIFF
--- a/advocacy_docs/pg_extensions/advanced_storage_pack/using.mdx
+++ b/advocacy_docs/pg_extensions/advanced_storage_pack/using.mdx
@@ -97,7 +97,7 @@ CREATE TABLE nyse_trade (
 	trade_time TIMESTAMP NOT NULL DEFAULT NOW(),
 	trade_price	FLOAT8 NOT NULL CHECK(trade_price >= 0.0),
 	trade_volume BIGINT NOT NULL CHECK(trade_volume >= 1)
-); --  USING autocluster;
+) USING autocluster;
 CREATE INDEX ON nyse_trade USING BTREE(nyse_symbol_id);
 SELECT autocluster.autocluster(
 	rel := 'nyse_trade'::regclass,


### PR DESCRIPTION
The example with the nyse tables should have one table using refdata and another using autocluster.

This commit uncomments the USING clause that should be applied to the second table.

## What Changed?

The table nyse_trade should have the USING autocluster clause applied to it.
This change removes the sql comment (`--`).
