### PR TITLE
EPAS 13-15: Fix some instructions on how to edit service files

### DIFF
--- a/product_docs/docs/epas/13/installing/linux_install_details/managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/13/installing/linux_install_details/managing_an_advanced_server_installation.mdx
@@ -297,7 +297,7 @@ Include the `--icu-short-form` keywords to create a cluster that uses a default 
 
 For more information about using `initdb`, and the available cluster configuration options, see the PostgreSQL Core Documentation available at:
 
-<https://www.postgresql.org/docs/current/static/app-initdb.html>
+`<https://www.postgresql.org/docs/current/static/app-initdb.html>`
 
 You can also view online help for `initdb` by assuming superuser privileges and entering:
 

--- a/product_docs/docs/epas/13/installing/linux_install_details/managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/13/installing/linux_install_details/managing_an_advanced_server_installation.mdx
@@ -103,7 +103,7 @@ You can use the `pg_ctl` utility to control an Advanced Server service from the 
 
 For more information about using the `pg_ctl` utility, or the command line options available, see the official PostgreSQL Core Documentation available at:
 
-<https://www.postgresql.org/docs/current/static/app-pg-ctl.html>
+`<https://www.postgresql.org/docs/current/static/app-pg-ctl.html>`
 
 **Choosing Between pg_ctl and the service Command**
 
@@ -139,7 +139,7 @@ Where:
 
 `edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. . For more information about using the command line client, see the PostgreSQL Core Documentation at:
 
-<https://www.postgresql.org/docs/current/static/app-psql.html>
+`<https://www.postgresql.org/docs/current/static/app-psql.html>`
 
 ## Configuring a package installation
 
@@ -154,7 +154,7 @@ The PostgreSQL `initdb` command creates a database cluster; when installing Adva
 
 To review the `initdb` documentation, visit:
 
-<https://www.postgresql.org/docs/current/static/app-initdb.html>
+`<https://www.postgresql.org/docs/current/static/app-initdb.html>`
 
 After specifying any options in the service configuration file, you can create the database cluster and start the service; these steps are platform specific.
 

--- a/product_docs/docs/epas/13/installing/linux_install_details/managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/13/installing/linux_install_details/managing_an_advanced_server_installation.mdx
@@ -311,41 +311,40 @@ Where `path_to_initdb_installation_directory` specifies the location of the `ini
 
 ### on RHEL or CentOS 7.x | RHEL or Rocky Linux 8.x
 
-On a RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x host, the unit file is named `edb-as-13.service` and resides in `/usr/lib/systemd/system`. The unit file contains references to the location of the Advanced Server `data` directory. You should avoid making any modifications directly to the unit file because it may be overwritten during package upgrades.
+On a RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x host, the unit file is named `edb-as-13.service` and resides in `/usr/lib/systemd/system`. The unit file contains references to the location of the Advanced Server `data` directory.
+
+!!! Important
+You should never make changes to files residing in `/usr/lib/systemd/system` or `/lib/systemd/system`, as they are provided by EDB packages.
+!!!
 
 By default, data files reside under `/var/lib/edb/as13/data` directory. To use a data directory that resides in a non-default location, perform the following steps:
 
--   Create a copy of the unit file under the `/etc` directory:
+-   Edit the database service using `systemctl edit`:
 
-    ```text
-    cp /usr/lib/systemd/system/edb-as-13.service /etc/systemd/system/
+    ```shell
+    systemctl edit edb-as-13.service
     ```
 
--   After copying the unit file to the new location, create the service file `/etc/systemd/system/edb-as-13.service`.
+    This will open a text editor (usually nano or vi, depending on your `EDITOR` environment variable and your distribution defaults).
 
--   Update the following values with new location of data directory in the `/lib/systemd/system/edb-as-13.service` file:
+-   In the text editor, add the lines:
 
