### PR TITLE
docs/tde/latest/enabling_tde - Adding -pbkdf2 to Examples

### DIFF
--- a/product_docs/docs/tde/15/enabling_tde.mdx
+++ b/product_docs/docs/tde/15/enabling_tde.mdx
@@ -80,8 +80,8 @@ This example uses EDB Postgres Advanced Server 15 running on a Linux platform. I
 1. Set the data encryption key (wrap) and decryption (unwrap) environment variables:
 
    ```shell
-   export PGDATAKEYWRAPCMD='openssl enc -e -aes-128-cbc -pass pass:ok -out %p'
-   export PGDATAKEYUNWRAPCMD='openssl enc -d -aes-128-cbc -pass pass:ok -in %p'
+   export PGDATAKEYWRAPCMD='openssl enc -e -aes-128-cbc -pbkdf2 -pass pass:ok -out %p'
+   export PGDATAKEYUNWRAPCMD='openssl enc -d -aes-128-cbc -pbkdf2 -pass pass:ok -in %p'
    ```
    !!!note
    If you are on Windows you don't need the single quotes around the variable value.
@@ -103,7 +103,7 @@ This example uses EDB Postgres Advanced Server 15 running on a Linux platform. I
    ```shell
    grep data_encryption_key_unwrap_command /var/lib/edb/as15/data/postgresql.conf
    __OUTPUT__
-   data_encryption_key_unwrap_command = 'openssl enc -d -aes-128-cbc -pass pass:ok -in %p'
+   data_encryption_key_unwrap_command = 'openssl enc -d -aes-128-cbc -pbkdf2 -pass pass:ok -in %p'
    ```
 
 ## Checking for TDE presence using SQL


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy. 
Here is our suggestion

## What Changed?

Added -pbkdf2 option to Example section. 
This might avoid "deprecated key derivation used." by openssl.

Kind Regards,
Yuki Tei