### PR TITLE
Move scrolling to proper callback, avoid animation 

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,23 +3,6 @@ require("prismjs/plugins/command-line/prism-command-line.css");
 
 exports.onRouteUpdate = ({ location }) => scrollToAnchor(location);
 
-exports.shouldUpdateScroll = ({
-  prevRouterProps,
-  routerProps,
-  pathname,
-  getSavedScrollPosition,
-}) => {
-  let hashElem =
-    routerProps.location.hash &&
-    document.getElementById(routerProps.location.hash.substring(1));
-  // avoid obscure issue where scrolling to hash in gatsby-react-router-scroll slams to end of page if animated
-  if (hashElem) {
-    hashElem.scrollIntoView({ behavior: "instant" });
-    return false;
-  }
-  return true; // default
-};
-
 /**
  *
  * @desc - a function to jump to the correct scroll position

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,6 +3,23 @@ require("prismjs/plugins/command-line/prism-command-line.css");
 
 exports.onRouteUpdate = ({ location }) => scrollToAnchor(location);
 
+exports.shouldUpdateScroll = ({
+  prevRouterProps,
+  routerProps,
+  pathname,
+  getSavedScrollPosition,
+}) => {
+  let hashElem =
+    routerProps.location.hash &&
+    document.getElementById(routerProps.location.hash.substring(1));
+  // avoid obscure issue where scrolling to hash in gatsby-react-router-scroll slams to end of page if animated
+  if (hashElem) {
+    hashElem.scrollIntoView({ behavior: "instant" });
+    return false;
+  }
+  return true; // default
+};
+
 /**
  *
  * @desc - a function to jump to the correct scroll position
@@ -16,23 +33,6 @@ function scrollToAnchor(location, mainNavHeight = 0) {
   // right-nav: scroll
   const toc = document.querySelector(".toc-sticky .active");
   if (toc) toc.scrollIntoView({ block: "nearest" });
-
-  // Check for location so build does not fail
-  if (location && location.hash) {
-    try {
-      const item = document.getElementById(location.hash.substring(1));
-
-      if (item) {
-        window.scrollTo({
-          top: item.offsetTop - mainNavHeight,
-          behavior: "smooth",
-        });
-      }
-    } catch (error) {
-      // if hash is bad exception will be raised
-      console.error(error);
-    }
-  }
 
   return true;
 }

--- a/src/styles/_helpers.scss
+++ b/src/styles/_helpers.scss
@@ -123,8 +123,12 @@ svg {
 .arrow-list {
   list-style-type: "→";
 }
-html {
-  scroll-behavior: smooth;
+
+
+// force-disable this - it causes annoying jumps when navigating, and a bug w/ anchor links in Firefox
+$enable-smooth-scroll: false;
+:root {
+  scroll-behavior: auto !important;
 }
 
 /* fill colors */


### PR DESCRIPTION
## What Changed?

Appears there were at least three different places where scrolling would potentially be forced on navigation:

1. a script injected by the autolink headers plugin (only on page load)
2. gatsby's router logic (page load and internal navigation)
3. navigation callback in gatsby-browser.js (page load and internal navigation)

...not to mention the default browser behavior, which would (should?) also work on page load.

Generally, this didn't seem to cause issues, but occasionally an odd behavior would emerge: navigating to a section within a page would jump the scroll position much further down. Oddly, this seems to disappear if the \#3 logic is eliminated in favor of a selective override of \#2. 