-    ```text
+    ```ini
+    [Service]
     Environment=PGDATA=/var/lib/edb/as13/data
     PIDFile=/var/lib/edb/as13/data/postmaster.pid
     ```
 
--   Delete the entire content of `/etc/systemd/system/edb-as-13.service` file, except the following line:
+    Note: In the lines above, replace `/var/lib/edb/as13/data` with the desired location for your data directory.
 
-    ```text
-    .include /lib/systemd/system/edb-as-13.service
-    ```
+-   Save the file
+
+    Note: when editing systemd units using `systemd edit`, there is no need to reload the daemon, as systemd does it automatically as you exit the editor.
 
 -   Run the following command to initialize the cluster at the new location:
 
     ```text
     PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb
-    ```
-
--   Use the following command to reload `systemd`, updating the modified service scripts:
-
-    ```text
-    systemctl daemon-reload
     ```
 
 -   Start the Advanced Server service with the following command:
@@ -401,16 +400,27 @@ By default, the data files resides under `/var/lib/edb/as13/data` directory. To 
     mv /var/lib/edb/as13/data /opt/edb/
     ```
 
--   Create a file `edb-as-13.service` under `/etc/systemd/system` directory to include the location of a new data directory:
+-   Edit the database service using `systemctl edit`:
 
-    ```text
-    .include /lib/systemd/system/edb-as-13.service
+    ```shell
+    systemctl edit edb-as-13.service
+    ```
+
+    This will open a text editor (usually nano or vi, depending on your `EDITOR` environment variable and your distribution defaults).
+
+-   In the text editor, add the lines:
+
+    ```ini
     [Service]
     Environment=PGDATA=/opt/edb/data
     PIDFile=/opt/edb/data/postmaster.pid
     ```
 
--   Use the `semanage` utility to set the context mapping for `/opt/edb/`. The mapping is written to `/etc/selinux/targeted/contexts/files/file.contexts.local` file.
+-   Save the file
+
+    Note: when editing systemd units using `systemd edit`, there is no need to reload the daemon, as systemd does it automatically as you exit the editor.
+
+-   Use the `semanage` utility to set the context mapping for `/opt/edb/`. The mapping is written to the `/etc/selinux/targeted/contexts/files/file.contexts.local` file.
 
     ```text
     semanage fcontext --add --equal /var/lib/edb/as13/data /opt/edb
@@ -420,12 +430,6 @@ By default, the data files resides under `/var/lib/edb/as13/data` directory. To 
 
     ```text
     restorecon -rv /opt/edb/
-    ```
-
--   Reload `systemd` to modify the service script using the following command:
-
-    ```text
-    systemctl daemon-reload
     ```
 
 -   Now, the `/opt/edb` location has been labeled correctly with the context, use the following command to start the service:

--- a/product_docs/docs/epas/14/installing/linux_install_details/managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/14/installing/linux_install_details/managing_an_advanced_server_installation.mdx
@@ -314,41 +314,40 @@ Where `path_to_initdb_installation_directory` specifies the location of the `ini
 
 ### On RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x
 
-On a RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x host, the unit file is named `edb-as-14.service` and resides in `/usr/lib/systemd/system`. The unit file contains references to the location of the EDB Postgres Advanced Server `data` directory. You should avoid making any modifications directly to the unit file because it may be overwritten during package upgrades.
+On a RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x host, the unit file is named `edb-as-14.service` and resides in `/usr/lib/systemd/system`. The unit file contains references to the location of the EDB Postgres Advanced Server `data` directory.
+
+!!! Important
+You should never make changes to files residing in `/usr/lib/systemd/system` or `/lib/systemd/system`, as they are provided by EDB packages.
+!!!
 
 By default, data files reside under `/var/lib/edb/as14/data` directory. To use a data directory that resides in a non-default location, perform the following steps:
 
--   Create a copy of the unit file under the `/etc` directory:
+-   Edit the database service using `systemctl edit`:
 
-    ```text
-    cp /usr/lib/systemd/system/edb-as-14.service /etc/systemd/system/
+    ```shell
+    systemctl edit edb-as-14.service
     ```
 
