### PR TITLE
Automating index generation for the security pages

### DIFF
--- a/advocacy_docs/security/advisories/cve.mdx.template
+++ b/advocacy_docs/security/advisories/cve.mdx.template
@@ -1,6 +1,7 @@
 ---
 title: CVE Title
 navTitle: CVE ID as CVE-Year-Number
+affectedProducts: one liner covering which products affected
 ---
 
 First Published: YYYY/MM/DD (ISO8601)

--- a/advocacy_docs/security/advisories/cve20074639.mdx
+++ b/advocacy_docs/security/advisories/cve20074639.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2007-4639 - EDB Advanced Server 8.2 improperly handles debugging function calls
 navTitle: CVE-2007-4639
+affectedProducts: EDB Advanced Server 8.2
 ---
 
 First Published: 2007/08/31

--- a/advocacy_docs/security/advisories/cve20074639.mdx
+++ b/advocacy_docs/security/advisories/cve20074639.mdx
@@ -14,10 +14,14 @@ EDB Postgres Advanced Server 8.2 (EPAS) does not properly handle certain debuggi
 
 ## Vulnerability details
 
-CVE-ID:  [CVE-2007-4639](https://nvd.nist.gov/vuln/detail/CVE-2007-4639)  
-CVSS Base Score: Undefined  
-CVSS Temporal Score: Undefined  
-CVSS Environmental Score: Undefined  
+CVE-ID:  [CVE-2007-4639](https://nvd.nist.gov/vuln/detail/CVE-2007-4639)
+
+CVSS Base Score: Undefined
+
+CVSS Temporal Score: Undefined
+
+CVSS Environmental Score: Undefined
+
 CVSS Vector: Undefined
 
 ## Affected products and versions

--- a/advocacy_docs/security/advisories/cve201910128.mdx
+++ b/advocacy_docs/security/advisories/cve201910128.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2019-10128 - EDB supplied PostgreSQL inherits ACL for installation directory
 navTitle: CVE-2019-10128
+affectedProducts: PostgreSQL
 ---
 
 First Published: 2021/03/19

--- a/advocacy_docs/security/advisories/cve201910128.mdx
+++ b/advocacy_docs/security/advisories/cve201910128.mdx
@@ -14,10 +14,14 @@ A vulnerability was found in PostgreSQL versions 11.x prior to 11.3. The Windows
 
 ## Vulnerability details
 
-CVE-ID:   [CVE-2019-10128](https://nvd.nist.gov/vuln/detail/CVE-2019-10128)  
-CVSS Base Score: 7.8  
-CVSS Temporal Score: Undefined  
-CVSS Environmental Score: Undefined  
+CVE-ID:   [CVE-2019-10128](https://nvd.nist.gov/vuln/detail/CVE-2019-10128)
+
+CVSS Base Score: 7.8
+
+CVSS Temporal Score: Undefined
+
+CVSS Environmental Score: Undefined
+
 CVSS Vector: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
 
 ## Affected products and versions

--- a/advocacy_docs/security/advisories/cve202331043.mdx
+++ b/advocacy_docs/security/advisories/cve202331043.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-31043 - EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0
 navTitle: CVE-2023-31043
+affectedProducts: EDB Postgres Advanced Server 10.23.32 to 14.5.0
 ---
 
 First Published: 2023/04/23

--- a/advocacy_docs/security/advisories/cve202331043.mdx
+++ b/advocacy_docs/security/advisories/cve202331043.mdx
@@ -14,10 +14,14 @@ EDB Postgres Advanced Server (EPAS) versions before 14.6.0 log unredacted passwo
 
 ## Vulnerability details
 
-CVE-ID:  [CVE-2023-31043](https://nvd.nist.gov/vuln/detail/CVE-2023-31043)  
-CVSS Base Score: 7.5  
-CVSS Temporal Score: Undefined  
-CVSS Environmental Score: Undefined  
+CVE-ID:  [CVE-2023-31043](https://nvd.nist.gov/vuln/detail/CVE-2023-31043)
+
+CVSS Base Score: 7.5
+
+CVSS Temporal Score: Undefined
+
+CVSS Environmental Score: Undefined
+
 CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
 
 ## Affected products and versions

--- a/advocacy_docs/security/advisories/cve202341113.mdx
+++ b/advocacy_docs/security/advisories/cve202341113.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41113 - EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory() 
 navTitle: CVE-2023-41113
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21

--- a/advocacy_docs/security/advisories/cve202341114.mdx
+++ b/advocacy_docs/security/advisories/cve202341114.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41114 - EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL
 navTitle: CVE-2023-41114
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21

--- a/advocacy_docs/security/advisories/cve202341115.mdx
+++ b/advocacy_docs/security/advisories/cve202341115.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41115 - EDB Postgres Advanced Server (EPAS) permission bypass for large objects
 navTitle: CVE-2023-41115
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21

--- a/advocacy_docs/security/advisories/cve202341116.mdx
+++ b/advocacy_docs/security/advisories/cve202341116.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41116 - EDB Postgres Advanced Server (EPAS) permission bypass for materialized views
 navTitle: CVE-2023-41116
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21
@@ -9,10 +10,7 @@ Last Updated: 2023/08/30
 
 ## Summary 
 
-An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before
-11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and
-15.x before 15.4.0. It allows an authenticated user to refresh any materialized
-view, regardless of that user's permissions.
+An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It allows an authenticated user to refresh any materialized view, regardless of that user's permissions.
 
 ## Vulnerability details
 

--- a/advocacy_docs/security/advisories/cve202341117.mdx
+++ b/advocacy_docs/security/advisories/cve202341117.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41117 - EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path
 navTitle: CVE-2023-41117
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21

--- a/advocacy_docs/security/advisories/cve202341118.mdx
+++ b/advocacy_docs/security/advisories/cve202341118.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41118 - EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass
 navTitle: CVE-2023-41118
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21

--- a/advocacy_docs/security/advisories/cve202341119.mdx
+++ b/advocacy_docs/security/advisories/cve202341119.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41119 - EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser
 navTitle: CVE-2023-41119
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21

--- a/advocacy_docs/security/advisories/cve202341120.mdx
+++ b/advocacy_docs/security/advisories/cve202341120.mdx
@@ -1,6 +1,7 @@
 ---
 title: CVE-2023-41120 - EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission
 navTitle: CVE-2023-41120
+affectedProducts: All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0
 ---
 
 First Published: 2023/08/21

--- a/advocacy_docs/security/advisories/index.mdx
+++ b/advocacy_docs/security/advisories/index.mdx
@@ -1,4 +1,5 @@
 ---
+WARNING: THIS IS AN AUTOMATICALLY GENERATED FILE - DO NOT MANUALLY EDIT - SEE tools/automation/generators/advisoryindex
 title: EDB Security Advisories
 navTitle: Advisories
 iconName: Security
@@ -34,7 +35,7 @@ navigation:
 <details><summary><h3 style="display:inline"> CVE-2023-41120 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341120">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -53,7 +54,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41119 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341119">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -72,7 +73,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41118 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341118">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -91,7 +92,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41117 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341117">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -110,7 +111,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41116 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341116">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -129,7 +130,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41115 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341115">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -148,7 +149,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41114 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341114">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -167,7 +168,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41113 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341113">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -186,7 +187,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-31043 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202331043">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/05/02 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/05/02</span>
 <h4>EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
 <h5> EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
 </summary>
@@ -210,7 +211,7 @@ EDB Postgres Advanced Server (EPAS) versions before 14.6.0 log unredacted passwo
 <details><summary><h3 style="display:inline"> CVE-2019-10128 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve201910128">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2022/01/01 </span>
+&nbsp;&nbsp;Updated: </span><span>2022/01/01</span>
 <h4>EDB supplied PostgreSQL inherits ACL for installation directory</h4>
 <h5> PostgreSQL</h5>
 </summary>
@@ -234,13 +235,13 @@ A vulnerability was found in PostgreSQL versions 11.x prior to 11.3. The Windows
 <details><summary><h3 style="display:inline"> CVE-2007-4639 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve20074639">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2018/10/15 </span>
+&nbsp;&nbsp;Updated: </span><span>2018/10/15</span>
 <h4>EDB Advanced Server 8.2 improperly handles debugging function calls</h4>
 <h5> EDB Advanced Server 8.2</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-EDB Postgres Advanced Server 8.2 (EPAS) does not properly handle certain debugging function calls that occur before a call to `pldbg_create_listener`, which allows remote authenticated users to cause a denial of service (daemon crash) and possibly execute arbitrary code via a SELECT statement that invokes a `pldbg_` function, as demonstrated by (1) `pldbg_get_stack` and (2) `pldbg_abort_target`, which triggers use of an uninitialized pointer.
+EDB Postgres Advanced Server 8.2 (EPAS) does not properly handle certain debugging function calls that occur before a call to <code>pldbg_create_listener</code>, which allows remote authenticated users to cause a denial of service (daemon crash) and possibly execute arbitrary code via a SELECT statement that invokes a <code>pldbg_</code> function, as demonstrated by (1) <code>pldbg_get_stack</code> and (2) <code>pldbg_abort_target</code>, which triggers use of an uninitialized pointer.
 <br/>
 <a href="cve20074639">Read More...</a>
 </details></td></tr>

--- a/advocacy_docs/security/advisories/index.mdx
+++ b/advocacy_docs/security/advisories/index.mdx
@@ -35,7 +35,7 @@ navigation:
 <span>
 &nbsp;&nbsp;<a href="cve202341120">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41120 - EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
+<h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -54,7 +54,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202341119">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41119 - EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
+<h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -73,7 +73,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202341118">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41118 - EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
+<h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -92,7 +92,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202341117">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41117 - EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
+<h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -111,7 +111,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202341116">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41116 - EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
+<h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -130,7 +130,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202341115">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41115 - EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
+<h4>EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -149,7 +149,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202341114">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41114 - EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
+<h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -168,7 +168,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202341113">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41113 - EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
+<h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -187,7 +187,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="cve202331043">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/05/02 </span>
-<h4>CVE-2023-31043 - EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
+<h4>EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
 <h5> EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
 </summary>
 <hr/>
@@ -211,7 +211,7 @@ EDB Postgres Advanced Server (EPAS) versions before 14.6.0 log unredacted passwo
 <span>
 &nbsp;&nbsp;<a href="cve201910128">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2022/01/01 </span>
-<h4>CVE-2019-10128 - EDB supplied PostgreSQL inherits ACL for installation directory</h4>
+<h4>EDB supplied PostgreSQL inherits ACL for installation directory</h4>
 <h5> PostgreSQL</h5>
 </summary>
 <hr/>
@@ -235,7 +235,7 @@ A vulnerability was found in PostgreSQL versions 11.x prior to 11.3. The Windows
 <span>
 &nbsp;&nbsp;<a href="cve20074639">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2018/10/15 </span>
-<h4>CVE-2007-4639 - EDB Advanced Server 8.2 improperly handles debugging function calls</h4>
+<h4>EDB Advanced Server 8.2 improperly handles debugging function calls</h4>
 <h5> EDB Advanced Server 8.2</h5>
 </summary>
 <hr/>

--- a/advocacy_docs/security/advisories/index.mdx
+++ b/advocacy_docs/security/advisories/index.mdx
@@ -18,18 +18,25 @@ navigation:
 - cve20074639
 ---
 
-## Updated 2023
+
+
+
+
+
+
+   
+<h2>Updated 2023</h2>
 
 <table class="table-bordered">
 
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41120</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41120 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341120">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41120 - EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -38,31 +45,37 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <a href="cve202341120">Read More...</a>
 </details></td></tr>
 
+
+
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41119</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41119 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341119">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser
-</h4>
-<h5>All EnterpriseDB Postgres Advanced Server (EPAS) versions prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0 </h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41119 - EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It contains the function _dbms_aq_move_to_exception_queue that may be used to elevate a user's privileges to superuser. This function accepts the OID of a table, and then accesses that table as the superuser by using SELECT and DML commands.
 <br/>
 <a href="cve202341119">Read More...</a>
-</details>
-</td></tr>
+</details></td></tr>
+
+
+
+
 
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41118</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41118 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341118">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5></summary>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41118 - EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+</summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete.
@@ -70,30 +83,36 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <a href="cve202341118">Read More...</a>
 </details></td></tr>
 
+
+
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41117</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41117 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341117">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41117 - EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It contain packages, standalone packages, and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks.
 <br/>
 <a href="cve202341117">Read More...</a>
-</details>
-</td></tr>
+</details></td></tr>
+
+
+
+
 
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41116</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41116 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341116">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41116 - EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -102,14 +121,17 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <a href="cve202341116">Read More...</a>
 </details></td></tr>
 
+
+
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41115</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41115 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341115">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) permission bypass for large objects
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41115 - EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -119,14 +141,16 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 </details></td></tr>
 
 
+
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41114</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41114 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341114">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41114 - EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -135,32 +159,36 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <a href="cve202341114">Read More...</a>
 </details></td></tr>
 
+
+
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41113</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41113 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202341113">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory() 
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41113 - EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It allows an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents (regardless of permissions). This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections.
- <br/>
+<br/>
 <a href="cve202341113">Read More...</a>
-</details>
-</td></tr>
+</details></td></tr>
+
+
+
 
 
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-31043</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-31043 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202331043">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/05/02</span>
-<h4>EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0
-</h4>
-<h5>EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/05/02 </span>
+<h4>CVE-2023-31043 - EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
+<h5> EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -168,43 +196,54 @@ EDB Postgres Advanced Server (EPAS) versions before 14.6.0 log unredacted passwo
 <br/>
 <a href="cve202331043">Read More...</a>
 </details></td></tr>
-</table>
 
-## Updated 2022
 
-<table>
+
+
+</table>   
+<h2>Updated 2022</h2>
+
+<table class="table-bordered">
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2019-10128</h3>
+<details><summary><h3 style="display:inline"> CVE-2019-10128 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve201910128">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2022/01/01</span>
-<h4>EDB supplied PostgreSQL inherits ACL for installation directory
-</h4>
-<h5>PostgreSQL</h5>
+&nbsp;&nbsp;Updated: </span><span>2022/01/01 </span>
+<h4>CVE-2019-10128 - EDB supplied PostgreSQL inherits ACL for installation directory</h4>
+<h5> PostgreSQL</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-A vulnerability was found in PostgreSQL versions 11.x prior to 11.3. The Windows installer for EDB-supplied PostgreSQL does not lock down the ACL of the binary installation directory or the ACL of the data directory; it keeps the inherited ACL. In the default configuration, this allows a local attacker to read arbitrary data directory files, essentially bypassing database-imposed read access limitations. In plausible non-default configurations, an attacker having both an unprivileged Windows account and an unprivileged PostgreSQL account can cause the PostgreSQL service account to execute arbitrary code.
+A vulnerability was found in PostgreSQL versions 11.x prior to 11.3. The Windows installer for EnterpriseDB-supplied PostgreSQL does not lock down the ACL of the binary installation directory or the ACL of the data directory; it keeps the inherited ACL. In the default configuration, this allows a local attacker to read arbitrary data directory files, essentially bypassing database-imposed read access limitations. In plausible non-default configurations, an attacker having both an unprivileged Windows account and an unprivileged PostgreSQL account can cause the PostgreSQL service account to execute arbitrary code.
 <br/>
 <a href="cve201910128">Read More...</a>
 </details></td></tr>
-</table>
 
-## Updated 2018
 
-<table>
+
+
+</table>   
+<h2>Updated 2018</h2>
+
+<table class="table-bordered">
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2007-4639</h3>
+<details><summary><h3 style="display:inline"> CVE-2007-4639 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve20074639">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2018/10/15</span>
-<h4>EDB Advanced Server 8.2 improperly handles debugging function calls
-</h4>
-<h5>EDB Postgres Advanced Server version 8.2</h5>
+&nbsp;&nbsp;Updated: </span><span>2018/10/15 </span>
+<h4>CVE-2007-4639 - EDB Advanced Server 8.2 improperly handles debugging function calls</h4>
+<h5> EDB Advanced Server 8.2</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-EDB Postgres Advanced Server 8.2 does not properly handle certain debugging function calls that occur before a call to <code>pldbg_create_listener</code>, which allows remote authenticated users to cause a denial of service (daemon crash) and possibly execute arbitrary code via a SELECT statement that invokes a <code>pldbg_</code> function, as demonstrated by (1) <code>pldbg_get_stack</code> and (2) <code>pldbg_abort_target</code>, which triggers use of an uninitialized pointer.<br/>
+EDB Postgres Advanced Server 8.2 (EPAS) does not properly handle certain debugging function calls that occur before a call to `pldbg_create_listener`, which allows remote authenticated users to cause a denial of service (daemon crash) and possibly execute arbitrary code via a SELECT statement that invokes a `pldbg_` function, as demonstrated by (1) `pldbg_get_stack` and (2) `pldbg_abort_target`, which triggers use of an uninitialized pointer.
+<br/>
 <a href="cve20074639">Read More...</a>
-</details></td></tr></table>
+</details></td></tr>
+
+</table>
 

--- a/advocacy_docs/security/index.mdx
+++ b/advocacy_docs/security/index.mdx
@@ -24,14 +24,15 @@ This policy outlines how EnterpriseDB handles disclosures related to suspected v
 ## Most Recent Advisories
 
 <table class="table-bordered">
+
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41120</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41120 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341120">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41120 - EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -40,31 +41,31 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <a href="advisories/cve202341120">Read More...</a>
 </details></td></tr>
 
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41119</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41119 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341119">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser
-</h4>
-<h5>All EnterpriseDB Postgres Advanced Server (EPAS) versions prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0 </h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41119 - EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It contains the function _dbms_aq_move_to_exception_queue that may be used to elevate a user's privileges to superuser. This function accepts the OID of a table, and then accesses that table as the superuser by using SELECT and DML commands.
 <br/>
 <a href="advisories/cve202341119">Read More...</a>
-</details>
-</td></tr>
+</details></td></tr>
+
 
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41118</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41118 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341118">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5></summary>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41118 - EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+</summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It may allow an authenticated user to bypass authorization requirements and access underlying implementation functions. When a superuser has configured file locations using CREATE DIRECTORY, these functions allow users to take a wide range of actions, including read, write, copy, rename, and delete.
@@ -72,31 +73,30 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <a href="advisories/cve202341118">Read More...</a>
 </details></td></tr>
 
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41117</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41117 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341117">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41117 - EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It contain packages, standalone packages, and functions that run SECURITY DEFINER but are inadequately secured against search_path attacks.
 <br/>
 <a href="advisories/cve202341117">Read More...</a>
-</details>
-</td></tr>
+</details></td></tr>
 
 
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41116</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41116 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341116">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41116 - EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -105,14 +105,14 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <a href="advisories/cve202341116">Read More...</a>
 </details></td></tr>
 
+
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41115</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41115 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341115">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) permission bypass for large objects
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41115 - EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -122,21 +122,13 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 </details></td></tr>
 
 
-
-
-
-
-
-
-
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41114</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41114 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341114">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41114 - EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -147,30 +139,28 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 
 
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-41113</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-41113 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341113">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
-<h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory() 
-</h4>
-<h5>All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+<h4>CVE-2023-41113 - EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
+<h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
 An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 11.21.32, 12.x before 12.16.20, 13.x before 13.12.16, 14.x before 14.9.0, and 15.x before 15.4.0. It allows an authenticated user to to obtain information about whether certain files exist on disk, what errors if any occur when attempting to read them, and some limited information about their contents (regardless of permissions). This can occur when a superuser has configured one or more directories for filesystem access via CREATE DIRECTORY and adopted certain non-default settings for log_line_prefix and log_connections.
 <br/>
 <a href="advisories/cve202341113">Read More...</a>
-</details>
-</td></tr>
+</details></td></tr>
+
 
 <tr><td>
-<details><summary><h3 style="display:inline">CVE-2023-31043</h3>
+<details><summary><h3 style="display:inline"> CVE-2023-31043 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202331043">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/05/02</span>
-<h4>EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0
-</h4>
-<h5>EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
+&nbsp;&nbsp;Updated: </span><span>2023/05/02 </span>
+<h4>CVE-2023-31043 - EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
+<h5> EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
@@ -178,4 +168,6 @@ EDB Postgres Advanced Server (EPAS) versions before 14.6.0 log unredacted passwo
 <br/>
 <a href="advisories/cve202331043">Read More...</a>
 </details></td></tr>
+
 </table>
+

--- a/advocacy_docs/security/index.mdx
+++ b/advocacy_docs/security/index.mdx
@@ -31,7 +31,7 @@ This policy outlines how EnterpriseDB handles disclosures related to suspected v
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341120">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41120 - EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
+<h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -47,7 +47,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341119">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41119 - EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
+<h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -63,7 +63,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341118">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41118 - EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
+<h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -79,7 +79,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341117">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41117 - EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
+<h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -95,7 +95,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341116">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41116 - EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
+<h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -111,7 +111,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341115">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41115 - EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
+<h4>EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -127,7 +127,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341114">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41114 - EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
+<h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -143,7 +143,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341113">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
-<h4>CVE-2023-41113 - EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
+<h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
 <hr/>
@@ -159,7 +159,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202331043">Read Advisory</a>
 &nbsp;&nbsp;Updated: </span><span>2023/05/02 </span>
-<h4>CVE-2023-31043 - EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
+<h4>EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
 <h5> EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
 </summary>
 <hr/>

--- a/advocacy_docs/security/index.mdx
+++ b/advocacy_docs/security/index.mdx
@@ -1,4 +1,5 @@
 ---
+WARNING: THIS IS AN AUTOMATICALLY GENERATED FILE - DO NOT MANUALLY EDIT - SEE tools/automation/generators/advisoryindex
 title: EDB Security
 navTitle: EDB Security
 directoryDefaults:
@@ -30,7 +31,7 @@ This policy outlines how EnterpriseDB handles disclosures related to suspected v
 <details><summary><h3 style="display:inline"> CVE-2023-41120 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341120">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) DBMS_PROFILER data may be removed without permission</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -46,7 +47,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41119 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341119">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) dbms_aq helper function may run arbitrary SQL as a superuser</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -62,7 +63,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41118 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341118">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) UTL_FILE permission bypass</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -78,7 +79,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41117 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341117">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) SECURITY DEFINER functions and procedures may be hijacked via search_path</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -94,7 +95,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41116 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341116">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for materialized views</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -110,7 +111,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41115 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341115">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) permission bypass for large objects</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -126,7 +127,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41114 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341114">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) authenticated users may fetch any URL</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -142,7 +143,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-41113 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202341113">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/08/30 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/08/30</span>
 <h4>EDB Postgres Advanced Server (EPAS) permissions bypass via accesshistory()</h4>
 <h5> All versions of EnterpriseDB Postgres Advanced Server (EPAS) prior to 11.21.32, 12.16.20, 13.12.17, 14.9.0, 15.4.0</h5>
 </summary>
@@ -158,7 +159,7 @@ An issue was discovered in EnterpriseDB Postgres Advanced Server (EPAS) before 1
 <details><summary><h3 style="display:inline"> CVE-2023-31043 </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/cve202331043">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2023/05/02 </span>
+&nbsp;&nbsp;Updated: </span><span>2023/05/02</span>
 <h4>EDB Postgres Advanced Server (EPAS) logs unredacted passwords prior to 14.6.0</h4>
 <h5> EDB Postgres Advanced Server 10.23.32 to 14.5.0</h5>
 </summary>

--- a/advocacy_docs/security/templates/advisoriesindex.njs
+++ b/advocacy_docs/security/templates/advisoriesindex.njs
@@ -1,4 +1,5 @@
 ---
+WARNING: THIS IS AN AUTOMATICALLY GENERATED FILE - DO NOT MANUALLY EDIT - SEE tools/automation/generators/advisoryindex
 title: EDB Security Advisories
 navTitle: Advisories
 iconName: Security
@@ -12,7 +13,7 @@ navigation:{% for cve in cvesorted %}
 
 {% for cve in cvesorted %}
 {% set thiscve = cves[cve] %}
-{% set lastUpdatedYear = thiscve.open_last_updated.slice(0,4) %}
+{% set lastUpdatedYear = thiscve.open.last_updated.slice(0,4) %}
 {% if  lastUpdatedYear != updatedYear %}
 {% if updatedYear != -1 %}</table>{% endif %}   
 <h2>Updated {{ lastUpdatedYear }}</h2>
@@ -21,16 +22,16 @@ navigation:{% for cve in cvesorted %}
 {% endif %}
 
 <tr><td>
-<details><summary><h3 style="display:inline"> {{ thiscve.vulnerability_details_cve_id }} </h3>
+<details><summary><h3 style="display:inline"> {{ thiscve.vulnerability_details.cve_id }} </h3>
 <span>
 &nbsp;&nbsp;<a href="{{ thiscve.filename }}">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>{{ thiscve.open_last_updated }} </span>
-<h4>{{ thiscve.frontmatter_title }}</h4>
-<h5> {{ thiscve.frontmatter_affectedProducts }}</h5>
+&nbsp;&nbsp;Updated: </span><span>{{ thiscve.open.last_updated }}</span>
+<h4>{{ thiscve.frontmatter.title }}</h4>
+<h5> {{ thiscve.frontmatter.affectedProducts }}</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-{{ thiscve.summary_0 }}
+{{ thiscve.summary[0].replaceAll(r/`([^`]*)`/g,"<code>$1</code>") }}
 <br/>
 <a href="{{ thiscve.filename }}">Read More...</a>
 </details></td></tr>

--- a/advocacy_docs/security/templates/advisoriesindex.njs
+++ b/advocacy_docs/security/templates/advisoriesindex.njs
@@ -1,0 +1,39 @@
+---
+title: EDB Security Advisories
+navTitle: Advisories
+iconName: Security
+hideKBLink: true
+hideToC: false
+navigation:{% for cve in cvesorted %}
+- {{ cve }}{% endfor %}
+---
+
+{% set updatedYear = -1 %}
+
+{% for cve in cvesorted %}
+{% set thiscve = cves[cve] %}
+{% set lastUpdatedYear = thiscve.open_last_updated.slice(0,4) %}
+{% if  lastUpdatedYear != updatedYear %}
+{% if updatedYear != -1 %}</table>{% endif %}   
+<h2>Updated {{ lastUpdatedYear }}</h2>
+{% set updatedYear = lastUpdatedYear %}
+<table class="table-bordered">
+{% endif %}
+
+<tr><td>
+<details><summary><h3 style="display:inline"> {{ thiscve.vulnerability_details_cve_id }} </h3>
+<span>
+&nbsp;&nbsp;<a href="{{ thiscve.filename }}">Read Advisory</a>
+&nbsp;&nbsp;Updated: </span><span>{{ thiscve.open_last_updated }} </span>
+<h4>{{ thiscve.frontmatter_title }}</h4>
+<h5> {{ thiscve.frontmatter_affectedProducts }}</h5>
+</summary>
+<hr/>
+<em>Summary:</em>&nbsp;
+{{ thiscve.summary_0 }}
+<br/>
+<a href="{{ thiscve.filename }}">Read More...</a>
+</details></td></tr>
+{% endfor %}
+</table>
+

--- a/advocacy_docs/security/templates/securityindex.njs
+++ b/advocacy_docs/security/templates/securityindex.njs
@@ -1,4 +1,5 @@
 ---
+WARNING: THIS IS AN AUTOMATICALLY GENERATED FILE - DO NOT MANUALLY EDIT - SEE tools/automation/generators/advisoryindex
 title: EDB Security
 navTitle: EDB Security
 directoryDefaults:
@@ -27,16 +28,16 @@ This policy outlines how EnterpriseDB handles disclosures related to suspected v
 {% for cve in shortcvelist %}
 {% set thiscve = cves[cve] %}
 <tr><td>
-<details><summary><h3 style="display:inline"> {{ thiscve.vulnerability_details_cve_id }} </h3>
+<details><summary><h3 style="display:inline"> {{ thiscve.vulnerability_details.cve_id }} </h3>
 <span>
 &nbsp;&nbsp;<a href="advisories/{{ thiscve.filename }}">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>{{ thiscve.open_last_updated }} </span>
-<h4>{{ thiscve.frontmatter_title }}</h4>
-<h5> {{ thiscve.frontmatter_affectedProducts }}</h5>
+&nbsp;&nbsp;Updated: </span><span>{{ thiscve.open.last_updated }}</span>
+<h4>{{ thiscve.frontmatter.title }}</h4>
+<h5> {{ thiscve.frontmatter.affectedProducts }}</h5>
 </summary>
 <hr/>
 <em>Summary:</em>&nbsp;
-{{ thiscve.summary_0 }}
+{{ thiscve.summary[0].replaceAll(r/`([^`]*)`/g,"<code>$1</code>") }}
 <br/>
 <a href="advisories/{{ thiscve.filename }}">Read More...</a>
 </details></td></tr>

--- a/advocacy_docs/security/templates/securityindex.njs
+++ b/advocacy_docs/security/templates/securityindex.njs
@@ -1,0 +1,45 @@
+---
+title: EDB Security
+navTitle: EDB Security
+directoryDefaults:
+  iconName: Security
+  indexCards: none
+  hideKBLink: true
+navigation:
+  - vulnerability-disclosure-policy
+  - advisories
+---
+
+EDB is committed to a security first approach, from the products we build and the platforms we operate, to the services we provide our customers. Transparency is a core principle for the program and part of this effort includes welcoming incoming reports so that we can address concerns surfaced by our customers or security researchers. You’ll also find it in our advisories, which detail issues found and the required fixes or mitigations needed to keep your data and databases safe.
+
+## Policies
+
+* <h3><a href="vulnerability-disclosure-policy">EDB Vulnerability Disclosure Policy</a></h3>
+This policy outlines how EnterpriseDB handles disclosures related to suspected vulnerabilities within our products, systems, or services. It also provides guidance for those who wish to perform security research, or may have discovered a potential security vulnerability impacting EDB.
+
+## Advisories
+
+* <h3><a href="advisories/">Full list of advisories issued</a></h3>
+
+## Most Recent Advisories
+
+<table class="table-bordered">
+{% for cve in shortcvelist %}
+{% set thiscve = cves[cve] %}
+<tr><td>
+<details><summary><h3 style="display:inline"> {{ thiscve.vulnerability_details_cve_id }} </h3>
+<span>
+&nbsp;&nbsp;<a href="advisories/{{ thiscve.filename }}">Read Advisory</a>
+&nbsp;&nbsp;Updated: </span><span>{{ thiscve.open_last_updated }} </span>
+<h4>{{ thiscve.frontmatter_title }}</h4>
+<h5> {{ thiscve.frontmatter_affectedProducts }}</h5>
+</summary>
+<hr/>
+<em>Summary:</em>&nbsp;
+{{ thiscve.summary_0 }}
+<br/>
+<a href="advisories/{{ thiscve.filename }}">Read More...</a>
+</details></td></tr>
+{% endfor %}
+</table>
+

--- a/tools/automation/generators/advisoryindex/advisoryindex.js
+++ b/tools/automation/generators/advisoryindex/advisoryindex.js
@@ -1,0 +1,173 @@
+const fs = require('fs');
+const matter = require('gray-matter');
+const MarkdownIt = require('markdown-it');
+const njk = require('nunjucks');
+const { basename, join } = require('path');
+const parseArgs = require('minimist');
+const { addAbortListener } = require('events');
+
+var argv = parseArgs(process.argv.slice(2));
+
+if (argv.root == undefined) {
+    console.log("Need --root");
+    process.exit(1);
+}
+
+const securityRoot = argv.root;
+
+let seccount=10;
+
+if (argv.count != undefined) {
+    seccount=parseInt(argv.count);
+}
+
+// We are going to process the advisories in
+const advisoriesDir = join(securityRoot, "advisories");
+// To produce an index file named
+const advisoriesIndex = join(advisoriesDir, "index.mdx");
+// And another similar but shorted one named
+const securityIndex = join(securityRoot, "index.mdx");
+
+// Using templates in a directory called
+const templatesDir = join(securityRoot, "templates");
+
+function parseMarkdownFile(filePath) {
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const parsedMatter = matter(fileContent);
+
+    const sections = parsedMatter.content.split('\n#').slice(0); // split at headings
+    const sectionDicts = sections.map(section => {
+        const lines = section.split('\n');
+        const heading = lines[0].replace('#', '').trim();
+        const content = lines.slice(1);
+        var parsedContent = [];
+        content.forEach((line, index) => {
+            if (line !== '') {
+                if (line.startsWith('* [')) {
+                    // This is a line with a link
+                    // For now, we drop links completely
+                } else if (line.indexOf(':') > 0) {
+                    const colon = line.indexOf(':');
+                    let key = line.slice(0, colon);
+                    if (key.startsWith('* ')) {
+                        key = key.slice(2);
+                    }
+                    const value = line.slice(colon + 1).trim();
+
+                    parsedContent.push({ [slugify(key)]: value });
+                } else {
+                    parsedContent.push(line);
+                }
+            }
+        });
+
+        if (heading === '') {
+            return { ["open"]: parsedContent };
+        }
+
+        return { [slugify(heading)]: parsedContent };
+    });
+
+    let docMap = {}
+
+    // add the parsedMatter data to the docmap
+    Object.keys(parsedMatter.data).forEach(key => {
+        docMap["frontmatter_" + key] = parsedMatter.data[key];
+    });
+
+    const path = basename(filePath, ".mdx");
+
+    docMap["filename"] = path;
+
+    // add the flattened sections to the docMap
+    sectionDicts.forEach(section => {
+        Object.keys(section).forEach(key => {
+            let value = section[key];
+            if (Array.isArray(value)) {
+                for (let i = 0; i < value.length; i++) {
+                    if (typeof value[i] === 'object') {
+                        Object.keys(value[i]).forEach(subkey => {
+                            docMap[key + '_' + subkey] = value[i][subkey];
+                        })
+                    } else {
+                        docMap[key + '_' + i] = value[i];
+                    }
+                }
+                value = value.join('\n');
+            } else {
+                docMap[key] = value;
+            }
+        })
+    });;
+
+    return docMap;
+}
+
+// function that takes a string and returns it in lower case, with no spaces
+function slugify(string) {
+    return string
+        .toLowerCase()
+        .replace(/[-]+/g, '_')
+        .replace(/\s+/g, '_')
+        .replace(/[^\w-]+/g, '')
+        ;
+}
+
+function cleanCVE(string) {
+    if (string[0] == "[") {
+        return string.slice(1, string.indexOf("]", 1));
+    }
+    return string;
+}
+
+// Iterate over all the files that start cve and end with mdx in the source directory, and parse them
+
+njk.configure(templatesDir, { autoescape: false });
+
+
+
+const files = fs.readdirSync(advisoriesDir).filter(fn => fn.startsWith('cve') && fn.endsWith('mdx'));
+files.sort().reverse();
+const cvelist = files.map(file => { return file.replace(/\.[^/.]+$/, "") });
+
+let namespace = {};
+let allDocMap = {};
+
+cvelist.forEach(cve => {
+    const docMap = parseMarkdownFile(join(advisoriesDir, cve + '.mdx'));
+    docMap['vulnerability_details_cve_id'] = cleanCVE(docMap['vulnerability_details_cve_id']);
+    allDocMap[cve] = docMap;
+});
+
+
+let shortcvelist = [];
+let lastyear = "";
+let count = 0;
+cvelist.forEach(cve => {
+    const year = cve.substring(3, 7);
+    if (lastyear=="") {
+        count = 0;
+        lastyear = year;
+    } else if (lastyear!=year) {
+        return;
+    }
+    if (count < seccount) {
+        shortcvelist.push(cve);
+        count++;
+    }
+});
+
+namespace["shortcvelist"]= shortcvelist;
+namespace["cvesorted"] = cvelist;
+namespace["cves"] = allDocMap;
+
+//console.log(JSON.stringify(namespace, null, 2));
+
+const res = njk.render("advisoriesindex.njs", namespace);
+
+fs.writeFileSync(advisoriesIndex, res);
+
+const res2 = njk.render("securityindex.njs", namespace);
+
+fs.writeFileSync(securityIndex,res2);
+

--- a/tools/automation/generators/advisoryindex/advisoryindex.js
+++ b/tools/automation/generators/advisoryindex/advisoryindex.js
@@ -135,7 +135,10 @@ let allDocMap = {};
 
 cvelist.forEach(cve => {
     const docMap = parseMarkdownFile(join(advisoriesDir, cve + '.mdx'));
+    // make sure the cve id isn't a link
     docMap['vulnerability_details_cve_id'] = cleanCVE(docMap['vulnerability_details_cve_id']);
+    // trim the cve id off the front of the title
+    docMap['frontmatter_title']=docMap['frontmatter_title'].slice(docMap['frontmatter_title'].indexOf(" - ")+3);
     allDocMap[cve] = docMap;
 });
 

--- a/tools/automation/generators/advisoryindex/package-lock.json
+++ b/tools/automation/generators/advisoryindex/package-lock.json
@@ -1,0 +1,216 @@
+{
+  "name": "jssecindexes",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jssecindexes",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^13.0.1",
+        "minimist": "^1.2.8",
+        "nunjucks": "^3.2.4"
+      }
+    },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+    }
+  }
+}

--- a/tools/automation/generators/advisoryindex/package.json
+++ b/tools/automation/generators/advisoryindex/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "advisoryindex.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/tools/automation/generators/advisoryindex/package.json
+++ b/tools/automation/generators/advisoryindex/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "jssecindexes",
+  "version": "1.0.0",
+  "description": "",
+  "main": "advisoryindex.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "markdown-it": "^13.0.1",
+    "minimist": "^1.2.8",
+    "nunjucks": "^3.2.4"
+  }
+}


### PR DESCRIPTION
## What Changed?

Bit of a biggie; there's slight reworks on all the existing CVE's to add some new metadata (affectedProducts).

Then there's tools/automation/generators/advisoryindex/advisoryindex.js

cd into that directory and run node advisoryindex.js --source path_to_security_folder_in_docs

And that'll make both index pages. Uses nunjucks to template content - templates are in the security directory folder templates.

