### PR TITLE
BigAnimal: pooler language updates

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -183,7 +183,7 @@ For information on replication lag while using read-only workloads, see [Standby
 !!! Note
     Enabling PgBouncer incurs additional costs. For more information, see [PgBouncer costs](../../pricing_and_billing/#pgbouncer-costs).
 
-Enable **PgBouncer** to have it manage your connections to Postgres databases and help your workloads run more efficiently. To learn more about PgBouncer, see [Connection poolers](/biganimal/latest/overview/poolers/#edb-pgbouncer).
+Enable **PgBouncer** to have it manage your connections to Postgres databases and help your workloads run more efficiently &mdash; all entirely managed by BigAnimal. To learn more about PgBouncer, see [Connection poolers](/biganimal/latest/overview/poolers/#edb-pgbouncer).
 
 Use the **PgBouncer Configuration Settings** menu to set PgBouncer-specific settings. Select the **Read-Write** and **Read-Only** tabs according to the type of connection you want to configure. The **Read-Only** tab is available if you're creating a primary/standby high-availability cluster and have enabled read-only workloads. 
 

--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -183,7 +183,7 @@ For information on replication lag while using read-only workloads, see [Standby
 !!! Note
     Enabling PgBouncer incurs additional costs. For more information, see [PgBouncer costs](../../pricing_and_billing/#pgbouncer-costs).
 
-Enable **PgBouncer** to have it manage your connections to Postgres databases and help your workloads run more efficiently &mdash; all entirely managed by BigAnimal. To learn more about PgBouncer, see [Connection poolers](/biganimal/latest/overview/poolers/#edb-pgbouncer).
+Enable **PgBouncer** to have it manage your connections to Postgres databases and help your workloads run more efficiently &mdash; all entirely managed by BigAnimal. Learn more about [EDB PgBouncer](/biganimal/latest/overview/poolers/).
 
 Use the **PgBouncer Configuration Settings** menu to set PgBouncer-specific settings. Select the **Read-Write** and **Read-Only** tabs according to the type of connection you want to configure. The **Read-Only** tab is available if you're creating a primary/standby high-availability cluster and have enabled read-only workloads. 
 

--- a/product_docs/docs/biganimal/release/knowledge_base.mdx
+++ b/product_docs/docs/biganimal/release/knowledge_base.mdx
@@ -27,7 +27,7 @@ See the following articles for step-by-step instructions for creating links to r
 - [Using edb_dblink_oci](https://support.biganimal.com/hc/en-us/articles/5528996025497-How-to-create-a-database-link-from-EnterpriseDB-PostgreSQL-Advanced-Server-EPAS-cluster-to-remote-Oracle-server)
 - [Using dblink_ora_connect()](https://support.biganimal.com/hc/en-us/articles/11737021242649-How-to-establish-a-database-link-from-EPAS-cluster-to-a-remote-Oracle-server-using-dblink-ora-connect-function)
 
-## Configuring self-hosted connection poolers
+## Deploying connection poolers outside of BigAnimal
 
 See the following articles for step-by-step instructions for setting up self-hosted connection poolers:
 

--- a/product_docs/docs/biganimal/release/knowledge_base.mdx
+++ b/product_docs/docs/biganimal/release/knowledge_base.mdx
@@ -27,9 +27,8 @@ See the following articles for step-by-step instructions for creating links to r
 - [Using edb_dblink_oci](https://support.biganimal.com/hc/en-us/articles/5528996025497-How-to-create-a-database-link-from-EnterpriseDB-PostgreSQL-Advanced-Server-EPAS-cluster-to-remote-Oracle-server)
 - [Using dblink_ora_connect()](https://support.biganimal.com/hc/en-us/articles/11737021242649-How-to-establish-a-database-link-from-EPAS-cluster-to-a-remote-Oracle-server-using-dblink-ora-connect-function)
 
-## Deploying connection poolers outside of BigAnimal
+## Deploying PgBouncer outside of BigAnimal
 
-See the following articles for step-by-step instructions for setting up self-hosted connection poolers:
+See the following article for step-by-step instructions for setting up deploying PgBouncer outside of BigAnimal:
 
 - [How to configure PgBouncer with a BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/4848726654745-How-to-configure-PgBouncer-with-BigAnimal-Cluster)
-- [How to configure Pgpool-II with a BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/5475273722009-How-to-configure-Pgpool-with-BigAnimal-Cluster)

--- a/product_docs/docs/biganimal/release/overview/extensions_tools.mdx
+++ b/product_docs/docs/biganimal/release/overview/extensions_tools.mdx
@@ -30,4 +30,5 @@ EDB develops and maintains several extensions and tools. These include:
 - [PG Failover Slots](/pg_extensions/pg_failover_slots/) &mdash; Is an extension released as open source software under the PostgreSQL License. If you have logical replication publications on Postgres databases that are also part of a streaming replication architecture, PG Failover Slots avoids the need for you to reseed your logical replication tables when a new standby gets promoted to primary.
 
 - [Foreign Data Wrappers](foreign_data_wrappers) &mdash; Allow you to connect your Postgres database server to external data sources.
-- [Connection poolers](poolers) &mdash; Allow you to manage your connections to your Postgres database. 
+
+- [EDB PgBouncer](poolers) &mdash; Allows you to manage your connections to your Postgres database. 

--- a/product_docs/docs/biganimal/release/overview/poolers.mdx
+++ b/product_docs/docs/biganimal/release/overview/poolers.mdx
@@ -1,11 +1,6 @@
 ---
-title: Connection poolers
+title: EDB PgBouncer
 ---
-
-BigAnimal supports [EDB PgBouncer](/pgbouncer/latest/) and [EDB Pgpool-II](/pgpool/latest/) to manage your connections to your Postgres database. PgBouncer can be hosted on BigAnimal or self-hosted, while EDB Pgpool-II can only be self-hosted.
-
-
-### EDB PgBouncer
 
 EDB PgBouncer can manage your connections to Postgres databases and help your workloads run more efficiently. It's particularly useful if you plan to use more than a few hundred active connections. You can enable EDB PgBouncer to be entirely managed by BigAnimal, when creating your cluster. See [Creating a cluster](/biganimal/latest/getting_started/creating_a_cluster/#pgbouncer). 
 
@@ -17,11 +12,5 @@ BigAnimal provisions up to three instances per EDB PgBouncer-enabled cluster to 
 If you want to deploy and manage PgBouncer outside of BigAnimal, see the [How to configure EDB PgBouncer with BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/4848726654745-How-to-configure-PgBouncer-with-BigAnimal-Cluster) knowledge-base article.
 
 
-
-### EDB Pgpool-II
-
-EDB Pgpool-II acts as middleware between client applications and a Postgres database server. It saves connections to the Postgres servers and reuses them whenever a new connection with the same properties (that is, username, database, protocol version) comes in. It reduces connection overhead and improves the system's overall throughput.
-
-See [EDB Pgpool-II](/pgpool/latest/) for information on installing and configuring EDB Pgpool-II outside of BigAnimal. You can find other related content in the [How to configure EDB Pgpool with a BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/5475273722009-How-to-configure-Pgpool-with-BigAnimal-Cluster) knowledge-base article.
 
 

--- a/product_docs/docs/biganimal/release/overview/poolers.mdx
+++ b/product_docs/docs/biganimal/release/overview/poolers.mdx
@@ -7,14 +7,14 @@ BigAnimal supports [EDB PgBouncer](/pgbouncer/latest/) and [EDB Pgpool-II](/pgpo
 
 ### EDB PgBouncer
 
-EDB PgBouncer can manage your connections to Postgres databases and help your workloads run more efficiently. It's particularly useful if you plan to use more than a few hundred active connections. You can enable EDB PgBouncer to be hosted by BigAnimal when creating your cluster. See [Creating a cluster](/biganimal/latest/getting_started/creating_a_cluster/#pgbouncer). 
+EDB PgBouncer can manage your connections to Postgres databases and help your workloads run more efficiently. It's particularly useful if you plan to use more than a few hundred active connections. You can enable EDB PgBouncer to be entirely managed by BigAnimal, when creating your cluster. See [Creating a cluster](/biganimal/latest/getting_started/creating_a_cluster/#pgbouncer). 
 
 BigAnimal provisions up to three instances per EDB PgBouncer-enabled cluster to ensure that performance is unaffected, so each availability zone receives its own instance of EDB PgBouncer. 
 
 !!!Note
    Currently you can't enable EDB PgBouncer when using BigAnimal's cloud account or when creating an  distributed high-availability cluster using your cloud account.
 
-If you want to self-host your EDB PgBouncer deployment, see the [How to configure EDB PgBouncer with BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/4848726654745-How-to-configure-PgBouncer-with-BigAnimal-Cluster) knowledge-base article.
+If you want to deploy and manage PgBouncer outside of BigAnimal, see the [How to configure EDB PgBouncer with BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/4848726654745-How-to-configure-PgBouncer-with-BigAnimal-Cluster) knowledge-base article.
 
 
 
@@ -22,6 +22,6 @@ If you want to self-host your EDB PgBouncer deployment, see the [How to configur
 
 EDB Pgpool-II acts as middleware between client applications and a Postgres database server. It saves connections to the Postgres servers and reuses them whenever a new connection with the same properties (that is, username, database, protocol version) comes in. It reduces connection overhead and improves the system's overall throughput.
 
-See [EDB Pgpool-II](/pgpool/latest/) for information on installing and configuring self-hosted EDB Pgpool-II. You can find other related content in the [How to configure EDB Pgpool with a BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/5475273722009-How-to-configure-Pgpool-with-BigAnimal-Cluster) knowledge-base article.
+See [EDB Pgpool-II](/pgpool/latest/) for information on installing and configuring EDB Pgpool-II outside of BigAnimal. You can find other related content in the [How to configure EDB Pgpool with a BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/5475273722009-How-to-configure-Pgpool-with-BigAnimal-Cluster) knowledge-base article.
 
 


### PR DESCRIPTION
## What Changed?

moving away from "self-hosted" terminology for poolers deployed and managed separate from BigAnimal