### PR TITLE
Release: 2023-09-26

### DIFF
--- a/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.2_rel_notes.mdx
+++ b/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.2_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 41.2.0"
+title: "EDB*Plus 41.2.0 release notes"
+navTitle: Version 41.2.0
 ---
+
+Released: 23 Aug 2023
 
 New features, enhancements, bug fixes, and other changes in EDB\*Plus 41.2.0 include:
 

--- a/product_docs/docs/efm/4/efm_rel_notes/03_efm_47_rel_notes.mdx
+++ b/product_docs/docs/efm/4/efm_rel_notes/03_efm_47_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 4.7"
+title: "Failover Manager 4.7 release notes"
+navTitle: Version 4.7
 ---
+
+Released: 20 Jun 2023
 
 Enhancements, bug fixes, and other changes in EFM 4.7 include:
 

--- a/product_docs/docs/epas/11/epas_rel_notes/index.mdx
+++ b/product_docs/docs/epas/11/epas_rel_notes/index.mdx
@@ -23,28 +23,29 @@ EDB Postgres Advanced Server 11 is built on the open source PostgreSQL 11. EDB P
 
 The EDB Postgres Advanced Server (Advanced Server) documentation describes the latest version of Advanced Server 11 including minor releases and patches. The release notes in this section provide information on what was new in each release. 
 
