### PR TITLE
BDR: remove reference to the "bdr-enterprise" extension in 5.x docs

### DIFF
--- a/product_docs/docs/pgd/5/monitoring/sql.mdx
+++ b/product_docs/docs/pgd/5/monitoring/sql.mdx
@@ -149,9 +149,6 @@ column that refers to the time required for the peer node to catch up to the
 local node data. The other fields are also available from the [`bdr.node_slots`](/pgd/latest/reference/catalogs-visible/#bdrnode_slots)
 view.
 
-!!! Note
-    This catalog is present only when the bdr-enterprise extension is installed.
-
 Administrators can query [`bdr.node_slots`](/pgd/latest/reference/catalogs-visible/#bdrnode_slots) for outgoing replication from the
 local node. It shows information about replication status of all other nodes
 in the group that are known to the current node as well as any additional


### PR DESCRIPTION
## What Changed?

As of BDR 4.0, the referenced `bdr-enterprise` extension no longer exists, and the catalogue table in question is always installed.

(I checked the BDR 4.x docs, it is not present there)


