### PR TITLE
Update 05_using_efm.mdx

### DIFF
--- a/product_docs/docs/efm/4/05_using_efm.mdx
+++ b/product_docs/docs/efm/4/05_using_efm.mdx
@@ -265,27 +265,37 @@ After creating the `acctg.properties` and `sales.properties` files, create a ser
 
 ### RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x
 
-If you're using RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x, copy the `edb-efm-4.<x>` unit file to a new file with a name that is unique for each cluster. For example, if you have two clusters named acctg and sales, the unit file names might be:
+If you're using RHEL/CentOS 7.x or RHEL/Rocky Linux/AlmaLinux 8.x, copy the service file `/usr/lib/systemd/system/edb-efm-4.<x>.service` to `/etc/systemd/system` with a new name that is unique for each cluster.
 
-```text
-/usr/lib/systemd/system/efm-acctg.service
+For example, if you have two clusters named `acctg` and `sales` managed by EFM 4.7, the unit file names might be `efm-acctg.service` and `efm-sales.service`, and they can be created with:
 
-/usr/lib/systemd/system/efm-sales.service
+```shell
+cp /usr/lib/systemd/system/edb-efm-4.7.service /etc/systemd/system/efm-acctg.service
+cp /usr/lib/systemd/system/edb-efm-4.7.service /etc/systemd/system/efm-sales.service
 ```
 
-Then, edit the `CLUSTER` variable in each unit file, changing the specified cluster name from `efm` to the new cluster name. For example, for a cluster named `acctg`, the value specifies:
+Then use `systemctl edit` to edit the `CLUSTER` variable in each unit file, changing the specified cluster name from `efm` to the new cluster name.
+Also update the value of the `PIDfile` parameter to match the new cluster name.
 
-```text
-Environment=CLUSTER=acctg
-```
-
-Also update the value of the `PIDfile` parameter to specify the new cluster name. For example:
+In our example, edit the `acctg` cluster by running `systemctl edit efm-acctg.service` and write:
 
 ```ini
-PIDFile=/var/run/efm-4.7/acctg.pid
+[Service]
+Environment=CLUSTER=acctg
+PIDFile=/run/efm-4.7/acctg.pid
 ```
 
-After copying the service scripts, enable the services:
+And edit the `sales` cluster by running `systemctl edit efm-sales.service` and write:
+
+```ini
+[Service]
+Environment=CLUSTER=sales
+PIDFile=/run/efm-4.7/sales.pid
+```
+
+Note: You could also have edited the files in `/etc/systemd/system` directly, but then you'll have to run `systemctl daemon-reload`, which is unecessary when using `systemd edit` to change the override files.
+
+After saving the changes, enable the services:
 
 ```text
 # systemctl enable efm-acctg.service
@@ -296,7 +306,7 @@ After copying the service scripts, enable the services:
 Then, use the new service scripts to start the agents. For example, to start the `acctg` agent:
 
 ```text
-# systemctl start efm-acctg`
+# systemctl start efm-acctg
 ```
 
 For information about customizing a unit file, see [Understanding and administering systemd](https://docs.fedoraproject.org/en-US/quick-docs/understanding-and-administering-systemd/index.html).


### PR DESCRIPTION
This changes the instructions on how to customize systemd service files. The instructions were directing the reader to edit files in /usr/lib/systemd/system, which is not the adequate location. Whenever a system administrator edits service files, they should always do so in /etc/systemd/system, either with systemctl edit or editing the files directly, but never editing anything in /lib or /usr.

It also shows what the reader should expect to see in each file completely (i.e, exactly three lines), which helps them review their steps before proceeding further with the documentation. Previously, the instructions mentioned lines separately in an unnumbered set of instructions, which is more difficult to follow.