### PR TITLE
BigAnimal: fixing PEM remote monitoring link

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/index.mdx
@@ -20,7 +20,7 @@ With BigAnimal, you have a few options for monitoring and logging solutions:
 
 - BigAnimal provides a Prometheus-compatible endpoint you can use to connect to your own metrics infrastructure, such as your AWS Managed Grafana. It also provides the option to view logs from your cloud provider's blob storage solution. For more information, see [Other monitoring and logging solutions](other_monitoring). This ability is an optional solution when you're using your own cloud account but is the only option when using BigAnimal's cloud account.
 
-- Existing Postgres Enterprise Manager (PEM) users who want to monitor BigAnimal clusters alongside self-managed Postgres clusters can use the remote monitoring capability of PEM. See [Remote monitoring](/pem/latest/pem_admin/02a_pem_remote_monitoring). 
+- Existing Postgres Enterprise Manager (PEM) users who want to monitor BigAnimal clusters alongside self-managed Postgres clusters can use the remote monitoring capability of PEM. See [Remote monitoring](/pem/latest/monitoring_performance/pem_remote_monitoring/). 
 
   With remote monitoring, you have access to many PEM features, including the ability to profile the workloads on your BigAnimal clusters. See [Profiling workloads](/pem/latest/profiling_workloads) for more information.
 


### PR DESCRIPTION
## What Changed?

The Remote monitoring link in the third bullet on this [page](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/05_monitoring_and_logging/) 404s even though there is a redirect for it. This PR fixes the link, but it might be worth investigating why the redirect didn't work.