### PR TITLE
Edits to PGD edits in PR 4688

### DIFF
--- a/product_docs/docs/pgd/5/cli/discover_connections.mdx
+++ b/product_docs/docs/pgd/5/cli/discover_connections.mdx
@@ -5,7 +5,7 @@ indexdepth: 2
 deepToC: true
 ---
 
-You can install PGD CLI on any system that can connect to the PGD cluster. To use PGD CLI, you need a user with PGD superuser privileges or equivalent. The PGD user with superuser privileges is the [bdr_superuser role](../security). An example of an equivalent user is `edb_admin` on an EDB BigAnimal Distributed High Availability cluster.
+You can install PGD CLI on any system that can connect to the PGD cluster. To use PGD CLI, you need a user with PGD superuser privileges or equivalent. The PGD user with superuser privileges is the [bdr_superuser role](../security). An example of an equivalent user is edb_admin on an EDB BigAnimal distributed high-availability cluster.
 
 ## PGD CLI and database connection strings
 
@@ -21,7 +21,7 @@ Because TPA is so flexible, you have to derive your connection string from your 
 
 - You need the name or IP address of a host with the role pgd-proxy listed for it. This host has a proxy you can connect to. Usually the proxy listens on port 6432. (Check the setting for `default_pgd_proxy_options` and `listen_port` in the config to confirm.) 
 - The default database name is `bdrdb`. (Check the setting `bdr_database` in the config to confirm.) 
-- The default PGD superuser is `enterprisedb` for EDB Postgres Advanced Server and `postgres` for Postgres and Postgres Extended.
+- The default PGD superuser is enterprisedb for EDB Postgres Advanced Server and postgres for Postgres and Postgres Extended.
 
 You can then assemble a connection string based on that information:
 
@@ -65,10 +65,10 @@ The connection string for this cluster is:
 The example uses the IP address because the configuration is from a Docker TPA install with no name resolution available. Generally, you can use the host name as configured.
 !!!
 
-### For an EDB BigAnimal Distributed High Availability cluster
+### For an EDB BigAnimal distributed high-availability cluster
 
 1. Log in to the [BigAnimal clusters](https://portal.biganimal.com/clusters) view.
-1. In the filter, set the Cluster Type to "Distributed High Availability" to only show clusters which work with PGD CLI.
+1. In the filter, set **Cluster Type** to **Distributed High Availability** to show only clusters that work with PGD CLI.
 1. Select your cluster.
 1. In the view of your cluster, select the **Connect** tab.
 1. Copy the read/write URI from the connection info. This is your connection string.
@@ -83,7 +83,7 @@ As with TPA, EDB PGD for Kubernetes is very flexible, and there are multiple way
 
 Consult your configuration file to determine this information. 
 
-Establish a host name or IP address, port, database name, and username. The default database name is `bdrdb`, and the default username is `enterprisedb` for EDB Postgres Advanced Server and `postgres` for Postgres and Postgres Extended.).
+Establish a host name or IP address, port, database name, and username. The default database name is `bdrdb`, and the default username is enterprisedb for EDB Postgres Advanced Server and postgres for Postgres and Postgres Extended.).
 
 You can then assemble a connection string based on that information:
 

--- a/product_docs/docs/pgd/5/cli/index.mdx
+++ b/product_docs/docs/pgd/5/cli/index.mdx
@@ -13,7 +13,7 @@ directoryDefaults:
   description: "The PGD Command Line Interface (CLI) is a tool to manage your EDB Postgres Distributed cluster"
 ---
 
-The EDB Postgres Distributed Command Line Interface (PGD CLI) is a tool for managing your EDB Postgres Distributed cluster. It allows you to run commands against EDB Postgres Distributed clusters. It is installed automatically on systems in a TPA-deployed PGD cluster. Or it can be installed manually on systems that can connect to any PGD cluster, such as EDB BigAnimal Distributed High Availability clusters or PGD clusters deployed using the EDB PGD for Kubernetes operator.
+The EDB Postgres Distributed Command Line Interface (PGD CLI) is a tool for managing your EDB Postgres Distributed cluster. It allows you to run commands against EDB Postgres Distributed clusters. It's installed automatically on systems in a TPA-deployed PGD cluster. Or it can be installed manually on systems that can connect to any PGD cluster, such as EDB BigAnimal distributed high-availability clusters or PGD clusters deployed using the EDB PGD for Kubernetes operator.
 
 See [Installing PGD CLI](installing_cli) for information about how to manually install PGD CLI on systems.
 

--- a/product_docs/docs/pgd/5/cli/installing_cli.mdx
+++ b/product_docs/docs/pgd/5/cli/installing_cli.mdx
@@ -3,7 +3,7 @@ title: "Installing PGD CLI"
 navTitle: "Installing PGD CLI"
 ---
 
-You can install PGD CLI on any system that can connect to the PGD cluster. To use PGD CLI, you need a user with PGD superuser privileges or equivalent. The PGD user with superuser privileges is the [bdr_superuser role](../security). An example of an equivalent user is edb_admin on a BigAnimal distributed high-availability cluster.
+You can install PGD CLI on any system that can connect to the PGD cluster. To use PGD CLI, you need a user with PGD superuser privileges or equivalent. The PGD user with superuser privileges is the [bdr_superuser role](../security). An example of an equivalent user is edb_admin on an EDB BigAnimal distributed high-availability cluster.
 
 ## Installing automatically with Trusted Postgres Architect (TPA)
 

--- a/product_docs/docs/pgd/5/cli/using_cli.mdx
+++ b/product_docs/docs/pgd/5/cli/using_cli.mdx
@@ -5,7 +5,7 @@ navTitle: "Using PGD CLI"
 
 ## What is the PGD CLI?
 
-The PGD CLI is a convenient way to connect to and manage your PGD cluster. To use it, you need a user with PGD superuser privileges or equivalent. The PGD user with superuser privileges is the [bdr_superuser role](../security). An example of an equivalent user is edb_admin on a BigAnimal distributed high-availability cluster.
+The PGD CLI is a convenient way to connect to and manage your PGD cluster. To use it, you need a user with PGD superuser privileges or equivalent. The PGD user with superuser privileges is the [bdr_superuser role](../security). An example of an equivalent user is edb_admin on an EDB BigAnimal distributed high-availability cluster.
 
 !!! Important Setting passwords
 PGD CLI doesn't interactively prompt for your password. You must pass your password using one of the following methods:


### PR DESCRIPTION
Minor edits. Also, we don't tag user names and roles, and we are not capitalizing distributed high availability. Distributed high availability does get the hyphen when forming a compound adjective.

We've applied these capitalization and hyphenation standards throughout the doc. Please connect with Dee Dee if these are an issue.

