### PR TITLE
Add edb_sqlpatch information on minor version up page for EPAS 15 manual

### DIFF
--- a/product_docs/docs/epas/15/upgrading/05_performing_a_minor_version_update_of_an_rpm_installation.mdx
+++ b/product_docs/docs/epas/15/upgrading/05_performing_a_minor_version_update_of_an_rpm_installation.mdx
@@ -27,3 +27,16 @@ yum update edb*
     The `yum update` command performs an update only between minor releases. To update between major releases, use `pg_upgrade`.
 
 For more information about using `yum` commands and options, enter `yum --help` at the command line.
+
+!!! If edb_sqlpatch result gives below message, it is necessary to execute edb_sqlpatch for system catalog.
+    Here is an output example:
+    ```shell
+    * database edb
+    0 patches were previously applied to this database.
+    58 patches need to be applied to this database.
+    ```
+    In this case , you need to execute this post rpm update:
+    ```shell
+    edb_sqlpatch -af
+    ```
+For more information about using `edb_sqlpatch` commands and options, please see [edb_sqlpatch](https://www.enterprisedb.com/docs/tools/edb_sqlpatch/#overview) page.

--- a/product_docs/docs/epas/15/upgrading/05_performing_a_minor_version_update_of_an_rpm_installation.mdx
+++ b/product_docs/docs/epas/15/upgrading/05_performing_a_minor_version_update_of_an_rpm_installation.mdx
@@ -28,15 +28,24 @@ yum update edb*
 
 For more information about using `yum` commands and options, enter `yum --help` at the command line.
 
-!!! If edb_sqlpatch result gives below message, it is necessary to execute edb_sqlpatch for system catalog.
-    Here is an output example:
-    ```shell
-    * database edb
-    0 patches were previously applied to this database.
-    58 patches need to be applied to this database.
-    ```
-    In this case , you need to execute this post rpm update:
-    ```shell
-    edb_sqlpatch -af
-    ```
-For more information about using `edb_sqlpatch` commands and options, please see [edb_sqlpatch](https://www.enterprisedb.com/docs/tools/edb_sqlpatch/#overview) page.
+!!! Important
+    
+If upgrading to version 15.4,  or later, you should run `edb_sqlpatch`
+
+If the command responds that it has a number of patches needing to be applied like so:
+
+```console
+* database edb
+0 patches were previously applied to this database.
+58 patches need to be applied to this database.
+```
+
+Then it will be necessary to execute edb_sqlpatch to patch the system catalog. Run:
+
+```shell
+edb_sqlpatch -af
+```
+
+!!!
+
+For more information about using `edb_sqlpatch` commands and options, please see [edb_sqlpatch](/tools/edb_sqlpatch/) page.


### PR DESCRIPTION
Hi team,
Greetings.

We've found that your minor upgrade page lacks the information about edb_sqlpatch description, which is needed for example v15.4.

## What Changed?
Add edb_sqlpatch command sample and link to its manual page at bottom.
