### PR TITLE
Removed defunct shared entry in reference

### DIFF
--- a/product_docs/docs/tpa/23/reference/platform-shared.mdx
+++ b/product_docs/docs/tpa/23/reference/platform-shared.mdx
@@ -1,5 +1,0 @@
----
-title: Shared instances
-originalFilePath: platform-shared.md
-
----


### PR DESCRIPTION
## What Changed?

Empty shared instance page (and reference section block) are gone.