### PR TITLE
Correction of spelling typo

### DIFF
--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/20_adding_tablefilters_to_publication.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/20_adding_tablefilters_to_publication.mdx
@@ -28,7 +28,7 @@ If the filter rule isn't enabled on a target subscription or non-MDN node, then 
 See [Table filters](../../02_overview/02_replication_concepts_and_definitions/13_table_filters/#table_filters) for more information.
 
 !!! Note
-    The schema names and table or view names that you supply as values for the tables or views parameters are case sensitive. Unless quoted identifiers were used to build the database objects, you must enter Oracle names using uppercase letters (for example, `EDB.DEPT`) and EDB Postgres Advanced Server names in lowercase letters (for example `edb.dept`). See [Quoted edentifiers and default case translation](../../10_appendix/03_miscellaneous_xdb_processing_topics/05_quoted_identifiers/#quoted_identifiers) for more information.
+    The schema names and table or view names that you supply as values for the tables or views parameters are case sensitive. Unless quoted identifiers were used to build the database objects, you must enter Oracle names using uppercase letters (for example, `EDB.DEPT`) and EDB Postgres Advanced Server names in lowercase letters (for example `edb.dept`). See [Quoted identifiers and default case translation](../../10_appendix/03_miscellaneous_xdb_processing_topics/05_quoted_identifiers/#quoted_identifiers) for more information.
 
 ## Parameters
 


### PR DESCRIPTION
Changed "edentifiers" to "identifiers" in link label (quoted_identifiers) page

## What Changed?

