### PR TITLE
 BDR-4362-The-docs-do-not-specify-the-OTEL-protocol-used 

### DIFF
--- a/product_docs/docs/pgd/5/monitoring/otel.mdx
+++ b/product_docs/docs/pgd/5/monitoring/otel.mdx
@@ -13,6 +13,11 @@ These are attached to all metrics and traces:
  - The `service.instance.id` is always set to the system identifier of the Postgres instance.
  - The `service.version` is set to the current version of the BDR extension loaded in the Postgresql instance.
 
+## OTEL and OLTP compatibility
+
+For OTEL connections the integration supports OLTP/HTTP version 1.0.0 only,
+over HTTP or HTTPS. It doesn't support OLTP/gRPC.
+
 ## Metrics collection
 
 Setting the configuration option


### PR DESCRIPTION
## What Changed?

Added OTEL/OLTP information (derived from source).