--   After copying the unit file to the new location, create the service file `/etc/systemd/system/edb-as-14.service`.
+    This will open a text editor (usually nano or vi, depending on your `EDITOR` environment variable and your distribution defaults).
 
--   Update the following values with new location of data directory in the `/lib/systemd/system/edb-as-14.service` file:
+-   In the text editor, add the lines:
 
-    ```text
+    ```ini
+    [Service]
     Environment=PGDATA=/var/lib/edb/as14/data
     PIDFile=/var/lib/edb/as14/data/postmaster.pid
     ```
 
--   Delete the entire content of `/etc/systemd/system/edb-as-14.service` file, except the following line:
+    Note: In the lines above, replace `/var/lib/edb/as14/data` with the desired location for your data directory.
 
-    ```text
-    .include /lib/systemd/system/edb-as-14.service
-    ```
+-   Save the file
+
+    Note: when editing systemd units using `systemd edit`, there is no need to reload the daemon, as systemd does it automatically as you exit the editor.
 
 -   Run the following command to initialize the cluster at the new location:
 
     ```text
     PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb
-    ```
-
--   Use the following command to reload `systemd`, updating the modified service scripts:
-
-    ```text
-    systemctl daemon-reload
     ```
 
 -   Start the EDB Postgres Advanced Server service with the following command:
@@ -404,16 +403,27 @@ By default, the data files resides under `/var/lib/edb/as14/data` directory. To 
     mv /var/lib/edb/as14/data /opt/edb/
     ```
 
--   Create a file `edb-as-14.service` under `/etc/systemd/system` directory to include the location of a new data directory:
+-   Edit the database service using `systemctl edit`:
 
-    ```text
-    .include /lib/systemd/system/edb-as-14.service
+    ```shell
+    systemctl edit edb-as-14.service
+    ```
+
+    This will open a text editor (usually nano or vi, depending on your `EDITOR` environment variable and your distribution defaults).
+
+-   In the text editor, add the lines:
+
+    ```ini
     [Service]
     Environment=PGDATA=/opt/edb/data
     PIDFile=/opt/edb/data/postmaster.pid
     ```
 
--   Use the `semanage` utility to set the context mapping for `/opt/edb/`. The mapping is written to `/etc/selinux/targeted/contexts/files/file.contexts.local` file.
+-   Save the file
+
+    Note: when editing systemd units using `systemd edit`, there is no need to reload the daemon, as systemd does it automatically as you exit the editor.
+
+-   Use the `semanage` utility to set the context mapping for `/opt/edb/`. The mapping is written to the `/etc/selinux/targeted/contexts/files/file.contexts.local` file.
 
     ```text
     semanage fcontext --add --equal /var/lib/edb/as14/data /opt/edb
@@ -423,12 +433,6 @@ By default, the data files resides under `/var/lib/edb/as14/data` directory. To 
 
     ```text
     restorecon -rv /opt/edb/
-    ```
-
--   Reload `systemd` to modify the service script using the following command:
-
-    ```text
-    systemctl daemon-reload
     ```
 
 -   Now, the `/opt/edb` location has been labeled correctly with the context, use the following command to start the service:

--- a/product_docs/docs/epas/14/installing/linux_install_details/managing_an_advanced_server_installation.mdx
+++ b/product_docs/docs/epas/14/installing/linux_install_details/managing_an_advanced_server_installation.mdx
@@ -100,9 +100,7 @@ You can use the `pg_ctl` utility to control an EDB Postgres Advanced Server serv
 -   `reload` sends the server a `SIGHUP` signal, reloading configuration parameters
 -   `status` to discover the current status of the service.
 