-| Version | Release Date | Upstream Merge | 
-| ------- | ------------ | -------------- | 
-| [11.21.32](epas11_21_32_rel_notes.mdx) | 21 Aug 2023 | [11.21](https://www.postgresql.org/docs/11/release-11-21.html)           |
-| [11.20.31](epas11_20_31_rel_notes.mdx) | 11 May 2023 | [11.20](https://www.postgresql.org/docs/11/release-11-20.html)           |
-| [11.19.30](epas11_19_30_rel_notes.mdx) | 10 Feb 2023 | [11.19](https://www.postgresql.org/docs/11/release-11-19.html)           |
-| [11.18.29](epas11_18_29_rel_notes.mdx) | 10 Nov 2022 | [11.18](https://www.postgresql.org/docs/11/release-11-18.html)           |
-| [11.17.28](epas11_17_28_rel_notes.mdx) | 11 Aug 2022 | [11.17](https://www.postgresql.org/docs/11/release-11-17.html)           |
-| [11.16.26](epas11_16_26_rel_notes.mdx) | 12 May 2022 | [11.16](https://www.postgresql.org/docs/11/release-11-16.html)           | 
-| [11.15.25](09_epas11.15.25_rel_notes.mdx) | 10 Feb 2022 | [11.15](https://www.postgresql.org/docs/11/release-11-15.html)           | 
-| [11.14.24](10_epas11.14.24_rel_notes.mdx) | 11 Nov 2021| [11.14](https://www.postgresql.org/docs/11/release-11-14.html) | 
-| [11.13.23](11_epas11.13.23_rel_notes.mdx) | 08 Sep 2021| [11.13](https://www.postgresql.org/docs/11/release-11-13.html) | 
-| [11.12.22](13_epas11.12.22_rel_notes.mdx) | 05 May 2021| [11.12](https://www.postgresql.org/docs/11/release-11-12.html) | 
-| [11.12.21](15_epas11.12.21_rel_notes.mdx) | 15 Apr 2021| [11.12](https://www.postgresql.org/docs/11/release-11-12.html) | 
-| [11.11.20](17_epas11.11.20_rel_notes.mdx) | 12 Feb 2021| [11.11](https://www.postgresql.org/docs/11/release-11-11.html) | 
-| [11.10.19](19_epas11.10.19_rel_notes.mdx) | 20 Nov 2020| [11.10](https://www.postgresql.org/docs/11/release-11-10.html) | 
-| [11.9.17](21_epas11.9.17_rel_notes.mdx)   | 18 Aug 2020| [11.9](https://www.postgresql.org/docs/11/release-11-9.html)   | 
-| [11.9.16](23_epas11.9.16_rel_notes.mdx)   | 17 Aug 2020| [11.9](https://www.postgresql.org/docs/11/release-11-9.html)   | 
-| [11.8.15](25_epas11.8.15_rel_notes.mdx)   | 18 May 2020| [11.8](https://www.postgresql.org/docs/11/release-11-8.html)   | 
-| [11.7.14](27_epas11.7.14_rel_notes.mdx)   | 14 Feb 2020| [11.7](https://www.postgresql.org/docs/11/release-11-7.html) | 
-| [11.6.13](29_epas11.6.13_rel_notes.mdx)   | 19 Nov 2019| [11.6](https://www.postgresql.org/docs/11/release-11-6.html) | 
-| [11.5.12](31_epas11.5.12_rel_notes.mdx)   | 26 Aug 2019| [11.5](https://www.postgresql.org/docs/11/release-11-5.html) | 
-| [11.4.11](33_epas11.4.11_rel_notes.mdx)   | 25 Jun 2019| [11.4](https://www.postgresql.org/docs/11/release-11-4.html) | 
-| [11.3.10](35_epas11.3.10_rel_notes.mdx)   | 13 May 2019| [11.3](https://www.postgresql.org/docs/11/release-11-3.html) | 
-| [11.2.9](37_epas11.2.9_rel_notes.mdx)     | 22 Feb 2019| [11.2](https://www.postgresql.org/docs/11/release-11-2.html) | 
-| [11.1.7](39_epas11.1.7_rel_notes.mdx)     | 28 Nov 2018| [11.1](https://www.postgresql.org/docs/11/release-11-1.html) | 
+|                  Version                  | Release Date |                         Upstream Merge                         |
+| ----------------------------------------- | ------------ | -------------------------------------------------------------- |
+| [11.21.33](epas11_21_33_rel_notes.mdx)    | 25 Sep 2023  |                                                                |
+| [11.21.32](epas11_21_32_rel_notes.mdx)    | 21 Aug 2023  | [11.21](https://www.postgresql.org/docs/11/release-11-21.html) |
+| [11.20.31](epas11_20_31_rel_notes.mdx)    | 11 May 2023  | [11.20](https://www.postgresql.org/docs/11/release-11-20.html) |
+| [11.19.30](epas11_19_30_rel_notes.mdx)    | 10 Feb 2023  | [11.19](https://www.postgresql.org/docs/11/release-11-19.html) |
+| [11.18.29](epas11_18_29_rel_notes.mdx)    | 10 Nov 2022  | [11.18](https://www.postgresql.org/docs/11/release-11-18.html) |
+| [11.17.28](epas11_17_28_rel_notes.mdx)    | 11 Aug 2022  | [11.17](https://www.postgresql.org/docs/11/release-11-17.html) |
+| [11.16.26](epas11_16_26_rel_notes.mdx)    | 12 May 2022  | [11.16](https://www.postgresql.org/docs/11/release-11-16.html) |
+| [11.15.25](09_epas11.15.25_rel_notes.mdx) | 10 Feb 2022  | [11.15](https://www.postgresql.org/docs/11/release-11-15.html) |
+| [11.14.24](10_epas11.14.24_rel_notes.mdx) | 11 Nov 2021  | [11.14](https://www.postgresql.org/docs/11/release-11-14.html) |
+| [11.13.23](11_epas11.13.23_rel_notes.mdx) | 08 Sep 2021  | [11.13](https://www.postgresql.org/docs/11/release-11-13.html) |
+| [11.12.22](13_epas11.12.22_rel_notes.mdx) | 05 May 2021  | [11.12](https://www.postgresql.org/docs/11/release-11-12.html) |
+| [11.12.21](15_epas11.12.21_rel_notes.mdx) | 15 Apr 2021  | [11.12](https://www.postgresql.org/docs/11/release-11-12.html) |
+| [11.11.20](17_epas11.11.20_rel_notes.mdx) | 12 Feb 2021  | [11.11](https://www.postgresql.org/docs/11/release-11-11.html) |
+| [11.10.19](19_epas11.10.19_rel_notes.mdx) | 20 Nov 2020  | [11.10](https://www.postgresql.org/docs/11/release-11-10.html) |
+| [11.9.17](21_epas11.9.17_rel_notes.mdx)   | 18 Aug 2020  | [11.9](https://www.postgresql.org/docs/11/release-11-9.html)   |
+| [11.9.16](23_epas11.9.16_rel_notes.mdx)   | 17 Aug 2020  | [11.9](https://www.postgresql.org/docs/11/release-11-9.html)   |
+| [11.8.15](25_epas11.8.15_rel_notes.mdx)   | 18 May 2020  | [11.8](https://www.postgresql.org/docs/11/release-11-8.html)   |
+| [11.7.14](27_epas11.7.14_rel_notes.mdx)   | 14 Feb 2020  | [11.7](https://www.postgresql.org/docs/11/release-11-7.html)   |
+| [11.6.13](29_epas11.6.13_rel_notes.mdx)   | 19 Nov 2019  | [11.6](https://www.postgresql.org/docs/11/release-11-6.html)   |
+| [11.5.12](31_epas11.5.12_rel_notes.mdx)   | 26 Aug 2019  | [11.5](https://www.postgresql.org/docs/11/release-11-5.html)   |
+| [11.4.11](33_epas11.4.11_rel_notes.mdx)   | 25 Jun 2019  | [11.4](https://www.postgresql.org/docs/11/release-11-4.html)   |
+| [11.3.10](35_epas11.3.10_rel_notes.mdx)   | 13 May 2019  | [11.3](https://www.postgresql.org/docs/11/release-11-3.html)   |
+| [11.2.9](37_epas11.2.9_rel_notes.mdx)     | 22 Feb 2019  | [11.2](https://www.postgresql.org/docs/11/release-11-2.html)   |
+| [11.1.7](39_epas11.1.7_rel_notes.mdx)     | 28 Nov 2018  | [11.1](https://www.postgresql.org/docs/11/release-11-1.html)   |

--- a/product_docs/docs/epas/12/epas_rel_notes/index.mdx
+++ b/product_docs/docs/epas/12/epas_rel_notes/index.mdx
@@ -26,22 +26,23 @@ EDB Postgres Advanced Server 12 adds a number of new outstanding features, inclu
 
 The EDB Postgres Advanced Server (Advanced Server) documentation describes the latest version of Advanced Server 12 including minor releases and patches. The release notes in this section provide information on what was new in each release. 
 
-| Version | Release Date | Upstream Merges | 
-| ------- | ------------ | --------------- | 
-| [12.16.20](epas12_16_20_rel_notes.mdx) | 21 Aug 2023 | [12.16](https://www.postgresql.org/docs/12/release-12-16.html)     
-| [12.15.19](epas12_15_19_rel_notes.mdx) | 11 May 2023 | [12.15](https://www.postgresql.org/docs/12/release-12-15.html)           | 
-| [12.14.18](epas12_14_18_rel_notes.mdx) | 10 Feb 2023 | [12.14](https://www.postgresql.org/docs/12/release-12-14.html)           | 
-| [12.13.17](epas12_13_17_rel_notes.mdx) | 10 Nov 2022 | [12.13](https://www.postgresql.org/docs/12/release-12-13.html)           | 
-| [12.12.16](epas12_12_16_rel_notes.mdx) | 11 Aug 2022 | [12.12](https://www.postgresql.org/docs/12/release-12-12.html)           | 
-| [12.11.15](epas12_11_15_rel_notes.mdx) | 12 May 2022 | [12.11](https://www.postgresql.org/docs/12/release-12-11.html)           | 
-| [12.10.14](05_epas12.10.14_rel_notes.mdx) | 10 Feb 2022 | [12.10](https://www.postgresql.org/docs/12/release-12-10.html)           | | [12.10.14](05_epas12.10.14_rel_notes.mdx) | 10 Feb 2022 | [12.10](https://www.postgresql.org/docs/12/release-12-10.html)           | 
-| [12.9.13](06_epas12.9.13_rel_notes.mdx) | 11 Nov 2021| [12.9](https://www.postgresql.org/docs/12/release-12-9.html) | 
-| [12.8.12](07_epas12.8.12_rel_notes.mdx) | 28 Sep 2021| [12.8](https://www.postgresql.org/docs/12/release-12-8.html) | 
-| [12.7.10](08_epas12.7.10_rel_notes.mdx) | 25 May 2021| [12.7](https://www.postgresql.org/docs/12/release-12-7.html) | 
-| [12.7](09_epas12.7_rel_notes.mdx)       | 14 May 2021| [12.7](https://www.postgresql.org/docs/12/release-12-7.html) | 
-| [12.6.7](10_epas12.6.7_rel_notes.mdx)   | 12 Feb 2021| [12.6](https://www.postgresql.org/docs/12/release-12-6.html) | 
-| [12.5.6](11_epas12.5.6_rel_notes.mdx)   | 20 Nov 2020| [12.5](https://www.postgresql.org/docs/12/release-12-5.html) | 
-| [12.4.5](13_epas12.4.5_rel_notes.mdx)   | 17 Aug 2020| [12.4](https://www.postgresql.org/docs/12/release-12-4.html) | 
-| [12.3.4](15_epas12.3.4_rel_notes.mdx)   | 18 May 2020| [12.3](https://www.postgresql.org/docs/12/release-12-3.html) | 
-| [12.2.3](17_epas12.2.3_rel_notes.mdx)   | 14 Feb 2020| [12.2](https://www.postgresql.org/docs/12/release-12-2.html) | 
-| [12.1.2](19_epas12.1.2_rel_notes.mdx)   | 10 Dec 2019| [12.0](https://www.postgresql.org/docs/12/release-12.html) | 
+|                  Version                  | Release Date |                        Upstream Merges                         |
+| ----------------------------------------- | ------------ | -------------------------------------------------------------- |
+| [12.16.21](epas12_16_21_rel_notes.mdx)    | 25 Sep 2023  |                                                                |
+| [12.16.20](epas12_16_20_rel_notes.mdx)    | 21 Aug 2023  | [12.16](https://www.postgresql.org/docs/12/release-12-16.html) |
+| [12.15.19](epas12_15_19_rel_notes.mdx)    | 11 May 2023  | [12.15](https://www.postgresql.org/docs/12/release-12-15.html) |
+| [12.14.18](epas12_14_18_rel_notes.mdx)    | 10 Feb 2023  | [12.14](https://www.postgresql.org/docs/12/release-12-14.html) |
+| [12.13.17](epas12_13_17_rel_notes.mdx)    | 10 Nov 2022  | [12.13](https://www.postgresql.org/docs/12/release-12-13.html) |
+| [12.12.16](epas12_12_16_rel_notes.mdx)    | 11 Aug 2022  | [12.12](https://www.postgresql.org/docs/12/release-12-12.html) |
+| [12.11.15](epas12_11_15_rel_notes.mdx)    | 12 May 2022  | [12.11](https://www.postgresql.org/docs/12/release-12-11.html) |
+| [12.10.14](05_epas12.10.14_rel_notes.mdx) | 10 Feb 2022  | [12.10](https://www.postgresql.org/docs/12/release-12-10.html) |
+| [12.9.13](06_epas12.9.13_rel_notes.mdx)   | 11 Nov 2021  | [12.9](https://www.postgresql.org/docs/12/release-12-9.html)   |
+| [12.8.12](07_epas12.8.12_rel_notes.mdx)   | 28 Sep 2021  | [12.8](https://www.postgresql.org/docs/12/release-12-8.html)   |
+| [12.7.10](08_epas12.7.10_rel_notes.mdx)   | 25 May 2021  | [12.7](https://www.postgresql.org/docs/12/release-12-7.html)   |
+| [12.7](09_epas12.7_rel_notes.mdx)         | 14 May 2021  | [12.7](https://www.postgresql.org/docs/12/release-12-7.html)   |
+| [12.6.7](10_epas12.6.7_rel_notes.mdx)     | 12 Feb 2021  | [12.6](https://www.postgresql.org/docs/12/release-12-6.html)   |
+| [12.5.6](11_epas12.5.6_rel_notes.mdx)     | 20 Nov 2020  | [12.5](https://www.postgresql.org/docs/12/release-12-5.html)   |
+| [12.4.5](13_epas12.4.5_rel_notes.mdx)     | 17 Aug 2020  | [12.4](https://www.postgresql.org/docs/12/release-12-4.html)   |
+| [12.3.4](15_epas12.3.4_rel_notes.mdx)     | 18 May 2020  | [12.3](https://www.postgresql.org/docs/12/release-12-3.html)   |
+| [12.2.3](17_epas12.2.3_rel_notes.mdx)     | 14 Feb 2020  | [12.2](https://www.postgresql.org/docs/12/release-12-2.html)   |
+| [12.1.2](19_epas12.1.2_rel_notes.mdx)     | 10 Dec 2019  | [12.0](https://www.postgresql.org/docs/12/release-12.html)     |

--- a/product_docs/docs/epas/13/epas_rel_notes/index.mdx
+++ b/product_docs/docs/epas/13/epas_rel_notes/index.mdx
@@ -19,18 +19,19 @@ EDB Postgres Advanced Server 13 is built on open-source PostgreSQL 13, which int
 
 The EDB Postgres Advanced Server (Advanced Server) documentation describes the latest version of Advanced Server 13 including minor releases and patches. The release notes in this section provide information on what was new in each release. 
 
-| Version                               | Release Date | Upstream Merges                                                                                                  | 
-| ------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- | 
-| [13.12.17](epas13_12_17_rel_notes) | 21 Aug 2023 | [13.12](https://www.postgresql.org/docs/release/13.12/)           |
-| [13.11.15](epas13_11_15_rel_notes) | 11 May 2023 | [13.11](https://www.postgresql.org/docs/release/13.11/)           |
-| [13.10.14](epas13_10_14_rel_notes) | 10 Feb 2023 | [13.10](https://www.postgresql.org/docs/release/13.10/)           |
-| [13.9.13](epas13_9_13_rel_notes) | 10 Nov 2022 | [13.9](https://www.postgresql.org/docs/release/13.9/)           |
-| [13.8.12](epas13_8_12_rel_notes) | 11 Aug 2022 | [13.8](https://www.postgresql.org/docs/release/13.8/)           |
-| [13.7.11](epas13_7_11_rel_notes) | 23 May 2022 | [13.7](https://www.postgresql.org/docs/release/13.7/)           
-| [13.6.10](13_epas13.6.10_rel_notes) | 10 Feb 2022 | [13.6](https://www.postgresql.org/docs/13/release-13-6.html)           | 
-| [13.5.9](14_epas13.5.9_rel_notes) | 11 Nov 2021 | [13.5](https://www.postgresql.org/docs/13/release-13-5.html)           | 
-| [13.4.8](15_epas13.4.8_rel_notes) | 28 Sep 2021 | [13.4](https://www.postgresql.org/docs/13/release-13-4.html)     | 
-| [13.3.7](16_epas13.3.7_rel_notes) | 25 May 2021 | NA                                                                                                               |
-| [13.3.6](17_epas13.3.6_rel_notes) | 14 May 2021 | [13.3](https://www.postgresql.org/docs/13/release-13-3.html)               |
-| [13.2.5](19_epas13.2.5_rel_notes) | 02 Feb 2021  | [13.2](https://www.postgresql.org/docs/13/release-13-2.html)          |
-| [13.1.4](20_epas13_rel_notes)         | 12 Dec 2020 | [13](https://www.postgresql.org/docs/13/release-13.html), [13.1](https://www.postgresql.org/docs/13/release-13-1.html) |
+|               Version               | Release Date |                                                    Upstream Merges                                                     |
+| ----------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| [13.12.18](epas13_12_17_rel_notes)  | 25 Sep 2023  |                                                                                                                        |
+| [13.12.17](epas13_12_17_rel_notes)  | 21 Aug 2023  | [13.12](https://www.postgresql.org/docs/release/13.12/)                                                                |
+| [13.11.15](epas13_11_15_rel_notes)  | 11 May 2023  | [13.11](https://www.postgresql.org/docs/release/13.11/)                                                                |
+| [13.10.14](epas13_10_14_rel_notes)  | 10 Feb 2023  | [13.10](https://www.postgresql.org/docs/release/13.10/)                                                                |
+| [13.9.13](epas13_9_13_rel_notes)    | 10 Nov 2022  | [13.9](https://www.postgresql.org/docs/release/13.9/)                                                                  |
+| [13.8.12](epas13_8_12_rel_notes)    | 11 Aug 2022  | [13.8](https://www.postgresql.org/docs/release/13.8/)                                                                  |
+| [13.7.11](epas13_7_11_rel_notes)    | 23 May 2022  | [13.7](https://www.postgresql.org/docs/release/13.7/)                                                                  |
+| [13.6.10](13_epas13.6.10_rel_notes) | 10 Feb 2022  | [13.6](https://www.postgresql.org/docs/13/release-13-6.html)                                                           |
+| [13.5.9](14_epas13.5.9_rel_notes)   | 11 Nov 2021  | [13.5](https://www.postgresql.org/docs/13/release-13-5.html)                                                           |
+| [13.4.8](15_epas13.4.8_rel_notes)   | 28 Sep 2021  | [13.4](https://www.postgresql.org/docs/13/release-13-4.html)                                                           |
+| [13.3.7](16_epas13.3.7_rel_notes)   | 25 May 2021  | NA                                                                                                                     |
+| [13.3.6](17_epas13.3.6_rel_notes)   | 14 May 2021  | [13.3](https://www.postgresql.org/docs/13/release-13-3.html)                                                           |
+| [13.2.5](19_epas13.2.5_rel_notes)   | 02 Feb 2021  | [13.2](https://www.postgresql.org/docs/13/release-13-2.html)                                                           |
+| [13.1.4](20_epas13_rel_notes)       | 12 Dec 2020  | [13](https://www.postgresql.org/docs/13/release-13.html), [13.1](https://www.postgresql.org/docs/13/release-13-1.html) |

--- a/product_docs/docs/epas/14/epas_rel_notes/index.mdx
+++ b/product_docs/docs/epas/14/epas_rel_notes/index.mdx
@@ -18,17 +18,18 @@ EDB Postgres Advanced Server 14 is built on open-source PostgreSQL 14, which int
 
 The EDB Postgres Advanced Server (EDB Postgres Advanced Server) documentation describes the latest version of EDB Postgres Advanced Server 14 including minor releases and patches. The release notes in this section provide information on what was new in each release. 
 
-| Version                               | Release date | Upstream merges                                                                                                  | 
-| ------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- | 
-| [14.9.0](epas14_9_0_rel_notes)       | 21 Aug 2023 | [14.9](https://www.postgresql.org/docs/14/release-14-9.html)                                                     |    
-| [14.8.0](epas14_8_0_rel_notes)        | 11 May 2023 | [14.8](https://www.postgresql.org/docs/14/release-14-8.html)                                                     |
-| [14.7.0](epas14_7_0_rel_notes)        | 10 Feb 2023 | [14.7](https://www.postgresql.org/docs/14/release-14-7.html)                                                     |
-| [14.6.0](epas14_6_0_rel_notes)        | 10 Nov 2022 | [14.6](https://www.postgresql.org/docs/14/release-14-6.html)                                                     |
-| [14.5.0](epas14_5_0_rel_notes)        | 11 Aug 2022 | [14.5](https://www.postgresql.org/docs/14/release-14-5.html)                                                     |
-| [14.4.0](epas14_4_0_rel_notes)        | 16 Jun 2022 | [14.4](https://www.postgresql.org/docs/14/release-14-4.html)                                                     |
-| [14.3.0](epas14_3_0_rel_notes)        | 12 May 2022 | [14.3](https://www.postgresql.org/docs/14/release-14-3.html)                                                     |
-| [14.2.1](19_epas14.2.1_rel_notes)     | 10 Feb 2022 | [14.2](https://www.postgresql.org/docs/14/release-14-2.html)                                                     |
-| [14.1.0](20_epas14_rel_notes)         | 01 Dec 2021 | [14.0](https://www.postgresql.org/docs/14/release-14.html), [14.1](https://www.postgresql.org/docs/14/release-14-1.html)  |
+|              Version              | Release date |                                                     Upstream merges                                                      |
+| --------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| [14.9.1](epas14_9_1_rel_notes)    | 25 Sep 2023  |                                                                                                                          |
+| [14.9.0](epas14_9_0_rel_notes)    | 21 Aug 2023  | [14.9](https://www.postgresql.org/docs/14/release-14-9.html)                                                             |
+| [14.8.0](epas14_8_0_rel_notes)    | 11 May 2023  | [14.8](https://www.postgresql.org/docs/14/release-14-8.html)                                                             |
+| [14.7.0](epas14_7_0_rel_notes)    | 10 Feb 2023  | [14.7](https://www.postgresql.org/docs/14/release-14-7.html)                                                             |
+| [14.6.0](epas14_6_0_rel_notes)    | 10 Nov 2022  | [14.6](https://www.postgresql.org/docs/14/release-14-6.html)                                                             |
+| [14.5.0](epas14_5_0_rel_notes)    | 11 Aug 2022  | [14.5](https://www.postgresql.org/docs/14/release-14-5.html)                                                             |
+| [14.4.0](epas14_4_0_rel_notes)    | 16 Jun 2022  | [14.4](https://www.postgresql.org/docs/14/release-14-4.html)                                                             |
+| [14.3.0](epas14_3_0_rel_notes)    | 12 May 2022  | [14.3](https://www.postgresql.org/docs/14/release-14-3.html)                                                             |
+| [14.2.1](19_epas14.2.1_rel_notes) | 10 Feb 2022  | [14.2](https://www.postgresql.org/docs/14/release-14-2.html)                                                             |
+| [14.1.0](20_epas14_rel_notes)     | 01 Dec 2021  | [14.0](https://www.postgresql.org/docs/14/release-14.html), [14.1](https://www.postgresql.org/docs/14/release-14-1.html) |
 
 ## Support announcements
 

--- a/product_docs/docs/epas/15/epas_rel_notes/index.mdx
+++ b/product_docs/docs/epas/15/epas_rel_notes/index.mdx
@@ -12,11 +12,12 @@ EDB Postgres Advanced Server 15 is built on open-source PostgreSQL 15, which int
 
 The EDB Postgres Advanced Server documentation describes the latest version of EDB Postgres Advanced Server 15 including minor releases and patches. These release notes provide information on what was new in each release. 
 
-| Version                               | Release date | Upstream merges                                                                                                                                                       | 
-| ------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | 
-| [15.4.0](epas15_4_0_rel_notes)        | 21 Aug 2023 | [15.4](https://www.postgresql.org/docs/release/15.4/)
-| [15.3.0](epas15_3_0_rel_notes)        | 11 May 2023 | [15.3](https://www.postgresql.org/docs/release/15.3/)   |
-| [15.2.0](epas15_2_0_rel_notes)        | 14 Feb 2023 | [15.0](https://www.postgresql.org/docs/release/15.0/), [15.1](https://www.postgresql.org/docs/release/15.1/), [15.2](https://www.postgresql.org/docs/release/15.2/)   |
+|            Version             | Release date |                                                                           Upstream merges                                                                           |
+| ------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [15.4.1](epas15_4_1_rel_notes) | 25 Sep 2023  |                                                                                                                                                                     |
+| [15.4.0](epas15_4_0_rel_notes) | 21 Aug 2023  | [15.4](https://www.postgresql.org/docs/release/15.4/)                                                                                                               |
+| [15.3.0](epas15_3_0_rel_notes) | 11 May 2023  | [15.3](https://www.postgresql.org/docs/release/15.3/)                                                                                                               |
+| [15.2.0](epas15_2_0_rel_notes) | 14 Feb 2023  | [15.0](https://www.postgresql.org/docs/release/15.0/), [15.1](https://www.postgresql.org/docs/release/15.1/), [15.2](https://www.postgresql.org/docs/release/15.2/) |
 
 
 ## Component certification

--- a/product_docs/docs/hadoop_data_adapter/2/hadoop_rel_notes/hadoop_rel_notes_2.3.1.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/hadoop_rel_notes/hadoop_rel_notes_2.3.1.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 2.3.1"
+title: "Hadoop Foreign Data Wrapper 2.3.1 release notes"
+navTitle: Version 2.3.1
 ---
+
+Released: 20 Jul 2023
 
 Enhancements, bug fixes, and other changes in Hadoop Foreign Data Wrapper 2.3.1 include:
 

--- a/product_docs/docs/jdbc_connector/42.5.4.1/01_jdbc_rel_notes/jdbc_42.5.4.1_rel_notes.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.1/01_jdbc_rel_notes/jdbc_42.5.4.1_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Version 42.5.4.1"
-
+title: "EDB JDBC Connector 42.5.4.1 release notes"
+navTitle: Version 42.5.4.1
 ---
+
+Released: 16 Mar 2023
 
 The EDB JDBC connector provides connectivity between a Java application and an EDB Postgres Advanced Server database.
 

--- a/product_docs/docs/livecompare/2/rel_notes/2.5_rel_notes.mdx
+++ b/product_docs/docs/livecompare/2/rel_notes/2.5_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 2.5"
+title: "LiveCompare 2.5 release notes"
+navTitle: Version 2.5
 ---
+
+Released: 09 May 2023
 
 LiveCompare 2.5 includes the following new features, enhancements, bug fixes, and other changes:
 

--- a/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.5.1_rel_notes.mdx
+++ b/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.5.1_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 4.5.1"
+title: "Migration Portal 4.5.1 release notes"
+navTitle: Version 4.5.1
 ---
+
+Released: 12 Jul 2023
 
 
 New features, enhancements, bug fixes, and other changes in Migration Portal 4.5.1 include the following:

--- a/product_docs/docs/migration_toolkit/55/mtk_rel_notes/mtk_5561_rel_notes.mdx
+++ b/product_docs/docs/migration_toolkit/55/mtk_rel_notes/mtk_5561_rel_notes.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Version 55.6.1"
+title: "Migration Toolkit 55.6.1 release notes"
+navTitle: Version 55.6.1
 ---
 
 Released: 06 Sep 2023

--- a/product_docs/docs/mongo_data_adapter/5/mongo_rel_notes/mongo5.5.1_rel_notes.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/mongo_rel_notes/mongo5.5.1_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 5.5.0"
+title: "MongoDB Foreign Data Wrapper 5.5.1 release notes"
+navTitle: Version 5.5.1
 ---
+
+Released: 20 Jul 2023
 
 Enhancements, bug fixes, and other changes in MongoDB Foreign Data Wrapper 5.5.0 
 include:

--- a/product_docs/docs/mysql_data_adapter/2/mysql_rel_notes/mysql2.9.1_rel_notes.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/mysql_rel_notes/mysql2.9.1_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Version 2.9.1"
+title: "MySQL Foreign Data Wrapper 2.9.1 release notes"
+navTitle: Version 2.9.1
 ---
 
+Released: 20 Jul 2023
 
 Enhancements, bug fixes, and other changes in MySQL Foreign Data Wrapper 2.9.1 include:
 

--- a/product_docs/docs/ocl_connector/15/ocl_rel_notes/15.2.0.4_ocl_release_notes.mdx
+++ b/product_docs/docs/ocl_connector/15/ocl_rel_notes/15.2.0.4_ocl_release_notes.mdx
@@ -1,6 +1,10 @@
 ---
-title: "Version 15.2.0.4"
+title: "EDB OCL Connector 15.2.0.4 release notes"
+navTitle: Version 15.2.0.4
 ---
+
+Released: 24 Aug 2023
+
 The EDB OCL Connector provides an API similar to the Oracle Call Interface.
 
 New features, enhancements, bug fixes, and other changes in the EDB OCL Connector 15.2.0.4 include:

--- a/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/odbc_13.2.0.02_rel_notes.mdx
+++ b/product_docs/docs/odbc_connector/13/01_odbc_rel_notes/odbc_13.2.0.02_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 13.02.0000.02"
+title: "EDB ODBC Connector 13.02.0000.02 release notes"
+navTitle: Version 13.02.0000.02
 ---
+
+Released: 14 Feb 2023
 
 EDB ODBC Connector 13.02.0000.02 includes the following enhancement:
 

--- a/product_docs/docs/pem/9/pem_rel_notes/930_rel_notes.mdx
+++ b/product_docs/docs/pem/9/pem_rel_notes/930_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 9.3.0"
+title: "Postgres Enterprise Manager 9.3.0 release notes"
+navTitle: Version 9.3.0
 ---
+
+Released: 31 Aug 2023
 
 New features, enhancements, bug fixes, and other changes in PEM 9.3.0 include:
 

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/06_11900_rel_notes.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/06_11900_rel_notes.mdx
@@ -1,6 +1,9 @@
 ---
-title: "Version 1.19.0.0"
+title: "EDB PgBouncer 1.19.0.0 release notes"
+navTitle: Version 1.19.0.0
 ---
+
+Released: 07 Jun 2023
 
 EDB PgBouncer 1.19.0.0 includes the following upstream merge and security fix:
 

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.2.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.2.0_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Release notes for EDB Postgres Distributed version 5.2.0"
+title: "EDB Postgres Distributed 5.2.0 release notes"
 navTitle: "Version 5.2.0"
 ---
+
+Released: 04 Aug 2023
 
 EDB Postgres Distributed version 5.2.0 is a minor version of EDB Postgres Distributed.
 

--- a/product_docs/docs/pge/15/release_notes/rel_notes15.4.mdx
+++ b/product_docs/docs/pge/15/release_notes/rel_notes15.4.mdx
@@ -1,7 +1,9 @@
 ---
-title: "EDB Postgres Extended Server version 15.4"
+title: "EDB Postgres Extended Server 15.4 release notes"
 navTitle: Version 15.4
 ---
+
+Released: 21 Aug 2023
 
 New features, enhancements, bug fixes, and other changes in EDB Postgres Extended Server 15.2 include:
 

--- a/product_docs/docs/pgpool/4/pgpool_rel_notes/442_rel_notes.mdx
+++ b/product_docs/docs/pgpool/4/pgpool_rel_notes/442_rel_notes.mdx
@@ -1,7 +1,9 @@
 ---
-title: "Version 4.4.2"
+title: "EDB PgPool-II 4.4.2 release notes"
+navTitle: Version 4.4.2
 ---
 
+Released: 14 Feb 2023
 
 EDB Pgpool-II 4.4.2 includes the following upstream merge:
 

--- a/product_docs/docs/postgis/3.2/01_release_notes/rel_notes321.mdx
+++ b/product_docs/docs/postgis/3.2/01_release_notes/rel_notes321.mdx
@@ -1,6 +1,10 @@
 ---
-title: "Version 3.2.1"
+title: "PostGIS 3.2.1 release notes"
+navTitle: Version 3.2.1
 ---
+
+Released: 04 Aug 2022
+
 EDB PostGIS is a PostgreSQL extension that allows you to store geographic information systems (GIS) objects in an EDB Postgres Advanced Server database.
 
 New features, enhancements, bug fixes, and other changes in PostGIS 3.2.1 include:

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_20_2_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_20_2_rel_notes.mdx
@@ -3,6 +3,8 @@ title: "EDB Postgres for Kubernetes 1.20.2 release notes"
 navTitle: "Version 1.20.2"
 ---
 
+Released: 27 Jul 2023
+
 This release of EDB Postgres for Kubernetes includes the following:
 
 |      Type      |                                                                                  Description                                                                                   |


### PR DESCRIPTION
## What Changed?

- EPAS: updated [release notes table](https://github.com/EnterpriseDB/docs/pull/4840)  by @nidhibhammar 
- All products: Added [release date and updated title](https://github.com/EnterpriseDB/docs/pull/4843) to the latest versions by @dwicinas 
