### PR TITLE
Docs/pgd/fix/ bdr 4298 update pgd docs with pg pge epas 16 support

### DIFF
--- a/product_docs/docs/pgd/5/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/index.mdx
@@ -2,6 +2,7 @@
 title: "EDB Postgres Distributed Release notes"
 navTitle: "Release notes"
 navigation:
+- pgd_5.3.0_rel_notes
 - pgd_5.2.0_rel_notes
 - pgd_5.1.0_rel_notes
 - pgd_5.0.1_rel_notes
@@ -20,6 +21,7 @@ that introduced the feature.
 
 | Release Date  |   EDB Postgres Distributed   | BDR extension | PGD CLI | PGD Proxy |
 | ------------- | ---------------------------- | ------------- | ------- | --------- |
+| 14 Nov 2023  | [5.3.0](pgd_5.3.0_rel_notes) | 5.3.0         | 5.3.0   | 5.3.0     |
 | 4 Aug 2023   | [5.2.0](pgd_5.2.0_rel_notes) | 5.2.0         | 5.2.0   | 5.2.0     |
 | 16 May 2023  | [5.1.0](pgd_5.1.0_rel_notes) | 5.1.0         | 5.1.0   | 5.1.0     |
 | 21 Mar 2023  | [5.0.1](pgd_5.0.1_rel_notes) | 5.0.0         | 5.0.1   | 5.0.1     |

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -1,0 +1,31 @@
+---
+title: "EDB Postgres Distributed 5.3.0 release notes"
+navTitle: "Version 5.3.0"
+---
+
+Released: 14 Nov 2023
+
+EDB Postgres Distributed version 5.3.0 is a minor version of EDB Postgres Distributed.
+
+## Highlights of EDB Postgres Distributed 5.3.0
+
+<Add the highlights bullet points here>
+
+!!! Important Recommended upgrade
+    We recommend that users of PGD 5.2 upgrade to PGD 5.3.
+
+!!! Note PostgreSQL version compatibility
+This version is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8, and later.
+!!!
+
+
+| Component | Version | Type        | Description  |
+|-----------|---------|-------------|--------------|
+| CLI       | 5.3.0   | Bug fix     | Fix `shared_preload_libraries` verification |
+| CLI       | 5.3.0   | Bug fix     | Set the correct defaults for verbose flag |
+| CLI       | 5.3.0   | Bug fix     | Fix the replication slots check in `check-health` command in a scenario where cluster is reduced to a single node and the node is a witness node |
+| Proxy     | 5.3.0   | Enhancement | Add the default service unit file with pgd-proxy package |
+| Proxy     | 5.3.0   | Bug fix     | Always set the server conn close behaviour to discard unsent or unacknowledged data at the time of connection creation itself. Earlier, this was set only on client conn error. However, this could cause undesired behaviour specially in situation like n/w partition. (BDR-4060) |
+| Proxy     | 5.3.0   | Bug fix     | Add a retry delay to node watcher for all failed nodes (BDR-3978) |
+| Utilities | 1.2.0   | Enhancement | Add support for pg_upgrade of BDR 3.7 |
+| Utilities | 1.2.0   | Bug fix     | Remove the pre-upgrade step which alters the CONNECTION LIMIT to 0 at database level (BDR-4159) |

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -7,25 +7,55 @@ Released: 14 Nov 2023
 
 EDB Postgres Distributed version 5.3.0 is a minor version of EDB Postgres Distributed.
 
-## Highlights of EDB Postgres Distributed 5.3.0
-
-<Add the highlights bullet points here>
-
 !!! Important Recommended upgrade
-    We recommend that users of PGD 5.2 upgrade to PGD 5.3.
-
-!!! Note PostgreSQL version compatibility
-This version is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8, and later.
+We recommend that all users of PGD 5 upgrade to PGD 5.3.
 !!!
 
+## Highlights of EDB Postgres Distributed 5.3.0
 
