### PR TITLE
Fix for bug introduced in #5105

### DIFF
--- a/src/components/search/formComps.js
+++ b/src/components/search/formComps.js
@@ -33,7 +33,7 @@ const TryAdvancedSearch = (props) => {
     searchingLatest || searchingVersion
       ? "Searching only documentation for " +
         (searchingLatest
-          ? "latest versions"
+          ? productFilter + " latest version" + (productFilter ? "" : "s")
           : productFilter + " " + searchingVersion.replace(":", " "))
       : "";
 

--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -235,7 +235,8 @@ const SearchBar = ({ searchProduct, searchVersion }) => {
       : Object.entries(products)
           .filter(([id, { noSearch }]) => noSearch)
           .map(([id]) => `product:-${id}`);
-    if (searchVersion) facets.push("version:" + searchVersion);
+    if (searchVersion && searchProduct === currentProduct)
+      facets.push("version:" + searchVersion);
     else facets.push("isLatest:true");
 
     return {
@@ -243,7 +244,7 @@ const SearchBar = ({ searchProduct, searchVersion }) => {
       advancedSyntax: true,
       facetFilters: facets,
     };
-  }, [currentProduct, searchVersion]);
+  }, [currentProduct, searchProduct, searchVersion]);
 
   // use SSR provider just to trigger static rendering of search form. Speeds this up a LOT
   return (


### PR DESCRIPTION
## What Changed?

When selecting alternate product (or all products) while searching from a product page, disregard current product version and return to "latest version" default filter.

