### PR TITLE
Update step02-backup-setup.mdx

### DIFF
--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -103,13 +103,18 @@ In order for Barman to connect via the user specified, we'll need to add the pas
 
 ```shell
 cat <<'EOF' >>~/.pgpass
-pg:*:*:barman:example-password
-pg:*:*:streaming_barman:example-password
+pg:5432:*:barman:example-password
+pg:5432:replication:streaming_barman:example-password
 EOF
 chmod 0600 ~/.pgpass
 ```
+Each line in the `.pgpass` file need to follow below format:
+```
+[db_host]:[db_port]:[db_name]:[db_user]:[db_password]
+```
+Also note that the database name [db_name] for the barman streaming user MUST be `replication`
 
-Note the change in permissions - this is necessary to protect the visibility of the file, and PostgreSQL will not use it unless permissions are restricted.
+**Note the change in permissions** - this is necessary to protect the visibility of the file, and PostgreSQL will not use it unless permissions are restricted.
 
 !!! Tip Further reading
     For more details on configuration files, see: [the Configuration section in the Barman guide](http://docs.pgbarman.org/release/2.12/#configuration).

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -108,7 +108,7 @@ pg:5432:replication:streaming_barman:example-password
 EOF
 chmod 0600 ~/.pgpass
 ```
-Each line in the `.pgpass` file need to follow below format:
+Each line in the `.pgpass` file needs to follow below format:
 ```
 [db_host]:[db_port]:[db_name]:[db_user]:[db_password]
 ```

--- a/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
+++ b/advocacy_docs/supported-open-source/barman/single-server-streaming/step02-backup-setup.mdx
@@ -112,9 +112,9 @@ Each line in the `.pgpass` file needs to follow below format:
 ```
 [db_host]:[db_port]:[db_name]:[db_user]:[db_password]
 ```
-Also note that the database name [db_name] for the barman streaming user MUST be `replication`
+The database name [db_name] for the barman streaming user must be `replication`
 
-**Note the change in permissions** - this is necessary to protect the visibility of the file, and PostgreSQL will not use it unless permissions are restricted.
+**Note the change in permissions** - this is necessary to protect the visibility of the file. PostgreSQL won't use it unless permissions are restricted.
 
 !!! Tip Further reading
     For more details on configuration files, see: [the Configuration section in the Barman guide](http://docs.pgbarman.org/release/2.12/#configuration).


### PR DESCRIPTION
fix to .pgpass template 
- using `*` instead of `replication` does not work as we receive the following errors:
```
connection to server at "192.168.1.20", port 5432 failed: fe_sendauth: no password supplied
```

## What Changed?

