### PR TITLE
Docs/pgd/add/apibreakcompatibility

### DIFF
--- a/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
@@ -7,6 +7,19 @@ title: Supported BDR upgrade paths
 Beginning with version 4, EDB Postgres Distributed adopted [semantic versioning](https://semver.org/). All changes within the same major version are backward compatible, lowering the risk when upgrading and allowing you to choose any later minor or patch release as the upgrade target. You can upgrade from any version 4.x release to a later 4.x release.
 
 
+Due to interdependencies between EDB Postgres Distributed and EDB Postgres Advanced Server or EDB Postgres Extended, there are occasions when it is important to always upgrade both components at once. More detailed compatibility information can be found below.
+
+PGD version	| EPAS version | PGE version
+------------|--------------|-------------------
+Up to 4.3.0 | Up to 14.7/ 15.2 | Up to 14.9/ 15.4
+4.3.1,4.3.2	| 14.8,14.9/ 15.3, 15.4	| Up to 14.9/ 15.4
+4.3.3 and higher | 14.10 / 15.5 and higher | 14.10 / 15.5 and higher
+
+This dependency is bidirectional dependency. 
+
+* Upgrading your Postgres servers will require you to upgrade your PGD installation to the relevant version.
+* Upgrading your PGD installation will require you to upgrade your Postgres servers to the relevant version.
+
 ## Upgrading from version 3.7 to version 4
 
 Generally, we recommend that you upgrade to the latest version 3.7 release before

--- a/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/4/upgrades/upgrade_paths.mdx
@@ -9,10 +9,10 @@ Beginning with version 4, EDB Postgres Distributed adopted [semantic versioning]
 
 Due to interdependencies between EDB Postgres Distributed and EDB Postgres Advanced Server or EDB Postgres Extended, there are occasions when it is important to always upgrade both components at once. More detailed compatibility information can be found below.
 
-PGD version	| EPAS version | PGE version
-------------|--------------|-------------------
-Up to 4.3.0 | Up to 14.7/ 15.2 | Up to 14.9/ 15.4
-4.3.1,4.3.2	| 14.8,14.9/ 15.3, 15.4	| Up to 14.9/ 15.4
+ PGD version     | EPAS version            | PGE version 
+-----------------|-------------------------|------------------
+Up to 4.3.0      | Up to 14.7 / 15.2       | Up to 14.9 / 15.4
+4.3.1, 4.3.2     | 14.8, 14.9 / 15.3, 15.4 | Up to 14.9/ 15.4
 4.3.3 and higher | 14.10 / 15.5 and higher | 14.10 / 15.5 and higher
 
 This dependency is bidirectional dependency. 


### PR DESCRIPTION
## What Changed?

BDR4/PGD4 page for upgrading now covers versions where API compatibility is important