### PR TITLE
Update 06_configuring_for_eager_failover.mdx

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/06_configuring_for_eager_failover.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/06_configuring_for_eager_failover.mdx
@@ -29,18 +29,17 @@ You can set up Eager Failover by  performing the following steps. The example us
 
 - Ensure that the database server and the local Failover Manager agent are running.
 
-- As root, create `/etc/systemd/system/edb-as-12.service` file and include:
-
-    ```ini
-    .include /lib/systemd/system/edb-as-12.service
-    [Unit]
-    BindsTo=edb-efm-4.5.service
-    ```
-
-- Run the following command to reload the configuration files:
+- As root, edit the service `edb-as-12.service` file using the command:
 
     ```shell
-    systemctl daemon-reload
+    systemctl edit edb-as-12.service
+    ```
+
+- Add the following lines into the text editor, then save:
+
+    ```ini
+    [Unit]
+    BindsTo=edb-efm-4.5.service
     ```
 
 With these changes, when the Failover Manager agent is stopped or ended, the rest of the cluster treats this situation as a failure and attempts a failover.


### PR DESCRIPTION
The safest way for end users to edit service files is using `systemctl edit`. Alternatively, we can instruct them on how to edit the overrides files in `/etc/systemd/system/<unitname>.d/override.conf`. But creating a new file and `.include` shouldn't have been an option. Moreover, the `.include` feature has been removed from recent systemd versions, so it must be changed before it starts erroring out in the customer's hands.
