### PR TITLE
New style for release notes adding full title and date

### DIFF
--- a/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.2_rel_notes.mdx
+++ b/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.2_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 41.2.0"
+title: "EDB*Plus 41.2.0 release notes"
+navTitle: Version 41.2.0
 ---
+
+Released: 23 Aug 2023
 
 New features, enhancements, bug fixes, and other changes in EDB\*Plus 41.2.0 include:
 

--- a/product_docs/docs/efm/4/efm_rel_notes/03_efm_47_rel_notes.mdx
+++ b/product_docs/docs/efm/4/efm_rel_notes/03_efm_47_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 4.7"
+title: "Failover Manager 4.7 release notes"
+navTitle: Version 4.7
 ---
+
+Released: 20 Jun 2023
 
 Enhancements, bug fixes, and other changes in EFM 4.7 include:
 

--- a/product_docs/docs/hadoop_data_adapter/2/hadoop_rel_notes/hadoop_rel_notes_2.3.1.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/hadoop_rel_notes/hadoop_rel_notes_2.3.1.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 2.3.1"
+title: "Hadoop Foreign Data Wrapper 2.3.1 release notes"
+navTitle: Version 2.3.1
 ---
+
+Released: 20 Jul 2023
 
 Enhancements, bug fixes, and other changes in Hadoop Foreign Data Wrapper 2.3.1 include:
 

--- a/product_docs/docs/jdbc_connector/42.5.4.1/01_jdbc_rel_notes/jdbc_42.5.4.1_rel_notes.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/01_jdbc_rel_notes/jdbc_42.5.4.1_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Version 42.5.4.1"
-
+title: "EDB JDBC Connector 42.5.4.1 release notes"
+navTitle: Version 42.5.4.1
 ---
+
+Released: 16 Mar 2023
 
 The EDB JDBC connector provides connectivity between a Java application and an EDB Postgres Advanced Server database.
 

--- a/product_docs/docs/livecompare/2/rel_notes/2.5_rel_notes.mdx
+++ b/product_docs/docs/livecompare/2/rel_notes/2.5_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 2.5"
+title: "LiveCompare 2.5 release notes"
+navTitle: Version 2.5
 ---
+
+Released: 09 May 2023
 
 LiveCompare 2.5 includes the following new features, enhancements, bug fixes, and other changes:
 

--- a/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.5.1_rel_notes.mdx
+++ b/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.5.1_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 4.5.1"
+title: "Migration Portal 4.5.1 release notes"
+navTitle: Version 4.5.1
 ---
+
+Released: 12 Jul 2023
 
 
 New features, enhancements, bug fixes, and other changes in Migration Portal 4.5.1 include the following:

--- a/product_docs/docs/migration_toolkit/55/mtk_rel_notes/mtk_5561_rel_notes.mdx
+++ b/product_docs/docs/migration_toolkit/55/mtk_rel_notes/mtk_5561_rel_notes.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Version 55.6.1"
+title: "Migration Toolkit 55.6.1 release notes"
+navTitle: Version 55.6.1
 ---
 
 Released: 06 Sep 2023

--- a/product_docs/docs/mongo_data_adapter/5/mongo_rel_notes/mongo5.5.1_rel_notes.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/mongo_rel_notes/mongo5.5.1_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 5.5.0"
+title: "MongoDB Foreign Data Wrapper 5.5.1 release notes"
+navTitle: Version 5.5.1
 ---
+
+Released: 20 Jul 2023
 
 Enhancements, bug fixes, and other changes in MongoDB Foreign Data Wrapper 5.5.0 
 include:

--- a/product_docs/docs/mysql_data_adapter/2/mysql_rel_notes/mysql2.9.1_rel_notes.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/mysql_rel_notes/mysql2.9.1_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Version 2.9.1"
+title: "MySQL Foreign Data Wrapper 2.9.1 release notes"
+navTitle: Version 2.9.1
 ---
 
+Released: 20 Jul 2023
 
 Enhancements, bug fixes, and other changes in MySQL Foreign Data Wrapper 2.9.1 include:
 

--- a/product_docs/docs/ocl_connector/15/ocl_rel_notes/15.2.0.4_ocl_release_notes.mdx
+++ b/product_docs/docs/ocl_connector/15/ocl_rel_notes/15.2.0.4_ocl_release_notes.mdx
@@ -1,6 +1,10 @@
 ---