-For more information about using the `pg_ctl` utility, or the command line options available, see the official PostgreSQL Core Documentation available at:
-
-<https://www.postgresql.org/docs/current/static/app-pg-ctl.html>
+For more information about using the `pg_ctl` utility, or the command line options available, see the official [PostgreSQL Core Documentation](https://www.postgresql.org/docs/current/static/app-pg-ctl.html).
 
 **Choosing Between pg_ctl and the service Command**
 
@@ -136,17 +134,13 @@ Where:
 
 `-U` specifies the identity of the database user to use for the session.
 
-`edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. For more information about using the command line client, see the PostgreSQL Core Documentation at:
-
-<https://www.postgresql.org/docs/current/static/app-psql.html>
+`edb-psql` is a symbolic link to a binary called `psql`, a modified version of the PostgreSQL community `psql`, with added support for Advanced Server features. For more information about using the command line client, see the [PostgreSQL Core Documentation](https://www.postgresql.org/docs/current/static/app-psql.html).
 
 ### Managing authentication on a Debian or Ubuntu host
 
 By default, the server is running with the peer or md5 permission on a Debian or Ubuntu host. You can change the authentication method by modifying the `pg_hba.conf` file, located under `/etc/edb-as/14/main/`.
 
-For more information about modifying the `pg_hba.conf` file, see the PostgreSQL core documentation available at:
-
-<https://www.postgresql.org/docs/current/auth-pg-hba-conf.html>
+For more information about modifying the `pg_hba.conf` file, see the [PostgreSQL Core Documentation](https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html).
 
 ## Configuring a package installation
 
@@ -159,9 +153,7 @@ The PostgreSQL `initdb` command creates a database cluster; when installing EDB 
 -   Specify environment options on the command line.
 -   Include the `systemd` service manager on RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x and use a service configuration file to configure the environment.
 
-To review the `initdb` documentation, visit:
-
-<https://www.postgresql.org/docs/current/static/app-initdb.html>
+For more information see [`initdb` documentation](https://www.postgresql.org/docs/current/static/app-initdb.html).
 
 After specifying any options in the service configuration file, you can create the database cluster and start the service; these steps are platform specific.
 
@@ -298,9 +290,7 @@ Include the `--icu-short-form` keywords to create a cluster that uses a default 
 
 [https://www.enterprisedb.com/docs](/epas/latest/)
 
-For more information about using `initdb`, and the available cluster configuration options, see the PostgreSQL Core Documentation available at:
-
-<https://www.postgresql.org/docs/current/static/app-initdb.html>
+For more information about using `initdb`, and the available cluster configuration options, see the [PostgreSQL Core Documentation](https://www.postgresql.org/docs/current/static/app-initdb.html).
 
 You can also view online help for `initdb` by assuming superuser privileges and entering:
 

--- a/product_docs/docs/epas/15/installing/linux_install_details/managing_an_advanced_server_installation/modifying_the_data_directory_location.mdx
+++ b/product_docs/docs/epas/15/installing/linux_install_details/managing_an_advanced_server_installation/modifying_the_data_directory_location.mdx
@@ -4,41 +4,40 @@ title: "Modifying the data directory location"
 
 ## On RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x
 
-On a RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x host, the unit file is named `edb-as-<xx>.service`, where `<xx>` is the EDB Postgres Advanced Server version. It resides in `/usr/lib/systemd/system`. The unit file contains references to the location of the EDB Postgres Advanced Server `data` directory. Avoid making any modifications directly to the unit file because they might be overwritten during package upgrades.
+On a RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x host, the unit file is named `edb-as-<xx>.service`, where `<xx>` is the EDB Postgres Advanced Server version. It resides in `/usr/lib/systemd/system`. The unit file contains references to the location of the EDB Postgres Advanced Server `data` directory.
 
-By default, data files reside under the `/var/lib/edb/as15/data` directory. To use a data directory that resides in a nondefault location:
+!!! Important
+You should never make changes to files residing in `/usr/lib/systemd/system` or `/lib/systemd/system`, as they are provided by EDB packages.
+!!!
 
--   Create a copy of the unit file under the `/etc` directory:
+By default, data files reside under the `/var/lib/edb/as15/data` directory. To use a data directory that resides in a nondefault location, perform the following steps:
 
-    ```text
-    cp /usr/lib/systemd/system/edb-as-15.service /etc/systemd/system/
+-   Edit the database service using `systemctl edit`:
+
+    ```shell
+    systemctl edit edb-as-15.service
     ```
 
--   After copying the unit file to the new location, create the service file `/etc/systemd/system/edb-as-15.service`.
+    This will open a text editor (usually nano or vi, depending on your `EDITOR` environment variable and your distribution defaults).
 
--   In the `/lib/systemd/system/edb-as-15.service` file, update the following values with the new location of the data directory:
+-   In the text editor, add the lines:
 
-    ```text
+    ```ini
+    [Service]
     Environment=PGDATA=/var/lib/edb/as15/data
     PIDFile=/var/lib/edb/as15/data/postmaster.pid
     ```
 
--   Delete the content of the `/etc/systemd/system/edb-as-15.service` file except the following line:
+    Note: In the lines above, replace `/var/lib/edb/as15/data` with the desired location for your data directory.
 
-    ```text
-    .include /lib/systemd/system/edb-as-15.service
-    ```
+-   Save the file
+
+    Note: when editing systemd units using `systemd edit`, there is no need to reload the daemon, as systemd does it automatically as you exit the editor.
 
 -   Initialize the cluster at the new location:
 
     ```text
     PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb
-    ```
-
--   Reload systemd, updating the modified service scripts:
-
-    ```text
-    systemctl daemon-reload
     ```
 
 -   Start the EDB Postgres Advanced Server service:
@@ -94,16 +93,27 @@ By default, the data files reside under the `/var/lib/edb/as15/data` directory. 
     mv /var/lib/edb/as15/data /opt/edb/
     ```
 
--   Create a file `edb-as-15.service` under `/etc/systemd/system` to include the location of a new data directory:
+-   Edit the database service using `systemctl edit`:
 
-    ```text
-    .include /lib/systemd/system/edb-as-15.service
+    ```shell
+    systemctl edit edb-as-15.service
+    ```
+
+    This will open a text editor (usually nano or vi, depending on your `EDITOR` environment variable and your distribution defaults).
+
+-   In the text editor, add the lines:
+
+    ```ini
     [Service]
     Environment=PGDATA=/opt/edb/data
     PIDFile=/opt/edb/data/postmaster.pid
     ```
 
--   Use the semanage utility to set the context mapping for `/opt/edb/`. The mapping is written to the `/etc/selinux/targeted/contexts/files/file.contexts.local` file.
+-   Save the file
+
+    Note: when editing systemd units using `systemd edit`, there is no need to reload the daemon, as systemd does it automatically as you exit the editor.
+
+-   Use the `semanage` utility to set the context mapping for `/opt/edb/`. The mapping is written to the `/etc/selinux/targeted/contexts/files/file.contexts.local` file.
 
     ```text
     semanage fcontext --add --equal /var/lib/edb/as15/data /opt/edb
@@ -113,12 +123,6 @@ By default, the data files reside under the `/var/lib/edb/as15/data` directory. 
 
     ```text
     restorecon -rv /opt/edb/
-    ```
-
--   Reload systemd to modify the service script:
-
-    ```text
-    systemctl daemon-reload
     ```
 
 -   With the `/opt/edb` location labeled correctly with the context, start the service:


### PR DESCRIPTION
This not only removes the usage of the deprecated `.include` feature, but also corrects the instructions that wrongfully directed customers towards editing files that were not meant to be edited.

It only covers some of the instructions that edit service files. More fixing is necessary afterwards in other sections of the documentation.