-| Component | Version | Type        | Description  |
-|-----------|---------|-------------|--------------|
-| CLI       | 5.3.0   | Bug fix     | Fix `shared_preload_libraries` verification |
-| CLI       | 5.3.0   | Bug fix     | Set the correct defaults for verbose flag |
-| CLI       | 5.3.0   | Bug fix     | Fix the replication slots check in `check-health` command in a scenario where cluster is reduced to a single node and the node is a witness node |
-| Proxy     | 5.3.0   | Enhancement | Add the default service unit file with pgd-proxy package |
-| Proxy     | 5.3.0   | Bug fix     | Always set the server conn close behaviour to discard unsent or unacknowledged data at the time of connection creation itself. Earlier, this was set only on client conn error. However, this could cause undesired behaviour specially in situation like n/w partition. (BDR-4060) |
-| Proxy     | 5.3.0   | Bug fix     | Add a retry delay to node watcher for all failed nodes (BDR-3978) |
-| Utilities | 1.2.0   | Enhancement | Add support for pg_upgrade of BDR 3.7 |
-| Utilities | 1.2.0   | Bug fix     | Remove the pre-upgrade step which alters the CONNECTION LIMIT to 0 at database level (BDR-4159) |
+* Postgres 16 and EPAS 16 supported
+
+## Compatibility
+
+PGD 5.3 is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8, and later.
+
+## Features
+
+| Component | Version | Description  | Addresses | 
+|-----------|---------|-------------|-----------|
+| PGD | 5.3.0 | Add support for PostgreSQL 16 server. | |
+
+## Enhancements
+
+| Component | Version  |Description | Addresses |
+|-----------|---------|-------------|-----------|
+| Utilities | 1.2.0   | Add support for pg_upgrade of BDR 3.7 | |
+| Proxy     | 5.3.0   | Add the default service unit file with pgd-proxy package | |
+
+
+## Bug Fixes
+
+| Component | Version |Description  | Addresses | 
+|-----------|---------|-------------|-----------|
+| BDR       | 5.3.0   | Ensure that the WalSender process does not request locks on the partitions, thus avoiding a deadlock with user process waiting on sync commit. | RT97952 |
+| BDR       | 5.3.0   | Ensure that the taskmgr process does not ignore SIGINT. ||
+| BDR       | 5.3.0   | Speed up manager process startup by limiting the amount of WAL read for loading commit decisions. ||
+| BDR       | 5.3.0   | Clean up stale records in bdr.taskmgr_local_work_queue during physical join. ||
+| BDR       | 5.3.0   | Fix a bug in copying bdr.autopartition_rules during logical join. ||
+| BDR       | 5.3.0   | Override bdr.ddl_replication=off in taskmgr worker. ||
+| BDR       | 5.3.0   | Avoid a potential deadlock between `bdr.autopartition_wait_for_partitions()` and taskmgr||
+| BDR       | 5.3.0   | Fix writer missing updates in streaming mode with TDE enabled. ||
+| BDR       | 5.3.0   | Block new EPAS automatic partitioning on PGD cluster. ||
+| BDR       | 5.3.0   | Allow existing automatically partitioned tables when cluster is created or upgraded. ||
+| BDR       | 5.3.0   | Block PGD Autopartition on EPAS INTERVAL partitioned table. ||
+| BDR       | 5.3.0   | Ensure that replication does not break when bdr.autopartition() is invoked on a mixed version cluster, running with 3.7.23 and 4.3.3/5.3 ||
+| BDR       | 5.3.0   | Fix memory leak in LCR file TDE encryption. ||
+| BDR       | 5.3.0   | Fix row filter failure for partitions created after a table column was dropped | RT95149 |
+| CLI       | 5.3.0   | Fix `shared_preload_libraries` verification  | |
+| CLI       | 5.3.0   | Set the correct defaults for verbose flag   | |
+| CLI       | 5.3.0   | Fix the replication slots check in `check-health` command in a scenario where cluster is reduced to a single node and the node is a witness node | |
+| Proxy     | 5.3.0   | Always set the server conn close behaviour to discard unsent or unacknowledged data at the time of connection creation itself. Earlier, this was set only on client conn error. However, this could cause undesired behaviour specially in situation like n/w partition. | |
+| Proxy     | 5.3.0   | Add a retry delay to node watcher for all failed nodes | |
+| Utilities | 1.2.0   | Remove the pre-upgrade step which alters the CONNECTION LIMIT to 0 at database level | |
+
+

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -57,6 +57,7 @@ upgrades with an upgrade of Postgres Distributed.
 | BDR       | 5.3.0   | Ensure that replication does not break when bdr.autopartition() is invoked on a mixed version cluster, running with 3.7.23 and 4.3.3/5.3 ||
 | BDR       | 5.3.0   | Fix memory leak in LCR file TDE encryption. ||
 | BDR       | 5.3.0   | Fix row filter failure for partitions created after a table column was dropped | RT95149 |
+| BDR       | 5.3.0   | Avoid aborting a group commit transaction on receiving the first abort response, the other nodes are given a chance to respond and transaction can succeed if the required responses are received ||
 | CLI       | 5.3.0   | Fix `verify-settings` command if the `shared_preload_libraries` GUC contains file path | |
 | CLI       | 5.3.0   | Show replslots status as `Critical` in `check-health` command when PGD cluster is reduced to a single node and it is a witness node | |
 | Proxy     | 5.3.0   | Always set the server connection close behavior (setLinger(0)), earlier it was set only on client error | |

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -44,6 +44,8 @@ upgrades with an upgrade of Postgres Distributed.
 | Component | Version |Description  | Addresses |
 |-----------|---------|-------------|-----------|
 | BDR       | 5.3.0   | Ensure that the WalSender process does not request locks on the partitions, thus avoiding a deadlock with user process waiting on sync commit. | RT97952 |
