### PR TITLE
Fix installing.mdx

### DIFF
--- a/advocacy_docs/pg_extensions/pg_failover_slots/installing.mdx
+++ b/advocacy_docs/pg_extensions/pg_failover_slots/installing.mdx
@@ -28,16 +28,16 @@ Before you begin the installation process:
 
 ## Install the package
 
-The syntax for the RPM package install command is:
+The syntax for the package install command is:
 
 ```shell
-sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover-slots<major_version>
+sudo <package-manager> -y install edb-<postgres><postgres_version>-pg-failover-slots<major_version>
 ```
 
 The syntax for the Debian package install command is:
 
 ```shell
-sudo <package-manager> -y install pg-<postgres><postgres_version>-pg-failover-slots-<major_version>
+sudo <package-manager> -y install edb-<postgres><postgres_version>-pg-failover-slots-<major_version>
 ```
 
 Where: 
@@ -65,12 +65,12 @@ Where:
 For example, to install PG Failover Slots 1.0.0 for EDB Postgres Advanced Server 15 on a RHEL 8 platform:
 
 ```shell
-sudo dnf -y install pg-as15-pg-failover-slots1
+sudo dnf -y install edb-as15-pg-failover-slots1
 ```
 
 To install PG Failover Slots 1.0.0 for EDB Postgres Advanced Server 15 on a Debian 11 platform:
 
 ```shell
-sudo apt-get -y install pg-as15-pg-failover-slots-1
+sudo apt-get -y install edb-as15-pg-failover-slots-1
 ```
 


### PR DESCRIPTION

## What Changed?

Failover slots files have an edb, not a pg prefix, so all the examples were wrong. Validated package existence on RHEL and Ubuntu.


