### PR TITLE
BDR-4220 - fix the verbose flag defaults in show-replslots cmd

### DIFF
--- a/product_docs/docs/pgd/4/cli/command_ref/pgd_show-replslots.mdx
+++ b/product_docs/docs/pgd/4/cli/command_ref/pgd_show-replslots.mdx
@@ -121,7 +121,7 @@ pgd show-replslots [flags]
 
 ```text
   -h, --help      help for show-replslots
-  -v, --verbose   verbose output (default true)
+  -v, --verbose   verbose output
 ```
 
 ### Options inherited from parent commands

--- a/product_docs/docs/pgd/5/cli/command_ref/pgd_show-replslots.mdx
+++ b/product_docs/docs/pgd/5/cli/command_ref/pgd_show-replslots.mdx
@@ -121,7 +121,7 @@ pgd show-replslots [flags]
 
 ```text
   -h, --help      help for show-replslots
-  -v, --verbose   verbose output (default true)
+  -v, --verbose   verbose output
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## What Changed?

Fix the default value for verbose flag in show-replslots doc. This minor PR can be merged/published after review (no need to wait for PGD release). 