+| BDR       | 5.3.0   | Only consider CAMO transactions to be asynchronous when the CAMO setup was degraded to local mode. This solves the split brain problem when deciding fate of transactions that happened during failover. | RT78928 |
+| BDR       | 5.3.0   | Fix unsafe CAMO decisions in remote_write mode. ||
 | BDR       | 5.3.0   | Ensure that the taskmgr process does not ignore SIGINT. ||
 | BDR       | 5.3.0   | Speed up manager process startup by limiting the amount of WAL read for loading commit decisions. ||
 | BDR       | 5.3.0   | Clean up stale records in bdr.taskmgr_local_work_queue during physical join. ||
@@ -56,9 +58,16 @@ upgrades with an upgrade of Postgres Distributed.
 | BDR       | 5.3.0   | Block PGD Autopartition on EPAS INTERVAL partitioned table. ||
 | BDR       | 5.3.0   | Ensure that replication does not break when bdr.autopartition() is invoked on a mixed version cluster, running with 3.7.23 and 4.3.3/5.3 ||
 | BDR       | 5.3.0   | Fix memory leak in LCR file TDE encryption. ||
+| BDR       | 5.3.0   | Fix memory leak in streaming transaction processing. ||
+| BDR       | 5.3.0   | Allow force parting of nodes that are already being parted normally. ||
+| BDR       | 5.3.0   | Fix nodes getting stuck on PART_CATCHUP due to replication slot conflict. ||
+| BDR       | 5.3.0   | Fix nodes getting stuck on PART_CATCHUP due to node_catchup_info conflict. ||
 | BDR       | 5.3.0   | Fix row filter failure for partitions created after a table column was dropped | RT95149 |
 | BDR       | 5.3.0   | Avoid aborting a group commit transaction on receiving the first abort response, the other nodes are given a chance to respond and transaction can succeed if the required responses are received ||
-| CLI       | 5.3.0   | Fix `verify-settings` command if the `shared_preload_libraries` GUC contains file path | |
+| BDR       | 5.3.0   | Ensure that replication receiver worker reloads configuration correctly when `pg_reload_conf()` is called. ||
+| BDR       | 5.3.0   | Prevent duplicate Raft request ID generation which could break replication. ||
+| BDR       | 5.3.0   | Fix several rare memory access issues that could potentially cause crashes of workers. ||
+| CLI       | 5.3.0   | Fix `verify-settings` command if the `shared_preload_libraries` GUC contains file path ||
 | CLI       | 5.3.0   | Show replslots status as `Critical` in `check-health` command when PGD cluster is reduced to a single node and it is a witness node | |
 | Proxy     | 5.3.0   | Always set the server connection close behavior (setLinger(0)), earlier it was set only on client error | |
 | Proxy     | 5.3.0   | Fix the logs fill up issue when all nodes are down in a PGD cluster | |

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -17,7 +17,14 @@ We recommend that all users of PGD 5 upgrade to PGD 5.3.
 
 ## Compatibility
 
-PGD 5.3 is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8, and later.
+!!! Note PostgreSQL version compatibility
+This version requires the recently released Postgres versions 14.10, 15.4,
+or 16.1 (or later) of EDB Postgres Advanced Server or EDB Postgres Extended
+Server. No such restrictions exist for PostgreSQL Server.
+
+Package managers on Debian, RHEL, and SLES pull in the required EPAS or PGE
+upgrades with an upgrade of Postgres Distributed.
+!!!
 
 ## Features
 
@@ -30,6 +37,7 @@ PGD 5.3 is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8
 | Component | Version  |Description | Addresses |
 |-----------|---------|-------------|-----------|
 | Proxy     | 5.3.0   | Add the default service unit file to package | |
+| BDR       | 5.3.0   | Dependencies on EPAS and PGE are now reflected in packages. | |
 
 ## Bug Fixes
 

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -21,7 +21,7 @@ PGD 5.3 is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8
 
 ## Features
 
-| Component | Version | Description  | Addresses | 
+| Component | Version | Description  | Addresses |
 |-----------|---------|-------------|-----------|
 | PGD | 5.3.0 | Add support for PostgreSQL 16 server. | |
 
@@ -29,13 +29,11 @@ PGD 5.3 is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8
 
 | Component | Version  |Description | Addresses |
 |-----------|---------|-------------|-----------|
-| Utilities | 1.2.0   | Add support for pg_upgrade of BDR 3.7 | |
-| Proxy     | 5.3.0   | Add the default service unit file with pgd-proxy package | |
-
+| Proxy     | 5.3.0   | Add the default service unit file to package | |
 
 ## Bug Fixes
 
