### PR TITLE
Clean up last bad dates (four letter months!)

### DIFF
--- a/product_docs/docs/pgd/4/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/index.mdx
@@ -25,15 +25,15 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 
 | Release Date | EDB Postgres Distributed     | BDR   | HARP  |  CLI  | TPAexec                                                                          |
 | ------------ | ---------------------------- | ----- | ----- | ----- | -------------------------------------------------------------------------------- |
-| 2023 July 27  | [4.3.1-2 ](pgd_4.3.1-2_rel_notes)| 4.3.1 | 2.3.1 | 1.1.1 | [23.19](/tpa/latest/rel_notes/tpa_23.19_rel_notes)   |
-| 2023 July 12  | [4.3.1-1 ](pgd_4.3.1-1_rel_notes)| 4.3.1 | 2.3.0 | 1.1.1 | [23.19](/tpa/latest/rel_notes/tpa_23.19_rel_notes)   |
+| 27 Jul 2023 | [4.3.1-2 ](pgd_4.3.1-2_rel_notes)| 4.3.1 | 2.3.1 | 1.1.1 | [23.19](/tpa/latest/rel_notes/tpa_23.19_rel_notes)   |
+| 12 Jul 2023  | [4.3.1-1 ](pgd_4.3.1-1_rel_notes)| 4.3.1 | 2.3.0 | 1.1.1 | [23.19](/tpa/latest/rel_notes/tpa_23.19_rel_notes)   |
 | 17 May 2023 | [4.3.1](pgd_4.3.1_rel_notes) | 4.3.1 | 2.2.3 | 1.1.1 | [23.17](/tpa/latest/rel_notes/tpa_23.17_rel_notes)   |
 | 30 Mar 2023 | [4.3.0-1](pgd_4.3.0-1_rel_notes) | 4.3.0 | 2.2.2 | 1.1.0 | [23.9](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-239)   |
 | 14 Feb 2023 | [4.3.0](pgd_4.3.0_rel_notes) | 4.3.0 | 2.2.1 | 1.1.0 | [23.9](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-239)   |
 | 14 Dec 2022 | [4.2.2](pgd_4.2.2_rel_notes) | 4.2.2 | 2.2.1 | 1.1.0 | [23.9](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-239)   |
 | 16 Nov 2022 | [4.2.1](pgd_4.2.1_rel_notes) | 4.2.1 | 2.2.1 | 1.1.0 | [23.7](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-237)   |
 | 22 Aug 2022 | [4.2.0](pgd_4.2.0_rel_notes) | 4.2.0 | 2.2.0 | 1.1.0 | [23.5](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-235)   |
-| 2022 June 21 | [4.1.1](pgd_4.1.1_rel_notes) | 4.1.1 | 2.1.1 | 1.0.0 | [23.2](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-232)   |
+| 21 June 2022 | [4.1.1](pgd_4.1.1_rel_notes) | 4.1.1 | 2.1.1 | 1.0.0 | [23.2](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-232)   |
 | 17 May 2022 | [4.1.0](pgd_4.1.0_rel_notes) | 4.1.0 | 2.1.0 | 1.0.0 | [23.1](/tpa/latest/rel_notes/tpa_23.1-11_rel_notes/#tpa-231)   |
 | 31 Mar 2022 | [4.0.3](pgd_4.0.3_rel_notes) | -     | 2.0.3 | -     | 22.10 |
 | 24 Feb 2022 | [4.0.2](pgd_4.0.2_rel_notes) | 4.0.2 | 2.0.2 | -     | 22.9   |


### PR DESCRIPTION
## What Changed?

Some dates were missed on the grand update because for some reason June and July didn't need to be 3 characters like every other month.