### PR TITLE
EPAS 15 - Profile parameter update as per DF-356

### DIFF
--- a/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/29_create_profile.mdx
+++ b/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/29_create_profile.mdx
@@ -59,7 +59,7 @@ EDB Postgres Advanced Server supports these values for each parameter:
 -   `DEFAULT` &mdash; The value of `PASSWORD_LOCK_TIME` specified in the `DEFAULT` profile.
 -   `UNLIMITED` &mdash; The account is locked until manually unlocked by a database superuser.
 
-`PASSWORD_LIFE_TIME` specifies the number of days that the current password can be used before the user is prompted to provide a new password. Include the `PASSWORD_GRACE_TIME` clause when using the `PASSWORD_LIFE_TIME` clause to specify the number of days to pass after the password expires before connections by the role are rejected. If you don't specify `PASSWORD_GRACE_TIME`, the password expires on the day specified by the default value of `PASSWORD_GRACE_TIME`, and the user isn't allowed to execute any command until a new password is provided. Supported values are:
+`PASSWORD_LIFE_TIME` specifies the number of days that the current password can be used before the user is prompted to provide a new password. Include the `PASSWORD_GRACE_TIME` clause when using the `PASSWORD_LIFE_TIME` clause to specify the number of days to pass after the password expires before the user is forced to change their password. If you don't specify `PASSWORD_GRACE_TIME`, the password expires on the day specified by the default value of `PASSWORD_GRACE_TIME`, and the user isn't allowed to execute any command until a new password is provided. Supported values are:
 
 -   A `NUMERIC` value greater of `0` or greater. To specify a fractional portion of a day, specify a decimal value. For example, use the value `4.5` to specify 4 days, 12 hours.
 -   `DEFAULT` &mdash; The value of `PASSWORD_LIFE_TIME` specified in the `DEFAULT` profile.


### PR DESCRIPTION
## What Changed?

The parameter password_life_time updated as per [DF-356](https://enterprisedb.atlassian.net/browse/DF-356)



[DF-356]: https://enterprisedb.atlassian.net/browse/DF-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