### PR TITLE
BDR: fix typo in 4.x "bdr.stat_subscription" description

### DIFF
--- a/product_docs/docs/pgd/4/bdr/catalogs.mdx
+++ b/product_docs/docs/pgd/4/bdr/catalogs.mdx
@@ -832,7 +832,7 @@ is enabled.
 | nstream_file         | bigint                   | Number of transactions streamed to file                                                                             |
 | nstream_commit       | bigint                   | Number of streaming transactions committed                                                                          |
 | nstream_abort        | bigint                   | Number of streaming transactions aborted                                                                            |
-| nstream_start        | bigint                   | Number of STREAT START messages processed                                                                           |
+| nstream_start        | bigint                   | Number of STREAM START messages processed                                                                           |
 | nstream_stop         | bigint                   | Number of STREAM STOP messages processed                                                                            |
 | shared_blks_hit      | bigint                   | Total number of shared block cache hits by the subscription                                                         |
 | shared_blks_read     | bigint                   | Total number of shared blocks read by the subscription                                                              |


### PR DESCRIPTION
## What Changed?

`s/STREAT/STREAM/`. 
Already fixed in the 5.x docs.


