### PR TITLE
Update pgd_4.3.3_rel_notes.mdx

### DIFF
--- a/product_docs/docs/pgd/4/rel_notes/pgd_4.3.3_rel_notes.mdx
+++ b/product_docs/docs/pgd/4/rel_notes/pgd_4.3.3_rel_notes.mdx
@@ -10,7 +10,7 @@ Released: 14 Nov 2023
 EDB Postgres Distributed version 4.3.3 is a patch release of EDB Postgres Distributed 4, which includes bug fixes for issues identified in previous versions.
 
 !!! Note
-This version is required for EDB Postgres Advanced Server versions 12.14.18, 13.10.14, 14.7.0 and later.
+This version is required for EDB Postgres Advanced Server versions 12.14.18, 13.10.14, 14.10.0 and later.
 !!!
 
 | Component | Version |  Type        |                                                   Description                                                           |


### PR DESCRIPTION
Updated 14.x minimum PG version from 14.7 to 14.10. Previous release notes had reached 14.8, so falling back to 14.7 I assume was a mistake.

## What Changed?

4.3.3 Relnotes