-| Component | Version |Description  | Addresses | 
+| Component | Version |Description  | Addresses |
 |-----------|---------|-------------|-----------|
 | BDR       | 5.3.0   | Ensure that the WalSender process does not request locks on the partitions, thus avoiding a deadlock with user process waiting on sync commit. | RT97952 |
 | BDR       | 5.3.0   | Ensure that the taskmgr process does not ignore SIGINT. ||
@@ -51,11 +49,8 @@ PGD 5.3 is required for EDB Postgres Advanced Server versions 12.15, 13.11, 14.8
 | BDR       | 5.3.0   | Ensure that replication does not break when bdr.autopartition() is invoked on a mixed version cluster, running with 3.7.23 and 4.3.3/5.3 ||
 | BDR       | 5.3.0   | Fix memory leak in LCR file TDE encryption. ||
 | BDR       | 5.3.0   | Fix row filter failure for partitions created after a table column was dropped | RT95149 |
-| CLI       | 5.3.0   | Fix `shared_preload_libraries` verification  | |
-| CLI       | 5.3.0   | Set the correct defaults for verbose flag   | |
-| CLI       | 5.3.0   | Fix the replication slots check in `check-health` command in a scenario where cluster is reduced to a single node and the node is a witness node | |
-| Proxy     | 5.3.0   | Always set the server conn close behaviour to discard unsent or unacknowledged data at the time of connection creation itself. Earlier, this was set only on client conn error. However, this could cause undesired behaviour specially in situation like n/w partition. | |
-| Proxy     | 5.3.0   | Add a retry delay to node watcher for all failed nodes | |
-| Utilities | 1.2.0   | Remove the pre-upgrade step which alters the CONNECTION LIMIT to 0 at database level | |
-
-
+| CLI       | 5.3.0   | Fix `verify-settings` command if the `shared_preload_libraries` GUC contains file path | |
+| CLI       | 5.3.0   | Show replslots status as `Critical` in `check-health` command when PGD cluster is reduced to a single node and it is a witness node | |
+| Proxy     | 5.3.0   | Always set the server connection close behavior (setLinger(0)), earlier it was set only on client error | |
+| Proxy     | 5.3.0   | Fix the logs fill up issue when all nodes are down in a PGD cluster | |
+| Utilities | 1.2.0   | Remove the pre-upgrade step which sets the CONNECTION LIMIT to 0 at database level in `bdr_pg_upgrade` | |

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -13,11 +13,11 @@ We recommend that all users of PGD 5 upgrade to PGD 5.3.
 
 ## Highlights of EDB Postgres Distributed 5.3.0
 
-* Postgres 16 and EPAS 16 supported
+* Postgres 16, PGE 16 and EPAS 16 supported
 
 ## Compatibility
 
-!!! Note PostgreSQL version compatibility
+!!! Note EDB Server version compatibility
 This version requires the recently released Postgres versions 14.10, 15.4,
 or 16.1 (or later) of EDB Postgres Advanced Server or EDB Postgres Extended
 Server. No such restrictions exist for PostgreSQL Server.

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.3.0_rel_notes.mdx
@@ -57,6 +57,7 @@ upgrades with an upgrade of Postgres Distributed.
 | BDR       | 5.3.0   | Allow existing automatically partitioned tables when cluster is created or upgraded. ||
 | BDR       | 5.3.0   | Block PGD Autopartition on EPAS INTERVAL partitioned table. ||
 | BDR       | 5.3.0   | Ensure that replication does not break when bdr.autopartition() is invoked on a mixed version cluster, running with 3.7.23 and 4.3.3/5.3 ||
+| BDR       | 5.3.0   | Fix default selective replication behavior for data groups. The data groups are supposed to publish only replication sets of the group or any parent groups by default, which mirrors to what they subscribe. ||
 | BDR       | 5.3.0   | Fix memory leak in LCR file TDE encryption. ||
 | BDR       | 5.3.0   | Fix memory leak in streaming transaction processing. ||
 | BDR       | 5.3.0   | Allow force parting of nodes that are already being parted normally. ||

--- a/product_docs/docs/pgd/5/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/5/upgrades/upgrade_paths.mdx
@@ -21,8 +21,8 @@ release before upgrading to the latest version 5 release. After upgrading to
 | ---- | -- |
 | 4.3.0 | 5.0.0 or later |
 | 4.3.1 | 5.1.0 or later |
-| 4.3.2 | Upgrade to 5.3 (once it is released) |
-
+| 4.3.2 | 5.1.0 or later |
+| 4.3.3 | 5.1.0 or later |
 
 ## Upgrading from version 3.7 to version 5
 


### PR DESCRIPTION
## What Changed?

Updating docs with PG16 support where appropriate and flagging for 5.3 only.