### PR TITLE
Update installer metadata; update links and version numbers for v16 ODBC driver

### DIFF
--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -162,55 +162,55 @@ products:
     platforms:
       - name: CentOS 7
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: RHEL 9
         arch: ppc64le
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
-        supported versions: [13]      
+        supported versions: [13, 16]      
       - name: RHEL 7 or OL 7
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: Debian 10
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: Debian 11
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: Ubuntu 18.04
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: SLES 12
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: SLES 12
         arch: ppc64le
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: SLES 15
         arch: x86_64
-        supported versions: [13]
+        supported versions: [13, 16]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [13]
+        supported versions: [13, 16]
   - name: EDB pgBouncer
     platforms:
       - name: CentOS 7

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_debian_10.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_debian_10.mdx
@@ -39,7 +39,7 @@ Before you begin the installation process:
 
   1. Follow the instructions for setting up the EDB repository.
 
-- Download the GPG key to your APT keyring directly using the apt-key utility:
+- Download the GPG key to your APT keyring directly using the apt-key utility
   ```shell
   sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
   ```

--- a/product_docs/docs/odbc_connector/16/02_requirements_overview.mdx
+++ b/product_docs/docs/odbc_connector/16/02_requirements_overview.mdx
@@ -9,10 +9,11 @@ The ODBC Connector is supported on the same platforms as EDB Postgres Advanced S
 
 This table lists the latest ODBC Connector versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. 
 
-|                       ODBC Connector                        | EPAS 15 | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 |
-| ----------------------------------------------------------- | ------- | ------- | ------- | ------- | ------- |
-| [13.02.0.02](01_odbc_rel_notes/odbc_13.2.0.02_rel_notes)    | Y       | Y       | Y       | Y       | Y       |
-| [13.02.0.01](01_odbc_rel_notes/02_odbc_13.2.0.01_rel_notes) | N       | Y       | Y       | Y       | Y       |
-| [13.01.0.02](01_odbc_rel_notes/03_odbc_13.1.0.02_rel_notes) | N       | Y       | Y       | Y       | Y       |
-| [13.01.0.01](01_odbc_rel_notes/04_odbc_13.1.0.01_rel_notes) | N       | N       | Y       | Y       | Y       |
-| [13.00.0.01](01_odbc_rel_notes/05_odbc_13.0.0.01_rel_notes) | N       | N       | Y       | Y       | Y       |
+|                       ODBC Connector                                           | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 |
+| ------------------------------------------------------------------------------ | ------- | ------- | ------- | ------- | ------- | ------- |
+| [16.00.0000.01](01_odbc_rel_notes/odbc_16.00.00000.01_rel_notes)               | Y       | Y       | Y       | Y       | Y       | Y       |
+| [13.02.0.02](/odbc_connector/13/01_odbc_rel_notes/odbc_13.2.0.02_rel_notes)    | N       | Y       | Y       | Y       | Y       | Y       |
+| [13.02.0.01](/odbc_connector/13/01_odbc_rel_notes/02_odbc_13.2.0.01_rel_notes) | N       | N       | Y       | Y       | Y       | Y       |
+| [13.01.0.02](/odbc_connector/13/01_odbc_rel_notes/03_odbc_13.1.0.02_rel_notes) | N       | N       | Y       | Y       | Y       | Y       |
+| [13.01.0.01](/odbc_connector/13/01_odbc_rel_notes/04_odbc_13.1.0.01_rel_notes) | N       | N       | N       | Y       | Y       | Y       |
+| [13.00.0.01](/odbc_connector/13/01_odbc_rel_notes/05_odbc_13.0.0.01_rel_notes) | N       | N       | N       | Y       | Y       | Y       |

--- a/product_docs/docs/odbc_connector/16/index.mdx
+++ b/product_docs/docs/odbc_connector/16/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "EDB ODBC Connector"
 directoryDefaults:
-  description: "EDB ODBC Connector Version 12.2.0.2 Documentation and release notes."
+  description: "EDB ODBC Connector documentation and release notes."
 redirects:
  - 03_edb-odbc_overview/
 navigation:

--- a/product_docs/docs/odbc_connector/16/installing/index.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/index.mdx
@@ -8,10 +8,10 @@ title: Installing EDB ODBC Connector
 
 redirects:
   - ../03_edb-odbc_overview/01_installing_edb-odbc
-  - /odbc_connector/13/03_installing_edb_odbc/
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/07_odbc13_ubuntu20_deb10_x86/
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/12_odbc13_sles12_ppcle/
+  - /odbc_connector/16/03_installing_edb_odbc/
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/07_odbc13_ubuntu20_deb10_x86/
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/12_odbc13_sles12_ppcle/
 
 navigation:
   - linux_x86_64

--- a/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_rhel_8.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel8_ppcle
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_rhel_9.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_rhel_9.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on RHEL 9 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel9_ppcle
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_rhel9_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_sles_12.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_sles_15.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/odbc_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_centos_7.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_centos_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on CentOS 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_centos7_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_debian_10.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_debian_10.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on Debian 10 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_debian_11.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_debian_11.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on Debian 11 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb11_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_8.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on AlmaLinux 8 or Rocky Linux 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux8_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_9.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_9.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on AlmaLinux 9 or Rocky Linux 9 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux9_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_other_linux9_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_rhel_7.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_rhel_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on RHEL 7 or OL 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel7_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_rhel_8.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on RHEL 8 or OL 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel8_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_rhel_9.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_rhel_9.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on RHEL 9 or OL 9 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel9_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_rhel9_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_sles_12.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on SLES 12 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_sles_15.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on SLES 15 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_ubuntu_18.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_ubuntu_18.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on Ubuntu 18.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu18_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_ubuntu_20.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_ubuntu_20.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on Ubuntu 20.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_ubuntu_22.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_ubuntu_22.mdx
@@ -6,7 +6,7 @@ title: Installing EDB ODBC Connector on Ubuntu 22.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu22_x86
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_ubuntu22_x86
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## What Changed?

Includes generated installer files.

I've chosen to omit the version number from the index description metadata, as this is tedious to keep updated with point releases. If desired, I recommend re-adding only a major version.

Could use a sanity check on that compat table; I just guessed. Primary goal was to make the links work, but realistically... Do we need to list the v13 stuff there? Maybe just a link to the v13 table...