### PR TITLE
EFM does not drop the VIP when the primary agent is stopped

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
@@ -15,6 +15,9 @@ Failover Manager uses the `efm_address` script to assign or release a virtual IP
 !!! Note
     Virtual IP addresses aren't supported by many cloud providers. In those environments, use another mechanism, such as an elastic IP address on AWS, that can be changed when needed by a fencing or post-promotion script.
 
+!!! Note
+    Failover Manager will not drop the Virtual IP address (if used) from the primary node when the agent is stopped. As a convenience for testing, the primary agent will acquire the VIP at startup if the node does not already have it, but otherwise starting and stopping Failover Manager has no effect on the node having the virtual IP address.
+
 By default, the script resides in:
 
  `/usr/edb/efm-4.<x>/bin/efm_address`
@@ -82,7 +85,7 @@ When instructed to ping the VIP from a node, use the command defined by the `pin
    time 3000ms
    ```
 
-   You see 100% packet loss. 
+   You see 100% packet loss.
    !!!important
    Failover Manager uses the exit code of the ping command to determine whether the address was reachable. In this case, the exit code isn't zero. If you're using a command other than ping, it must return a non-zero exit code if the address isn't reachable.
 
@@ -107,7 +110,7 @@ When instructed to ping the VIP from a node, use the command defined by the `pin
    rtt min/avg/max/mdev = 0.023/0.025/0.029/0.006 ms
    ```
 
-   No packet loss occurs. 
+   No packet loss occurs.
    !!!Important
    Failover Manager uses the exit code of the ping command to determine whether the address was reachable. In this case, the exit code is zero. If you're using a command other than ping, it must return a zero exit code if the address is reachable.
 

--- a/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/05_using_vip_addresses.mdx
@@ -12,10 +12,10 @@ legacyRedirectsGenerated:
 
 Failover Manager uses the `efm_address` script to assign or release a virtual IP address.
 
-!!! Note
+!!! Note "Cloud provider support and alternatives"
     Virtual IP addresses aren't supported by many cloud providers. In those environments, use another mechanism, such as an elastic IP address on AWS, that can be changed when needed by a fencing or post-promotion script.
 
-!!! Note
+!!! Note "Behavior when the agent is stopped"
     Failover Manager will not drop the Virtual IP address (if used) from the primary node when the agent is stopped. As a convenience for testing, the primary agent will acquire the VIP at startup if the node does not already have it, but otherwise starting and stopping Failover Manager has no effect on the node having the virtual IP address.
 
 By default, the script resides in:
@@ -86,8 +86,9 @@ When instructed to ping the VIP from a node, use the command defined by the `pin
    ```
 
    You see 100% packet loss.
+   
    !!!important
-   Failover Manager uses the exit code of the ping command to determine whether the address was reachable. In this case, the exit code isn't zero. If you're using a command other than ping, it must return a non-zero exit code if the address isn't reachable.
+      Failover Manager uses the exit code of the ping command to determine whether the address was reachable. In this case, the exit code isn't zero. If you're using a command other than ping, it must return a non-zero exit code if the address isn't reachable.
 
 2. Run the `efm_address add4` command on the primary node to assign the VIP, and then confirm with ip address:
 
@@ -112,7 +113,7 @@ When instructed to ping the VIP from a node, use the command defined by the `pin
 
    No packet loss occurs.
    !!!Important
-   Failover Manager uses the exit code of the ping command to determine whether the address was reachable. In this case, the exit code is zero. If you're using a command other than ping, it must return a zero exit code if the address is reachable.
+      Failover Manager uses the exit code of the ping command to determine whether the address was reachable. In this case, the exit code is zero. If you're using a command other than ping, it must return a zero exit code if the address is reachable.
 
 4. Use the `efm_address del` command to release the address on the primary node and confirm the node was released with ip address:
 

--- a/product_docs/docs/efm/4/upgrading.mdx
+++ b/product_docs/docs/efm/4/upgrading.mdx
@@ -33,6 +33,8 @@ Failover Manager provides a utility to assist you when upgrading a cluster manag
    ```shell
    /usr/efm-4.4/bin/efm stop-cluster efm
    ```
+!!! Note
+    The primary agent will not drop the virtual IP address (if used) when it is stopped.
 
 6. Start the new [Failover Manager service](08_controlling_efm_service/#controlling_efm_service) (`edb-efm-4.7`) on each node of the cluster.
 

--- a/product_docs/docs/efm/4/upgrading.mdx
+++ b/product_docs/docs/efm/4/upgrading.mdx
@@ -34,7 +34,7 @@ Failover Manager provides a utility to assist you when upgrading a cluster manag
    /usr/efm-4.4/bin/efm stop-cluster efm
    ```
 !!! Note
-    The primary agent will not drop the virtual IP address (if used) when it is stopped.
+    The primary agent will not drop the virtual IP address (if used) when it is stopped; the database will remain up and accessible on the VIP during the EFM upgrade. See also: [Using Failover Manager with virtual IP addresses](04_configuring_efm/05_using_vip_addresses.mdx) 
 
 6. Start the new [Failover Manager service](08_controlling_efm_service/#controlling_efm_service) (`edb-efm-4.7`) on each node of the cluster.
 


### PR DESCRIPTION
This is occasionally a source of confusion, and we'd like to make it clear that EFM doesn't drop the vip when it exits. This would break a cluster that uses a VIP.

Am not sure if it makes sense to have two "Note" boxes next to each other at the top of the page, so if there's a better way to handle it am happy with any changes.

