### PR TITLE
Move online help redirects to PEM 9

### DIFF
--- a/product_docs/docs/pem/8/considerations/pem_pgbouncer/configuring_pgBouncer.mdx
+++ b/product_docs/docs/pem/8/considerations/pem_pgbouncer/configuring_pgBouncer.mdx
@@ -5,11 +5,6 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-enterprise-manager/installation-getting-started/pgbouncer-configuration-guide/8.0/configuring_pgBouncer.html"
 redirects:
     - /pem/latest/pem_pgbouncer/03_configuring_pgBouncer/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/01_pem_pgbouncer_server_agent_connection/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/02_pem_pgbouncer_preparing_dbserver/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/03_pem_pgbouncer_configuring_pgbouncer/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/04_pem_pgbouncer_configuring_pem_agent/
 ---
 
 You must configure PgBouncer to work with the PEM database server. This example runs PgBouncer as the enterprisedb system user and outlines the process of configuring pgBouncer version 1.9 or later.

--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/configuring_pgBouncer.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/configuring_pgBouncer.mdx
@@ -5,11 +5,7 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-enterprise-manager/installation-getting-started/pgbouncer-configuration-guide/8.0/configuring_pgBouncer.html"
 redirects:
     - /pem/latest/pem_pgbouncer/03_configuring_pgBouncer/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/01_pem_pgbouncer_server_agent_connection/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/02_pem_pgbouncer_preparing_dbserver/
     - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/03_pem_pgbouncer_configuring_pgbouncer/
-    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/04_pem_pgbouncer_configuring_pem_agent/
 ---
 
 You must configure PgBouncer to work with the PEM database server. 

--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/configuring_pgBouncer.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/configuring_pgBouncer.mdx
@@ -5,6 +5,11 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-enterprise-manager/installation-getting-started/pgbouncer-configuration-guide/8.0/configuring_pgBouncer.html"
 redirects:
     - /pem/latest/pem_pgbouncer/03_configuring_pgBouncer/
+    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/
+    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/01_pem_pgbouncer_server_agent_connection/
+    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/02_pem_pgbouncer_preparing_dbserver/
+    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/03_pem_pgbouncer_configuring_pgbouncer/
+    - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/04_pem_pgbouncer_configuring_pem_agent/
 ---
 
 You must configure PgBouncer to work with the PEM database server. 

--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/configuring_the_pem_agent.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/configuring_the_pem_agent.mdx
@@ -5,6 +5,7 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-enterprise-manager/installation-getting-started/pgbouncer-configuration-guide/8.0/configuring_the_pem_agent.html"
 redirects:
   - /pem/latest/pem_pgbouncer/04_configuring_the_pem_agent/
+  - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/04_pem_pgbouncer_configuring_pem_agent/
 ---
 
 You can use an RPM package to install a PEM agent. For detailed installation information, see [Installating the PEM agent](../../installing_pem_agent/).

--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/index.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/index.mdx
@@ -8,6 +8,7 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-enterprise-manager/installation-getting-started/pgbouncer-configuration-guide/8.0/index.html"
 redirects:
 - /pem/latest/pem_pgbouncer/
+- /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/
 navigation:
 
 - pem_server_pem_agent_connection_management_mechanism

--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/pem_server_pem_agent_connection_management_mechanism.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/pem_server_pem_agent_connection_management_mechanism.mdx
@@ -5,6 +5,7 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-enterprise-manager/installation-getting-started/pgbouncer-configuration-guide/8.0/the_pem_server_pem_agent_connection_management_mechanism.html"
 redirects:
   - /pem/latest/pem_pgbouncer/01_the_pem_server_pem_agent_connection_management_mechanism/
+  - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/01_pem_pgbouncer_server_agent_connection/
 ---
 
 Each PEM agent connects to the PEM database server using the SSL certificates for each user. For example, an agent with `ID#1` connects to the PEM database server using the agent1 user.

--- a/product_docs/docs/pem/9/considerations/pem_pgbouncer/preparing_the_pem_database_server.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_pgbouncer/preparing_the_pem_database_server.mdx
@@ -5,6 +5,7 @@ legacyRedirectsGenerated:
   - "/edb-docs/d/edb-postgres-enterprise-manager/installation-getting-started/pgbouncer-configuration-guide/8.0/preparing_the_pem_database_server.html"
 redirects:
   - /pem/latest/pem_pgbouncer/02_preparing_the_pem_database_server/
+  - /pem/latest/pem_online_help/09_toc_pem_configure_pgbouncer/02_pem_pgbouncer_preparing_dbserver/
 ---
 
 You must configure the PEM database server to work with PgBouncer. This example shows how to configure the PEM database server.


### PR DESCRIPTION
## What Changed?

Online help section was eliminated from the PEM 9 published docs - redirects should go there.