### PR TITLE
Update postgres-configuration.mdx to address invalid ordering

### DIFF
--- a/product_docs/docs/pgd/5/postgres-configuration.mdx
+++ b/product_docs/docs/pgd/5/postgres-configuration.mdx
@@ -15,8 +15,10 @@ For PGD's own settings, see the [PGD settings reference](reference/pgd-settings)
 To run correctly, PGD requires these Postgres settings:
 
 -   `wal_level` &mdash; Must be set to `logical`, since PGD relies on logical decoding.
--   `shared_preload_libraries` &mdash; Must start with `bdr`, before other
-    entries. Don't include `pglogical` in this list
+-   `shared_preload_libraries` &mdash; Must include `bdr` to enable the extension. Most other
+     extensions can appear before of after the bdr entry in the comma-separated list. One exception
+     to that is `pgaudit` which must appear in the list before `bdr`. Also, do not include 
+     `pglogical` in this list
 -   `track_commit_timestamp` &mdash; Must be set to `on` for conflict resolution to
     retrieve the timestamp for each conflicting row.
 


### PR DESCRIPTION
## What Changed?

Reworked the listing directions to specifically call out `pgaudit` as an exception to the rule that you can have any order of items in the list. 