### PR TITLE
Update Postgres 16 version

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/index.mdx
@@ -170,7 +170,7 @@ format for the following platforms: `linux/amd64`, `linux/arm64`, `linux/ppc64le
 
 The following versions of Postgres are currently supported:
 
--   PostgreSQL 15, 14, 13, 12, and 11
+-   PostgreSQL 16, 15, 14, 13 and 12
 -   EDB Postgres Advanced 15, 14, 13, 12, and 11
 
 All of the above versions are available on the following platforms: `linux/amd64`, `linux/arm64`, `linux/ppc64le`, `linux/s390x`.


### PR DESCRIPTION
## What Changed?
Support for PostgreSQL 16 version. PostgreSQL 11 is not supported anymore.
