### PR TITLE
BDR-4288 - Docs: Improve role management documentation

### DIFF
--- a/product_docs/docs/pgd/5/security/role-management.mdx
+++ b/product_docs/docs/pgd/5/security/role-management.mdx
@@ -2,30 +2,38 @@
 title: Role management
 ---
 
-Users are global objects in a PostgreSQL instance. A `CREATE ROLE` commands or its alias `CREATE USER` is replicated automatically if they're executed in a PGD replicated database. If a role or user is created in a non-PGD, un-replicated database, the role will only exist for that PostgreSQL instance. `GRANT ROLE` and `DROP ROLE` work in the same way, only replicating if applied to a PGD replicated database.
+Users are global objects in a PostgreSQL instance. A `CREATE ROLE` command or its alias `CREATE USER` is replicated automatically if they're executed in a PGD replicated database. If a role or user is created in a non-PGD, un-replicated database, the role will only exist for that PostgreSQL instance. `GRANT ROLE` and `DROP ROLE` work in the same way, only replicating if applied to a PGD replicated database.
 
-This automatic replication behavior can be disabled by turning off the
-[`bdr.role_replication`](/pgd/latest/reference/pgd-settings#bdrrole_replication)
-setting.
+!!! Note
+Remember that a user in Postgres terms is simply a role with login privileges.
+!!!
 
-## Roles for new nodes
+## Role Rule - No un-replicated roles
 
-New PGD nodes, added using [`bdr_init_physical`](/pgd/latest/reference/nodes#bdr_init_physical) will automatically replicate the roles from other nodes of the PGD cluster.
+It is especially important that if you do create a role or user in a non-PGD, un-replicated database, that you do not go on to make an object in the PGD replicated database rely on that role. It will break the replication process as PGD cannot replicate a role that is not in the PGD replicated database. 
 
-If a PGD node is joined a PGD group without doing that, existing users aren't copied to the newly joined node. This is intentional behavior to ensure that access isn't accidentally granted. Because PostgreSQL allows users to access multiple databases, with the default being to access any database, PGD doesn't know the access each user has to databases and so can't safely determine which users to copy across to the new node without possibly exposing a database. Therefore, it does not copy any users over.
+This automatic replication behavior can be disabled by turning off the[ bdr.role_replication](https://www.enterprisedb.com/docs/pgd/latest/reference/pgd-settings/#bdrrole_replication) setting but is not recommended.
 
-PostgreSQL allows you to dump all users with the command:
 
-```shell
+## **Roles for new nodes**
+
+New PGD nodes that are added using[ bdr_init_physical](https://www.enterprisedb.com/docs/pgd/latest/reference/nodes/#bdr_init_physical) will automatically replicate the roles from other nodes of the PGD cluster.
+
+If a PGD node is joined to a PGD group manually, without using bdr_init_physical, existing roles aren't copied to the newly joined node. This is intentional behavior to ensure that access isn't accidentally granted.
+
+Roles, by default, have access to all databases. Automatically copying users to a newly created node would therefore open the possibility of unintentionally exposing a database that exists on the node. If the PGD cluster had a user Alice, and Alice had been automatically created on a newly joined node, by directly connecting to that node, Alice would have access to all the databases on that node. PGD therefore doesn’t copy over existing roles and, in this situation, recommends that you copy over roles manually.
+
+PostgreSQL allows you to dump all roles with the command:
+
+```
 pg_dumpall --roles-only > roles.sql
 ```
 
-You can then edit the file `roles.sql` to remove unwanted users before
-reexecuting that on the newly created node.
+You can then edit the file `roles.sql` to remove unwanted users before re-executing that on the newly created node.
 
-Other mechanisms are possible, depending on your identity and access
-management solution (IAM) but aren't automated at this time.
+When joining a new node, the “No un-replicated roles” rule also applies. If an object in the to-be replicated database relies on an unreplicated role in an (unreplicated) local database, then the join will fail when it attempts to replicate that object.
 
+ 
 ## Connections and roles
 
 When allocating a new PGD node, the user supplied in the DSN for the `local_dsn`


### PR DESCRIPTION
## What Changed?

Text expanded to note where replication and joining may break when unreplicated roles or objects dependent on them are created.