### PR TITLE
Fix bluefin example

### DIFF
--- a/advocacy_docs/pg_extensions/advanced_storage_pack/using.mdx
+++ b/advocacy_docs/pg_extensions/advanced_storage_pack/using.mdx
@@ -19,8 +19,7 @@ CREATE TABLE truck_logs (
     velocity FLOAT,
     characteristics JSON,
     data JSON
-) PARTITION BY RANGE (ts)
-  USING bluefin;
+) PARTITION BY RANGE (ts);
 ```
 
 Each partition contains one month of data:


### PR DESCRIPTION
Reported by @GabriFedi97 , the create table statement of the parent of the partitioning scheme does not accept the USING clause. This change removes that clause, fixing the example.

This does not impact the example negatively in any way, since the data was always meant to go to the partitions, not the parent. The reason the USING clause is not accepted is that partitioned tables (roots/parents specifically) is that by design they are created with no storage (pg_class.relam=0), like views, instead of heap or any other. It is only the leaves of the partitioning tree (i.e., ones created with `CREATE TABLE ... PARTITION OF`, without `PARTITION BY`) that have a storage method, so as long as the second table of the example has the USING clause, the example is valid.