### PR TITLE
pg_failover_slots installing page: Package name seems wrong

### DIFF
--- a/advocacy_docs/pg_extensions/pg_failover_slots/installing.mdx
+++ b/advocacy_docs/pg_extensions/pg_failover_slots/installing.mdx
@@ -31,13 +31,13 @@ Before you begin the installation process:
 The syntax for the RPM package install command is:
 
 ```shell
-sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover-slots<major_version>
+sudo <package-manager> -y install edb-<postgres><postgres_version>-pg-failover-slots<major_version>
 ```
 
 The syntax for the Debian package install command is:
 
 ```shell
-sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover-slots-<major_version>
+sudo <package-manager> -y install edb-<postgres><postgres_version>-pg-failover-slots-<major_version>
 ```
 
 Where: 
@@ -65,12 +65,12 @@ Where:
 For example, to install PG Failover Slots 1.0.0 for EDB Postgres Advanced Server 15 on a RHEL 8 platform:
 
 ```shell
-sudo dnf -y install pg-as15-pg-failover-slots1
+sudo dnf -y install edb-pg15-pg-failover-slots1
 ```
 
 To install PG Failover Slots 1.0.0 for EDB Postgres Advanced Server 15 on a Debian 11 platform:
 
 ```shell
-sudo apt-get -y install pg-as15-pg-failover-slots-1
+sudo apt-get -y install edb-pg15-pg-failover-slots-1
 ```
 


### PR DESCRIPTION
Hi team,
Hope you are doing well and healthy.
We'd appreciate if you have time to take a look in this.

Seems package name doesn't match the rpm name in the Repository

## What Changed?
Package name "pg-as15-pg-failover-slots1" changed to "edb-pg15-pg-failover-slots1".
Please see my dnf search result:

[root@test01 ~]# dnf -y install --downloadonly --downloaddir=/work/temp pg-as15-pg-failover-slots1
AlmaLinux 8 - BaseOS                                                                                                          351 kB/s | 7.2 MB     00:21
AlmaLinux 8 - AppStream                                                                                                       329 kB/s |  13 MB     00:39
AlmaLinux 8 - Extras                                                                                                           11 kB/s |  24 kB     00:02
No match for argument: pg-as15-pg-failover-slots1
Error: Unable to find a match: pg-as15-pg-failover-slots1
[root@test01 ~]# dnf search failover
Last metadata expiration check: 0:01:18 ago on Tue 26 Sep 2023 09:13:42 AM JST.
============================================================== Name & Summary Matched: failover ==============================================================
edb-as11-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-as11-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-as11-pg-failover-slots1
edb-as12-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-as12-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-as12-pg-failover-slots1
edb-as13-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-as13-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-as13-pg-failover-slots1
edb-as14-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-as14-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-as14-pg-failover-slots1
edb-as15-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-as15-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-as15-pg-failover-slots1
edb-pg11-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-pg11-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-pg11-pg-failover-slots1
edb-pg12-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-pg12-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-pg12-pg-failover-slots1
edb-pg13-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-pg13-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-pg13-pg-failover-slots1
edb-pg14-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-pg14-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-pg14-pg-failover-slots1
edb-pg15-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-pg15-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-pg15-pg-failover-slots1
edb-pg16-pg-failover-slots1.x86_64 : EDB Failover Slots for PostgreSQL
edb-pg16-pg-failover-slots1-debuginfo.x86_64 : Debug information for package edb-pg16-pg-failover-slots1

Kind Regards,
Yuki Tei