### PR TITLE
Redirect unversioned product URLs to latest, search fixes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -582,11 +582,18 @@ exports.onPostBuild = async ({ graphql, reporter, pathPrefix }) => {
   //
   // get rid of compilation hash - speeds up netlify deploys
   //
+  const hashTimer = reporter.activityTimer("Removing compilation hashes");
+  hashTimer.start();
   const { globby } = await import("globby");
   const generatedHTML = await globby([
     path.join(__dirname, "/public/**/*.html"),
   ]);
-  for (let filename of generatedHTML) {
+  for (
+    let i = 0, filename;
+    i < generatedHTML.length, (filename = generatedHTML[i]);
+    ++i
+  ) {
+    hashTimer.setStatus(`${i + 1}/${generatedHTML.length}`);
     let file = await readFile(filename);
     file = file.replace(
       /window\.___webpackCompilationHash="[^"]+"/,
@@ -606,6 +613,7 @@ exports.onPostBuild = async ({ graphql, reporter, pathPrefix }) => {
       '"webpackCompilationHash":""',
     ),
   );
+  hashTimer.end();
 
   //
   // additional headers

--- a/src/components/advanced-search/form.js
+++ b/src/components/advanced-search/form.js
@@ -1,4 +1,10 @@
-import React, { useLayoutEffect, useCallback, useRef, useState } from "react";
+import React, {
+  useLayoutEffect,
+  useEffect,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { useSearchBox } from "react-instantsearch";
 import Icon, { iconNames } from "../icon";
 import { SlashIndicator, ClearButton } from "../search/formComps";
@@ -8,6 +14,10 @@ export const AdvancedSearchForm = () => {
   const inputRef = useRef(null);
   const [inputValue, setInputValue] = useState(query);
   const queryLength = (inputValue || "").length;
+
+  useEffect(() => {
+    setInputValue(query);
+  }, [query]);
 
   const onInputChange = useCallback(
     (e) => {

--- a/src/components/search/formComps.js
+++ b/src/components/search/formComps.js
@@ -37,12 +37,18 @@ const TryAdvancedSearch = (props) => {
 };
 
 const PageHits = ({ arrowIndex }) => {
-  const { hits } = useHits();
+  const { hits, sendEvent } = useHits();
 
   return (
     <>
       {hits.map((hit, i) => (
-        <div className="mb-3" key={i}>
+        <div
+          className="mb-3"
+          key={i}
+          onClickCapture={() =>
+            sendEvent("click", hit, "global search result clicked")
+          }
+        >
           <PageHit hit={hit} className={arrowIndex === i && "arrow-focus"} />
         </div>
       ))}

--- a/src/constants/algolia-indexing.js
+++ b/src/constants/algolia-indexing.js
@@ -72,25 +72,35 @@ const EXCERPT_SOFT_SPLIT_MAX_CHARS = 6000; // start looking for "good enough" pl
 
 const mdxTreeToSearchNodes = (rootNode) => {
   const searchNodes = [];
-  let lastHeading = null;
-  let lastHeadingParent = null;
+  let headings = [];
   let currentText = "";
 
   // keep track of the last heading encountered so that subsequent nodes can be tagged with it
   // also keep track of its parent, for those rare cases where a heading is nested below the root
   // (only blockquote, listItem and footnote allow this)
   const observeHeading = (heading, ancestors) => {
-    lastHeading = heading;
-    lastHeadingParent = ancestors[ancestors.length - 1];
+    while (
+      headings.length &&
+      (headings[headings.length - 1].heading.depth >= heading.depth ||
+        !ancestors.includes(headings[headings.length - 1].parent))
+    )
+      headings.pop();
+
+    headings.push({ heading, parent: ancestors[ancestors.length - 1] });
   };
 
   const storeCurrentText = (ancestors) => {
     if (!currentText.length) return;
 
     // the parent of the last observed heading should be among the ancestors of the current node for the last heading to be considered relevant.
-    const headingNode = ancestors.includes(lastHeadingParent) && lastHeading;
-    const heading = (headingNode && mdast2string(headingNode)) || "";
-    const headingId = heading && slugger.slug(heading);
+    while (
+      headings.length &&
+      !ancestors.includes(headings[headings.length - 1].parent)
+    )
+      headings.pop();
+    const headingNode = headings[headings.length - 1]?.heading;
+    const headingId = headingNode && slugger.slug(mdast2string(headingNode));
+    const heading = headings.map((h) => mdast2string(h.heading)).join(" » ");
     searchNodes.push({ text: currentText, heading, headingId });
 
     currentText = "";
@@ -183,10 +193,21 @@ const buildFinalAlgoliaNodes = (nodes, productVersions) => {
       let newNode = { ...node };
       delete newNode["mdxAST"];
 
-      newNode.id = `${newNode.path}-${i + 1}`;
-      newNode.heading = trimSpaces(searchNode.heading);
+      // this particular naming scheme is important, as algolia defaults to sorting by objectId when
+      // other rankings are equal. And it sorts in descending order... So for a given page, where multiple
+      // sections may match equally (say, because the match is in the page title) we want earlier sections
+      // to rank ahead of later sections.
+      newNode.id = `${newNode.algoliaId || newNode.path}${(
+        searchNodes.length - i
+      )
+        .toString()
+        .padStart(4, "0")}`;
+      delete newNode.algoliaId;
+      if (searchNode.heading) newNode.heading = trimSpaces(searchNode.heading);
+      if (newNode.heading)
+        newNode.title = newNode.title + " » " + newNode.heading;
       newNode.excerpt = utf8Truncate(
-        trimSpaces(`${searchNode.heading}: ${searchNode.text}`),
+        trimSpaces(searchNode.text),
         EXCERPT_HARD_TRUNCATE_BYTES,
       );
       if (searchNode.headingId) {
@@ -209,7 +230,34 @@ const algoliaTransformer = ({ data }) => {
 
   while (navStack.length > 0) {
     curr = navStack.pop();
-    curr.children.forEach((child) => navStack.push(child));
+    let parentId = curr.mdxNode?.algoliaId;
+    for (let child of curr.children)
+      if (child.mdxNode)
+        child.mdxNode.algoliaId = child.path
+          .split("/")
+          .slice(-2)[0]
+          .toLowerCase();
+    const navigation = (curr.mdxNode?.frontmatter?.navigation || [])
+      .map((n) => {
+        const navName = n.toString().toLowerCase();
+        return curr.children.find((c) => c.mdxNode?.algoliaId === navName);
+      })
+      .filter((n) => !!n);
+    navigation.push(
+      ...curr.children
+        .filter((child) => !navigation.includes(child))
+        .sort((a, b) =>
+          a.mdxNode?.algoliaId.localeCompare(b.mdxNode?.algoliaId),
+        ),
+    );
+    // used to set fallback sort in algolia to navigation order
+    for (let i = 0; i < navigation.length; ++i)
+      if (navigation[i].mdxNode)
+        navigation[i].mdxNode.algoliaId =
+          (parentId || navigation[i].path.split("/").slice(0, -2).join("")) +
+          (navigation.length - i).toString().padStart(3, "0") +
+          navigation[i].mdxNode.algoliaId;
+    navStack.push(...navigation);
     if (!curr.mdxNode) continue;
 
     curr.mdxNode.frontmatter = computeFrontmatterForTreeNode(curr);

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -89,6 +89,7 @@ const SuggestedLinksSearch = ({ queryParams }) => {
       searchClient={searchClient}
       indexName={algoliaIndex}
       initialUiState={{ [algoliaIndex]: queryParams }}
+      insights={true}
     >
       <SuggestedLinks />
       <Configure

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -32,8 +32,14 @@ const Search = (data) => {
             writeStateToQueryParams(uiState[algoliaIndex]);
             setUiState(uiState);
           }}
+          insights={true}
         >
-          <Configure hitsPerPage={30} facetingAfterDistinct={true} />
+          <Configure
+            hitsPerPage={30}
+            facetingAfterDistinct={true}
+            distinct="4"
+            advancedSyntax={true}
+          />
 
           <SideNavigation background="white">
             <AdvancedSearchFiltering />


### PR DESCRIPTION
## What Changed?

- Automatically add redirects from versioned product root to latest version. E.g., /pgd/ -> /pgd/latest/
- Choose object IDs for Algolia such that the default tie-breaker ordering (descending string order by ID) will mostly match navigation order.
- Include full hierarchy of section titles in search titles. E.g., # Installing ## Overview ### Linux -> Installing >> Overview >> Linux
- Pre-render global search bar (faster loading)
- Send search result click events to Algolia for better analytics, optimization
- Enable advanced syntax for searches (quoted terms, term exclusion). E.g., `"sql patch" -advisories`

Fixes #4872
Fixes #4331 