### PR TITLE
Fix missing () in pg_control_init

### DIFF
--- a/product_docs/docs/tde/15/enabling_tde.mdx
+++ b/product_docs/docs/tde/15/enabling_tde.mdx
@@ -113,7 +113,7 @@ You can find out whether TDE is present on a server by querying the `data_encryp
 A value of 0 means TDE isn't enabled. Any nonzero value reflects the version of TDE in use. Currently, when TDE is enabled, this value is 1.
 
 ```sql
-# select data_encryption_version from pg_control_init;
+# select data_encryption_version from pg_control_init();
  data_encryption_version
 -------------------------
                        1


### PR DESCRIPTION
## What Changed?

Missing () in pg_control_init as per https://edb.slack.com/archives/CSE2UK3EX/p1699952398387459
