### PR TITLE
Move batting data csv into this repo, reference it appropriately

### DIFF
--- a/product_docs/docs/biganimal/release/free_trial/detail/experiment/backup_and_restore.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/detail/experiment/backup_and_restore.mdx
@@ -26,7 +26,7 @@ Normally you use the log files to determine the moment in time that you want to 
 \set PROMPT1 '%`date +"%Y-%m-%dT%H:%M:%S%z"` %/%R%# '
 ```
 
-For this demonstration, we're just going to import batter data from the [Baseball Databank](https://github.com/chadwickbureau/baseballdatabank), which is in CSV form. While it's easy to import the data using [PostgreSQL's COPY command](https://www.postgresql.org/docs/current/sql-copy.html), we'll need to first define a table to put that data into. Most of the columns are integers, but there are a few strings to consider as well. You can copy and paste this command into your terminal.
+For this demonstration, we're just going to import batter data from the [Baseball Databank](https://github.com/cbwinslow/baseballdatabank), which is in CSV form. While it's easy to import the data using [PostgreSQL's COPY command](https://www.postgresql.org/docs/current/sql-copy.html), we'll need to first define a table to put that data into. Most of the columns are integers, but there are a few strings to consider as well. You can copy and paste this command into your terminal.
 
 ```sql
 CREATE TABLE batters (
@@ -60,7 +60,7 @@ CREATE TABLE batters (
 Now we can populate the table from the internet using the most recent data.
 
 ```sql
-\COPY batters(playerid,yearid,stint,teamid,lgid,g,ab,r,h,"2b","3b",hr,rbi,sb,cs,bb,so,ibb,hbp,sh,sf,gidp) FROM PROGRAM 'curl "https://raw.githubusercontent.com/chadwickbureau/baseballdatabank/master/core/Batting.csv"' DELIMITER ',' CSV HEADER
+\COPY batters(playerid,yearid,stint,teamid,lgid,g,ab,r,h,"2b","3b",hr,rbi,sb,cs,bb,so,ibb,hbp,sh,sf,gidp) FROM PROGRAM 'curl "https://raw.githubusercontent.com/EnterpriseDB/docs/main/product_docs/docs/biganimal/release/free_trial/detail/experiment/data/Batting.csv"' DELIMITER ',' CSV HEADER
 ```
 
 Just to prove there's data loaded, let's look at the home run leaders for the 1998 season.

--- a/product_docs/docs/biganimal/release/free_trial/detail/experiment/data/LICENSE
+++ b/product_docs/docs/biganimal/release/free_trial/detail/experiment/data/LICENSE
@@ -1,0 +1,3 @@
+Batting.csv is licensed by [Chadwick Baseball Bureau](www.chadwick-bureau.com)
+under the Creative Commons Attribution-ShareAlike 3.0 Unported License.  For details see
+http://creativecommons.org/licenses/by-sa/3.0/

--- a/product_docs/docs/biganimal/release/free_trial/detail/experiment/import_data.mdx
+++ b/product_docs/docs/biganimal/release/free_trial/detail/experiment/import_data.mdx
@@ -5,7 +5,7 @@ navTitle: "Import data"
 
 PostgreSQL includes a variety of ways to import data. Here, we'll show how to import a CSV file from the internet.
 
-For this demonstration, we're going to import batter data from the [Baseball Databank](https://github.com/chadwickbureau/baseballdatabank), which is in CSV form. While it's easy to import the data using [PostgreSQL's COPY command](https://www.postgresql.org/docs/current/sql-copy.html), we'll need to first define a table to put that data into. 
+For this demonstration, we're going to import batter data from the [Baseball Databank](https://github.com/cbwinslow/baseballdatabank), which is in CSV form. While it's easy to import the data using [PostgreSQL's COPY command](https://www.postgresql.org/docs/current/sql-copy.html), we'll need to first define a table to put that data into. 
 
 We're going to add a database called "baseball," which we'll populate with some Major League Baseball statistics. 
 
@@ -53,7 +53,7 @@ CREATE TABLE batters (
 Now we can populate the table from the internet using the most recent data.
 
 ```sql
-\COPY batters(playerid,yearid,stint,teamid,lgid,g,ab,r,h,"2b","3b",hr,rbi,sb,cs,bb,so,ibb,hbp,sh,sf,gidp) FROM PROGRAM 'curl "https://raw.githubusercontent.com/chadwickbureau/baseballdatabank/master/core/Batting.csv"' DELIMITER ',' CSV HEADER
+\COPY batters(playerid,yearid,stint,teamid,lgid,g,ab,r,h,"2b","3b",hr,rbi,sb,cs,bb,so,ibb,hbp,sh,sf,gidp) FROM PROGRAM 'curl "https://raw.githubusercontent.com/EnterpriseDB/docs/main/product_docs/docs/biganimal/release/free_trial/detail/experiment/data/Batting.csv"' DELIMITER ',' CSV HEADER
 ```
 
 Just to prove there's data loaded, let's look at the home run leaders for the 1998 season.


### PR DESCRIPTION
## What Changed?

Apparently the Chadwick Baseball Bureau is no longer publishing this particular file. As it is licensed permissively, I've grabbed the data from a fork, stored locally for future stability, and referenced this repo in the examples.

Also link to a fork to avoid confusing folks unnecessarily.

Fixes #5014

Note for review: the URL listed in examples won't exist until this is in production. Adjust as needed.