### PR TITLE
Correct SQL Server related typo

### DIFF
--- a/product_docs/docs/eprs/7/01_introduction/04_permitted_conf_and_permutations.mdx
+++ b/product_docs/docs/eprs/7/01_introduction/04_permitted_conf_and_permutations.mdx
@@ -40,7 +40,7 @@ The following table shows the combinations of source and target database server 
 
 
 
-| Source/target                               | Oracle | Microsoft SQL service| PostgreSQL | EDB Postgres Advanced Server (Oracle compatible) | EDB Postgres Advanced Server (PostgreSQL compatible)                                        |
+| Source/target                               | Oracle | Microsoft SQL Server | PostgreSQL | EDB Postgres Advanced Server (Oracle compatible) | EDB Postgres Advanced Server (PostgreSQL compatible)                                        |
 | ------------------------------------------- | ------ | -------------------- | ---------- | ----------------------------------- | --------------------------------------- |
 | Oracle                                      | No     | No                   | Yes        | Yes                                 | Yes                                     |
 | Microsoft SQL Server                        | No     | No                   | Yes        | Yes                                 | Yes                                     |


### PR DESCRIPTION
Changed occurrence of "Microsoft SQL service" to "Microsoft SQL Server"

## What Changed?

