### PR TITLE
removed text that was not needed

### DIFF
--- a/product_docs/docs/efm/4/upgrading.mdx
+++ b/product_docs/docs/efm/4/upgrading.mdx
@@ -26,9 +26,6 @@ Failover Manager provides a utility to assist you when upgrading a cluster manag
 
 3.  Modify the `.properties` and `.nodes` files for Failover Manager 4.7, specifying any new preferences. Use your choice of editor to modify any additional properties in the properties file (located in the `/etc/edb/efm-4.7` directory) before starting the service for that node. For detailed information about property settings, see [The cluster properties file](04_configuring_efm/01_cluster_properties/#cluster_properties).
 
-!!! Note
-    `db.bin` is a required property. When modifying the properties file, ensure that the `db.bin` property specifies the location of the Postgres `bin` directory.
-
 4.  If you're using Eager Failover, you must disable it before stopping the Failover Manager cluster. For more information, see [Disabling Eager Failover](04_configuring_efm/06_configuring_for_eager_failover/#disabling-eager-failover).
 
 5. Use a version-specific command to stop the old Failover Manager cluster. For example, you can use the following command to stop a version 4.4 cluster:
@@ -53,9 +50,6 @@ Upgrade of files is finished. The owner and group for properties and nodes files
 ```
 
 If you're [using a Failover Manager configuration without sudo](04_configuring_efm/04_extending_efm_permissions/#running_efm_without_sudo), include the `-source` flag and specify the name of the directory in which the configuration files reside when invoking `upgrade-conf`. If the directory isn't the configuration default directory, the upgraded files are created in the directory from which the `upgrade-conf` command was invoked.
-
-!!! Note
-    If you're using a unit file, manually update the file to reflect the new Failover Manager service name when you perform an upgrade.
 
 ## Uninstalling Failover Manager
 


### PR DESCRIPTION
The db.bin property is just one of many needed properties, so calling it out here in a note doesn't make sense. My guess is that we added that property some time back and an upgrade required setting it, but by now any installation that a user is upgrading from will already have it set.

The unit file comment I removed doesn't make sense here, and I don't know where it might have come from. When upgrading, the service name doesn't change, and there would be a new unit file anyway. This might be related to the multiple efm agents on a single node section, but doesn't make sense here that I can see.

## What Changed?