-title: "Version 15.2.0.4"
+title: "EDB OCL Connector 15.2.0.4 release notes"
+navTitle: Version 15.2.0.4
 ---
+
+Released: 24 Aug 2023
+
 The EDB OCL Connector provides an API similar to the Oracle Call Interface.
 
 New features, enhancements, bug fixes, and other changes in the EDB OCL Connector 15.2.0.4 include:

--- a/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/odbc_13.2.0.02_rel_notes.mdx
+++ b/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/odbc_13.2.0.02_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 13.02.0000.02"
+title: "EDB ODBC Connector 13.02.0000.02 release notes"
+navTitle: Version 13.02.0000.02
 ---
+
+Released: 14 Feb 2023
 
 EDB ODBC Connector 13.02.0000.02 includes the following enhancement:
 

--- a/product_docs/docs/pem/9/pem_rel_notes/930_rel_notes.mdx
+++ b/product_docs/docs/pem/9/pem_rel_notes/930_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 9.3.0"
+title: "Postgres Enterprise Manager 9.3.0 release notes"
+navTitle: Version 9.3.0
 ---
+
+Released: 31 Aug 2023
 
 New features, enhancements, bug fixes, and other changes in PEM 9.3.0 include:
 

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/06_11900_rel_notes.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/06_11900_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 1.19.0.0"
+title: "EDB PgBouncer 1.19.0.0 release notes"
+navTitle: Version 1.19.0.0
 ---
+
+Released: 07 Jun 2023
 
 EDB PgBouncer 1.19.0.0 includes the following upstream merge and security fix:
 

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.2.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.2.0_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Release notes for EDB Postgres Distributed version 5.2.0"
+title: "EDB Postgres Distributed 5.2.0 release notes"
 navTitle: "Version 5.2.0"
 ---
+
+Released: 04 Aug 2023
 
 EDB Postgres Distributed version 5.2.0 is a minor version of EDB Postgres Distributed.
 

--- a/product_docs/docs/pge/15/release_notes/rel_notes15.4.mdx
+++ b/product_docs/docs/pge/15/release_notes/rel_notes15.4.mdx
@@ -1,7 +1,9 @@
 ---
-title: "EDB Postgres Extended Server version 15.4"
+title: "EDB Postgres Extended Server 15.4 release notes"
 navTitle: Version 15.4
 ---
+
+Released: 21 Aug 2023
 
 New features, enhancements, bug fixes, and other changes in EDB Postgres Extended Server 15.2 include:
 

--- a/product_docs/docs/pgpool/4/pgpool_rel_notes/442_rel_notes.mdx
+++ b/product_docs/docs/pgpool/4/pgpool_rel_notes/442_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Version 4.4.2"
+title: "EDB PgPool-II 4.4.2 release notes"
+navTitle: Version 4.4.2
 ---
 
+Released: 14 Feb 2023
 
 EDB Pgpool-II 4.4.2 includes the following upstream merge:
 

--- a/product_docs/docs/postgis/3.2/01_release_notes/rel_notes321.mdx
+++ b/product_docs/docs/postgis/3.2/01_release_notes/rel_notes321.mdx
@@ -1,6 +1,10 @@
 ---
-title: "Version 3.2.1"
+title: "PostGIS 3.2.1 release notes"
+navTitle: Version 3.2.1
 ---
+
+Released: 04 Aug 2022
+
 EDB PostGIS is a PostgreSQL extension that allows you to store geographic information systems (GIS) objects in an EDB Postgres Advanced Server database.
 
 New features, enhancements, bug fixes, and other changes in PostGIS 3.2.1 include:

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_20_2_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_20_2_rel_notes.mdx
@@ -3,6 +3,8 @@ title: "EDB Postgres for Kubernetes 1.20.2 release notes"
 navTitle: "Version 1.20.2"
 ---
 
+Released: 27 Jul 2023
+
 This release of EDB Postgres for Kubernetes includes the following:
 
 |      Type      |                                                                                  Description                                                                                   |


### PR DESCRIPTION
## Added full title and release date for most recent version of all products with release notes in the product_docs/docs folder. Some products in that folder do not have release notes, and some products reside in a pg_extensions folder, for which I don't seem to have access.

