### PR TITLE
Release: 2023-12-22

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/addons.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/addons.mdx
@@ -10,10 +10,9 @@ per-cluster basis. These add-ons are:
 2.  [Kasten](#kasten)
 3.  [Velero](#velero)
 
-!!! Note
-If you are planning to use Velero in OpenShift, please refer to the
-[OADP section](openshift.md#oadp-for-velero) in the Openshift documentation.
-!!!
+!!! Info
+    If you are planning to use Velero in OpenShift, please refer to the
+    [OADP section](openshift.md#oadp-for-velero) in the Openshift documentation.
 
 All add-ons will automatically be available to the operator and to be used will
 need to be enabled at the cluster level via the `k8s.enterprisedb.io/addons`
@@ -405,7 +404,7 @@ Kasten is a very popular data protection tool for Kubernetes, enabling backup
 and restore, disaster recovery, and application mobility for Kubernetes
 applications. For more information, see the [Kasten
 website](https://www.kasten.io/) and the [Kasten by Veeam Implementation
-Guide](/partner_docs/KastenbyVeeam/)
+Guide](https://www.enterprisedb.com/docs/partner_docs/KastenbyVeeam/)
 
 In brief, to enable transparent integration with Kasten on an EDB Postgres for
 Kubernetes Cluster, you just need to add the `kasten` value to the
@@ -431,16 +430,13 @@ ahead replica instance to be the designated backup and will add Kasten-specific
 backup hooks through annotations and labels to that instance.
 
 !!! Important
-The operator will refuse to shut down a primary instance to take a cold
-backup unless the Cluster is annotated with
-```yaml
-k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled
-```
-!!!
+    The operator will refuse to shut down a primary instance to take a cold
+    backup unless the Cluster is annotated with
+    `k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled`
 
 For further guidance on how to configure and use Kasten, see the Implementation Guide's
-[Configuration](/partner_docs/KastenbyVeeam/04-ConfiguringVeeamKasten/) and
-[Using](/partner_docs/KastenbyVeeam/05-UsingVeeamKasten/) sections.
+[Configuration](https://www.enterprisedb.com/docs/partner_docs/KastenbyVeeam/04-ConfiguringVeeamKasten/) and
+[Using](https://www.enterprisedb.com/docs/partner_docs/KastenbyVeeam/05-UsingVeeamKasten/) sections.
 
 ### Limitations
 
@@ -498,12 +494,9 @@ These [annotations](https://velero.io/docs/latest/backup-hooks/) are used by
 Velero to run the commands to prepare the Postgres instance to be backed up.
 
 !!! Important
-The operator will refuse to shut down a primary instance to take a cold
-backup unless the Cluster is annotated with
-```yaml
-k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled`.
-```
-!!!
+    The operator will refuse to shut down a primary instance to take a cold
+    backup unless the Cluster is annotated with
+    `k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled`
 
 ### Limitations
 
@@ -522,7 +515,7 @@ terms of read-write operations. This use case is normally left to development
 environments.
 
 In terms of recovery, the integration with Velero supports snapshot recovery
-only. No Point-in-Time Recovery (PITR) is available at the moment with the
+only, for now. No Point-in-Time Recovery (PITR) is available at the moment with the
 Velero add-on, and RPO is determined by the frequency of the snapshots in your
 Velero environment. If your organization relies on Velero, this usually is
 acceptable, but if you need PITR we recommend you look at the native continuous

--- a/product_docs/docs/postgres_for_kubernetes/1/backup.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/backup.mdx
@@ -143,12 +143,12 @@ available methods for storing physical base backups.
 |                                   | Object store |   Volume Snapshots   |
 | --------------------------------- | :----------: | :------------------: |
 | **WAL archiving**                 |   Required   |    Recommended (1)   |
-| **Cold backup**                   |      𐄂      |           ✓          |
+| **Cold backup**                   |       ✗      |           ✓          |
 | **Hot backup**                    |       ✓      |           ✓          |
-| **Incremental copy**              |      𐄂      |        ✓  (2)        |
-| **Differential copy**             |      𐄂      |        ✓  (2)        |
+| **Incremental copy**              |       ✗      |        ✓  (2)        |
+| **Differential copy**             |       ✗      |        ✓  (2)        |
 | **Backup from a standby**         |       ✓      |           ✓          |
-| **Snapshot recovery**             |    𐄂 (3)    |           ✓          |
+| **Snapshot recovery**             |     ✗ (3)    |           ✓          |
 | **Point In Time Recovery (PITR)** |       ✓      | Requires WAL archive |
 | **Underlying technology**         | Barman Cloud |    Kubernetes API    |
 
@@ -165,7 +165,7 @@ Scheduled backups are the recommended way to configure your backup strategy in
 EDB Postgres for Kubernetes. They are managed by the `ScheduledBackup` resource.
 
 !!! Info
-    Please refer to [`ScheduledBackupSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-ScheduledBackupSpec)
+    Please refer to [`ScheduledBackupSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-ScheduledBackupSpec)
     in the API reference for a full list of options.
 
 The `schedule` field allows you to define a *six-term cron schedule* specification,
@@ -235,7 +235,7 @@ you can set `.spec.immediate: true`.
 ## On-demand backups
 
 !!! Info
-    Please refer to [`BackupSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BackupSpec)
+    Please refer to [`BackupSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-BackupSpec)
     in the API reference for a full list of options.
 
 To request a new backup, you need to create a new `Backup` resource

--- a/product_docs/docs/postgres_for_kubernetes/1/backup.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/backup.mdx
@@ -165,7 +165,7 @@ Scheduled backups are the recommended way to configure your backup strategy in
 EDB Postgres for Kubernetes. They are managed by the `ScheduledBackup` resource.
 
 !!! Info
-    Please refer to [`ScheduledBackupSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-ScheduledBackupSpec)
+    Please refer to [`ScheduledBackupSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-ScheduledBackupSpec)
     in the API reference for a full list of options.
 
 The `schedule` field allows you to define a *six-term cron schedule* specification,
@@ -235,7 +235,7 @@ you can set `.spec.immediate: true`.
 ## On-demand backups
 
 !!! Info
-    Please refer to [`BackupSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-BackupSpec)
+    Please refer to [`BackupSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BackupSpec)
     in the API reference for a full list of options.
 
 To request a new backup, you need to create a new `Backup` resource

--- a/product_docs/docs/postgres_for_kubernetes/1/backup_barmanobjectstore.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/backup_barmanobjectstore.mdx
@@ -30,9 +30,9 @@ as it is composed of a community PostgreSQL image and the latest
 
 A backup is performed from a primary or a designated primary instance in a
 `Cluster` (please refer to
-[replica clusters](replica_cluster.mdx)
+[replica clusters](replica_cluster.md)
 for more information about designated primary instances), or alternatively
-on a [standby](backup.md#backup-from-a-standby).
+on a [standby](#backup-from-a-standby).
 
 ## Common object stores
 
@@ -99,8 +99,8 @@ algorithms via `barman-cloud-backup` (for backups) and
 -   snappy
 
 The compression settings for backups and WALs are independent. See the
-[DataBackupConfiguration](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-DataBackupConfiguration) and
-[WALBackupConfiguration](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-WalBackupConfiguration) sections in
+[DataBackupConfiguration](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-DataBackupConfiguration) and
+[WALBackupConfiguration](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-WalBackupConfiguration) sections in
 the API reference.
 
 It is important to note that archival time, restore time, and size change

--- a/product_docs/docs/postgres_for_kubernetes/1/backup_barmanobjectstore.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/backup_barmanobjectstore.mdx
@@ -32,7 +32,7 @@ A backup is performed from a primary or a designated primary instance in a
 `Cluster` (please refer to
 [replica clusters](replica_cluster.md)
 for more information about designated primary instances), or alternatively
-on a [standby](#backup-from-a-standby).
+on a [standby](backup.md#backup-from-a-standby).
 
 ## Common object stores
 
@@ -99,8 +99,8 @@ algorithms via `barman-cloud-backup` (for backups) and
 -   snappy
 
 The compression settings for backups and WALs are independent. See the
-[DataBackupConfiguration](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-DataBackupConfiguration) and
-[WALBackupConfiguration](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-WalBackupConfiguration) sections in
+[DataBackupConfiguration](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-DataBackupConfiguration) and
+[WALBackupConfiguration](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-WalBackupConfiguration) sections in
 the API reference.
 
 It is important to note that archival time, restore time, and size change

--- a/product_docs/docs/postgres_for_kubernetes/1/backup_volumesnapshot.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/backup_volumesnapshot.mdx
@@ -73,7 +73,7 @@ EDB Postgres for Kubernetes allows you to configure a given Postgres cluster for
 Snapshot backups through the `backup.volumeSnapshot` stanza.
 
 !!! Info
-    Please refer to [`VolumeSnapshotConfiguration`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-VolumeSnapshotConfiguration)
+    Please refer to [`VolumeSnapshotConfiguration`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-VolumeSnapshotConfiguration)
     in the API reference for a full list of options.
 
 A generic example with volume snapshots (assuming that PGDATA and WALs share

--- a/product_docs/docs/postgres_for_kubernetes/1/backup_volumesnapshot.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/backup_volumesnapshot.mdx
@@ -73,7 +73,7 @@ EDB Postgres for Kubernetes allows you to configure a given Postgres cluster for
 Snapshot backups through the `backup.volumeSnapshot` stanza.
 
 !!! Info
-    Please refer to [`VolumeSnapshotConfiguration`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-VolumeSnapshotConfiguration)
+    Please refer to [`VolumeSnapshotConfiguration`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-VolumeSnapshotConfiguration)
     in the API reference for a full list of options.
 
 A generic example with volume snapshots (assuming that PGDATA and WALs share

--- a/product_docs/docs/postgres_for_kubernetes/1/before_you_start.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/before_you_start.mdx
@@ -75,8 +75,8 @@ specific to Kubernetes and PostgreSQL.
 [`kubectl`](https://kubernetes.io/docs/reference/kubectl/overview/)
 : `kubectl` is the command-line tool used to manage a Kubernetes cluster.
 
-EDB Postgres for Kubernetes requires a Kubernetes version supported by EDB. Please refer to the
-["Platform Compatibility"](https://www.enterprisedb.com/resources/platform-compatibility#pgk8s) page for details.
+EDB Postgres for Kubernetes requires a Kubernetes version supported by the community. Please refer to the
+["Supported releases"](/resources/platform-compatibility#pgk8s) page for details.
 
 ## PostgreSQL terminology
 

--- a/product_docs/docs/postgres_for_kubernetes/1/bootstrap.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/bootstrap.mdx
@@ -67,7 +67,7 @@ storage that the EDB Postgres for Kubernetes operator provides, please refer to 
 ["Recovery" section](recovery.md) for guidance on each method.
 
 !!! Seealso "API reference"
-    Please refer to the ["API reference for the `bootstrap` section](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapConfiguration)
+    Please refer to the ["API reference for the `bootstrap` section](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapConfiguration)
     for more information.
 
 ## The `externalClusters` section
@@ -120,7 +120,7 @@ continuously fed from the source, either via streaming, via WAL shipping
 through the PostgreSQL's `restore_command`, or any of the two.
 
 !!! Seealso "API reference"
-    Please refer to the ["API reference for the `externalClusters` section](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-ExternalCluster)
+    Please refer to the ["API reference for the `externalClusters` section](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-ExternalCluster)
     for more information.
 
 ### Password files

--- a/product_docs/docs/postgres_for_kubernetes/1/bootstrap.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/bootstrap.mdx
@@ -67,17 +67,29 @@ storage that the EDB Postgres for Kubernetes operator provides, please refer to 
 ["Recovery" section](recovery.md) for guidance on each method.
 
 !!! Seealso "API reference"
-    Please refer to the ["API reference for the `bootstrap` section](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapConfiguration)
+    Please refer to the ["API reference for the `bootstrap` section](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapConfiguration)
     for more information.
 
 ## The `externalClusters` section
 
-The `externalClusters` section allows you to define one or more PostgreSQL
-clusters that are somehow related to the current one. While in the future
-this section will enable more complex scenarios, it is currently intended
-to define a cross-region PostgreSQL cluster based on physical replication,
-and spanning over different Kubernetes clusters or even traditional VM/bare-metal
-environments.
+The `externalClusters` section provides a mechanism for specifying one or more
+PostgreSQL clusters associated with the current configuration. Its primary use
+cases include:
+
+1.  **Importing Databases:** Specify an external source to be utilized during
+    the [importation of databases](database_import.md) via logical backup and
+    restore, as part of the `initdb` bootstrap method.
+2.  **Cross-Region Replication:** Define a cross-region PostgreSQL cluster
+    employing physical replication, capable of extending across distinct Kubernetes
+    clusters or traditional VM/bare-metal environments.
+3.  **Recovery from Physical Base Backup:** Recover, fully or at a
+    given Point-In-Time, a PostgreSQL cluster by referencing a physical base
+    backup.
+
+!!! Info
+    Ongoing development will extend the functionality of `externalClusters` to
+    accommodate additional use cases, such as logical replication and foreign
+    servers in future releases.
 
 As far as bootstrapping is concerned, `externalClusters` can be used
 to define the source PostgreSQL cluster for either the `pg_basebackup`
@@ -108,8 +120,19 @@ continuously fed from the source, either via streaming, via WAL shipping
 through the PostgreSQL's `restore_command`, or any of the two.
 
 !!! Seealso "API reference"
-    Please refer to the ["API reference for the `externalClusters` section](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-ExternalCluster)
+    Please refer to the ["API reference for the `externalClusters` section](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-ExternalCluster)
     for more information.
+
+### Password files
+
+Whenever a password is supplied within an `externalClusters` entry,
+EDB Postgres for Kubernetes autonomously manages a [PostgreSQL password file](https://www.postgresql.org/docs/current/libpq-pgpass.html)
+for it, residing at `/controller/external/NAME/pgpass` in each instance.
+
+This approach empowers EDB Postgres for Kubernetes to securely establish connections with an
+external server without exposing any passwords in the connection string.
+Instead, the connection safely references the aforementioned file through the
+`passfile` connection parameter.
 
 ## Bootstrap an empty cluster (`initdb`)
 
@@ -437,7 +460,7 @@ The following requirements apply to the `pg_basebackup` bootstrap method:
 
 -   target and source must have the same hardware architecture
 -   target and source must have the same major PostgreSQL version
--   source must not have any tablespace defined (see ["Current limitations"](#current-limitations) below)
+-   target and source must have the same tablespaces
 -   source must be configured with enough `max_wal_senders` to grant
     access from the target for this one-off operation by providing at least
     one *walsender* for the backup plus one for WAL streaming
@@ -507,7 +530,7 @@ file on the source PostgreSQL instance:
 host replication streaming_replica all md5
 ```
 
-The following manifest creates a new PostgreSQL 16.0 cluster,
+The following manifest creates a new PostgreSQL 16.1 cluster,
 called `target-db`, using the `pg_basebackup` bootstrap method
 to clone an external PostgreSQL cluster defined as `source-db`
 (in the `externalClusters` array). As you can see, the `source-db`
@@ -522,7 +545,7 @@ metadata:
   name: target-db
 spec:
   instances: 3
-  imageName: quay.io/enterprisedb/postgresql:16.0
+  imageName: quay.io/enterprisedb/postgresql:16.1
 
   bootstrap:
     pg_basebackup:
@@ -542,7 +565,7 @@ spec:
 ```
 
 All the requirements must be met for the clone operation to work, including
-the same PostgreSQL version (in our case 16.0).
+the same PostgreSQL version (in our case 16.1).
 
 #### TLS certificate authentication
 
@@ -557,7 +580,7 @@ in the same Kubernetes cluster.
     This example can be easily adapted to cover an instance that resides
     outside the Kubernetes cluster.
 
-The manifest defines a new PostgreSQL 16.0 cluster called `cluster-clone-tls`,
+The manifest defines a new PostgreSQL 16.1 cluster called `cluster-clone-tls`,
 which is bootstrapped using the `pg_basebackup` method from the `cluster-example`
 external cluster. The host is identified by the read/write service
 in the same cluster, while the `streaming_replica` user is authenticated
@@ -572,7 +595,7 @@ metadata:
   name: cluster-clone-tls
 spec:
   instances: 3
-  imageName: quay.io/enterprisedb/postgresql:16.0
+  imageName: quay.io/enterprisedb/postgresql:16.1
 
   bootstrap:
     pg_basebackup:
@@ -637,21 +660,6 @@ With the above configuration, the following will happen after recovery is comple
     recovered from the original cluster.
 
 #### Current limitations
-
-##### Missing tablespace support
-
-EDB Postgres for Kubernetes does not currently include full declarative management
-of PostgreSQL global objects, namely roles, databases, and tablespaces.
-While roles and databases are copied from the source instance to the target
-cluster, tablespaces require a capability that this version of
-EDB Postgres for Kubernetes is missing: definition and management of additional
-persistent volumes. When dealing with base backup and tablespaces, PostgreSQL
-itself requires that the exact mount points in the source instance
-must also exist in the target instance, in our case, the pods in Kubernetes
-that EDB Postgres for Kubernetes manages. For this reason, you cannot directly
-migrate in EDB Postgres for Kubernetes a PostgreSQL instance that takes advantage
-of tablespaces (you first need to remove them from the source or, if your
-organization requires this feature, contact EDB to prioritize it).
 
 ##### Snapshot copy
 

--- a/product_docs/docs/postgres_for_kubernetes/1/cluster_conf.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/cluster_conf.mdx
@@ -53,14 +53,14 @@ duration of a pod's life, without persisting across pod restarts.
 ### Volume for temporary storage
 
 An ephemeral volume used for temporary storage. You can configure an upper
-bound on the size using the `spec.ephemeralVolumesSizeLimit.temporaryData`
+bound on the size using the `.spec.ephemeralVolumesSizeLimit.temporaryData`
 field in the cluster spec.
 
 ### Volume for shared memory
 
 This volume is used as shared memory space for Postgres and as an ephemeral
 type but stored in memory. You can configure an upper bound on the size using
-the `spec.ephemeralVolumesSizeLimit.shm` field in the cluster spec.
+the `.spec.ephemeralVolumesSizeLimit.shm` field in the cluster spec.
 Use this field only in case of
 [PostgreSQL running with `posix` shared memory dynamic allocation](postgresql_conf.md#dynamic-shared-memory-settings).
 

--- a/product_docs/docs/postgres_for_kubernetes/1/connection_pooling.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/connection_pooling.mdx
@@ -71,7 +71,7 @@ EDB Postgres for Kubernetes also creates a secret with the same name as the pool
 the configuration files used with PgBouncer.
 
 !!! Seealso "API reference"
-    For details, see [`PgBouncerSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-PgBouncerSpec)
+    For details, see [`PgBouncerSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-PgBouncerSpec)
     in the API reference.
 
 ## Pooler resource lifecycle
@@ -178,7 +178,7 @@ GRANT EXECUTE ON FUNCTION user_search(text)
 
 You can take advantage of pod templates specification in the `template`
 section of a `Pooler` resource. For details, see 
-[`PoolerSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-PoolerSpec) in the API reference.
+[`PoolerSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-PoolerSpec) in the API reference.
 
 Using templates, you can configure pods as you like, including fine control
 over affinity and anti-affinity rules for pods and nodes. By default,

--- a/product_docs/docs/postgres_for_kubernetes/1/connection_pooling.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/connection_pooling.mdx
@@ -71,7 +71,7 @@ EDB Postgres for Kubernetes also creates a secret with the same name as the pool
 the configuration files used with PgBouncer.
 
 !!! Seealso "API reference"
-    For details, see [`PgBouncerSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-PgBouncerSpec)
+    For details, see [`PgBouncerSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-PgBouncerSpec)
     in the API reference.
 
 ## Pooler resource lifecycle
@@ -178,7 +178,7 @@ GRANT EXECUTE ON FUNCTION user_search(text)
 
 You can take advantage of pod templates specification in the `template`
 section of a `Pooler` resource. For details, see 
-[`PoolerSpec`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-PoolerSpec) in the API reference.
+[`PoolerSpec`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-PoolerSpec) in the API reference.
 
 Using templates, you can configure pods as you like, including fine control
 over affinity and anti-affinity rules for pods and nodes. By default,

--- a/product_docs/docs/postgres_for_kubernetes/1/declarative_hibernation.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/declarative_hibernation.mdx
@@ -61,7 +61,7 @@ $ kubectl cnp status <cluster-name>
 Cluster Summary
 Name:              cluster-example
 Namespace:         default
-PostgreSQL Image:  quay.io/enterprisedb/postgresql:16.0
+PostgreSQL Image:  quay.io/enterprisedb/postgresql:16.1
 Primary instance:  cluster-example-2
 Status:            Cluster in healthy state 
 Instances:         3

--- a/product_docs/docs/postgres_for_kubernetes/1/declarative_role_management.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/declarative_role_management.mdx
@@ -42,7 +42,7 @@ spec:
 
 The role specification in `.spec.managed.roles` adheres to the
 [PostgreSQL structure and naming conventions](https://www.postgresql.org/docs/current/sql-createrole.html).
-Please refer to the [API reference](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-RoleConfiguration) for
+Please refer to the [API reference](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-RoleConfiguration) for
 the full list of attributes you can define for each role.
 
 A few points are worth noting:

--- a/product_docs/docs/postgres_for_kubernetes/1/declarative_role_management.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/declarative_role_management.mdx
@@ -40,9 +40,9 @@ spec:
         - pg_signal_backend
 ```
 
-The role specification in `spec.managed.roles` adheres to the
+The role specification in `.spec.managed.roles` adheres to the
 [PostgreSQL structure and naming conventions](https://www.postgresql.org/docs/current/sql-createrole.html).
-Please refer to the [API reference](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-RoleConfiguration) for
+Please refer to the [API reference](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-RoleConfiguration) for
 the full list of attributes you can define for each role.
 
 A few points are worth noting:
@@ -206,7 +206,8 @@ them in the cluster Status. Which segues into…
 
 ## Status of managed roles
 
-The CRD status includes a section for the managed roles' status, as shown below:
+The Cluster status includes a section for the managed roles' status, as shown
+below:
 
 ```yaml
 status:
@@ -236,6 +237,23 @@ EDB Postgres for Kubernetes) cannot honor, and which require human intervention.
 This section covers roles reserved for operator use and those that are **not**
 under declarative management, providing a comprehensive view of the roles in
 the database instances.
+
+The [kubectl plugin](kubectl-plugin.md) also shows the status of managed roles
+in its `status` sub-command:
+
+```txt
+Managed roles status
+Status                  Roles
+------                  -----
+pending-reconciliation  petrarca
+reconciled              app,dante
+reserved                postgres,streaming_replica
+
+Irreconcilable roles
+Role      Errors
+----      ------
+petrarca  could not perform UPDATE_MEMBERSHIPS on role petrarca: role "poets" does not exist
+```
 
 !!! Important
     In terms of backward compatibility, declarative role management is designed

--- a/product_docs/docs/postgres_for_kubernetes/1/failover.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/failover.mdx
@@ -4,7 +4,7 @@ originalFilePath: 'src/failover.md'
 ---
 
 In the case of unexpected errors on the primary for longer than the
-`spec.failoverDelay` (by default `0` seconds), the cluster will go into
+`.spec.failoverDelay` (by default `0` seconds), the cluster will go into
 **failover mode**. This may happen, for example, when:
 
 -   The primary pod has a disk failure
@@ -80,7 +80,7 @@ Failover may result in the service being impacted and/or data being lost:
 
 ## Delayed failover
 
-As anticipated above, the `spec.failoverDelay` option allows you to delay the start
+As anticipated above, the `.spec.failoverDelay` option allows you to delay the start
 of the failover procedure by a number of seconds after the primary has been
 detected to be unhealthy. By default, this setting is set to `0`, triggering the
 failover procedure immediately.

--- a/product_docs/docs/postgres_for_kubernetes/1/faq.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/faq.mdx
@@ -310,9 +310,8 @@ Postgres instance, with dedicated storage.
 We proved that this extreme architectural pattern works when we benchmarked
 [running PostgreSQL on bare metal Kubernetes with local persistent
 volumes](https://www.2ndquadrant.com/en/blog/local-persistent-volumes-and-postgresql-usage-in-kubernetes/).
-A current limitation of EDB Postgres for Kubernetes, which will be overcome in version 1.22,
-is the lack of support for tablespaces. Once tablespaces are available, horizontal partitioning can be
-easily implemented.
+Tablespaces and horizontal partitioning are data modeling techniques that you
+can use to improve the vertical scalability of you databases.
 
 **How can I specify a time zone in the PostgreSQL cluster?**
 
@@ -325,7 +324,7 @@ documentation:
 Although time zones can even be used at session, transaction and even as part
 of a query in PostgreSQL, a very common way is to set them up globally. With
 EDB Postgres for Kubernetes you can configure the cluster level time zone in the
-`spec.postgresql.parameters` section as in the following example:
+`.spec.postgresql.parameters` section as in the following example:
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1

--- a/product_docs/docs/postgres_for_kubernetes/1/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/index.mdx
@@ -109,7 +109,7 @@ primary/standby architecture, using native streaming replication.
 -   [Oracle compatibility](https://www.enterprisedb.com/docs/epas/latest/fundamentals/epas_fundamentals/epas_compat_ora_dev_guide/) through EDB Postgres Advanced Sever
 -   [Transparent Data Encryption (TDE)](https://www.enterprisedb.com/docs/tde/latest/) through EDB Postgres Advanced Server
 -   EDB Postgres for Kubernetes Plugin
--   Velero/OADP cold backup support
+-   Cold backup support with Kasten and Velero/OADP
 -   Generic adapter for third-party Kubernetes backup tools
 
 You can [evaluate EDB Postgres for Kubernetes for free](evaluation.md).
@@ -170,8 +170,8 @@ format for the following platforms: `linux/amd64`, `linux/arm64`, `linux/ppc64le
 
 The following versions of Postgres are currently supported:
 
--   PostgreSQL 16, 15, 14, 13, and 12
--   EDB Postgres Advanced 15, 14, 13, and 12
+-   PostgreSQL 15, 14, 13, 12, and 11
+-   EDB Postgres Advanced 15, 14, 13, 12, and 11
 
 All of the above versions are available on the following platforms: `linux/amd64`, `linux/arm64`, `linux/ppc64le`, `linux/s390x`.
 EDB supports operand images for `linux/ppc64le` and `linux/s390x` architectures

--- a/product_docs/docs/postgres_for_kubernetes/1/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/index.mdx
@@ -170,8 +170,8 @@ format for the following platforms: `linux/amd64`, `linux/arm64`, `linux/ppc64le
 
 The following versions of Postgres are currently supported:
 
--   PostgreSQL 15, 14, 13, 12, and 11
--   EDB Postgres Advanced 15, 14, 13, 12, and 11
+-   PostgreSQL 16, 15, 14, 13, and 12
+-   EDB Postgres Advanced 16, 15, 14, 13, and 12
 
 All of the above versions are available on the following platforms: `linux/amd64`, `linux/arm64`, `linux/ppc64le`, `linux/s390x`.
 EDB supports operand images for `linux/ppc64le` and `linux/s390x` architectures

--- a/product_docs/docs/postgres_for_kubernetes/1/installation_upgrade.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/installation_upgrade.mdx
@@ -19,12 +19,12 @@ The operator can be installed using the provided [Helm chart](https://github.com
 The operator can be installed like any other resource in Kubernetes,
 through a YAML manifest applied via `kubectl`.
 
-You can install the [latest operator manifest](https://get.enterprisedb.io/cnp/postgresql-operator-1.21.1.yaml)
+You can install the [latest operator manifest](https://get.enterprisedb.io/cnp/postgresql-operator-1.22.0.yaml)
 for this minor release as follows:
 
 ```sh
 kubectl apply -f \
-  https://get.enterprisedb.io/cnp/postgresql-operator-1.21.1.yaml
+  https://get.enterprisedb.io/cnp/postgresql-operator-1.22.0.yaml
 ```
 
 You can verify that with:
@@ -75,7 +75,7 @@ For example, you can install the latest snapshot of the operator with:
 
 ```sh
 curl -sSfL \
-  https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-1.21/manifests/operator-manifest.yaml | \
+  https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-1.22/manifests/operator-manifest.yaml | \
   kubectl apply -f -
 ```
 
@@ -84,7 +84,7 @@ specific minor release, you can just run:
 
 ```sh
 curl -sSfL \
-  https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-1.21/manifests/operator-manifest.yaml | \
+  https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-1.22/manifests/operator-manifest.yaml | \
   kubectl apply -f -
 ```
 
@@ -254,19 +254,55 @@ When versions are not directly upgradable, the old version needs to be
 removed before installing the new one. This won't affect user data but
 only the operator itself.
 
-### Upgrading to 1.21.0, 1.20.3 or 1.19.5
+### Upgrading to 1.22.0, 1.21.2 or 1.20.5
 
 !!! Important
     We encourage all existing users of EDB Postgres for Kubernetes to upgrade to version
-    1.21.0 or at least to the latest stable version of the minor release you are
-    currently using (namely 1.20.3 or 1.19.5).
+    1.22.0 or at least to the latest stable version of the minor release you are
+    currently using (namely 1.21.2 or 1.20.5).
 
 !!! Warning
     Every time you are upgrading to a higher minor release, make sure you
     go through the release notes and upgrade instructions of all the
     intermediate minor releases. For example, if you want to move
-    from 1.19.x to 1.21, make sure you go through the release notes
-    and upgrade instructions for 1.20 and 1.21.
+    from 1.20.x to 1.22, make sure you go through the release notes
+    and upgrade instructions for 1.21 and 1.22.
+
+EDB Postgres for Kubernetes continues to adhere to the security-by-default approach. As of
+version 1.22, the usage of the `ALTER SYSTEM` command is now disabled by
+default.
+
+The reason behind this choice is to ensure that, by default, changes to the
+PostgreSQL configuration in a database cluster controlled by EDB Postgres for Kubernetes are
+allowed only through the Kubernetes API.
+
+At the same time, we are providing an option to enable `ALTER SYSTEM` if you
+need to use it, even temporarily, from versions 1.22.0, 1.21.2, and 1.20.5,
+by setting `.spec.postgresql.enableAlterSystem` to `true`, as in the following
+excerpt:
+
+```yaml
+...
+  postgresql:
+    enableAlterSystem: true
+...
+```
+
+Clusters in 1.22 will have `enableAlterSystem` set to `false` by default.
+If you want to retain the existing behavior, in 1.22, you need to explicitly
+set `enableAlterSystem` to `true` as shown above.
+
+In versions 1.21.2 and 1.20.5, and later patch releases in the 1.20 and 1.21
+branches, `enableAlterSystem` will be set to `true` by default, keeping with
+the existing behavior. If you don't need to use `ALTER SYSTEM`, we recommend
+that you set `enableAlterSystem` explicitly to `false`.
+
+!!! Important
+    You can set the desired value for  `enableAlterSystem` immediately
+    following your upgrade to version 1.22.0, 1.21.2, or 1.20.5, as shown in
+    the example above.
+
+### Upgrading to 1.21 from a previous minor version
 
 With the goal to keep improving out-of-the-box the *convention over
 configuration* behavior of the operator, EDB Postgres for Kubernetes changes the default
@@ -277,9 +313,6 @@ value of several knobs in the following areas:
 -   security
 -   labels
 
-Some of the above changes have been backported to 1.20.3 and 1.19.5, as
-detailed below. Most of the changes will affect new PostgreSQL clusters only.
-
 !!! Warning
     Please read carefully the list of changes below, and how to modify the
     `Cluster` manifests to retain the existing behavior if you don't want to
@@ -288,9 +321,6 @@ detailed below. Most of the changes will affect new PostgreSQL clusters only.
     values unless you have valid reasons not to.
 
 #### Superuser access disabled
-
-!!! Important
-    This change takes effect starting from EDB Postgres for Kubernetes 1.21.0.
 
 Pushing towards *security-by-default*, EDB Postgres for Kubernetes now disables access
 `postgres` superuser access via the network in all new clusters, unless
@@ -308,11 +338,7 @@ spec:
 
 #### Replication slots for HA
 
-!!! Important
-    This change takes effect starting from EDB Postgres for Kubernetes 1.21.0.
-
-[As already anticipated in release 1.20](installation_upgrade.md#replication-slots-for-high-availability),
-replication slots for High Availability are now enabled by default.
+Replication slots for High Availability are enabled by default.
 
 If you want to ensure replication slots are disabled, regardless of which
 version of EDB Postgres for Kubernetes you are running, we advise you to explicitly declare
@@ -328,12 +354,7 @@ spec:
 
 #### Delay for PostgreSQL shutdown
 
-!!! Important
-    This change has been backported to all supported minor releases. As a
-    result, it will be available starting from versions 1.21.0, 1.20.3 and
-    1.19.5.
-
-Up to now, [the `stopDelay` parameter](instance_manager.md#shutdown-control)
+Up to 1.20.2, [the `stopDelay` parameter](instance_manager.md#shutdown-control)
 was set to 30 seconds. Despite the recommendations to change and tune this
 value, almost all the cases we have examined during support incidents or
 community issues show that this value is left unchanged.
@@ -370,17 +391,12 @@ spec:
 
 #### Delay for PostgreSQL startup
 
-!!! Important
-    This change has been backported to all supported minor releases. As a
-    result, it will be available starting from versions 1.21.0, 1.20.3 and
-    1.19.5.
-
-Until now, [the `startDelay` parameter](instance_manager.md#startup-liveness-and-readiness-probes)
+Up to 1.20.2, [the `startDelay` parameter](instance_manager.md#startup-liveness-and-readiness-probes)
 was set to 30 seconds, and EDB Postgres for Kubernetes used this parameter as
 `initialDelaySeconds` for the Kubernetes liveness probe. Given that all the
 supported Kubernetes releases provide [startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes),
-version 1.21 has adopted this approach as well (`startDelay` is now
-automatically divided into periods of 10 seconds of duration  each).
+`startDelay` is now automatically divided into periods of 10 seconds of
+duration  each.
 
 !!! Important
     In order to add the `startupProbe`, each pod needs to be restarted.
@@ -407,12 +423,7 @@ spec:
 
 #### Delay for PostgreSQL switchover
 
-!!! Important
-    This change has been backported to all supported minor releases. As a
-    result, it will be available starting from versions 1.21.0, 1.20.3 and
-    1.19.5.
-
-Up to now, [the `switchoverDelay` parameter](instance_manager.md#shutdown-of-the-primary-during-a-switchover)
+Up to 1.20.2, [the `switchoverDelay` parameter](instance_manager.md#shutdown-of-the-primary-during-a-switchover)
 was set by default to 40000000 seconds (over 15 months) to simulate a very long
 interval.
 
@@ -429,11 +440,6 @@ spec:
 
 #### Labels
 
-!!! Important
-    This change has been backported to all supported minor releases. As a
-    result, it will be available starting from versions 1.21.0, 1.20.3 and
-    1.19.5.
-
 In version 1.18, we deprecated the `postgresql` label in pods to identify the
 name of the cluster, and replaced it with the more canonical `k8s.enterprisedb.io/cluster`
 label. The `postgresql` label is no longer maintained.
@@ -444,9 +450,9 @@ in a future release.
 
 #### Shortcut for keeping the existing behavior
 
-If you want to explicitly keep the existing behavior of EDB Postgres for Kubernetes
-(we advise not to), you need to set these values in all your `Cluster`
-definitions **before upgrading** to version 1.21.0, 1.20.3 or 1.19.5:
+If you want to explicitly keep the behavior of EDB Postgres for Kubernetes up to version
+1.20.2 (we advise not to), you need to set these values in all your `Cluster`
+definitions **before upgrading** to a higher version:
 
 ```yaml
 spec:
@@ -530,9 +536,9 @@ spec:
 [Replication slots for High Availability](replication.md#replication-slots-for-high-availability)
 were introduced in EDB Postgres for Kubernetes in version 1.18, but disabled by default.
 
-In version 1.20 we are preparing to enable this feature by default from version
-1.21, as replication slots enhance the resilience and robustness of a High
-Availability cluster.
+Version 1.20 prepares the ground for enabling this feature by default in any
+future release, as replication slots enhance the resilience and robustness of a
+High Availability cluster.
 
 For future compatibility, if you already know that your environments won't ever
 need replication slots, our recommendation is that you explicitly disable their

--- a/product_docs/docs/postgres_for_kubernetes/1/labels_annotations.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/labels_annotations.mdx
@@ -5,36 +5,36 @@ originalFilePath: 'src/labels_annotations.md'
 
 Resources in Kubernetes are organized in a flat structure, with no hierarchical
 information or relationship between them. However, such resources and objects
-can be linked together and put in relationship through **labels** and
-**annotations**.
+can be linked together and put in relationship through *labels* and
+*annotations*.
 
 !!! info
-    For more information, please refer to the Kubernetes documentation on
+    For more information, see the Kubernetes documentation on
     [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) and
     [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 
-In short:
+In brief:
 
--   an annotation is used to assign additional non-identifying information to
-    resources with the goal to facilitate integration with external tools
--   a label is used to group objects and query them through Kubernetes' native
-    selector capability
+-   An annotation is used to assign additional non-identifying information to
+    resources with the goal of facilitating integration with external tools.
+-   A label is used to group objects and query them through the Kubernetes native
+    selector capability.
 
-You can select one or more labels and/or annotations you will use
+You can select one or more labels or annotations to use
 in your EDB Postgres for Kubernetes deployments. Then you need to configure the operator
-so that when you define these labels and/or annotations in a cluster's metadata,
-they are automatically inherited by all resources created by it (including pods).
+so that when you define these labels or annotations in a cluster's metadata,
+they're inherited by all resources created by it (including pods).
 
 !!! Note
     Label and annotation inheritance is the technique adopted by EDB Postgres for Kubernetes
-    in lieu of alternative approaches such as pod templates.
+    instead of alternative approaches such as pod templates.
 
 ## Predefined labels
 
-Below is a list of predefined labels that are managed by EDB Postgres for Kubernetes.
+These predefined labels are managed by EDB Postgres for Kubernetes.
 
 `k8s.enterprisedb.io/backupName`
-:   Backup identifier, only available on `Backup` and `VolumeSnapshot`
+:   Backup identifier, available only on `Backup` and `VolumeSnapshot`
     resources
 
 `k8s.enterprisedb.io/cluster`
@@ -42,17 +42,17 @@ Below is a list of predefined labels that are managed by EDB Postgres for Kubern
 
 `k8s.enterprisedb.io/immediateBackup`
 :   Applied to a `Backup` resource if the backup is the first one created from
-    a `ScheduledBackup` object having `immediate` set to `true`.
+    a `ScheduledBackup` object having `immediate` set to `true`
 
 `k8s.enterprisedb.io/instanceName`
-:   Name of the PostgreSQL instance - this label replaces the old and
-    deprecated `postgresql` label
+:   Name of the PostgreSQL instance (replaces the old and
+    deprecated `postgresql` label)
 
 `k8s.enterprisedb.io/jobRole`
-:   Role of the job (i.e. `import`, `initdb`, `join`, ...)
+:   Role of the job (that is, `import`, `initdb`, `join`, ...)
 
 `k8s.enterprisedb.io/podRole`
-:   Currently fixed to `instance` to identify a pod running PostgreSQL
+:   Role of the pod: `instance`, or `pooler`
 
 `k8s.enterprisedb.io/poolerName`
 :   Name of the PgBouncer pooler
@@ -62,7 +62,7 @@ Below is a list of predefined labels that are managed by EDB Postgres for Kubern
 
 `k8s.enterprisedb.io/reload`
 :   Available on `ConfigMap` and `Secret` resources. When set to `true`,
-    a change in the resource will be automatically reloaded by the operator.
+    a change in the resource is automatically reloaded by the operator.
 
 `k8s.enterprisedb.io/scheduled-backup`
 :   When available, name of the `ScheduledBackup` resource that created a given
@@ -81,41 +81,41 @@ Below is a list of predefined labels that are managed by EDB Postgres for Kubern
 : The year/month when a backup was taken
 
 `k8s.enterprisedb.io/backupDate`
-: The date in ISO  8601 format (`YYYYMMDD`) of the backup
+: The date of the backup in ISO 8601 format (`YYYYMMDD`) 
 
 `k8s.enterprisedb.io/onlineBackup`
-: Whether the backup is online (hot) or cold (taken when Postgres is down)
+: Whether the backup is online (hot) or taken when Postgres is down (cold)
 
 ## Predefined annotations
 
-Below is a list of predefined annotations that are managed by EDB Postgres for Kubernetes.
+These predefined annotations are managed by EDB Postgres for Kubernetes.
 
 `container.apparmor.security.beta.kubernetes.io/*`
 :   Name of the AppArmor profile to apply to the named container.
     See [AppArmor](security.md#restricting-pod-access-using-apparmor)
-    documentation for details
+    for details.
 
 `k8s.enterprisedb.io/coredumpFilter`
 :   Filter to control the coredump of Postgres processes, expressed with a
-    bitmask. By default it is set to `0x31` in order to exclude shared memory
-    segments from the dump. Please refer to ["PostgreSQL core dumps"](troubleshooting.md#postgresql-core-dumps)
+    bitmask. By default it's set to `0x31` to exclude shared memory
+    segments from the dump. See [PostgreSQL core dumps](troubleshooting.md#postgresql-core-dumps)
     for more information.
 
 `k8s.enterprisedb.io/clusterManifest`
-:   Manifest of the `Cluster` owning this resource (such as a PVC) - this label
-    replaces the old and deprecated `k8s.enterprisedb.io/hibernateClusterManifest` label
+:   Manifest of the `Cluster` owning this resource (such as a PVC). This label
+    replaces the old, deprecated `k8s.enterprisedb.io/hibernateClusterManifest` label.
 
 `k8s.enterprisedb.io/fencedInstances`
-:   List, expressed in JSON format, of the instances that need to be fenced.
+:   List of the instances that need to be fenced, expressed in JSON format.
     The whole cluster is fenced if the list contains the `*` element.
 
 `k8s.enterprisedb.io/forceLegacyBackup`
-:   Applied to a `Cluster` resource for testing purposes only, in order to
+:   Applied to a `Cluster` resource for testing purposes only, to
     simulate the behavior of `barman-cloud-backup` prior to version 3.4 (Jan 2023)
-    when the `--name` option was not available.
+    when the `--name` option wasn't available.
 
 `k8s.enterprisedb.io/hash`
-:   The hash value of the resource
+:   The hash value of the resource.
 
 `k8s.enterprisedb.io/hibernation`
 :   Applied to a `Cluster` resource to control the [declarative hibernation feature](declarative_hibernation.md).
@@ -123,38 +123,49 @@ Below is a list of predefined annotations that are managed by EDB Postgres for K
 
 `k8s.enterprisedb.io/managedSecrets`
 :   Pull secrets managed by the operator and automatically set in the
-    `ServiceAccount` resources for each Postgres cluster
+    `ServiceAccount` resources for each Postgres cluster.
 
 `k8s.enterprisedb.io/nodeSerial`
 :   On a pod resource, identifies the serial number of the instance within the
-    Postgres cluster
+    Postgres cluster.
 
 `k8s.enterprisedb.io/operatorVersion`
-:   Version of the operator
+:   Version of the operator.
 
 `k8s.enterprisedb.io/pgControldata`
-:   Output of the `pg_controldata` command - this annotation replaces the old and
-    deprecated `k8s.enterprisedb.io/hibernatePgControlData` annotation
+:   Output of the `pg_controldata` command. This annotation replaces the old,
+    deprecated `k8s.enterprisedb.io/hibernatePgControlData` annotation.
 
 `k8s.enterprisedb.io/podEnvHash`
-:   *Deprecated* as the `k8s.enterprisedb.io/podSpec` annotation now also contains the pod environment
+:   Deprecated, as the `k8s.enterprisedb.io/podSpec` annotation now also contains the pod environment.
 
 `k8s.enterprisedb.io/podSpec`
-:   Snapshot of the `spec` of the Pod generated by the operator - this annotation replaces
-    the old and deprecated `k8s.enterprisedb.io/podEnvHash` annotation
+:   Snapshot of the `spec` of the pod generated by the operator. This annotation replaces
+    the old, deprecated `k8s.enterprisedb.io/podEnvHash` annotation.
 
 `k8s.enterprisedb.io/poolerSpecHash`
-:   Hash of the pooler resource
+:   Hash of the pooler resource.
 
 `k8s.enterprisedb.io/pvcStatus`
-:   Current status of the pvc, one of `initializing`, `ready`, `detached`
+:   Current status of the PVC: `initializing`, `ready`, or `detached`.
+
+`k8s.enterprisedb.io/reconcilePodSpec`
+:   When set to `disabled` on a `Cluster`, the operator prevents instances
+   from being restarted in case of drift in the PodSpec.
+   PodSpec drift could be due, for example, to:
+
+```
+ - Changes to topology or affinity
+ - Change of scheduler
+ - Change to volumes or containers
+```
 
 `k8s.enterprisedb.io/reconciliationLoop`
 :   When set to `disabled` on a `Cluster`, the operator prevents the
-    reconciliation loop from running
+    reconciliation loop from running.
 
 `k8s.enterprisedb.io/reloadedAt`
-:   Contains the latest cluster `reload` time, `reload` is triggered by user through plugin
+:   Contains the latest cluster `reload` time. `reload` is triggered by the user through a plugin.
 
 `k8s.enterprisedb.io/skipEmptyWalArchiveCheck`
 :   When set to `true` on a `Cluster` resource, the operator disables the check
@@ -162,48 +173,48 @@ Below is a list of predefined annotations that are managed by EDB Postgres for K
     risk.
 
 `k8s.enterprisedb.io/backupStartWAL`
-: The WAL at the start of a backup
+: The WAL at the start of a backup.
 
 `k8s.enterprisedb.io/backupEndWAL`
-: The WAL at the conclusion of a backup
+: The WAL at the conclusion of a backup.
 
 `k8s.enterprisedb.io/backupStartTime`
-: The time a backup started
+: The time a backup started.
 
 `k8s.enterprisedb.io/backupEndTime`
-: The time a backup ended
+: The time a backup ended.
 
 `k8s.enterprisedb.io/snapshotStartTime`
-: The time a snapshot started
+: The time a snapshot started.
 
 `k8s.enterprisedb.io/snapshotEndTime`
-: The time a snapshot was marked as ready to use
+: The time a snapshot was marked as ready to use.
 
 `kubectl.kubernetes.io/restartedAt`
-:  When available, the time of last requested restart of a Postgres cluster
+:  When available, the time of last requested restart of a Postgres cluster.
 
-## Pre-requisites
+## Prerequisites
 
 By default, no label or annotation defined in the cluster's metadata is
 inherited by the associated resources.
-In order to enable label/annotation inheritance, you need to follow the
-instructions provided in the ["Operator configuration"](operator_conf.md) section.
+To enable label/annotation inheritance, follow the
+instructions provided in [Operator configuration](operator_conf.md).
 
-Below we will continue on that example and limit it to the following:
+The following continues from that example and limits it to the following:
 
--   annotations: `categories`
--   labels: `app`, `environment`, and `workload`
+-   Annotations: `categories`
+-   Labels: `app`, `environment`, and `workload`
 
 !!! Note
     Feel free to select the names that most suit your context for both
-    annotations and labels. Remember that you can also use wildcards
-    in naming and adopt strategies like `mycompany/*` for all labels
-    or annotations starting with `mycompany/` to be inherited.
+    annotations and labels. You can also use wildcards
+    in naming and adopt strategies like using `mycompany/*` for all labels
+    or setting annotations starting with `mycompany/` to be inherited.
 
 ## Defining cluster's metadata
 
-When defining the cluster, **before** any resource is deployed, you can
-properly set the metadata as follows:
+When defining the cluster, before any resource is deployed, you can
+set the metadata as follows:
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
@@ -221,7 +232,7 @@ spec:
 ```
 
 Once the cluster is deployed, you can verify, for example, that the labels
-have been correctly set in the pods with:
+were correctly set in the pods:
 
 ```shell
 kubectl get pods --show-labels
@@ -229,7 +240,7 @@ kubectl get pods --show-labels
 
 ## Current limitations
 
-Currently, EDB Postgres for Kubernetes does not automatically propagate labels or
+Currently, EDB Postgres for Kubernetes doesn't automatically propagate labels or
 annotations deletions. Therefore, when an annotation or label is removed from
-a Cluster, which was previously propagated to the underlying pods, the operator
-will not automatically remove it on the associated resources.
+a cluster that was previously propagated to the underlying pods, the operator
+doesn't remove it on the associated resources.

--- a/product_docs/docs/postgres_for_kubernetes/1/logging.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/logging.mdx
@@ -8,35 +8,34 @@ including PostgreSQL logs.
 
 Each log entry has the following fields:
 
--   `level`: log level (`info`, `notice`, ...)
--   `ts`: the timestamp (epoch with microseconds)
--   `logger`: the type of the record (e.g. `postgres` or `pg_controldata`)
--   `msg`: the actual message or the keyword `record` in case the message is parsed in JSON format
--   `record`: the actual record (with structure that varies depending on the
-    `logger` type)
--   `logging_pod`: the name of the pod where the log was created
+-   `level` – Log level (`info`, `notice`, ...).
+-   `ts` – The timestamp (epoch with microseconds).
+-   `logger` – The type of the record (for example, `postgres` or `pg_controldata`).
+-   `msg` – The actual message or the keyword `record` in case the message is parsed in JSON format.
+-   `record` – The actual record with structure that varies depending on the
+    `logger` type.
+-   `logging_podName` – The pod where the log was created.
 
 !!! Warning
     Long-term storage and management of logs is outside the operator's purview,
-    and needs to be provided at the level of the Kubernetes installation. Please
-    refer to the
+    and needs to be provided at the level of the Kubernetes installation.
+    See the
     [Kubernetes Logging Architecture](https://kubernetes.io/docs/concepts/cluster-administration/logging/)
     documentation.
 
 !!! Info
-    The `level` and `ts` field names can be renamed via the `log-field-level` and
-    `log-field-timestamp` flags of the operator controller, should your log ingestion
-    system require it. All you have to do is edit the `Deployment` definition of the
+    If your log ingestion system requires it, you can rename the `level` and `ts` field names using the `log-field-level` and
+    `log-field-timestamp` flags of the operator controller. Edit the `Deployment` definition of the
     `cloudnative-pg` operator.
 
 ## Operator log
 
-A log level can be specified in the cluster spec with the option `logLevel` and
-can be set to any of `error`, `warning`, `info`(default), `debug` or `trace`.
+You can specify a log level in the cluster spec with the option `logLevel`.
+You can set it to `error`, `warning`, `info`(default), `debug`, or `trace`.
 
-At the moment, the log level can only be set when an instance starts and can not be
-changed at runtime. If the value is changed in the cluster spec after the cluster
-was started, this will take effect only in the new pods and not the old ones.
+Currently, you can set the log level only when an instance starts. You can't
+change it at runtime. If you change the value in the cluster spec after the cluster
+was started, it takes effect only in the new pods and not the old ones.
 
 ## PostgreSQL log
 
@@ -79,8 +78,8 @@ to `postgres` and the structure described in the following example:
 }
 ```
 
-Internally, the operator relies on the PostgreSQL CSV log format. Please refer
-to the PostgreSQL documentation for more information about the [CSV log
+Internally, the operator relies on the PostgreSQL CSV log format. See
+the PostgreSQL documentation for more information about the [CSV log
 format](https://www.postgresql.org/docs/current/runtime-config-logging.html).
 
 ## PGAudit logs
@@ -88,14 +87,14 @@ format](https://www.postgresql.org/docs/current/runtime-config-logging.html).
 EDB Postgres for Kubernetes has transparent and native support for
 [PGAudit](https://www.pgaudit.org/) on PostgreSQL clusters.
 
-All you need to do is add the required `pgaudit` parameters to the `postgresql`
+To enable this support, add the required `pgaudit` parameters to the `postgresql`
 section in the configuration of the cluster.
 
 !!! Important
-    It is unnecessary to add the PGAudit library to `shared_preload_libraries`.
-    The library will be added automatically by EDB Postgres for Kubernetes based on the
+    You need to add the PGAudit library to `shared_preload_libraries`.
+    EDB Postgres for Kubernetes adds the library based on the
     presence of `pgaudit.*` parameters in the postgresql configuration.
-    The operator will detect and manage the addition and removal of the
+    The operator detects and manages the addition and removal of the
     library from `shared_preload_libraries`.
 
 The operator also takes care of creating and removing the extension from all
@@ -103,10 +102,10 @@ the available databases in the cluster.
 
 !!! Important
     EDB Postgres for Kubernetes runs the `CREATE EXTENSION` and
-    `DROP EXTENSION` command in all databases in the cluster that accept
+    `DROP EXTENSION` commands in all databases in the cluster that accept
     connections.
 
-Here is an example of a PostgreSQL 13 `Cluster` deployment which will result in
+This example shows a PostgreSQL 13 `Cluster` deployment that results in
 `pgaudit` being enabled with the requested configuration:
 
 ```yaml
@@ -132,13 +131,13 @@ spec:
 The audit CSV logs entries returned by PGAudit are then parsed and routed to
 stdout in JSON format, similarly to all the remaining logs:
 
--   `.logger` is set to `pgaudit`
--   `.msg` is set to `record`
--   `.record` contains the whole parsed record as a JSON object, similar to
-    `logging_collector` logs - except for `.record.audit`, which contains the
-    PGAudit CSV message formatted as a JSON object
+-   `.logger` is set to `pgaudit`.
+-   `.msg` is set to `record`.
+-   `.record` contains the whole parsed record as a JSON object. This is similar to
+    `logging_collector` logs, except for `.record.audit`, which contains the
+    PGAudit CSV message formatted as a JSON object.
 
-See the example below:
+This example shows sample log entries:
 
 ```json
 {
@@ -175,7 +174,7 @@ See the example below:
 }
 ```
 
-Please refer to the
+See the
 [PGAudit documentation](https://github.com/pgaudit/pgaudit/blob/master/README.md#format) 
 for more details about each field in a record.
 
@@ -271,8 +270,8 @@ for more details about the records' fields.
 ## Other logs
 
 All logs that are produced by the operator and its instances are in JSON
-format, with `logger` set accordingly to the process that produced them.
-Therefore, all the possible `logger` values are the following ones:
+format, with `logger` set according to the process that produced them.
+Therefore, all the possible `logger` values are the following:
 
 -   `barman-cloud-wal-archive`: from `barman-cloud-wal-archive` directly
 -   `barman-cloud-wal-restore`: from `barman-cloud-wal-restore` directly
@@ -288,5 +287,5 @@ Therefore, all the possible `logger` values are the following ones:
 -   `wal-restore`: from the `wal-restore` subcommand of the instance manager
 
 Except for `postgres` and `edb_audit` that have the aforementioned structures,
-all other possible values just have `msg` set to the escaped message that is
+all other possible values just have `msg` set to the escaped message that's
 logged.

--- a/product_docs/docs/postgres_for_kubernetes/1/monitoring.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/monitoring.mdx
@@ -176,7 +176,7 @@ cnp_collector_up{cluster="cluster-example"} 1
 
 # HELP cnp_collector_postgres_version Postgres version
 # TYPE cnp_collector_postgres_version gauge
-cnp_collector_postgres_version{cluster="cluster-example",full="16.0"} 16.0
+cnp_collector_postgres_version{cluster="cluster-example",full="16.1"} 16.1
 
 # HELP cnp_collector_last_failed_backup_timestamp The last failed backup as a unix timestamp
 # TYPE cnp_collector_last_failed_backup_timestamp gauge

--- a/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
@@ -865,7 +865,7 @@ that runs with the `quay.io/enterprisedb/pgbouncer` image.
 
 !!! Note "There's more"
     For more details about pod customization for the pooler, please refer to
-    the ["Pod templates"](connection_pooling.md#pod-templates) section in the
+    the ["Pod templates"](connection_pooling.md#podtemplates) section in the
     connection pooling documentation.
 
 You can change the image name from the advanced interface, specifically by

--- a/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/openshift.mdx
@@ -865,7 +865,7 @@ that runs with the `quay.io/enterprisedb/pgbouncer` image.
 
 !!! Note "There's more"
     For more details about pod customization for the pooler, please refer to
-    the ["Pod templates"](connection_pooling.md#podtemplates) section in the
+    the ["Pod templates"](connection_pooling.md#pod-templates) section in the
     connection pooling documentation.
 
 You can change the image name from the advanced interface, specifically by

--- a/product_docs/docs/postgres_for_kubernetes/1/operator_capability_levels.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/operator_capability_levels.mdx
@@ -1,56 +1,56 @@
 ---
-title: 'Operator Capability Levels'
+title: 'Operator capability levels'
 originalFilePath: 'src/operator_capability_levels.md'
 ---
 
-This section provides a summary of the capabilities implemented by EDB Postgres for Kubernetes,
+These capabilities were implemented by EDB Postgres for Kubernetes,
 classified using the
-["Operator SDK definition of Capability Levels"](https://operatorframework.io/operator-capabilities/)
+[Operator SDK definition of Capability Levels](https://operatorframework.io/operator-capabilities/)
 framework.
 
 ![Operator Capability Levels](./images/operator-capability-level.png)
 
 !!! Important
     Based on the [Operator Capability Levels model](operator_capability_levels.md),
-    You can expect a **"Level V - Auto Pilot"** set of capabilities from the
-    EDB Postgres for Kubernetes Operator.
+    you can expect a "Level V - Auto Pilot" set of capabilities from the
+    EDB Postgres for Kubernetes operator.
 
 Each capability level is associated with a certain set of management features the operator offers:
 
-1.  Basic Install
-2.  Seamless Upgrades
-3.  Full Lifecycle
-4.  Deep Insights
-5.  Auto Pilot
+1.  Basic install
+2.  Seamless upgrades
+3.  Full lifecycle
+4.  Deep insights
+5.  Auto pilot
 
 !!! Note
     We consider this framework as a guide for future work and implementations in the operator.
 
-## Level 1: Basic Install
+## Level 1: Basic install
 
-Capability level 1 involves **installation** and **configuration** of the
+Capability level 1 involves installing and configuring the
 operator. This category includes usability and user experience
 enhancements, such as improvements in how you interact with the
 operator and a PostgreSQL cluster configuration.
 
 !!! Important
-    We consider **Information Security** part of this level.
+    We consider information security part of this level.
 
 ### Operator deployment via declarative configuration
 
 The operator is installed in a declarative way using a Kubernetes manifest
-which defines 4 major `CustomResourceDefinition` objects: `Cluster`, `Pooler`,
+that defines four major `CustomResourceDefinition` objects: `Cluster`, `Pooler`,
 `Backup`, and `ScheduledBackup`.
 
 ### PostgreSQL cluster deployment via declarative configuration
 
-A PostgreSQL cluster (operand) is defined using the `Cluster` custom resource
+You define a PostgreSQL cluster (operand) using the `Cluster` custom resource
 in a fully declarative way. The PostgreSQL version is determined by the
 operand container image defined in the CR, which is automatically fetched
 from the requested registry. When deploying an operand, the operator also
-automatically creates the following resources: `Pod`, `Service`, `Secret`,
+creates the following resources: `Pod`, `Service`, `Secret`,
 `ConfigMap`,`PersistentVolumeClaim`, `PodDisruptionBudget`, `ServiceAccount`,
-`RoleBinding`, `Role`.
+`RoleBinding`, and `Role`.
 
 ### Override of operand images through the CRD
 
@@ -62,40 +62,42 @@ Community and published on quay.io by EDB.
 You can use any compatible image of PostgreSQL supporting the
 primary/standby architecture directly by setting the `imageName`
 attribute in the CR. The operator also supports `imagePullSecrets`
-to access private container registries, as well as digests in addition to
+to access private container registries, and it supports digests and
 tags for finer control of container image immutability.
 
 ### Labels and annotations
 
-The operator can be configured to support inheritance of labels and annotations
-that are defined in a cluster's metadata, with the goal to improve organizations
-of EDB Postgres for Kubernetes deployment in your Kubernetes infrastructure.
+You can configure the operator to support inheriting labels and annotations
+that are defined in a cluster's metadata. The goal is to improve the organization
+of the EDB Postgres for Kubernetes deployment in your Kubernetes infrastructure.
 
 ### Self-contained instance manager
 
-Instead of relying on an external tool such as Patroni or Stolon to
-coordinate PostgreSQL instances in the Kubernetes cluster pods, the operator
+Instead of relying on an external tool to
+coordinate PostgreSQL instances in the Kubernetes cluster pods, 
+such as Patroni or Stolon, the operator
 injects the operator executable inside each pod, in a file named
 `/controller/manager`. The application is used to control the underlying
-PostgreSQL instance and to reconcile the pod status with the instance itself
+PostgreSQL instance and to reconcile the pod status with the instance
 based on the PostgreSQL cluster topology. The instance manager also starts a
-web server that is invoked by the `kubelet` for probes. Unix signals invoked
-by the `kubelet` are filtered by the instance manager and, where appropriate,
+web server that's invoked by the `kubelet` for probes. Unix signals invoked
+by the `kubelet` are filtered by the instance manager. Where appropriate, they're
 forwarded to the `postgres` process for fast and controlled reactions to
 external events. The instance manager is written in Go and has no external
 dependencies.
 
 ### Storage configuration
 
-Storage is a critical component in a database workload. Taking advantage of
+Storage is a critical component in a database workload. Taking advantage of the
 Kubernetes native capabilities and resources in terms of storage, the
 operator gives you enough flexibility to choose the right storage for your
 workload requirements, based on what the underlying Kubernetes environment
 can offer. This implies choosing a particular storage class in
 a public cloud environment or fine-tuning the generated PVC through a
 PVC template in the CR's `storage` parameter.
+
 For better performance and finer control, you can also choose to host your
-cluster's Write-Ahead Log (WAL, also known as `pg_wal`) on a separate volume,
+cluster's write-ahead log (WAL, also known as `pg_wal`) on a separate volume,
 preferably on different storage.
 The [`cnp-bench`](https://github.com/EnterpriseDB/cnp-bench) open source
 project can be used to benchmark both the storage and the database prior to
@@ -103,41 +105,43 @@ production.
 
 ### Replica configuration
 
-The operator automatically detects replicas in a cluster
-through a single parameter called `instances`. If set to `1`, the cluster
+The operator detects replicas in a cluster
+through a single parameter, called `instances`. If set to `1`, the cluster
 comprises a single primary PostgreSQL instance with no replica. If higher
-than `1`, the operator manages `instances -1` replicas, including High
-Availability (HA) through automated failover and rolling updates through
+than `1`, the operator manages `instances -1` replicas, including high
+availability (HA) through automated failover and rolling updates through
 switchover operations.
-EDB Postgres for Kubernetes automatically manages replication slots for all the replicas
-in the HA cluster, with an implementation that is inspired by the previously
-proposed patch for PostgreSQL called
-["Failover slots"](https://wiki.postgresql.org/wiki/Failover_slots).
+
+EDB Postgres for Kubernetes manages replication slots for all the replicas
+in the HA cluster. The implementation is inspired by the previously
+proposed patch for PostgreSQL, called
+[failover slots](https://wiki.postgresql.org/wiki/Failover_slots).
 
 ### Database configuration
 
 The operator is designed to manage a PostgreSQL cluster with a single
 database. The operator transparently manages access to the database through
-three Kubernetes services automatically provisioned and managed for read-write,
+three Kubernetes services provisioned and managed for read-write,
 read, and read-only workloads.
-Using the convention over configuration approach, the operator creates a
+Using the convention-over-configuration approach, the operator creates a
 database called `app`, by default owned by a regular Postgres user with the
-same name. Both the database name and the user name can be specified if
+same name. You can specify both the database name and the user name, if
 required.
-Although no configuration is required to run the cluster, you can customize
-both PostgreSQL run-time configuration and PostgreSQL Host-Based
-Authentication rules in the `postgresql` section of the CR.
 
-### Configuration of Postgres roles, users and groups
+Although no configuration is required to run the cluster, you can customize
+both PostgreSQL runtime configuration and PostgreSQL host-based
+authentication rules in the `postgresql` section of the CR.
+
+### Configuration of Postgres roles, users, and groups
 
 EDB Postgres for Kubernetes supports
 [management of PostgreSQL roles, users, and groups through declarative configuration](declarative_role_management.md)
 using the `.spec.managed.roles` stanza.
 
-### Pod Security Policies
+### Pod security policies
 
-For InfoSec requirements, the operator does not require privileged mode for
-any container and enforces read only root filesystem to guarantee containers
+For InfoSec requirements, the operator doesn't require privileged mode for
+any container. It enforces a read-only root filesystem to guarantee containers
 immutability for both the operator and the operand pods. It also explicitly
 sets the required security contexts.
 
@@ -150,17 +154,17 @@ allocated UID and SELinux context.
 ### Affinity
 
 The cluster's `affinity` section enables fine-tuning of how pods and related
-resources such as persistent volumes are scheduled across the nodes of a
+resources, such as persistent volumes, are scheduled across the nodes of a
 Kubernetes cluster. In particular, the operator supports:
 
--   pod affinity and anti-affinity
--   node selector
--   taints and tolerations
+-   Pod affinity and anti-affinity
+-   Node selector
+-   Taints and tolerations
 
 ### Topology spread constraints
 
 The cluster's `topologySpreadConstraints` section enables additional control of
-the scheduling of pods across topologies, enhancing what affinity and
+scheduling pods across topologies, enhancing what affinity and
 anti-affinity can offer.
 
 ### License keys
@@ -179,91 +183,93 @@ reconciliation process until the license key is restored.
 
 ### Command line interface
 
-EDB Postgres for Kubernetes does not have its own command line interface.
-It simply relies on the best command line interface for Kubernetes, `kubectl`,
-by providing a plugin called `cnp` to enhance and simplify your PostgreSQL
+EDB Postgres for Kubernetes doesn't have its own command-line interface.
+It relies on the best command-line interface for Kubernetes, kubectl,
+by providing a plugin called `cnp`. This plugin enhances and simplifies your PostgreSQL
 cluster management experience.
 
 ### Current status of the cluster
 
 The operator continuously updates the status section of the CR with the
 observed status of the cluster. The entire PostgreSQL cluster status is
-continuously monitored by the instance manager running in each pod: the
+continuously monitored by the instance manager running in each pod. The
 instance manager is responsible for applying the required changes to the
 controlled PostgreSQL instance to converge to the required status of
-the cluster (for example: if the cluster status reports that pod `-1` is the
+the cluster. (For example, if the cluster status reports that pod `-1` is the
 primary, pod `-1` needs to promote itself while the other pods need to follow
-pod `-1`). The same status is used by the `cnp` plugin for `kubectl` to provide
+pod `-1`.) The same status is used by the `cnp` plugin for kubectl to provide
 details.
 
 ### Operator's certification authority
 
-The operator automatically creates a certification authority for itself.
+The operator creates a certification authority for itself.
 It creates and signs with the operator certification authority a leaf certificate
-to be used by the webhook server, to ensure safe communication between the
-Kubernetes API Server and the operator itself.
+for the webhook server to use. This certificate ensures safe communication between the
+Kubernetes API server and the operator.
 
 ### Cluster's certification authority
 
-The operator automatically creates a certification authority for every PostgreSQL
-cluster, which is used to issue and renew TLS certificates for clients' authentication,
+The operator creates a certification authority for every PostgreSQL
+cluster. This certification authority is used to issue and renew TLS certificates for clients' authentication,
 including streaming replication standby servers (instead of passwords).
 Support for a custom certification authority for client certificates is
-available through secrets: this also includes integration with cert-manager.
-Certificates can be issued with the `cnp` plugin for `kubectl`.
+available through secrets, which also includes integration with cert-manager.
+Certificates can be issued with the `cnp` plugin for kubectl.
 
 ### TLS connections
 
 The operator transparently and natively supports TLS/SSL connections
 to encrypt client/server communications for increased security using the
 cluster's certification authority.
-Support for custom server certificates is available through secrets: this also
+Support for custom server certificates is available through secrets, which also
 includes integration with cert-manager.
 
 ### Certificate authentication for streaming replication
 
-The operator relies on TLS client certificate authentication to authorize streaming
-replication connections from the standby servers, instead of relying on a password
-(and therefore a secret).
+To authorize streaming replication connections from the standby servers, 
+the operator relies on TLS client certificate authentication. This method is used
+instead of relying on a password (and therefore a secret).
 
 ### Continuous configuration management
 
 The operator enables you to apply changes to the `Cluster` resource YAML
-section of the PostgreSQL configuration and makes sure that all instances
-are properly reloaded or restarted, depending on the configuration option.
-*Current limitation:* changes with `ALTER SYSTEM` are not detected, meaning
-that the cluster state is not enforced.
+section of the PostgreSQL configuration. Depending on the configuration option,
+it also makes sure that all instances are properly reloaded or restarted.
+
+!!! Note Current limitation
+    Changes with `ALTER SYSTEM` aren't detected, meaning
+    that the cluster state isn't enforced.
 
 ### Import of existing PostgreSQL databases
 
-Since version 1.16, the operator provides a declarative way to import existing
-Postgres databases in a new EDB Postgres for Kubernetes `Cluster` in Kubernetes, using
+The operator provides a declarative way to import existing
+Postgres databases in a new EDB Postgres for Kubernetes cluster in Kubernetes, using
 offline migrations.
-The same feature covers also offline major upgrades of PostgreSQL databases.
+The same feature also covers offline major upgrades of PostgreSQL databases.
 Offline means that applications must stop their write operations at the source
 until the database is imported.
 The feature extends the `initdb` bootstrap method to create a new PostgreSQL
 cluster using a logical snapshot of the data available in another PostgreSQL
-database - which can be accessed via the network through a superuser
-connection. Import is from any supported version of Postgres and relies on
-`pg_dump` and `pg_restore` to be executed from the new cluster primary
-for all databases part of the operation and, if requested, for roles.
+database. This data can be accessed by way of the network through a superuser
+connection. Import is from any supported version of Postgres. It relies on
+`pg_dump` and `pg_restore` being executed from the new cluster primary
+for all databases that are part of the operation and, if requested, for roles.
 
 ### PostGIS clusters
 
 EDB Postgres for Kubernetes supports the installation of clusters with the [PostGIS](postgis.md)
-open source extension for geographical databases, one of the most popular
+open source extension for geographical databases. This extension is one of the most popular
 extensions for PostgreSQL.
 
 ### Basic LDAP authentication for PostgreSQL
 
 The operator allows you to configure LDAP authentication for your PostgreSQL
 clients, using either the *simple bind* or *search+bind* mode, as described in
-the ["PostgreSQL documentation: LDAP authentication" section](https://www.postgresql.org/docs/current/auth-ldap.html).
+the [LDAP authentication section of the PostgreSQL documentation](https://www.postgresql.org/docs/current/auth-ldap.html).
 
 ### Multiple installation methods
 
-The operator can be installed through a Kubernetes manifest via `kubectl
+The operator can be installed through a Kubernetes manifest by way of `kubectl
 apply`, to be used in a traditional Kubernetes installation in public
 and private cloud environments. Additionally, it can be deployed through
 the Operator Lifecycle Manager (OLM) from OperatorHub.io and the OpenShift
@@ -271,27 +277,28 @@ Container Platform by Red Hat. A Helm Chart for the operator is also available.
 
 ### Convention over configuration
 
-The operator supports the convention over configuration paradigm, deciding
+The operator supports the convention-over-configuration paradigm, deciding
 standard default values while allowing you to override them and customize
 them. You can specify a deployment of a PostgreSQL cluster using
-the `Cluster` CRD in a couple of YAML code lines.
+the `Cluster` CRD in a couple of lines of YAML code.
 
-## Level 2: Seamless Upgrades
+## Level 2: Seamless upgrades
 
-Capability level 2 is about enabling **updates of the operator and the actual
-workload**, in our case PostgreSQL servers. This includes **PostgreSQL minor
-release updates** (security and bug fixes normally) as well as **major online
-upgrades**.
+Capability level 2 is about enabling updates of the operator and the actual
+workload, in this case PostgreSQL servers. This includes PostgreSQL minor
+release updates (security and bug fixes normally) as well as major online
+upgrades.
 
 ### Upgrade of the operator
 
-You can upgrade the operator seamlessly as a new deployment. A change in the
-operator does not require a change in the operand - thanks to the instance
-manager's injection. The operator can manage older versions of the operand.
+You can upgrade the operator seamlessly as a new deployment. Because of the instance
+manager's injection, a change in the
+operator doesn't require a change in the operand. 
+The operator can manage older versions of the operand.
 
 EDB Postgres for Kubernetes also supports [in-place updates of the instance manager](installation_upgrade.md#in-place-updates-of-the-instance-manager)
-following an upgrade of the operator: in-place updates do not require a rolling
-update - and subsequent switchover - of the cluster.
+following an upgrade of the operator. In-place updates don't require a rolling
+update (and subsequent switchover) of the cluster.
 
 ### Upgrade of the managed workload
 
@@ -299,41 +306,42 @@ The operand can be upgraded using a declarative configuration approach as
 part of changing the CR and, in particular, the `imageName` parameter. The
 operator prevents major upgrades of PostgreSQL while making it possible to go
 in both directions in terms of minor PostgreSQL releases within a major
-version (enabling updates and rollbacks).
+version, enabling updates and rollbacks.
 
 In the presence of standby servers, the operator performs rolling updates
-starting from the replicas by dropping the existing pod and creating a new
+starting from the replicas. It does this by dropping the existing pod and creating a new
 one with the new requested operand image that reuses the underlying storage.
 Depending on the value of the `primaryUpdateStrategy`, the operator proceeds
-with a switchover before updating the former primary (`unsupervised`) or waits
-for the user to manually issue the switchover procedure (`supervised`) via the
-`cnp` plugin for `kubectl`.
-Which setting to use depends on the business requirements as the operation
-might generate some downtime for the applications, from a few seconds to
-minutes based on the actual database workload.
+with a switchover before updating the former primary (`unsupervised`). Or, it waits
+for the user to manually issue the switchover procedure (`supervised`) by way of the
+`cnp` plugin for kubectl.
+The setting to use depends on the business requirements, as the operation
+might generate some downtime for the applications. This downtime can range from a few seconds to
+minutes, based on the actual database workload.
 
 ### Display cluster availability status during upgrade
 
 At any time, convey the cluster's high availability status, for example,
 `Setting up primary`, `Creating a new replica`, `Cluster in healthy state`,
-`Switchover in progress`, `Failing over`, `Upgrading cluster`, etc.
+`Switchover in progress`, `Failing over`, and `Upgrading cluster`.
 
-## Level 3: Full Lifecycle
+## Level 3: Full lifecycle
 
-Capability level 3 requires the operator to manage aspects of **business
-continuity** and **scalability**.
-**Disaster recovery** is a business continuity component that requires
+Capability level 3 requires the operator to manage aspects of business
+continuity and scalability.
+
+*Disaster recovery* is a business continuity component that requires
 that both backup and recovery of a database work correctly. While as a
-starting point, the goal is to achieve RPO &lt; 5 minutes, the long term goal is
-to implement RPO=0 backup solutions. **High Availability** is the other
-important component of business continuity that, through PostgreSQL native
-physical replication and hot standby replicas, allows the operator to perform
+starting point, the goal is to achieve RPO &lt; 5 minutes, the long-term goal is
+to implement RPO=0 backup solutions. *High availability* is the other
+important component of business continuity. Through PostgreSQL native
+physical replication and hot standby replicas, it allows the operator to perform
 failover and switchover operations. This area includes enhancements in:
 
--   control of PostgreSQL physical replication, such as synchronous replication,
-    (cascading) replication clusters, and so on;
--   connection pooling, to improve performance and control through a
-    connection pooling layer with pgBouncer.
+-   Control of PostgreSQL physical replication, such as synchronous replication,
+    (cascading) replication clusters, and so on
+-   Connection pooling, to improve performance and control through a
+    connection pooling layer with pgBouncer
 
 ### PostgreSQL WAL archive
 
@@ -342,40 +350,41 @@ to an object store (AWS S3 and S3-compatible, Azure Blob Storage, Google Cloud
 Storage, and gateways like MinIO).
 
 WAL archiving is defined at the cluster level, declaratively, through the
-`backup` parameter in the cluster definition, by specifying an S3 protocol
+`backup` parameter in the cluster definition. This is done by specifying an S3 protocol
 destination URL (for example, to point to a specific folder in an AWS S3
 bucket) and, optionally, a generic endpoint URL.
 
-WAL archiving, a prerequisite for continuous backup, does not require any further
-action from the user: the operator will automatically and transparently set
+WAL archiving, a prerequisite for continuous backup, doesn't require any further
+user action. The operator transparently sets
 the `archive_command` to rely on `barman-cloud-wal-archive` to ship WAL
-files to the defined endpoint. Users can decide the compression algorithm,
+files to the defined endpoint. You can decide the compression algorithm,
 as well as the number of parallel jobs to concurrently upload WAL files
-in the archive. In addition to that `Instance Manager` automatically checks 
-the correctness of the archive destination, by performing `barman-cloud-check-wal-archive` 
-command before beginning to ship the very first set of WAL files.
+in the archive. In addition, `Instance Manager` checks 
+the correctness of the archive destination by performing the `barman-cloud-check-wal-archive` 
+command before beginning to ship the first set of WAL files.
 
-### PostgreSQL Backups
+### PostgreSQL backups
 
-The operator has been designed to provide application-level backups using
+The operator was designed to provide application-level backups using
 PostgreSQL’s native continuous hot backup technology based on
 physical base backups and continuous WAL archiving.
 Base backups can be saved on:
 
--   Kubernetes Volume Snapshots
--   object stores (AWS S3 and S3-compatible, Azure Blob Storage, Google Cloud
+-   Kubernetes volume snapshots
+-   Object stores (AWS S3 and S3-compatible, Azure Blob Storage, Google Cloud
     Storage, and gateways like MinIO)
 
 Base backups are defined at the cluster level, declaratively,
 through the `backup` parameter in the cluster definition.
 
-You can define base backups in two ways: on-demand (through the `Backup`
-custom resource definition) or scheduled (through the `ScheduledBackup`
-custom resource definition, using a cron-like syntax).
+You can define base backups in two ways: 
 
-Volume Snapshots rely directly on the Kubernetes API, which delegates this
+-   On-demand, through the `Backup` custom resource definition
+-   Scheduled, through the `ScheduledBackup`custom resource definition, using a cron-like syntax
+
+Volume snapshots rely directly on the Kubernetes API, which delegates this
 capability to the underlying storage classes and CSI drivers. Volume snapshot
-backups are suitable for Very Large Database (VLDB) contexts.
+backups are suitable for very large database (VLDB) contexts.
 
 Object store backups rely on `barman-cloud-backup` for the job (distributed as
 part of the application container image) to relay backups in the same endpoint,
@@ -384,14 +393,14 @@ alongside WAL files.
 Both `barman-cloud-wal-restore` and `barman-cloud-backup` are distributed in
 the application container image under GNU GPL 3 terms.
 
-Object store backups and Volume Snapshot backups are taken while PostgreSQL is
+Object store backups and volume snapshot backups are taken while PostgreSQL is
 up and running (hot backups). Volume snapshots also support taking consistent
 database snapshots with cold backups.
 
 ### Backups from a standby
 
 The operator supports offloading base backups onto a standby without impacting
-the RPO of the database. This allows to preserve resources on the primary, in
+the RPO of the database. This allows resources to be preserved on the primary, in
 particular I/O, for standard database operations.
 
 ### Full restore from a backup
@@ -401,28 +410,28 @@ starting from an existing and accessible backup, either on a volume snapshot
 or in an object store.
 
 Once the bootstrap process is completed, the operator initiates the instance in
-recovery mode and replays all available WAL files from the specified archive,
+recovery mode. It replays all available WAL files from the specified archive,
 exiting recovery and starting as a primary.
-Subsequently, the operator will clone the requested number of standby instances
+Subsequently, the operator clones the requested number of standby instances
 from the primary.
 EDB Postgres for Kubernetes supports parallel WAL fetching from the archive.
 
-### Point-In-Time Recovery (PITR) from a backup
+### Point-in-time recovery (PITR) from a backup
 
 The operator enables you to create a new PostgreSQL cluster by recovering
-an existing backup to a specific point-in-time, defined with a timestamp, a
-label or a transaction ID. This capability is built on top of the full restore
+an existing backup to a specific point in time, defined with a timestamp, a
+label, or a transaction ID. This capability is built on top of the full restore
 one and supports all the options available in
 [PostgreSQL for PITR](https://www.postgresql.org/docs/current/runtime-config-wal.html#RUNTIME-CONFIG-WAL-RECOVERY-TARGET).
 
-### Zero Data Loss clusters through synchronous replication
+### Zero-data-loss clusters through synchronous replication
 
-Achieve  *Zero Data Loss* (RPO=0) in your local High Availability EDB Postgres for Kubernetes
-cluster through quorum based synchronous replication support. The operator provides
+Achieve  *zero data loss* (RPO=0) in your local high-availability EDB Postgres for Kubernetes
+cluster through quorum-based synchronous replication support. The operator provides
 two configuration options that control the minimum and maximum number of
-expected synchronous standby replicas available at any time. The operator will
-react accordingly, based on the number of available and ready PostgreSQL
-instances in the cluster, through the following formula for the quorum (`q`):
+expected synchronous standby replicas available at any time. The operator
+reacts accordingly, based on the number of available and ready PostgreSQL
+instances in the cluster. It uses the following formula for the quorum (`q`):
 
 ```
 1 <= minSyncReplicas <= q <= maxSyncReplicas <= readyReplicas
@@ -430,48 +439,62 @@ instances in the cluster, through the following formula for the quorum (`q`):
 
 ### Replica clusters
 
-Define a cross Kubernetes cluster topology of PostgreSQL clusters, by taking
+Define a cross-Kubernetes cluster topology of PostgreSQL clusters by taking
 advantage of PostgreSQL native streaming and cascading replication.
-Through the `replica` option, you can setup an independent cluster to be
-continuously replicating data from another PostgreSQL source of the same major
-version: such a source can be anywhere, as long as a direct streaming
-connection via TLS is allowed from the two endpoints.
+Using the `replica` option, you can set up an independent cluster to
+continuously replicate data from another PostgreSQL source of the same major
+version. Such a source can be anywhere, as long as a direct streaming
+connection by way of TLS is allowed from the two endpoints.
+
 Moreover, the source can be even outside Kubernetes, running in a physical or
 virtual environment.
+
 Replica clusters can be created from a volume snapshot, a recovery object store
-(backup in Barman Cloud format) or via streaming through `pg_basebackup`.
+(backup in Barman Cloud format), or by way of streaming using `pg_basebackup`.
 Both WAL file shipping and WAL streaming are allowed.
 Replica clusters dramatically improve the business continuity posture of your
-PostgreSQL databases in Kubernetes, spanning over multiple datacenters and
-opening up for hybrid and multi-cloud setups (currently, manual switchover
-across data centers is required, while waiting for Kubernetes federation
-native capabilities).
+PostgreSQL databases in Kubernetes, spanning over multiple data centers and
+opening up for hybrid and multi-cloud setups. (Currently, while waiting for Kubernetes 
+federation native capabilities, manual switchover
+across data centers is required.)
+
+### Tablespace support
+
+EDB Postgres for Kubernetes seamlessly integrates robust support for PostgreSQL tablespaces
+by facilitating the declarative definition of individual persistent volumes.
+This innovative feature empowers you to efficiently distribute I/O operations
+across a diverse array of storage devices. Through the transparent
+orchestration of tablespaces, EDB Postgres for Kubernetes enhances the performance and
+scalability of PostgreSQL databases, ensuring a streamlined and optimized
+experience for managing large scale data storage in cloud-native environments.
+Support for temporary tablespaces is also included.
 
 ### Liveness and readiness probes
 
 The operator defines liveness and readiness probes for the Postgres
-Containers that are then invoked by the kubelet. They are mapped respectively
+containers that are then invoked by the kubelet. They're mapped respectively
 to the `/healthz` and `/readyz` endpoints of the web server managed
 directly by the instance manager.
+
 The liveness probe is based on the `pg_isready` executable, and the pod is
-considered healthy with exit codes 0  (server accepting connections normally)
-and 1 (server is rejecting connections, for example during startup).  The
+considered healthy with exit codes 0 (server accepting connections normally)
+and 1 (server is rejecting connections, for example, during startup). The
 readiness probe issues a simple query (`;`) to verify that the server is
 ready to accept connections.
 
 ### Rolling deployments
 
-The operator supports rolling deployments to minimize the downtime and, if a
-PostgreSQL cluster is exposed publicly, the Service will load-balance the
+The operator supports rolling deployments to minimize the downtime. If a
+PostgreSQL cluster is exposed publicly, the service load-balances the
 read-only traffic only to available pods during the initialization or the
 update.
 
 ### Scale up and down of replicas
 
 The operator allows you to scale up and down the number of instances in a
-PostgreSQL cluster. New replicas are automatically started up from the
-primary server and will participate in the cluster's HA infrastructure.
-The CRD declares a "scale" subresource that allows the user to use the
+PostgreSQL cluster. New replicas are started up from the
+primary server and participate in the cluster's HA infrastructure.
+The CRD declares a "scale" subresource that allows you to use the
 `kubectl scale` command.
 
 ### Maintenance window and PodDisruptionBudget for Kubernetes nodes
@@ -479,17 +502,17 @@ The CRD declares a "scale" subresource that allows the user to use the
 The operator creates a `PodDisruptionBudget` resource to limit the number of
 concurrent disruptions to one primary instance. This configuration prevents the
 maintenance operation from deleting all the pods in a cluster, allowing the
-specified number of instances to be created. The PodDisruptionBudget will be
-applied during the node draining operation, preventing any disruption of the
+specified number of instances to be created. The PodDisruptionBudget is
+applied during the node-draining operation, preventing any disruption of the
 cluster service.
 
-While this strategy is correct for Kubernetes Clusters where
-storage is shared among all the worker nodes, it may not be the best solution
-for clusters using Local Storage or for clusters installed in a private
-cloud. The operator allows you to specify a Maintenance Window and
+While this strategy is correct for Kubernetes clusters where
+storage is shared among all the worker nodes, it might not be the best solution
+for clusters using local storage or for clusters installed in a private
+cloud. The operator allows you to specify a maintenance window and
 configure the reaction to any underlying node eviction. The `ReusePVC` option
-in the maintenance window section enables to specify the strategy to be used:
-allocate new storage in a different PVC for the evicted instance or wait
+in the maintenance window section enables to specify the strategy to use.
+Allocate new storage in a different PVC for the evicted instance, or wait
 for the underlying node to be available again.
 
 ### Fencing
@@ -497,39 +520,39 @@ for the underlying node to be available again.
 Fencing is the process of protecting the data in one, more, or even all
 instances of a PostgreSQL cluster when they appear to be malfunctioning.
 When an instance is fenced, the PostgreSQL server process is
-guaranteed to be shut down, while the pod is kept running. This makes sure
-that, until the fence is lifted, data on the pod is not modified by PostgreSQL
-and that the file system can be investigated for debugging and troubleshooting
+guaranteed to be shut down, while the pod is kept running. This ensures
+that, until the fence is lifted, data on the pod isn't modified by PostgreSQL
+and that you can investigate file system for debugging and troubleshooting
 purposes.
 
 ### Hibernation (declarative)
 
 EDB Postgres for Kubernetes supports [hibernation of a running PostgreSQL cluster](declarative_hibernation.md)
 in a declarative manner, through the `k8s.enterprisedb.io/hibernation` annotation.
-Hibernation enables saving CPU power by removing the database Pods, while
+Hibernation enables saving CPU power by removing the database pods while
 keeping the database PVCs. This feature simulates scaling to 0 instances.
 
 ### Hibernation (imperative)
 
 EDB Postgres for Kubernetes supports [hibernation of a running PostgreSQL cluster](kubectl-plugin.md#cluster-hibernation)
-via the `cnp` plugin. Hibernation shuts down all Postgres instances in the
-High Availability cluster, and keeps a static copy of the PVC group of the
-primary, containing `PGDATA` and WALs. The plugin enables to exit the
-hibernation phase, by resuming the primary and then recreating all the
-replicas - if they exist.
+by way of the `cnp` plugin. Hibernation shuts down all Postgres instances in the
+high-availability cluster and keeps a static copy of the PVC group of the
+primary. The copy contains `PGDATA` and WALs. The plugin enables you to exit the
+hibernation phase by resuming the primary and then recreating all the
+replicas, if they exist.
 
-### Reuse of Persistent Volumes storage in Pods
+### Reuse of persistent volumes storage in pods
 
-When the operator needs to create a pod that has been deleted by the user or
-has been evicted by a Kubernetes maintenance operation, it reuses the
-`PersistentVolumeClaim` if available, avoiding the need
-to re-clone the data from the primary.
+When the operator needs to create a pod that was deleted by the user or
+was evicted by a Kubernetes maintenance operation, it reuses the
+`PersistentVolumeClaim`, if available. This ability avoids the need
+to clone the data from the primary again.
 
 ### CPU and memory requests and limits
 
 The operator allows administrators to control and manage resource usage by
-the cluster's pods, through the `resources` section of the manifest. In
-particular `requests` and `limits` values can be set for both CPU and RAM.
+the cluster's pods in the `resources` section of the manifest. In
+particular, you can set `requests` and `limits` values for both CPU and RAM.
 
 ### Connection pooling with PgBouncer
 
@@ -537,17 +560,21 @@ EDB Postgres for Kubernetes provides native support for connection pooling with
 [PgBouncer](connection_pooling.md), one of the most popular open source
 connection poolers for PostgreSQL. From an architectural point of view, the
 native implementation of a PgBouncer connection pooler introduces a new layer
-to access the database which optimizes the query flow towards the instances
-and makes the usage of the underlying PostgreSQL resources more efficient.
+to access the database. This optimizes the query flow toward the instances
+and makes the use of the underlying PostgreSQL resources more efficient.
 Instead of connecting directly to a PostgreSQL service, applications can now
 connect to the PgBouncer service and start reusing any existing connection.
 
 ### Integration with external backup tools for Kubernetes
 
-EDB Postgres for Kubernetes provides an add-on to integrate with
-[Velero](https://velero.io/), a very popular open source tool to
-back up and restore Kubernetes resources and persistent volumes and
-[OpenShift API for Data Protection (OADP)](https://github.com/openshift/oadp-operator).
+EDB Postgres for Kubernetes provides add-ons to integrate with:
+
+-   [Kasten](https://kasten.io/), a very popular data protection tool for
+    Kubernetes, enabling backup and restore, disaster recovery, and application
+    mobility for cloud native applications
+-   [Velero](https://velero.io/), a very popular open source tool to
+    back up and restore Kubernetes resources and persistent volumes and
+    [OpenShift API for Data Protection (OADP)](https://github.com/openshift/oadp-operator)
 
 Moreover, the [external backup adapter add-on](addons/#external-backup-adapter)
 provides a generic interface to integrate EDB Postgres for Kubernetes in any
@@ -555,32 +582,32 @@ third-party tool for backups.
 
 ## Level 4: Deep Insights
 
-Capability level 4 is about **observability**: in particular, monitoring,
-alerting, trending, log processing. This might involve the use of external tools
-such as Prometheus, Grafana, Fluent Bit, as well as extensions in the
+Capability level 4 is about *observability*: monitoring,
+alerting, trending, and log processing. This might involve the use of external tools,
+such as Prometheus, Grafana, and Fluent Bit, as well as extensions in the
 PostgreSQL engine for the output of error logs directly in JSON format.
 
-EDB Postgres for Kubernetes has been designed to provide everything that is needed
-to easily integrate with industry-standard and community accepted tools for
+EDB Postgres for Kubernetes was designed to provide everything needed
+to easily integrate with industry-standard and community-accepted tools for
 flexible monitoring and logging.
 
 ### Prometheus exporter with configurable queries
 
-The instance manager provides a pluggable framework and, via its own web server
-listening on the `metrics` port (9187), exposes an endpoint to export metrics
+The instance manager provides a pluggable framework. By way of its own web server
+listening on the `metrics` port (9187), it exposes an endpoint to export metrics
 for the [Prometheus](https://prometheus.io/) monitoring and alerting tool.
 The operator supports custom monitoring queries defined as `ConfigMap`
-and/or `Secret` objects using a syntax that is compatible with the
+or `Secret` objects using a syntax that's compatible with
 [`postgres_exporter` for Prometheus](https://github.com/prometheus-community/postgres_exporter).
 EDB Postgres for Kubernetes provides a set of basic monitoring queries for
 PostgreSQL that can be integrated and adapted to your context.
 
 ### Standard output logging of PostgreSQL error messages in JSON format
 
-Every log message is delivered to standard output in JSON format, with the first level
-definition of the timestamp, the log level and the type of log entry, such as
+Every log message is delivered to standard output in JSON format. The first level is the
+definition of the timestamp, the log level, and the type of log entry, such as
 `postgres` for the canonical PostgreSQL error message channel.
-As a result, every Pod managed by EDB Postgres for Kubernetes can be easily and directly
+As a result, every pod managed by EDB Postgres for Kubernetes can be easily and directly
 integrated with any downstream log processing stack that supports JSON as source
 data type.
 
@@ -588,23 +615,23 @@ data type.
 
 EDB Postgres for Kubernetes transparently and natively supports:
 
--   the essential [`pg_stat_statements` extension](https://www.postgresql.org/docs/current/pgstatstatements.html),
+-   The essential [`pg_stat_statements` extension](https://www.postgresql.org/docs/current/pgstatstatements.html),
     which enables tracking of planning and execution statistics of all SQL
-    statements executed by a PostgreSQL server;
--   the [`auto_explain` extension](https://www.postgresql.org/docs/current/auto-explain.html),
+    statements executed by a PostgreSQL server
+-   The [`auto_explain` extension](https://www.postgresql.org/docs/current/auto-explain.html),
     which provides a means for logging execution plans of slow statements
     automatically, without having to manually run `EXPLAIN` (helpful for tracking
-    down un-optimized queries);
--   the [`pg_failover_slots` extension](https://github.com/EnterpriseDB/pg_failover_slots),
+    down un-optimized queries)
+-   The [`pg_failover_slots` extension](https://github.com/EnterpriseDB/pg_failover_slots),
     which makes logical replication slots usable across a physical failover,
     ensuring resilience in change data capture (CDC) contexts based on PostgreSQL's
-    native logical replication;
+    native logical replication
 
 ### Audit
 
 EDB Postgres for Kubernetes allows database and security administrators, auditors,
-and operators to track and analyze database activities using PGAudit (for
-PostgreSQL) and the EDB Audit Logging functionality (for EDB Postgres
+and operators to track and analyze database activities using PGAudit for
+PostgreSQL and the EDB Audit Logging functionality (for EDB Postgres
 Advanced).
 Such activities flow directly in the JSON log and can be properly routed to the
 correct downstream target using common log brokers like Fluentd.
@@ -612,27 +639,27 @@ correct downstream target using common log brokers like Fluentd.
 ### Kubernetes events
 
 Record major events as expected by the Kubernetes API, such as creating resources,
-removing nodes, upgrading, and so on. Events can be displayed through
-the `kubectl describe` and `kubectl get events` command.
+removing nodes, and upgrading. Events can be displayed by using
+the `kubectl describe` and `kubectl get events` commands.
 
-## Level 5: Auto Pilot
+## Level 5: Auto pilot
 
-Capability level 5 is focused on **automated scaling**, **healing** and
-**tuning** - through the discovery of anomalies and insights that emerged
+Capability level 5 is focused on automated scaling, healing, and
+tuning through the discovery of anomalies and insights that emerged
 from the observability layer.
 
-### Automated Failover for self-healing
+### Automated failover for self-healing
 
-In case of detected failure on the primary, the operator will change the
+In case of detected failure on the primary, the operator changes the
 status of the cluster by setting the most aligned replica as the new target
-primary. As a consequence, the instance manager in each alive pod will
-initiate the required procedures to align itself with the requested status of
-the cluster, by either becoming the new primary or by following it.
-In case the former primary comes back up, the same mechanism will avoid a
+primary. As a consequence, the instance manager in each alive pod
+initiates the required procedures to align itself with the requested status of
+the cluster. It does this by either becoming the new primary or by following it.
+In case the former primary comes back up, the same mechanism avoids a
 split-brain by preventing applications from reaching it, running `pg_rewind` on
 the server and restarting it as a standby.
 
 ### Automated recreation of a standby
 
-In case the pod hosting a standby has been removed, the operator initiates
-the procedure to recreate a standby server.
+If the pod hosting a standby is removed, the operator initiates
+the procedure to re-create a standby server.

--- a/product_docs/docs/postgres_for_kubernetes/1/pg4k.v1.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/pg4k.v1.mdx
@@ -1,9 +1,6 @@
 ---
 title: 'API Reference'
 originalFilePath: 'src/pg4k.v1.md'
-redirects:
-- ../api_reference
-- cloudnative-pg.v1
 ---
 
 <p>Package v1 contains API Schema definitions for the postgresql v1 API group</p>
@@ -24,15 +21,15 @@ redirects:
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>Backup</code></td></tr>
-<tr><td><code>metadata</code> <b>[Required]</b><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
+<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>Backup</code></td></tr>
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <b>[Required]</b><br/>
+<tr><td><code>spec</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-BackupSpec"><i>BackupSpec</i></a>
 </td>
 <td>
@@ -61,15 +58,15 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>Cluster</code></td></tr>
-<tr><td><code>metadata</code> <b>[Required]</b><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
+<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>Cluster</code></td></tr>
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <b>[Required]</b><br/>
+<tr><td><code>spec</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-ClusterSpec"><i>ClusterSpec</i></a>
 </td>
 <td>
@@ -98,15 +95,15 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>Pooler</code></td></tr>
-<tr><td><code>metadata</code> <b>[Required]</b><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
+<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>Pooler</code></td></tr>
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <b>[Required]</b><br/>
+<tr><td><code>spec</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-PoolerSpec"><i>PoolerSpec</i></a>
 </td>
 <td>
@@ -135,15 +132,15 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>ScheduledBackup</code></td></tr>
-<tr><td><code>metadata</code> <b>[Required]</b><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
+<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>ScheduledBackup</code></td></tr>
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <b>[Required]</b><br/>
+<tr><td><code>spec</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-ScheduledBackupSpec"><i>ScheduledBackupSpec</i></a>
 </td>
 <td>
@@ -203,7 +200,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/</p
 </td>
 </tr>
 <tr><td><code>nodeAffinity</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#nodeaffinity-v1-core"><i>core/v1.NodeAffinity</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nodeaffinity-v1-core"><i>core/v1.NodeAffinity</i></a>
 </td>
 <td>
    <p>NodeAffinity describes node affinity scheduling rules for the pod.
@@ -211,7 +208,7 @@ More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-no
 </td>
 </tr>
 <tr><td><code>tolerations</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core"><i>[]core/v1.Toleration</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core"><i>[]core/v1.Toleration</i></a>
 </td>
 <td>
    <p>Tolerations is a list of Tolerations that should be set for all the pods, in order to allow them to run
@@ -232,7 +229,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-p
 </td>
 </tr>
 <tr><td><code>additionalPodAntiAffinity</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podantiaffinity-v1-core"><i>core/v1.PodAntiAffinity</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podantiaffinity-v1-core"><i>core/v1.PodAntiAffinity</i></a>
 </td>
 <td>
    <p>AdditionalPodAntiAffinity allows to specify pod anti-affinity terms to be added to the ones generated
@@ -240,7 +237,7 @@ by the operator if EnablePodAntiAffinity is set to true (default) or to be used 
 </td>
 </tr>
 <tr><td><code>additionalPodAffinity</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podaffinity-v1-core"><i>core/v1.PodAffinity</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podaffinity-v1-core"><i>core/v1.PodAffinity</i></a>
 </td>
 <td>
    <p>AdditionalPodAffinity allows to specify pod affinity terms to be passed to all the cluster's pods.</p>
@@ -412,18 +409,26 @@ the selected PostgreSQL instance</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <b>[Required]</b><br/>
+<tr><td><code>name</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
    <p>Name is the snapshot resource name</p>
 </td>
 </tr>
-<tr><td><code>type</code> <b>[Required]</b><br/>
+<tr><td><code>type</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
-   <p>Type is tho role of the snapshot in the cluster, such as PG_DATA and PG_WAL</p>
+   <p>Type is tho role of the snapshot in the cluster, such as PG_DATA, PG_WAL and PG_TABLESPACE</p>
+</td>
+</tr>
+<tr><td><code>tablespaceName</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>TablespaceName is the name of the snapshotted tablespace. Only set
+when type is PG_TABLESPACE</p>
 </td>
 </tr>
 </tbody>
@@ -497,7 +502,7 @@ errors with certificate issuer and barman-cloud-wal-archive.</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>cluster</code> <b>[Required]</b><br/>
+<tr><td><code>cluster</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-LocalObjectReference"><i>LocalObjectReference</i></a>
 </td>
 <td>
@@ -627,14 +632,14 @@ parameter is omitted</p>
 </td>
 </tr>
 <tr><td><code>startedAt</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta"><i>meta/v1.Time</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>meta/v1.Time</i></a>
 </td>
 <td>
    <p>When the backup was started</p>
 </td>
 </tr>
 <tr><td><code>stoppedAt</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta"><i>meta/v1.Time</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>meta/v1.Time</i></a>
 </td>
 <td>
    <p>When the backup was terminated</p>
@@ -724,7 +729,7 @@ parameter is omitted</p>
    <p>The backup method being used</p>
 </td>
 </tr>
-<tr><td><code>online</code> <b>[Required]</b><br/>
+<tr><td><code>online</code> <B>[Required]</B><br/>
 <i>bool</i>
 </td>
 <td>
@@ -829,7 +834,7 @@ Useful when using self-signed certificates to avoid
 errors with certificate issuer and barman-cloud-wal-archive</p>
 </td>
 </tr>
-<tr><td><code>destinationPath</code> <b>[Required]</b><br/>
+<tr><td><code>destinationPath</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -1083,7 +1088,7 @@ a physical backup of an existing PostgreSQL cluster</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>source</code> <b>[Required]</b><br/>
+<tr><td><code>source</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -1358,7 +1363,7 @@ and digests for deterministic and repeatable deployments
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#pullpolicy-v1-core"><i>core/v1.PullPolicy</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core"><i>core/v1.PullPolicy</i></a>
 </td>
 <td>
    <p>Image pull policy.
@@ -1392,7 +1397,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/</p>
    <p>The GID of the <code>postgres</code> user inside the image, defaults to <code>26</code></p>
 </td>
 </tr>
-<tr><td><code>instances</code> <b>[Required]</b><br/>
+<tr><td><code>instances</code> <B>[Required]</B><br/>
 <i>int</i>
 </td>
 <td>
@@ -1554,7 +1559,7 @@ to be unhealthy</p>
 </td>
 </tr>
 <tr><td><code>topologySpreadConstraints</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core"><i>[]core/v1.TopologySpreadConstraint</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#topologyspreadconstraint-v1-core"><i>[]core/v1.TopologySpreadConstraint</i></a>
 </td>
 <td>
    <p>TopologySpreadConstraints specifies how to spread matching pods among the given topology.
@@ -1563,7 +1568,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constrai
 </td>
 </tr>
 <tr><td><code>resources</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core"><i>core/v1.ResourceRequirements</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core"><i>core/v1.ResourceRequirements</i></a>
 </td>
 <td>
    <p>Resources requirements of every generated Pod. Please refer to
@@ -1571,7 +1576,7 @@ https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 for more information.</p>
 </td>
 </tr>
-<tr><td><code>ephemeralVolumesSizeLimit</code> <b>[Required]</b><br/>
+<tr><td><code>ephemeralVolumesSizeLimit</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-EphemeralVolumesSizeLimitConfiguration"><i>EphemeralVolumesSizeLimitConfiguration</i></a>
 </td>
 <td>
@@ -1632,7 +1637,7 @@ the license agreement that comes with the operator.</p>
 </td>
 </tr>
 <tr><td><code>licenseKeySecret</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>The reference to the license key. When this is set it take precedence over LicenseKey.</p>
@@ -1660,7 +1665,7 @@ the license agreement that comes with the operator.</p>
 </td>
 </tr>
 <tr><td><code>projectedVolumeTemplate</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#projectedvolumesource-v1-core"><i>core/v1.ProjectedVolumeSource</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core"><i>core/v1.ProjectedVolumeSource</i></a>
 </td>
 <td>
    <p>Template to be used to define projected volumes, projected volumes will be mounted
@@ -1668,7 +1673,7 @@ under <code>/projected</code> base folder</p>
 </td>
 </tr>
 <tr><td><code>env</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core"><i>[]core/v1.EnvVar</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core"><i>[]core/v1.EnvVar</i></a>
 </td>
 <td>
    <p>Env follows the Env format to pass environment variables
@@ -1676,7 +1681,7 @@ to the pods created in the cluster</p>
 </td>
 </tr>
 <tr><td><code>envFrom</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envfromsource-v1-core"><i>[]core/v1.EnvFromSource</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core"><i>[]core/v1.EnvFromSource</i></a>
 </td>
 <td>
    <p>EnvFrom follows the EnvFrom format to pass environment variables
@@ -1691,11 +1696,18 @@ sources to the pods to be used by Env</p>
 </td>
 </tr>
 <tr><td><code>seccompProfile</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#seccompprofile-v1-core"><i>core/v1.SeccompProfile</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#seccompprofile-v1-core"><i>core/v1.SeccompProfile</i></a>
 </td>
 <td>
    <p>The SeccompProfile applied to every Pod and Container.
 Defaults to: <code>RuntimeDefault</code></p>
+</td>
+</tr>
+<tr><td><code>tablespaces</code><br/>
+<a href="#postgresql-k8s-enterprisedb-io-v1-TablespaceConfiguration"><i>[]TablespaceConfiguration</i></a>
+</td>
+<td>
+   <p>The tablespaces configuration</p>
 </td>
 </tr>
 </tbody>
@@ -1747,6 +1759,13 @@ Defaults to: <code>RuntimeDefault</code></p>
 </td>
 <td>
    <p>ManagedRolesStatus reports the state of the managed roles in the cluster</p>
+</td>
+</tr>
+<tr><td><code>tablespacesStatus</code><br/>
+<a href="#postgresql-k8s-enterprisedb-io-v1-TablespaceState"><i>[]TablespaceState</i></a>
+</td>
+<td>
+   <p>TablespacesStatus reports the state of the declarative tablespaces in the cluster</p>
 </td>
 </tr>
 <tr><td><code>timelineID</code><br/>
@@ -1901,14 +1920,30 @@ configmap data</p>
 <i>string</i>
 </td>
 <td>
-   <p>The first recoverability point, stored as a date in RFC3339 format</p>
+   <p>The first recoverability point, stored as a date in RFC3339 format.
+This field is calculated from the content of FirstRecoverabilityPointByMethod</p>
+</td>
+</tr>
+<tr><td><code>firstRecoverabilityPointByMethod</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>map[BackupMethod]meta/v1.Time</i></a>
+</td>
+<td>
+   <p>The first recoverability point, stored as a date in RFC3339 format, per backup method type</p>
 </td>
 </tr>
 <tr><td><code>lastSuccessfulBackup</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>Stored as a date in RFC3339 format</p>
+   <p>Last successful backup, stored as a date in RFC3339 format
+This field is calculated from the content of LastSuccessfulBackupByMethod</p>
+</td>
+</tr>
+<tr><td><code>lastSuccessfulBackupByMethod</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>map[BackupMethod]meta/v1.Time</i></a>
+</td>
+<td>
+   <p>Last successful backup, stored as a date in RFC3339 format, per backup method type</p>
 </td>
 </tr>
 <tr><td><code>lastFailedBackup</code><br/>
@@ -1937,7 +1972,7 @@ configmap data</p>
 </td>
 <td>
    <p>The timestamp when the primary was detected to be unhealthy
-This field is reported when spec.failoverDelay is populated or during online upgrades</p>
+This field is reported when <code>.spec.failoverDelay</code> is populated or during online upgrades</p>
 </td>
 </tr>
 <tr><td><code>targetPrimaryTimestamp</code><br/>
@@ -1962,7 +1997,7 @@ This field is reported when spec.failoverDelay is populated or during online upg
 </td>
 </tr>
 <tr><td><code>conditions</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta"><i>[]meta/v1.Condition</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta"><i>[]meta/v1.Condition</i></a>
 </td>
 <td>
    <p>Conditions for cluster object</p>
@@ -2029,7 +2064,7 @@ the key of a ConfigMap</p>
    <p>The name of the secret in the pod's namespace to select from.</p>
 </td>
 </tr>
-<tr><td><code>key</code> <b>[Required]</b><br/>
+<tr><td><code>key</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -2133,19 +2168,48 @@ PostgreSQL cluster from an existing storage</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>storage</code> <b>[Required]</b><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#typedlocalobjectreference-v1-core"><i>core/v1.TypedLocalObjectReference</i></a>
+<tr><td><code>storage</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#typedlocalobjectreference-v1-core"><i>core/v1.TypedLocalObjectReference</i></a>
 </td>
 <td>
    <p>Configuration of the storage of the instances</p>
 </td>
 </tr>
 <tr><td><code>walStorage</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#typedlocalobjectreference-v1-core"><i>core/v1.TypedLocalObjectReference</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#typedlocalobjectreference-v1-core"><i>core/v1.TypedLocalObjectReference</i></a>
 </td>
 <td>
    <p>Configuration of the storage for PostgreSQL WAL (Write-Ahead Log)</p>
 </td>
+</tr>
+<tr><td><code>tablespaceStorage</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#typedlocalobjectreference-v1-core"><i>map[string]core/v1.TypedLocalObjectReference</i></a>
+</td>
+<td>
+   <p>Configuration of the storage for PostgreSQL tablespaces</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+<div id='postgresql-k8s-enterprisedb-io-v1-DatabaseRoleRef'></div>
+
+## DatabaseRoleRef
+
+**Appears in:**
+
+-   [TablespaceConfiguration](#postgresql-k8s-enterprisedb-io-v1-TablespaceConfiguration)
+
+<p>DatabaseRoleRef is a reference an a role available inside PostgreSQL</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>name</code><br/>
+<i>string</i>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
 </tbody>
 </table>
@@ -2249,15 +2313,15 @@ storage</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>shm</code> <b>[Required]</b><br/>
-<i>k8s.io/apimachinery/pkg/api/resource.Quantity</i>
+<tr><td><code>shm</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><i>k8s.io/apimachinery/pkg/api/resource.Quantity</i></a>
 </td>
 <td>
    <p>Shm is the size limit of the shared memory volume</p>
 </td>
 </tr>
-<tr><td><code>temporaryData</code> <b>[Required]</b><br/>
-<i>k8s.io/apimachinery/pkg/api/resource.Quantity</i>
+<tr><td><code>temporaryData</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><i>k8s.io/apimachinery/pkg/api/resource.Quantity</i></a>
 </td>
 <td>
    <p>TemporaryData is the size limit of the temporary data volume</p>
@@ -2280,7 +2344,7 @@ external cluster which is used in the other sections of the configuration</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <b>[Required]</b><br/>
+<tr><td><code>name</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -2295,7 +2359,7 @@ external cluster which is used in the other sections of the configuration</p>
 </td>
 </tr>
 <tr><td><code>sslCert</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>The reference to an SSL certificate to be used to connect to this
@@ -2303,7 +2367,7 @@ instance</p>
 </td>
 </tr>
 <tr><td><code>sslKey</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>The reference to an SSL private key to be used to connect to this
@@ -2311,7 +2375,7 @@ instance</p>
 </td>
 </tr>
 <tr><td><code>sslRootCert</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>The reference to an SSL CA public key to be used to connect to this
@@ -2319,10 +2383,16 @@ instance</p>
 </td>
 </tr>
 <tr><td><code>password</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
-   <p>The reference to the password to be used to connect to the server</p>
+   <p>The reference to the password to be used to connect to the server.
+If a password is provided, EDB Postgres for Kubernetes creates a PostgreSQL
+passfile at <code>/controller/external/NAME/pass</code> (where &quot;NAME&quot; is the
+cluster's name). This passfile is automatically referenced in the
+connection string when establishing a connection to the remote
+PostgreSQL server from the current PostgreSQL <code>Cluster</code>. This ensures
+secure and efficient password management for external clusters.</p>
 </td>
 </tr>
 <tr><td><code>barmanObjectStore</code><br/>
@@ -2380,21 +2450,21 @@ default to false.</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>source</code> <b>[Required]</b><br/>
+<tr><td><code>source</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-ImportSource"><i>ImportSource</i></a>
 </td>
 <td>
    <p>The source of the import</p>
 </td>
 </tr>
-<tr><td><code>type</code> <b>[Required]</b><br/>
+<tr><td><code>type</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-SnapshotType"><i>SnapshotType</i></a>
 </td>
 <td>
    <p>The import type. Can be <code>microservice</code> or <code>monolith</code>.</p>
 </td>
 </tr>
-<tr><td><code>databases</code> <b>[Required]</b><br/>
+<tr><td><code>databases</code> <B>[Required]</B><br/>
 <i>[]string</i>
 </td>
 <td>
@@ -2441,7 +2511,7 @@ database right after is imported - to be used with extreme care
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>externalCluster</code> <b>[Required]</b><br/>
+<tr><td><code>externalCluster</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -2494,7 +2564,7 @@ database right after is imported - to be used with extreme care
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>isPrimary</code> <b>[Required]</b><br/>
+<tr><td><code>isPrimary</code> <B>[Required]</B><br/>
 <i>bool</i>
 </td>
 <td>
@@ -2571,7 +2641,7 @@ the bind+search LDAP authentication process</p>
 </td>
 </tr>
 <tr><td><code>bindPassword</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>Secret with the password for the user to bind to the directory</p>
@@ -2700,7 +2770,7 @@ local object with a known type inside the same namespace</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <b>[Required]</b><br/>
+<tr><td><code>name</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -2855,6 +2925,20 @@ Default: false.</p>
 </td>
 <td>
    <p>Enable or disable the <code>PodMonitor</code></p>
+</td>
+</tr>
+<tr><td><code>podMonitorMetricRelabelings</code><br/>
+<a href="https://pkg.go.dev/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1#RelabelConfig"><i>[]*github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig</i></a>
+</td>
+<td>
+   <p>The list of metric relabelings for the <code>PodMonitor</code>. Applied to samples before ingestion.</p>
+</td>
+</tr>
+<tr><td><code>podMonitorRelabelings</code><br/>
+<a href="https://pkg.go.dev/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1#RelabelConfig"><i>[]*github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig</i></a>
+</td>
+<td>
+   <p>The list of relabelings for the <code>PodMonitor</code>. Applied to samples before scraping.</p>
 </td>
 </tr>
 </tbody>
@@ -3127,7 +3211,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 </td>
 </tr>
 <tr><td><code>spec</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podspec-v1-core"><i>core/v1.PodSpec</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podspec-v1-core"><i>core/v1.PodSpec</i></a>
 </td>
 <td>
    <p>Specification of the desired behavior of the pod.
@@ -3194,6 +3278,20 @@ part for now.</p>
    <p>Enable or disable the <code>PodMonitor</code></p>
 </td>
 </tr>
+<tr><td><code>podMonitorMetricRelabelings</code><br/>
+<a href="https://pkg.go.dev/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1#RelabelConfig"><i>[]*github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig</i></a>
+</td>
+<td>
+   <p>The list of metric relabelings for the <code>PodMonitor</code>. Applied to samples before ingestion.</p>
+</td>
+</tr>
+<tr><td><code>podMonitorRelabelings</code><br/>
+<a href="https://pkg.go.dev/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1#RelabelConfig"><i>[]*github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig</i></a>
+</td>
+<td>
+   <p>The list of relabelings for the <code>PodMonitor</code>. Applied to samples before scraping.</p>
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -3254,7 +3352,7 @@ part for now.</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>cluster</code> <b>[Required]</b><br/>
+<tr><td><code>cluster</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-LocalObjectReference"><i>LocalObjectReference</i></a>
 </td>
 <td>
@@ -3283,7 +3381,7 @@ Pooler name should never match with any cluster name within the same namespace.<
    <p>The template of the Pod to be created</p>
 </td>
 </tr>
-<tr><td><code>pgbouncer</code> <b>[Required]</b><br/>
+<tr><td><code>pgbouncer</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-PgBouncerSpec"><i>PgBouncerSpec</i></a>
 </td>
 <td>
@@ -3291,7 +3389,7 @@ Pooler name should never match with any cluster name within the same namespace.<
 </td>
 </tr>
 <tr><td><code>deploymentStrategy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#deploymentstrategy-v1-apps"><i>apps/v1.DeploymentStrategy</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#deploymentstrategy-v1-apps"><i>apps/v1.DeploymentStrategy</i></a>
 </td>
 <td>
    <p>The deployment strategy to use for pgbouncer to replace existing pods with new ones</p>
@@ -3449,6 +3547,16 @@ Default value is 40000000, greater than one year in seconds,
 big enough to simulate an infinite timeout</p>
 </td>
 </tr>
+<tr><td><code>enableAlterSystem</code><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>If this parameter is true, the user will be able to invoke <code>ALTER SYSTEM</code>
+on this EDB Postgres for Kubernetes Cluster.
+This should only be used for debugging and troubleshooting.
+Defaults to false.</p>
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -3570,14 +3678,14 @@ cluster</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>source</code> <b>[Required]</b><br/>
+<tr><td><code>source</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
    <p>The name of the external cluster which is the replication origin</p>
 </td>
 </tr>
-<tr><td><code>enabled</code> <b>[Required]</b><br/>
+<tr><td><code>enabled</code> <B>[Required]</B><br/>
 <i>bool</i>
 </td>
 <td>
@@ -3684,7 +3792,7 @@ Reference: https://www.postgresql.org/docs/current/sql-createrole.html</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <b>[Required]</b><br/>
+<tr><td><code>name</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -3722,7 +3830,7 @@ connections the role can make. <code>-1</code> (the default) means no limit.</p>
 </td>
 </tr>
 <tr><td><code>validUntil</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta"><i>meta/v1.Time</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>meta/v1.Time</i></a>
 </td>
 <td>
    <p>Date and time after which the role's password is no longer valid.
@@ -3901,7 +4009,7 @@ files to S3. It can be provided in two alternative ways:</p>
    <p>If the first backup has to be immediately start after creation or not</p>
 </td>
 </tr>
-<tr><td><code>schedule</code> <b>[Required]</b><br/>
+<tr><td><code>schedule</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -3910,7 +4018,7 @@ as it includes an additional seconds specifier,
 see https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format</p>
 </td>
 </tr>
-<tr><td><code>cluster</code> <b>[Required]</b><br/>
+<tr><td><code>cluster</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-LocalObjectReference"><i>LocalObjectReference</i></a>
 </td>
 <td>
@@ -3983,21 +4091,21 @@ Overrides the default settings specified in the cluster '.backup.volumeSnapshot.
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>lastCheckTime</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta"><i>meta/v1.Time</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>meta/v1.Time</i></a>
 </td>
 <td>
    <p>The latest time the schedule</p>
 </td>
 </tr>
 <tr><td><code>lastScheduleTime</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta"><i>meta/v1.Time</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>meta/v1.Time</i></a>
 </td>
 <td>
    <p>Information when was the last time that backup was successfully scheduled.</p>
 </td>
 </tr>
 <tr><td><code>nextScheduleTime</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta"><i>meta/v1.Time</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>meta/v1.Time</i></a>
 </td>
 <td>
    <p>Next time we will run a backup</p>
@@ -4041,7 +4149,7 @@ the key of a Secret</p>
    <p>The name of the secret in the pod's namespace to select from.</p>
 </td>
 </tr>
-<tr><td><code>key</code> <b>[Required]</b><br/>
+<tr><td><code>key</code> <B>[Required]</B><br/>
 <i>string</i>
 </td>
 <td>
@@ -4160,6 +4268,13 @@ managed by the operator</p>
    <p>The resource version of the Barman Endpoint CA if provided</p>
 </td>
 </tr>
+<tr><td><code>externalClusterSecretVersion</code><br/>
+<i>map[string]string</i>
+</td>
+<td>
+   <p>The resource versions of the external cluster secrets</p>
+</td>
+</tr>
 <tr><td><code>metrics</code><br/>
 <i>map[string]string</i>
 </td>
@@ -4184,7 +4299,7 @@ Map keys are the secret names, map values are the versions</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>metadata</code> <b>[Required]</b><br/>
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-Metadata"><i>Metadata</i></a>
 </td>
 <td>
@@ -4228,7 +4343,10 @@ This specifies which owner the processed resources should relate to.</p>
 
 -   [ClusterSpec](#postgresql-k8s-enterprisedb-io-v1-ClusterSpec)
 
-<p>StorageConfiguration is the configuration of the storage of the PostgreSQL instances</p>
+-   [TablespaceConfiguration](#postgresql-k8s-enterprisedb-io-v1-TablespaceConfiguration)
+
+<p>StorageConfiguration is the configuration used to create and reconcile PVCs,
+usable for WAL volumes, PGDATA volumes, or tablespaces</p>
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -4237,9 +4355,9 @@ This specifies which owner the processed resources should relate to.</p>
 <i>string</i>
 </td>
 <td>
-   <p>StorageClass to use for database data (<code>PGDATA</code>). Applied after
+   <p>StorageClass to use for PVCs. Applied after
 evaluating the PVC template, if available.
-If not specified, generated PVCs will be satisfied by the
+If not specified, the generated PVCs will use the
 default storage class</p>
 </td>
 </tr>
@@ -4260,7 +4378,7 @@ Size cannot be decreased.</p>
 </td>
 </tr>
 <tr><td><code>pvcTemplate</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaimspec-v1-core"><i>core/v1.PersistentVolumeClaimSpec</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimspec-v1-core"><i>core/v1.PersistentVolumeClaimSpec</i></a>
 </td>
 <td>
    <p>Template to be used to generate the Persistent Volume Claim</p>
@@ -4292,7 +4410,7 @@ if all the labels values match.</p>
    <p>A list of node labels values to extract and compare to evaluate if the pods reside in the same topology or not</p>
 </td>
 </tr>
-<tr><td><code>enabled</code> <b>[Required]</b><br/>
+<tr><td><code>enabled</code> <B>[Required]</B><br/>
 <i>bool</i>
 </td>
 <td>
@@ -4323,28 +4441,28 @@ if all the labels values match.</p>
 </td>
 </tr>
 <tr><td><code>secretKeyRef</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>Reference to the secret that contains the encryption key</p>
 </td>
 </tr>
 <tr><td><code>wrapCommand</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>WrapCommand is the encrypt command provided by the user</p>
 </td>
 </tr>
 <tr><td><code>unwrapCommand</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>UnwrapCommand is the decryption command provided by the user</p>
 </td>
 </tr>
 <tr><td><code>passphraseCommand</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core"><i>core/v1.SecretKeySelector</i></a>
 </td>
 <td>
    <p>PassphraseCommand is the command executed to get the passphrase that will be
@@ -4353,6 +4471,110 @@ passed to the OpenSSL command to encrypt and decrypt</p>
 </tr>
 </tbody>
 </table>
+
+<div id='postgresql-k8s-enterprisedb-io-v1-TablespaceConfiguration'></div>
+
+## TablespaceConfiguration
+
+**Appears in:**
+
+-   [ClusterSpec](#postgresql-k8s-enterprisedb-io-v1-ClusterSpec)
+
+<p>TablespaceConfiguration is the configuration of a tablespace, and includes
+the storage specification for the tablespace</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>The name of the tablespace</p>
+</td>
+</tr>
+<tr><td><code>storage</code> <B>[Required]</B><br/>
+<a href="#postgresql-k8s-enterprisedb-io-v1-StorageConfiguration"><i>StorageConfiguration</i></a>
+</td>
+<td>
+   <p>The storage configuration for the tablespace</p>
+</td>
+</tr>
+<tr><td><code>owner</code><br/>
+<a href="#postgresql-k8s-enterprisedb-io-v1-DatabaseRoleRef"><i>DatabaseRoleRef</i></a>
+</td>
+<td>
+   <p>Owner is the PostgreSQL user owning the tablespace</p>
+</td>
+</tr>
+<tr><td><code>temporary</code><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>When set to true, the tablespace will be added as a <code>temp_tablespaces</code>
+entry in PostgreSQL, and will be available to automatically house temp
+database objects, or other temporary files. Please refer to PostgreSQL
+documentation for more information on the <code>temp_tablespaces</code> GUC.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+<div id='postgresql-k8s-enterprisedb-io-v1-TablespaceState'></div>
+
+## TablespaceState
+
+**Appears in:**
+
+-   [ClusterStatus](#postgresql-k8s-enterprisedb-io-v1-ClusterStatus)
+
+<p>TablespaceState represents the state of a tablespace in a cluster</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Name is the name of the tablespace</p>
+</td>
+</tr>
+<tr><td><code>owner</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Owner is the PostgreSQL user owning the tablespace</p>
+</td>
+</tr>
+<tr><td><code>state</code> <B>[Required]</B><br/>
+<a href="#postgresql-k8s-enterprisedb-io-v1-TablespaceStatus"><i>TablespaceStatus</i></a>
+</td>
+<td>
+   <p>State is the latest reconciliation state</p>
+</td>
+</tr>
+<tr><td><code>error</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Error is the reconciliation error, if any</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+<div id='postgresql-k8s-enterprisedb-io-v1-TablespaceStatus'></div>
+
+## TablespaceStatus
+
+(Alias of `string`)
+
+**Appears in:**
+
+-   [TablespaceState](#postgresql-k8s-enterprisedb-io-v1-TablespaceState)
+
+<p>TablespaceStatus represents the status of a tablespace in the cluster</p>
 
 <div id='postgresql-k8s-enterprisedb-io-v1-Topology'></div>
 
@@ -4436,6 +4658,14 @@ It is the default class for the other types if no specific class is present</p>
 </td>
 <td>
    <p>WalClassName specifies the Snapshot Class to be used for the PG_WAL PersistentVolumeClaim.</p>
+</td>
+</tr>
+<tr><td><code>tablespaceClassName</code><br/>
+<i>map[string]string</i>
+</td>
+<td>
+   <p>TablespaceClassName specifies the Snapshot Class to be used for the tablespaces.
+defaults to the PGDATA Snapshot Class, if set</p>
 </td>
 </tr>
 <tr><td><code>snapshotOwnerReference</code><br/>

--- a/product_docs/docs/postgres_for_kubernetes/1/pg4k.v1.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/pg4k.v1.mdx
@@ -21,15 +21,15 @@ originalFilePath: 'src/pg4k.v1.md'
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>Backup</code></td></tr>
-<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>Backup</code></td></tr>
+<tr><td><code>metadata</code> <b>[Required]</b><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-BackupSpec"><i>BackupSpec</i></a>
 </td>
 <td>
@@ -58,15 +58,15 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>Cluster</code></td></tr>
-<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>Cluster</code></td></tr>
+<tr><td><code>metadata</code> <b>[Required]</b><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-ClusterSpec"><i>ClusterSpec</i></a>
 </td>
 <td>
@@ -95,15 +95,15 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>Pooler</code></td></tr>
-<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>Pooler</code></td></tr>
+<tr><td><code>metadata</code> <b>[Required]</b><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-PoolerSpec"><i>PoolerSpec</i></a>
 </td>
 <td>
@@ -132,15 +132,15 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>apiVersion</code> <B>[Required]</B><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
-<tr><td><code>kind</code> <B>[Required]</B><br/>string</td><td><code>ScheduledBackup</code></td></tr>
-<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<tr><td><code>apiVersion</code> <b>[Required]</b><br/>string</td><td><code>postgresql.k8s.enterprisedb.io/v1</code></td></tr>
+<tr><td><code>kind</code> <b>[Required]</b><br/>string</td><td><code>ScheduledBackup</code></td></tr>
+<tr><td><code>metadata</code> <b>[Required]</b><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta"><i>meta/v1.ObjectMeta</i></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-<tr><td><code>spec</code> <B>[Required]</B><br/>
+<tr><td><code>spec</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-ScheduledBackupSpec"><i>ScheduledBackupSpec</i></a>
 </td>
 <td>
@@ -409,21 +409,21 @@ the selected PostgreSQL instance</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
    <p>Name is the snapshot resource name</p>
 </td>
 </tr>
-<tr><td><code>type</code> <B>[Required]</B><br/>
+<tr><td><code>type</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
    <p>Type is tho role of the snapshot in the cluster, such as PG_DATA, PG_WAL and PG_TABLESPACE</p>
 </td>
 </tr>
-<tr><td><code>tablespaceName</code> <B>[Required]</B><br/>
+<tr><td><code>tablespaceName</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -502,7 +502,7 @@ errors with certificate issuer and barman-cloud-wal-archive.</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>cluster</code> <B>[Required]</B><br/>
+<tr><td><code>cluster</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-LocalObjectReference"><i>LocalObjectReference</i></a>
 </td>
 <td>
@@ -729,7 +729,7 @@ parameter is omitted</p>
    <p>The backup method being used</p>
 </td>
 </tr>
-<tr><td><code>online</code> <B>[Required]</B><br/>
+<tr><td><code>online</code> <b>[Required]</b><br/>
 <i>bool</i>
 </td>
 <td>
@@ -834,7 +834,7 @@ Useful when using self-signed certificates to avoid
 errors with certificate issuer and barman-cloud-wal-archive</p>
 </td>
 </tr>
-<tr><td><code>destinationPath</code> <B>[Required]</B><br/>
+<tr><td><code>destinationPath</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -1088,7 +1088,7 @@ a physical backup of an existing PostgreSQL cluster</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>source</code> <B>[Required]</B><br/>
+<tr><td><code>source</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -1397,7 +1397,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/</p>
    <p>The GID of the <code>postgres</code> user inside the image, defaults to <code>26</code></p>
 </td>
 </tr>
-<tr><td><code>instances</code> <B>[Required]</B><br/>
+<tr><td><code>instances</code> <b>[Required]</b><br/>
 <i>int</i>
 </td>
 <td>
@@ -1576,7 +1576,7 @@ https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 for more information.</p>
 </td>
 </tr>
-<tr><td><code>ephemeralVolumesSizeLimit</code> <B>[Required]</B><br/>
+<tr><td><code>ephemeralVolumesSizeLimit</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-EphemeralVolumesSizeLimitConfiguration"><i>EphemeralVolumesSizeLimitConfiguration</i></a>
 </td>
 <td>
@@ -2064,7 +2064,7 @@ the key of a ConfigMap</p>
    <p>The name of the secret in the pod's namespace to select from.</p>
 </td>
 </tr>
-<tr><td><code>key</code> <B>[Required]</B><br/>
+<tr><td><code>key</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -2168,7 +2168,7 @@ PostgreSQL cluster from an existing storage</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>storage</code> <B>[Required]</B><br/>
+<tr><td><code>storage</code> <b>[Required]</b><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#typedlocalobjectreference-v1-core"><i>core/v1.TypedLocalObjectReference</i></a>
 </td>
 <td>
@@ -2313,14 +2313,14 @@ storage</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>shm</code> <B>[Required]</B><br/>
+<tr><td><code>shm</code> <b>[Required]</b><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><i>k8s.io/apimachinery/pkg/api/resource.Quantity</i></a>
 </td>
 <td>
    <p>Shm is the size limit of the shared memory volume</p>
 </td>
 </tr>
-<tr><td><code>temporaryData</code> <B>[Required]</B><br/>
+<tr><td><code>temporaryData</code> <b>[Required]</b><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><i>k8s.io/apimachinery/pkg/api/resource.Quantity</i></a>
 </td>
 <td>
@@ -2344,7 +2344,7 @@ external cluster which is used in the other sections of the configuration</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -2450,21 +2450,21 @@ default to false.</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>source</code> <B>[Required]</B><br/>
+<tr><td><code>source</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-ImportSource"><i>ImportSource</i></a>
 </td>
 <td>
    <p>The source of the import</p>
 </td>
 </tr>
-<tr><td><code>type</code> <B>[Required]</B><br/>
+<tr><td><code>type</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-SnapshotType"><i>SnapshotType</i></a>
 </td>
 <td>
    <p>The import type. Can be <code>microservice</code> or <code>monolith</code>.</p>
 </td>
 </tr>
-<tr><td><code>databases</code> <B>[Required]</B><br/>
+<tr><td><code>databases</code> <b>[Required]</b><br/>
 <i>[]string</i>
 </td>
 <td>
@@ -2511,7 +2511,7 @@ database right after is imported - to be used with extreme care
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>externalCluster</code> <B>[Required]</B><br/>
+<tr><td><code>externalCluster</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -2564,7 +2564,7 @@ database right after is imported - to be used with extreme care
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>isPrimary</code> <B>[Required]</B><br/>
+<tr><td><code>isPrimary</code> <b>[Required]</b><br/>
 <i>bool</i>
 </td>
 <td>
@@ -2770,7 +2770,7 @@ local object with a known type inside the same namespace</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -3352,7 +3352,7 @@ part for now.</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>cluster</code> <B>[Required]</B><br/>
+<tr><td><code>cluster</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-LocalObjectReference"><i>LocalObjectReference</i></a>
 </td>
 <td>
@@ -3381,7 +3381,7 @@ Pooler name should never match with any cluster name within the same namespace.<
    <p>The template of the Pod to be created</p>
 </td>
 </tr>
-<tr><td><code>pgbouncer</code> <B>[Required]</B><br/>
+<tr><td><code>pgbouncer</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-PgBouncerSpec"><i>PgBouncerSpec</i></a>
 </td>
 <td>
@@ -3678,14 +3678,14 @@ cluster</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>source</code> <B>[Required]</B><br/>
+<tr><td><code>source</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
    <p>The name of the external cluster which is the replication origin</p>
 </td>
 </tr>
-<tr><td><code>enabled</code> <B>[Required]</B><br/>
+<tr><td><code>enabled</code> <b>[Required]</b><br/>
 <i>bool</i>
 </td>
 <td>
@@ -3792,7 +3792,7 @@ Reference: https://www.postgresql.org/docs/current/sql-createrole.html</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -4009,7 +4009,7 @@ files to S3. It can be provided in two alternative ways:</p>
    <p>If the first backup has to be immediately start after creation or not</p>
 </td>
 </tr>
-<tr><td><code>schedule</code> <B>[Required]</B><br/>
+<tr><td><code>schedule</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -4018,7 +4018,7 @@ as it includes an additional seconds specifier,
 see https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format</p>
 </td>
 </tr>
-<tr><td><code>cluster</code> <B>[Required]</B><br/>
+<tr><td><code>cluster</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-LocalObjectReference"><i>LocalObjectReference</i></a>
 </td>
 <td>
@@ -4149,7 +4149,7 @@ the key of a Secret</p>
    <p>The name of the secret in the pod's namespace to select from.</p>
 </td>
 </tr>
-<tr><td><code>key</code> <B>[Required]</B><br/>
+<tr><td><code>key</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -4299,7 +4299,7 @@ Map keys are the secret names, map values are the versions</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<tr><td><code>metadata</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-Metadata"><i>Metadata</i></a>
 </td>
 <td>
@@ -4410,7 +4410,7 @@ if all the labels values match.</p>
    <p>A list of node labels values to extract and compare to evaluate if the pods reside in the same topology or not</p>
 </td>
 </tr>
-<tr><td><code>enabled</code> <B>[Required]</B><br/>
+<tr><td><code>enabled</code> <b>[Required]</b><br/>
 <i>bool</i>
 </td>
 <td>
@@ -4486,14 +4486,14 @@ the storage specification for the tablespace</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
    <p>The name of the tablespace</p>
 </td>
 </tr>
-<tr><td><code>storage</code> <B>[Required]</B><br/>
+<tr><td><code>storage</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-StorageConfiguration"><i>StorageConfiguration</i></a>
 </td>
 <td>
@@ -4533,7 +4533,7 @@ documentation for more information on the <code>temp_tablespaces</code> GUC.</p>
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>name</code> <B>[Required]</B><br/>
+<tr><td><code>name</code> <b>[Required]</b><br/>
 <i>string</i>
 </td>
 <td>
@@ -4547,7 +4547,7 @@ documentation for more information on the <code>temp_tablespaces</code> GUC.</p>
    <p>Owner is the PostgreSQL user owning the tablespace</p>
 </td>
 </tr>
-<tr><td><code>state</code> <B>[Required]</B><br/>
+<tr><td><code>state</code> <b>[Required]</b><br/>
 <a href="#postgresql-k8s-enterprisedb-io-v1-TablespaceStatus"><i>TablespaceStatus</i></a>
 </td>
 <td>

--- a/product_docs/docs/postgres_for_kubernetes/1/postgis.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/postgis.mdx
@@ -98,7 +98,7 @@ both the template database and the application database, ready for use.
 
 !!! Info
     Take some time and look at the available options in `.spec.bootstrap.initdb`
-    from the [API reference](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapInitDB), such as
+    from the [API reference](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapInitDB), such as
     `postInitApplicationSQL`.
 
 You can easily verify the available version of PostGIS that is in the

--- a/product_docs/docs/postgres_for_kubernetes/1/postgis.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/postgis.mdx
@@ -98,7 +98,7 @@ both the template database and the application database, ready for use.
 
 !!! Info
     Take some time and look at the available options in `.spec.bootstrap.initdb`
-    from the [API reference](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapInitDB), such as
+    from the [API reference](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BootstrapInitDB), such as
     `postInitApplicationSQL`.
 
 You can easily verify the available version of PostGIS that is in the

--- a/product_docs/docs/postgres_for_kubernetes/1/postgresql_conf.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/postgresql_conf.mdx
@@ -3,8 +3,8 @@ title: 'PostgreSQL Configuration'
 originalFilePath: 'src/postgresql_conf.md'
 ---
 
-Users that are familiar with PostgreSQL are aware of the existence of the following two files
-to configure an instance:
+Users that are familiar with PostgreSQL are aware of the existence of the
+following two files to configure an instance:
 
 -   `postgresql.conf`: main run-time configuration file of PostgreSQL
 -   `pg_hba.conf`: clients authentication file
@@ -23,6 +23,7 @@ These settings are the same across all instances.
     that are normally controlled by the operator might indeed lead to an
     unpredictable/unrecoverable state of the cluster.
     Moreover, `ALTER SYSTEM` changes are not replicated across the cluster.
+    See ["Enabling ALTER SYSTEM"](#enabling-alter-system) below for details.
 
 A reference for custom settings usage is included in the samples, see
 [`cluster-example-custom.yaml`](../samples/cluster-example-custom.yaml).
@@ -364,7 +365,7 @@ host all all all scram-sha-256 # (or md5 for PostgreSQL version <= 13)
 Refer to the PostgreSQL documentation for [more information on `pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
 
 Inside the cluster manifest, `pg_hba` lines are added as list items
-in `spec.postgresql.pg_hba`, as in the following excerpt:
+in `.spec.postgresql.pg_hba`, as in the following excerpt:
 
 ```yaml
   postgresql:
@@ -414,6 +415,33 @@ configuration to apply the changes.
 If the change involves a parameter requiring a restart, the operator will
 perform a rolling upgrade.
 
+## Enabling `ALTER SYSTEM`
+
+EDB Postgres for Kubernetes strongly advocates employing the Cluster manifest as the
+exclusive method for altering the configuration of a PostgreSQL cluster. This
+approach guarantees coherence across the entire high-availability cluster and
+aligns with best practices for Infrastructure-as-Code.
+
+In EDB Postgres for Kubernetes version 1.22 and onwards, the default configuration disables
+the use of `ALTER SYSTEM` on new Postgres clusters. This decision is rooted in
+the recognition of potential risks associated with this command. To enable the
+use of `ALTER SYSTEM`, you can explicitly set `.spec.postgresql.enableAlterSystem`
+to `true`.
+
+!!! Warning
+    Proceed with caution when utilizing `ALTER SYSTEM`. This command operates
+    directly on the connected instance and does not undergo replication.
+    EDB Postgres for Kubernetes assumes responsibility for certain fixed parameters and complete
+    control over others, emphasizing the need for careful consideration.
+
+When `.spec.postgresql.enableAlterSystem` is configured as `false`, any attempt
+to execute `ALTER SYSTEM` will result in an error. The error message might
+resemble the following:
+
+```output
+ERROR:  could not open file "postgresql.auto.conf": Permission denied
+```
+
 ## Dynamic Shared Memory settings
 
 PostgreSQL supports a few implementations for dynamic shared memory
@@ -447,7 +475,7 @@ shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=******)
 ```
 
 If you would like to set a maximum size for the `shm` volume, you can do so by
-setting the `spec.ephemeralVolumesSizeLimit.shm` field in the `Cluster` resource.
+setting the `.spec.ephemeralVolumesSizeLimit.shm` field in the `Cluster` resource.
 For example:
 
 ```yaml
@@ -554,13 +582,10 @@ Users are not allowed to set the following configuration parameters in the
 -   `ssl`
 -   `ssl_ca_file`
 -   `ssl_cert_file`
--   `ssl_ciphers`
 -   `ssl_crl_file`
 -   `ssl_dh_params_file`
 -   `ssl_ecdh_curve`
 -   `ssl_key_file`
--   `ssl_max_protocol_version`
--   `ssl_min_protocol_version`
 -   `ssl_passphrase_command`
 -   `ssl_passphrase_command_supports_reload`
 -   `ssl_prefer_server_ciphers`

--- a/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
@@ -150,7 +150,7 @@ spec:
 
 !!! Note "There's more"
     For more detailed information about the available options, please refer
-    to the ["API Reference" section](pg4k.v1.md).
+    to the ["API Reference" section](cloudnative-pg.v1.md).
 
 In order to create the 3-node PostgreSQL cluster, you need to run the following command:
 

--- a/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
@@ -150,7 +150,7 @@ spec:
 
 !!! Note "There's more"
     For more detailed information about the available options, please refer
-    to the ["API Reference" section](cloudnative-pg.v1.md).
+    to the ["API Reference" section](pg4k.v1.md).
 
 In order to create the 3-node PostgreSQL cluster, you need to run the following command:
 

--- a/product_docs/docs/postgres_for_kubernetes/1/recovery.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/recovery.mdx
@@ -4,66 +4,68 @@ originalFilePath: 'src/recovery.md'
 ---
 
 In PostgreSQL terminology, recovery is the process of starting a PostgreSQL
-instance using a previously taken backup. The PostgreSQL recovery mechanism
-is very solid and rich. It also supports Point In Time Recovery, which allows
-you to restore a given cluster up to any point in time from the first available
-backup in your catalog to the last archived WAL (as you can see, the WAL
-archive is mandatory in this case).
+instance using an existing backup. The PostgreSQL recovery mechanism
+is very solid and rich. It also supports point-in-time recovery (PITR), which allows
+you to restore a given cluster up to any point in time, from the first available
+backup in your catalog to the last archived WAL. (The WAL
+archive is mandatory in this case.)
 
-In EDB Postgres for Kubernetes, recovery cannot be performed "in-place" on an existing
-cluster. Recovery is rather a way to bootstrap a new Postgres cluster
+In EDB Postgres for Kubernetes, you can't perform recovery in place on an existing
+cluster. Recovery is instead a way to bootstrap a new Postgres cluster
 starting from an available physical backup.
 
 !!! Note
-    For details on the `bootstrap` stanza, please refer to the
-    ["Bootstrap" section](bootstrap.md).
+    For details on the `bootstrap` stanza, see
+    [Bootstrap](bootstrap.md).
 
-The `recovery` bootstrap mode lets you create a new cluster from an existing
-physical base backup, and then reapply the WAL files containing the REDO log
+The `recovery` bootstrap mode lets you create a cluster from an existing
+physical base backup. You then reapply the WAL files containing the REDO log
 from the archive.
 
 WAL files are pulled from the defined *recovery object store*.
 
-Base backups may be taken either on object stores, or using volume snapshots
+Base backups can be taken either on object stores or using volume snapshots
 (from version 1.21).
 
 !!! Warning
     Recovery using volume snapshots had an initial release on 1.20.1. Because of
-    the amount of progress on the feature for 1.21.0, it is strongly advised
-    that you upgrade to 1.21.0 or more advanced releases to use volume
-    snapshots.
+    the amount of progress on the feature for 1.21.0, to use volume
+    snapshots, we strongly advise you to upgrade to 1.21 or more advanced
+    releases.
 
-Recovery from a *recovery object store* can be achieved in two ways:
+You can achieve recovery from a *recovery object store* in two ways:
 
--   using a recovery object store, that is, a backup of another cluster
-    created by Barman Cloud and defined via the `barmanObjectStore` option
-    in the `externalClusters` section (*recommended*)
--   using an existing `Backup` object in the same namespace (this was the
-    only option available before version 1.8.0).
+-   We recommend using a recovery object store, that is, a backup of another cluster
+    created by Barman Cloud and defined by way of the `barmanObjectStore` option
+    in the `externalClusters` section.
+-   Alternatively, you can use an existing `Backup` object in the same namespace.
 
 Both recovery methods enable either full recovery (up to the last
 available WAL) or up to a [point in time](#point-in-time-recovery-pitr).
-When performing a full recovery, the cluster can also be started
+When performing a full recovery, you can also start the cluster
 in replica mode (see [replica clusters](replica_cluster.md) for reference).
-If using replica mode, make sure that the PostgreSQL configuration
-(`.spec.postgresql.parameters`) of the recovered cluster is
-compatible, from a physical replication standpoint, with the original one.
 
-For recovery using volume snapshots:
+!!! Important
+    If using replica mode, make sure that the PostgreSQL configuration
+    (`.spec.postgresql.parameters`) of the recovered cluster is compatible with
+    the original one from a physical replication standpoint.
 
--   using a consistent set of `VolumeSnapshot` objects that all belong to the
-    same backup, and identified by the same `k8s.enterprisedb.io/cluster` and
-    `k8s.enterprisedb.io/backupName` labels, then recovering through the `volumeSnapshots`
+For recovery using *volume snapshots*:
+
+-   Use a consistent set of `VolumeSnapshot` objects that all belong to the
+    same backup and are identified by the same `k8s.enterprisedb.io/cluster` and
+    `k8s.enterprisedb.io/backupName` labels. Then, recover through the `volumeSnapshots`
     option in the `.spec.bootstrap.recovery` stanza, as described in
-    ["Recovery from `VolumeSnapshot` objects"](#recovery-from-volumesnapshot-objects) below
+    [Recovery from `VolumeSnapshot` objects](#recovery-from-volumesnapshot-objects).
 
 ## Recovery from an object store
 
 You can recover from a backup created by Barman Cloud and stored on a supported
-object store. Once you have defined the external cluster, including all the
-required configuration in the `barmanObjectStore` section, you need to
-reference it in the `.spec.recovery.source` option. The following example
-defines a recovery object store in a blob container in Azure:
+object store. After you define the external cluster, including all the required
+configuration in the `barmanObjectStore` section, you need to reference it in
+the `.spec.recovery.source` option.
+
+This example defines a recovery object store in a blob container in Azure:
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
@@ -75,7 +77,7 @@ spec:
   
   superuserSecret:
     name: superuser-secret
-    
+
   bootstrap:
     recovery:
       source: clusterBackup
@@ -96,33 +98,32 @@ spec:
 ```
 
 !!! Important
-    By default the `recovery` method strictly uses the `name` of the
+    By default, the `recovery` method strictly uses the `name` of the
     cluster in the `externalClusters` section as the name of the main folder
-    of the backup data within the object store, which is normally reserved
+    of the backup data within the object store. This name is normally reserved
     for the name of the server. You can specify a different folder name
-    with the `barmanObjectStore.serverName` property.
+    using the `barmanObjectStore.serverName` property.
 
 !!! Note
-    In the above example we are taking advantage of the parallel WAL restore
-    feature, dedicating up to 8 jobs to concurrently fetch the required WAL
-    files from the archive. This feature can appreciably reduce the recovery time.
-    Make sure that you plan ahead for this scenario and correctly tune the
-    value of this parameter for your environment. It will certainly make a
-    difference **when** (not if) you'll need it.
+    This example takes advantage of the parallel WAL restore feature,
+    dedicating up to 8 jobs to concurrently fetch the required WAL files from the
+    archive. This feature can appreciably reduce the recovery time. Make sure that
+    you plan ahead for this scenario and correctly tune the value of this parameter
+    for your environment. It will make a difference when you need it, and you will.
 
 ## Recovery from `VolumeSnapshot` objects
 
 !!! Warning
-    When creating replicas after having recovered the primary instance from
+    When creating replicas after recovering the primary instance from
     the volume snapshot, the operator might end up using `pg_basebackup`
-    to synchronize them, resulting in a slower process depending on the size
-    of the database. This limitation will be lifted in the future when support
-    for online backups and PVC cloning will be introduced.
+    to synchronize them. This behavior results in a slower process, depending
+    on the size of the database. This limitation will be lifted in the future when
+    support for online backups and PVC cloning are introduced.
 
 EDB Postgres for Kubernetes can create a new cluster from a `VolumeSnapshot` of a PVC of an
-existing `Cluster` that's been taken using the declarative API for
-[volume snapshot backups](backup_volumesnapshot.md).
-You will need to specify the name of the snapshot, as in the following example:
+existing `Cluster` that's been taken using the declarative API for [volume
+snapshot backups](backup_volumesnapshot.md). You must specify the name of the
+snapshot, as in the following example:
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
@@ -132,7 +133,7 @@ metadata:
 spec:
   [...]
 
-bootstrap:
+  bootstrap:
     recovery:
       volumeSnapshots:
         storage:
@@ -152,7 +153,7 @@ metadata:
 spec:
   [...]
 
-bootstrap:
+  bootstrap:
     recovery:
       volumeSnapshots:
         storage:
@@ -169,17 +170,17 @@ bootstrap:
 !!! Warning
     If bootstrapping a replica-mode cluster from snapshots, to leverage
     snapshots for the standby instances and not just the primary,
-    it would be advisable to:
+    we recommend that you:
 
-    1.  start with a single instance replica cluster. The primary instance will
-        be recovered using the snapshot and available WALs form the source cluster
-    2.  take a snapshot of the primary in the replica cluster
-    3.  increase the number of instances in the replica cluster as desired
+    1.  Start with a single instance replica cluster. The primary instance will
+        be recovered using the snapshot, and available WALs form the source cluster.
+    2.  Take a snapshot of the primary in the replica cluster.
+    3.  Increase the number of instances in the replica cluster as desired.
 
 ## Recovery from a `Backup` object
 
-In case a `Backup` resource is already available in the namespace in which the
-cluster should be created, you can specify its name through
+If a `Backup` resource is already available in the namespace in which you need
+to create the cluster, you can specify the name using
 `.spec.bootstrap.recovery.backup.name`, as in the following example:
 
 ```yaml
@@ -202,10 +203,10 @@ spec:
 This bootstrap method allows you to specify just a reference to the
 backup that needs to be restored.
 
-The previous example implies the application database and its owning user to be
+The previous example implies the application database and its owning user is
 the default one, `app`. If the PostgreSQL cluster being restored was using
-different names, they can be specified as documented in the [Configure the
-application database](#configure-the-application-database) section.
+different names, you can specify them as documented in [Configure the
+application database](#configure-the-application-database).
 
 ## Additional considerations
 
@@ -213,16 +214,15 @@ Whether you recover from a recovery object store, a volume snapshot, or an
 existing `Backup` resource, the following considerations apply:
 
 -   The application database name and the application database user are preserved
-    from the backup that is being restored. The operator does not currently attempt
+    from the backup that's being restored. The operator doesn't currently attempt
     to back up the underlying secrets, as this is part of the usual maintenance
-    activity of the Kubernetes cluster itself.
--   To preserve the original `postgres` user password, you need to properly
+    activity of the Kubernetes cluster.
+-   To preserve the original postgres user password, you need to properly
     configure `enableSuperuserAccess` and supply a `superuserSecret`.
--   By default, the recovery will continue up to the latest
-    available WAL on the default target timeline (`current` for PostgreSQL up to
-    11, `latest` for version 12 and above).
-    You can optionally specify a `recoveryTarget` to perform a point in time
-    recovery (see the ["Point in time recovery" section](#point-in-time-recovery-pitr)).
+-   By default, the recovery continues up to the latest
+    available WAL on the default target timeline (`latest`).
+    You can optionally specify a `recoveryTarget` to perform a point-in-time
+    recovery (see [Point in time recovery (PITR)](#point-in-time-recovery-pitr)).
 
 !!! Important
     Consider using the `barmanObjectStore.wal.maxParallel` option to speed
@@ -231,23 +231,23 @@ existing `Backup` resource, the following considerations apply:
 
 ## Point in time recovery (PITR)
 
-Instead of replaying all the WALs up to the latest one, we can ask PostgreSQL
-to stop replaying WALs at any given point in time, after having extracted a
-base backup. PostgreSQL uses this technique to achieve *point-in-time* recovery
-(PITR). The presence of a WAL archive is mandatory.
+Instead of replaying all the WALs up to the latest one, after extracting a base
+backup, you can ask PostgreSQL to stop replaying WALs at any given point in
+time. PostgreSQL uses this technique to achieve PITR. The presence of a WAL
+archive is mandatory.
 
 !!! Important
-    PITR requires you to specify a **recovery target**, by using the options
-    described in the ["Recovery targets" section](#recovery-targets) below.
+    PITR requires you to specify a recovery target by using the options
+    described in [Recovery targets](#recovery-targets).
 
-The operator will generate the configuration parameters required for this
-feature to work in case a recovery target is specified.
+The operator generates the configuration parameters required for this
+feature to work if you specify a recovery target.
 
 ### PITR from an object store
 
-The example below uses a recovery object store in Azure that contains both
+This example uses a recovery object store in Azure that contains both
 the base backups and the WAL archive. The recovery target is based on a
-requested timestamp:
+requested timestamp.
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
@@ -283,37 +283,37 @@ spec:
           maxParallel: 8
 ```
 
-You might have noticed that in the above example you only had to specify
-the `targetTime` in the form of a timestamp, without having to worry about
-specifying the base backup from which to start the recovery.
+In this example, you had to specify only the `targetTime` in the form of a
+timestamp. You didn't have to specify the base backup from which to start the
+recovery.
 
 The `backupID` option is the one that allows you to specify the base backup
 from which to initiate the recovery process. By default, this value is
 empty.
 
 If you assign a value to it (in the form of a Barman backup ID), the operator
-will use that backup as base for the recovery.
+uses that backup as the base for the recovery.
 
 !!! Important
     You need to make sure that such a backup exists and is accessible.
 
-If the backup ID is not specified, the operator will automatically detect the
-base backup for the recovery as follows:
+If you don't specify the backup ID, the operator detects the base backup for
+the recovery as follows:
 
--   when you use `targetTime` or `targetLSN`, the operator selects the closest
-    backup that was completed before that target
--   otherwise the operator selects the last available backup in chronological
+-   When you use `targetTime` or `targetLSN`, the operator selects the closest
+    backup that was completed before that target.
+-   Otherwise, the operator selects the last available backup, in chronological
     order.
 
-### PITR from `VolumeSnapshot` Objects
+### PITR from `VolumeSnapshot` objects
 
-The example below uses:
+The example that follows uses:
 
--   a Kubernetes volume snapshot for the `PGDATA` containing the base backup from
-    which to start the recovery process, identified in the
-    `recovery.volumeSnapshots` section and called `test-snapshot-1`
--   a recovery object store in MinIO containing the WAL archive, identified by
-    the `recovery.source` option in the form of an external cluster definition
+-   A Kubernetes volume snapshot for the `PGDATA` containing the base backup from
+    which to start the recovery process. This snapshot is identified in the
+    `recovery.volumeSnapshots` section and called `test-snapshot-1`.
+-   A recovery object store in MinIO containing the WAL archive. The object store is identified by
+    the `recovery.source` option in the form of an external cluster definition.
 
 The recovery target is based on a requested timestamp.
 
@@ -349,53 +349,52 @@ spec:
 ```
 
 !!! Note
-    In case the backed up Cluster had `walStorage` enabled, you also must
-    specify the volume snapshot containing the `PGWAL` directory, as mentioned
-    in the [Recovery from VolumeSnapshot objects](#recovery-from-volumesnapshot-objects)
-    section.
+    If the backed-up cluster had `walStorage` enabled, you also must specify
+    the volume snapshot containing the `PGWAL` directory, as mentioned in
+    [Recovery from VolumeSnapshot objects](#recovery-from-volumesnapshot-objects).
 
 !!! Warning
-    It is your responsibility to ensure that the end time of the base backup in
-    the volume snapshot is prior to the recovery target timestamp.
+    It's your responsibility to ensure that the end time of the base backup in
+    the volume snapshot is before the recovery target timestamp.
 
 ### Recovery targets
 
 Here are the recovery target criteria you can use:
 
 targetTime
-:  time stamp up to which recovery will proceed, expressed in
-   [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format
-   (the precise stopping point is also influenced by the `exclusive` option)
+:  Time stamp up to which recovery proceeds, expressed in
+   [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.
+   (The precise stopping point is also influenced by the `exclusive` option.)
 
 targetXID
-:  transaction ID up to which recovery will proceed
-   (the precise stopping point is also influenced by the `exclusive` option);
-   keep in mind that while transaction IDs are assigned sequentially at
+:  Transaction ID up to which recovery proceeds.
+   (The precise stopping point is also influenced by the `exclusive` option.)
+   Keep in mind that while transaction IDs are assigned sequentially at
    transaction start, transactions can complete in a different numeric order.
-   The transactions that will be recovered are those that committed before
-   (and optionally including) the specified one
+   The transactions that are recovered are those that committed before
+   (and optionally including) the specified one.
 
 targetName
-:  named restore point (created with `pg_create_restore_point()`) to which
-   recovery will proceed
+:  Named restore point (created with `pg_create_restore_point()`) to which
+   recovery proceeds.
 
 targetLSN
-:  LSN of the write-ahead log location up to which recovery will proceed
-   (the precise stopping point is also influenced by the `exclusive` option)
+:  LSN of the write-ahead log location up to which recovery proceeds.
+   (The precise stopping point is also influenced by the `exclusive` option.)
 
 targetImmediate
-:  recovery should end as soon as a consistent state is reached - i.e. as early
+:  Recovery ends as soon as a consistent state is reached, that is, as early
    as possible. When restoring from an online backup, this means the point where
-   taking the backup ended
+   taking the backup ended.
 
 !!! Important
-    While the operator is able to automatically retrieve the closest backup
-    when either `targetTime` or `targetLSN` is specified, this is not possible
-    for the remaining targets: `targetName`, `targetXID`, and `targetImmediate`.
-    In such cases, it is important to specify `backupID`, unless you are OK with
-    the last available backup in the catalog.
+    The operator can retrieve the closest backup when you specify either
+    `targetTime` or `targetLSN`. However, this isn't possible for the remaining
+    targets: `targetName`, `targetXID`, and `targetImmediate`. In such cases, it's
+    important to specify `backupID`, unless the last available backup in the
+    catalog is acceptable.
 
-The example below uses a `targetName` based recovery target:
+This example uses a `targetName`-based recovery target:
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
@@ -410,18 +409,20 @@ kind: Cluster
 [...]
 ```
 
-You can choose only a single one among the targets above in each
-`recoveryTarget` configuration.
+You can choose only a single one among the targets in each `recoveryTarget`
+configuration.
 
-Additionally, you can specify `targetTLI` force recovery to a specific
+Additionally, you can specify `targetTLI` to force recovery to a specific
 timeline.
 
 By default, the previous parameters are considered to be inclusive, stopping
-just after the recovery target, matching [the behavior in PostgreSQL](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-RECOVERY-TARGET-INCLUSIVE)
-You can request exclusive behavior,
-stopping right before the recovery target, by setting the `exclusive` parameter to
-`true` like in the following example relying on a blob container in Azure
-for both base backups and the WAL archive:
+just after the recovery target, matching
+[the behavior in PostgreSQL](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-RECOVERY-TARGET-INCLUSIVE).
+
+You can request exclusive behavior, stopping right before the recovery target,
+by setting the `exclusive` parameter to `true`. The following example shows
+this behavior, relying on a blob container in Azure for both base backups and
+the WAL archive:
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
@@ -459,16 +460,16 @@ spec:
 
 ## Configure the application database
 
-For the recovered cluster, we can configure the application database name and
+For the recovered cluster, you can configure the application database name and
 credentials with additional configuration. To update application database
-credentials, we can generate our own passwords, store them as secrets, and
-update the database use the secrets. Or we can also let the operator generate a
-secret with randomly secure password for use. Please reference the
-["Bootstrap an empty cluster"](bootstrap.md#bootstrap-an-empty-cluster-initdb)
-section for more information about secrets.
+credentials, you can generate your own passwords, store them as secrets, and
+update the database to use the secrets. Or you can also let the operator
+generate a secret with a randomly secure password for use.
+See [Bootstrap an empty cluster](bootstrap.md#bootstrap-an-empty-cluster-initdb)
+for more information about secrets.
 
-The following example configure the application database `app` with owner
-`app`, and supplied secret `app-secret`.
+This example configures the application database `app` with owner `app` and
+supplied secret `app-secret`.
 
 ```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
@@ -484,42 +485,45 @@ spec:
       [...]
 ```
 
-With the above configuration, the following will happen after recovery is completed:
+With this configuration, the following happens after recovery is complete:
 
-1.  if database `app` does not exist, a new database `app` will be created.
-2.  if user `app` does not exist, a new user `app` will be created.
-3.  if user `app` is not the owner of database, user `app` will be granted
+1.  If database `app` doesn't exist, a new database `app` is created.
+2.  If user `app` doesn't exist, a new user `app` is created.
+3.  if user `app` isn't the owner of the database, user `app` is granted
     as owner of database `app`.
-4.  If value of `username` match value of `owner` in secret, the password of
-    application database will be changed to the value of `password` in secret.
+4.  If the value of `username` matches the value of `owner` in the secret, the
+    password of application database is changed to the value of `password` in the
+    secret.
 
 !!! Important
-    For a replica cluster with replica mode enabled, the operator will not
-    create any database or user in the PostgreSQL instance, as these will be
+    For a replica cluster with replica mode enabled, the operator doesn't
+    create any database or user in the PostgreSQL instance. These are
     recovered from the original cluster.
 
 ## How recovery works under the hood
 
 
 
-You can use the data uploaded to the object storage to *bootstrap* a
-new cluster from a previously taken backup.
-The operator will orchestrate the recovery process using the
-`barman-cloud-restore` tool (for the base backup) and the
+
+
+You can use the data uploaded to the object storage to *bootstrap* a new
+cluster from an existing backup. The operator orchestrates the recovery process
+using the `barman-cloud-restore` tool (for the base backup) and the
 `barman-cloud-wal-restore` tool (for WAL files, including parallel support, if
 requested).
 
-For details and instructions on the `recovery` bootstrap method, please refer
-to the ["Bootstrap from a backup" section](bootstrap.md#bootstrap-from-a-backup-recovery).
+For details and instructions on the `recovery` bootstrap method, see
+[Bootstrap from a backup](bootstrap.md#bootstrap-from-a-backup-recovery).
 
 !!! Important
-    If you are not familiar with how [PostgreSQL PITR](https://www.postgresql.org/docs/current/continuous-archiving.html#BACKUP-PITR-RECOVERY)
+    If you're not familiar with how
+    [PostgreSQL PITR](https://www.postgresql.org/docs/current/continuous-archiving.html#BACKUP-PITR-RECOVERY)
     works, we suggest that you configure the recovery cluster as the original
     one when it comes to `.spec.postgresql.parameters`. Once the new cluster is
     restored, you can then change the settings as desired.
 
-Under the hood, the operator will inject an init container in the first
-instance of the new cluster, and the init container will start recovering the
+The way it works is that the operator injects an init container in the first
+instance of the new cluster, and the init container starts recovering the
 backup from the object storage.
 
 !!! Important
@@ -527,39 +531,37 @@ backup from the object storage.
     the size of the backup, as well as the speed of both the network and the
     storage.
 
-When the base backup recovery process is completed, the operator starts the
-Postgres instance in recovery mode: in this phase, PostgreSQL is up, albeit not
+When the base backup recovery process is complete, the operator starts the
+Postgres instance in recovery mode. In this phase, PostgreSQL is up, though not
 able to accept connections, and the pod is healthy according to the
-liveness probe. Through the `restore_command`, PostgreSQL starts fetching WAL
-files from the archive (you can speed up this phase by setting the
-`maxParallel` option and enable the parallel WAL restore capability).
+liveness probe. By way of the `restore_command`, PostgreSQL starts fetching WAL
+files from the archive. (You can speed up this phase by setting the
+`maxParallel` option and enabling the parallel WAL restore capability.)
 
 This phase terminates when PostgreSQL reaches the target (either the end of the
-WAL or the required target in case of Point-In-Time-Recovery). Indeed, you can
-optionally specify a `recoveryTarget` to perform a point in time recovery. If
-left unspecified, the recovery will continue up to the latest available WAL on
-the default target timeline (`current` for PostgreSQL up to 11, `latest` for
-version 12 and above).
+WAL or the required target in case of PITR. You can optionally specify a
+`recoveryTarget` to perform a PITR. If left unspecified, the recovery continues
+up to the latest available WAL on the default target timeline (`latest`).
 
-Once the recovery is complete, the operator will set the required
-superuser password into the instance. The new primary instance will start
-as usual, and the remaining instances will join the cluster as replicas.
+Once the recovery is complete, the operator sets the required superuser
+password into the instance. The new primary instance starts as usual, and the
+remaining instances join the cluster as replicas.
 
-The process is transparent for the user and it is managed by the instance
-manager running in the Pods.
+The process is transparent for the user and is managed by the instance manager
+running in the pods.
 
 ## Restoring into a cluster with a backup section
 
 
 
-A manifest for a cluster restore may include a `backup` section.
-This means that the new cluster, after recovery, will start archiving WAL's and
-taking backups if configured to do so.
+A manifest for a cluster restore might include a `backup` section. This means
+that,after recovery, the new cluster starts archiving WALs and taking backups
+if configured to do so.
 
-For example, the section below could be part of a manifest for a Cluster
-bootstrapping from Cluster `cluster-example-backup`, and would create a
-new folder in the storage bucket named `recoveredCluster` where the base backups
-and WAL's of the recovered cluster would be stored.
+For example, this section is part of a manifest for a cluster bootstrapping
+from the cluster `cluster-example-backup`. In the storage bucket, it creates a
+folder named `recoveredCluster`, where the base backups and WALs of the
+recovered cluster are stored.
 
 ```yaml
   backup:
@@ -584,21 +586,21 @@ and WAL's of the recovered cluster would be stored.
       s3Credentials:
 ```
 
-You should not re-use the exact same `barmanObjectStore` configuration
-for different clusters. There could be cases where the existing information
-in the storage buckets could be overwritten by the new cluster.
+Don't reuse the same `barmanObjectStore` configuration for different clusters.
+There might be cases where the existing information in the storage buckets
+could be overwritten by the new cluster.
 
 !!! Warning
-    The operator includes a safety check to ensure a cluster will not
-    overwrite a storage bucket that contained information. A cluster that would
-    overwrite existing storage will remain in state `Setting up primary` with
-    Pods in an Error state.
-    The pod logs will show:
-    `ERROR: WAL archive check failed for server recoveredCluster: Expected empty archive`
+    The operator includes a safety check to ensure a cluster doesn't overwrite
+
+a storage bucket that contained information. A cluster that would overwrite
+existing storage remains in the state `Setting up primary` with pods in an
+error state. The pod logs show: `ERROR: WAL archive check failed for server
+recoveredCluster: Expected empty archive`.
 
 !!! Important
-    If you set the `k8s.enterprisedb.io/skipEmptyWalArchiveCheck` annotation to `enabled` in
-    the recovered cluster, you can skip the above check. This is not recommended
-    as for the general use case the above check works fine. Please don't do
-    this unless you are familiar with PostgreSQL recovery system, as this can lead
-    you to severe data loss.
+    If you set the `k8s.enterprisedb.io/skipEmptyWalArchiveCheck` annotation to `enabled`
+    in the recovered cluster, you can skip the safety check. We don't recommend
+    skipping the check because, for the general use case, the check works fine.
+    Skip this check only if you're familiar with the PostgreSQL recovery system, as
+    severe data loss can occur.

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_18_9_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_18_9_rel_notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "EDB Postgres for Kubernetes 1.18.9 release notes"
+navTitle: "Version 1.18.9"
+---
+
+Released: 22 Dec 2023
+
+EDB Postgres for Kubernetes version 1.8.9 is an LTS release of EDB Postgres for Kubernetes; there is no corresponding upstream release of CloudNativePG.
+
+This release of EDB Postgres for Kubernetes includes the following:
+
+| Type         | Subsystem         | Description |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Security     |                   | By default, TLSv1.3 is now enforced on all PostgreSQL 12 or higher installations. Additionally, users can configure the `ssl_ciphers`, `ssl_min_protocol_version`, and `ssl_max_protocol_version` GUCs ([#3408](https://github.com/cloudnative-pg/cloudnative-pg/pull/3408)). |
+| Security     |                   | Integrated Docker image scanning with Dockle to enhance security measures. |
+| Defaults     |                   | Default operand image is now PostgreSQL 16.1 ([#3270](https://github.com/cloudnative-pg/cloudnative-pg/pull/3270)). |
+| Enhancement  |                   | Improved reconciliation of external clusters ([#3533](https://github.com/cloudnative-pg/cloudnative-pg/pull/3533)). |
+| Enhancement  |                   | Introduced the ability to enable/disable the `ALTER SYSTEM` command ([#3535](https://github.com/cloudnative-pg/cloudnative-pg/pull/3535)). |
+| Enhancement  |                   | Added support for Prometheus' dynamic relabeling through the `podMonitorMetricRelabelings` and `podMonitorRelabelings` options in the `.spec.monitoring` stanza of the `Cluster` and `Pooler` resources ([#3075](https://github.com/cloudnative-pg/cloudnative-pg/pull/3075)). |
+| Enhancement  |                   | Eliminated the use of the `PGPASSFILE` environment variable when establishing a network connection to PostgreSQL ([#3522](https://github.com/cloudnative-pg/cloudnative-pg/pull/3522)). |
+| Enhancement  |                   | Improved `cnp report` plugin command by collecting a cluster's PVCs ([#3357](https://github.com/cloudnative-pg/cloudnative-pg/pull/3357)). |
+| Enhancement  | Connection pooler | Scaling down instances of a `Pooler` resource to 0 is now possible ([#3517](https://github.com/cloudnative-pg/cloudnative-pg/pull/3517)). |
+| Enhancement  | Connection pooler | Added the `k8s.enterprisedb.io/podRole` label with a value of 'pooler' to every pooler deployment, differentiating them from instance pods ([#3396](https://github.com/cloudnative-pg/cloudnative-pg/pull/3396)). |
+| Bug fix      |                   | Reconciled metadata, annotations, and labels of `PodDisruptionBudget`
+  resources ([#3312](https://github.com/cloudnative-pg/cloudnative-pg/pull/3312) and [#3434](https://github.com/cloudnative-pg/cloudnative-pg/pull/3434)). |
+| Bug fix      |                   | Reconciled the metadata of the managed credential secrets ([#3316](https://github.com/cloudnative-pg/cloudnative-pg/pull/3316)). |
+| Bug fix      |                   | Disabled wal_sender_timeout when joining through pg_basebackup ([#3586](https://github.com/cloudnative-pg/cloudnative-pg/pull/3586)).  |
+| Bug fix      |                   | Secrets labeled `cnpg.io/reload=true` and used by external clusters are now reloaded when they change ([#3565](https://github.com/cloudnative-pg/cloudnative-pg/pull/3565)).  |
+| Bug fix      | Connection pooler | Ensured the controller watches all secrets owned by a `Pooler` resource ([#3428](https://github.com/cloudnative-pg/cloudnative-pg/pull/3428)).  |
+| Bug fix      | Connection pooler | Reconciled `RoleBinding` for `Pooler` resources ([#3391](https://github.com/cloudnative-pg/cloudnative-pg/pull/3391)).  |
+| Bug fix      | Connection pooler | Reconciled `imagePullSecret` for `Pooler` resources ([#3389](https://github.com/cloudnative-pg/cloudnative-pg/pull/3389)).  |
+| Bug fix      | Connection pooler | Reconciled the service of a `Pooler` and addition of the required labels ([#3349](https://github.com/cloudnative-pg/cloudnative-pg/pull/3349)).  |
+| Bug fix      | Connection pooler | Extended `Pooler` labels to the deployment as well, not just the pods ([#3350](https://github.com/cloudnative-pg/cloudnative-pg/pull/3350)).  |
+

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_18_9_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_18_9_rel_notes.mdx
@@ -5,12 +5,12 @@ navTitle: "Version 1.18.9"
 
 Released: 22 Dec 2023
 
-EDB Postgres for Kubernetes version 1.8.9 is an LTS release of EDB Postgres for Kubernetes; there is no corresponding upstream release of CloudNativePG.
+EDB Postgres for Kubernetes version 1.18.9 is an LTS release of EDB Postgres for Kubernetes; there is no corresponding upstream release of CloudNativePG.
 
 This release of EDB Postgres for Kubernetes includes the following:
 
 | Type         | Subsystem         | Description |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| ------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | Security     |                   | By default, TLSv1.3 is now enforced on all PostgreSQL 12 or higher installations. Additionally, users can configure the `ssl_ciphers`, `ssl_min_protocol_version`, and `ssl_max_protocol_version` GUCs ([#3408](https://github.com/cloudnative-pg/cloudnative-pg/pull/3408)). |
 | Security     |                   | Integrated Docker image scanning with Dockle to enhance security measures. |
 | Defaults     |                   | Default operand image is now PostgreSQL 16.1 ([#3270](https://github.com/cloudnative-pg/cloudnative-pg/pull/3270)). |
@@ -21,8 +21,7 @@ This release of EDB Postgres for Kubernetes includes the following:
 | Enhancement  |                   | Improved `cnp report` plugin command by collecting a cluster's PVCs ([#3357](https://github.com/cloudnative-pg/cloudnative-pg/pull/3357)). |
 | Enhancement  | Connection pooler | Scaling down instances of a `Pooler` resource to 0 is now possible ([#3517](https://github.com/cloudnative-pg/cloudnative-pg/pull/3517)). |
 | Enhancement  | Connection pooler | Added the `k8s.enterprisedb.io/podRole` label with a value of 'pooler' to every pooler deployment, differentiating them from instance pods ([#3396](https://github.com/cloudnative-pg/cloudnative-pg/pull/3396)). |
-| Bug fix      |                   | Reconciled metadata, annotations, and labels of `PodDisruptionBudget`
-  resources ([#3312](https://github.com/cloudnative-pg/cloudnative-pg/pull/3312) and [#3434](https://github.com/cloudnative-pg/cloudnative-pg/pull/3434)). |
+| Bug fix      |                   | Reconciled metadata, annotations, and labels of `PodDisruptionBudget` resources ([#3312](https://github.com/cloudnative-pg/cloudnative-pg/pull/3312) and [#3434](https://github.com/cloudnative-pg/cloudnative-pg/pull/3434)). |
 | Bug fix      |                   | Reconciled the metadata of the managed credential secrets ([#3316](https://github.com/cloudnative-pg/cloudnative-pg/pull/3316)). |
 | Bug fix      |                   | Disabled wal_sender_timeout when joining through pg_basebackup ([#3586](https://github.com/cloudnative-pg/cloudnative-pg/pull/3586)).  |
 | Bug fix      |                   | Secrets labeled `cnpg.io/reload=true` and used by external clusters are now reloaded when they change ([#3565](https://github.com/cloudnative-pg/cloudnative-pg/pull/3565)).  |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_20_5_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_20_5_rel_notes.mdx
@@ -1,0 +1,12 @@
+---
+title: "EDB Postgres for Kubernetes 1.20.5 release notes"
+navTitle: "Version 1.20.5"
+---
+
+Released: 22 Dec 2023
+
+This release of EDB Postgres for Kubernetes includes the following:
+
+|      Type      |                                                                                  Description                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Upstream merge |  Merged with community CloudNativePG 1.20.5. See the community [Release Notes](https://cloudnative-pg.io/documentation/1.20/release_notes/v1.20/).                                    |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_21_2_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_21_2_rel_notes.mdx
@@ -1,0 +1,12 @@
+---
+title: "EDB Postgres for Kubernetes 1.21.2 release notes"
+navTitle: "Version 1.21.2"
+---
+
+Released: 22 Dec 2023
+
+This release of EDB Postgres for Kubernetes includes the following:
+
+|      Type      |                                                                                  Description                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Upstream merge |  Merged with community CloudNativePG 1.21.2. See the community [Release Notes](https://cloudnative-pg.io/documentation/1.21/release_notes/v1.21/).                                    |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_22_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_22_0_rel_notes.mdx
@@ -1,0 +1,12 @@
+---
+title: "EDB Postgres for Kubernetes 1.22.0 release notes"
+navTitle: "Version 1.22.0"
+---
+
+Released: 08 Nov 2023
+
+This release of EDB Postgres for Kubernetes includes the following:
+
+|      Type      |                                                                                  Description                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Upstream merge |  Merged with community CloudNativePG 1.22.0. See the community [Release Notes](https://cloudnative-pg.io/documentation/1.22/release_notes/v1.22/).                                    |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
@@ -4,8 +4,11 @@ navTitle: "Release notes"
 redirects:
 - ../release_notes
 navigation:
+- 1_22_0_rel_notes
+- 1_21_2_rel_notes
 - 1_21_1_rel_notes
 - 1_21_0_rel_notes
+- 1_20_5_rel_notes
 - 1_20_4_rel_notes
 - 1_20_3_rel_notes
 - 1_20_2_rel_notes
@@ -18,6 +21,7 @@ navigation:
 - 1_19_2_rel_notes
 - 1_19_1_rel_notes
 - 1_19_0_rel_notes
+- 1_18_9_rel_notes
 - 1_18_8_rel_notes
 - 1_18_7_rel_notes
 - 1_18_6_rel_notes
@@ -71,20 +75,24 @@ The EDB Postgres for Kubernetes documentation describes the major version of EDB
 
 |          Version           | Release date |                                       Upstream merges                                       |
 | -------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| [1.22.0](1_22_0_rel_notes) | 22 Dec 2023  | Upstream [1.22.0](https://cloudnative-pg.io/documentation/1.22/release_notes/v1.22/) |
+| [1.21.2](1_21_2_rel_notes) | 22 Dec 2023  | Upstream [1.21.2](https://cloudnative-pg.io/documentation/1.21/release_notes/v1.21/) |
 | [1.21.1](1_21_1_rel_notes) | 08 Nov 2023  | Upstream [1.21.1](https://cloudnative-pg.io/documentation/1.21/release_notes/v1.21/) |
 | [1.21.0](1_21_0_rel_notes) | 18 Oct 2023  | Upstream [1.21.0](https://cloudnative-pg.io/documentation/1.21/release_notes/v1.21/) |
+| [1.20.5](1_20_5_rel_notes) | 22 Dec 2023  | Upstream [1.20.5](https://cloudnative-pg.io/documentation/1.20/release_notes/v1.20/) |
 | [1.20.4](1_20_4_rel_notes) | 08 Nov 2023  | Upstream [1.20.4](https://cloudnative-pg.io/documentation/1.20/release_notes/v1.20/) |
 | [1.20.3](1_20_3_rel_notes) | 18 Oct 2023  | Upstream [1.20.3](https://cloudnative-pg.io/documentation/1.20/release_notes/v1.20/) |
 | [1.20.2](1_20_2_rel_notes) | 27 Jul 2023  | Upstream [1.20.2](https://cloudnative-pg.io/documentation/1.20/release_notes/v1.20/) |
 | [1.20.1](1_20_1_rel_notes) | 13 Jun 2023  | Upstream [1.20.1](https://cloudnative-pg.io/documentation/1.20/release_notes/v1.20/) |
 | [1.20.0](1_20_0_rel_notes) | 27 Apr 2023  | Upstream [1.20.0](https://cloudnative-pg.io/documentation/1.20/release_notes/v1.20/) |
-| [1.19.6](1_19_6_rel_notes) | 08 Nov 2023  | Upstream [1.19.6](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/)  |
-| [1.19.5](1_19_5_rel_notes) | 18 Oct 2023  | Upstream [1.19.5](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/)  |
-| [1.19.4](1_19_4_rel_notes) | 27 Jul 2023  | Upstream [1.19.4](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/)  |
+| [1.19.6](1_19_6_rel_notes) | 08 Nov 2023  | Upstream [1.19.6](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/) |
+| [1.19.5](1_19_5_rel_notes) | 18 Oct 2023  | Upstream [1.19.5](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/) |
+| [1.19.4](1_19_4_rel_notes) | 27 Jul 2023  | Upstream [1.19.4](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/) |
 | [1.19.3](1_19_3_rel_notes) | 13 Jun 2023  | Upstream [1.19.3](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/) |
 | [1.19.2](1_19_2_rel_notes) | 27 Apr 2023  | Upstream [1.19.2](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/) |
 | [1.19.1](1_19_1_rel_notes) | 20 Mar 2023  | Upstream [1.19.1](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/) |
 | [1.19.0](1_19_0_rel_notes) | 14 Feb 2023  | Upstream [1.19.0](https://cloudnative-pg.io/documentation/1.19/release_notes/v1.19/) |
+| [1.18.9](1_18_9_rel_notes) | 22 Dec 2023 | None |
 | [1.18.8](1_18_8_rel_notes) | 08 Nov 2023 | None |
 | [1.18.7](1_18_7_rel_notes) | 18 Oct 2023 | None |
 | [1.18.6](1_18_6_rel_notes) | 27 Jul 2023 | None |

--- a/product_docs/docs/postgres_for_kubernetes/1/replica_cluster.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/replica_cluster.mdx
@@ -91,9 +91,9 @@ file and define the following parts accordingly:
 -   define the bootstrap part for the replica cluster. We can either bootstrap via
     streaming using the `pg_basebackup` section, or bootstrap from a volume snapshot
     or an object store using the `recovery` section
--   define the continuous recovery part (`spec.replica`) in the replica cluster. All
-    we need to do is to enable the replica mode through option `spec.replica.enabled`
-    and set the `externalClusters` name in option `spec.replica.source`
+-   define the continuous recovery part (`.spec.replica`) in the replica cluster. All
+    we need to do is to enable the replica mode through option `.spec.replica.enabled`
+    and set the `externalClusters` name in option `.spec.replica.source`
 
 #### Example using pg_basebackup
 
@@ -209,7 +209,7 @@ for it in the `samples/` subdirectory.
 
 To promote the **designated primary** to **primary**, all we need to do is to
 disable the replica mode in the replica cluster through the option
-`spec.replica.enabled`
+`.spec.replica.enabled`
 
 ```yaml
  replica:

--- a/product_docs/docs/postgres_for_kubernetes/1/replication.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/replication.mdx
@@ -229,7 +229,7 @@ In EDB Postgres for Kubernetes, we use the terms:
 
 This feature, introduced in EDB Postgres for Kubernetes 1.18, is now enabled by default and
 can be disabled via configuration. For details, please refer to the
-["replicationSlots" section in the API reference](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-ReplicationSlotsConfiguration).
+["replicationSlots" section in the API reference](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-ReplicationSlotsConfiguration).
 Here follows a brief description of the main options:
 
 `.spec.replicationSlots.highAvailability.enabled`

--- a/product_docs/docs/postgres_for_kubernetes/1/replication.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/replication.mdx
@@ -174,7 +174,7 @@ the replicas are eligible for synchronous replication.
     (see ["Synchronous replication"](replication.md#synchronous-replication)).
 
 The example below shows how this can be done through the
-`syncReplicaElectionConstraint` section within `spec.postgresql`.
+`syncReplicaElectionConstraint` section within `.spec.postgresql`.
 `nodeLabelsAntiAffinity` allows you to specify those node labels that need to
 be evaluated to make sure that synchronous replication will be dynamically
 configured by the operator between the current primary and the replicas which
@@ -229,7 +229,7 @@ In EDB Postgres for Kubernetes, we use the terms:
 
 This feature, introduced in EDB Postgres for Kubernetes 1.18, is now enabled by default and
 can be disabled via configuration. For details, please refer to the
-["replicationSlots" section in the API reference](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-ReplicationSlotsConfiguration).
+["replicationSlots" section in the API reference](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-ReplicationSlotsConfiguration).
 Here follows a brief description of the main options:
 
 `.spec.replicationSlots.highAvailability.enabled`

--- a/product_docs/docs/postgres_for_kubernetes/1/resource_management.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/resource_management.mdx
@@ -54,7 +54,7 @@ while creating a cluster:
     in a VM or physical machine scenario - see below).
 -   Set up database server pods on a dedicated node using nodeSelector.
     See the "nodeSelector" and "tolerations" fields of the
-    [“affinityconfiguration"](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration) resource on the API reference page.
+    [“affinityconfiguration"](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration) resource on the API reference page.
 
 You can refer to the following example manifest:
 

--- a/product_docs/docs/postgres_for_kubernetes/1/resource_management.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/resource_management.mdx
@@ -54,7 +54,7 @@ while creating a cluster:
     in a VM or physical machine scenario - see below).
 -   Set up database server pods on a dedicated node using nodeSelector.
     See the "nodeSelector" and "tolerations" fields of the
-    [“affinityconfiguration"](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration) resource on the API reference page.
+    [“affinityconfiguration"](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration) resource on the API reference page.
 
 You can refer to the following example manifest:
 

--- a/product_docs/docs/postgres_for_kubernetes/1/samples.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples.mdx
@@ -12,7 +12,7 @@ your PostgreSQL Cluster.
     or Kind as described in the ["Quickstart"](quickstart.md).
 
 !!! Seealso "Reference"
-    For a list of available options, please refer to the ["API Reference" page](cloudnative-pg.v1.md).
+    For a list of available options, please refer to the ["API Reference" page](pg4k.v1.md).
 
 ## Basics
 
@@ -127,4 +127,4 @@ your PostgreSQL Cluster.
     Remember to update `bootstrap.recovery.backup.name` with the backup name.
 : [`cluster-restore-with-tablespaces.yaml`](../samples/cluster-restore-with-tablespaces.yaml)
 
-For a list of available options, see the ["API Reference" page](cloudnative-pg.v1.md).
+For a list of available options, see the ["API Reference" page](pg4k.v1.md).

--- a/product_docs/docs/postgres_for_kubernetes/1/samples.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples.mdx
@@ -7,60 +7,77 @@ In this section, you can find some examples of configuration files to set up
 your PostgreSQL Cluster.
 
 !!! Important
-    These are here for demonstration and experimentation
+    These examples are here for demonstration and experimentation
     purposes, and can be executed on a personal Kubernetes cluster with Minikube
     or Kind as described in the ["Quickstart"](quickstart.md).
 
-Basic cluster
+!!! Seealso "Reference"
+    For a list of available options, please refer to the ["API Reference" page](cloudnative-pg.v1.md).
+
+## Basics
+
+**Basic cluster**
 :  [`cluster-example.yaml`](../samples/cluster-example.yaml)
    a basic example of  a cluster.
 
-Custom cluster
+**Custom cluster**
 :  [`cluster-example-custom.yaml`](../samples/cluster-example-custom.yaml)
    a basic cluster that uses the default storage class and custom parameters for
    the `postgresql.conf` and `pg_hba.conf` files.
 
-Customized storage class
+**Cluster with customized storage class**
 : [`cluster-storage-class.yaml`](../samples/cluster-storage-class.yaml):
    a basic cluster that uses a specified storage class of `standard`.
 
-Customized storage class and backups
-:   **Prerequisites**: bucket storage should be available. The sample config is for AWS,
+**Cluster with PVC Template (Persistent Volume Claim) configured**
+: [`cluster-pvc-template.yaml`](../samples/cluster-pvc-template.yaml):
+   a basic cluster that with an explicit persistent volume claim template.
+
+**Extended configuration example**
+: [`cluster-example-full.yaml`](../samples/cluster-example-full.yaml):
+   a cluster that sets most of the available options.
+
+**Bootstrap cluster with SQL files**
+: [`cluster-example-initdb-sql-refs.yaml`](../samples/cluster-example-initdb-sql-refs.yaml):
+   a cluster example that will execute a set of queries defined in a Secret and a ConfigMap right after the database is created.
+
+**Sample cluster with customized `pg_hba` configuration**
+: [`cluster-example-pg-hba.yaml`](../samples/cluster-example-pg-hba.yaml):
+  a basic cluster that enables user `app` to authenticate using certificates.
+
+**Sample cluster with Secret and Configmap mounted using projected volume template**
+: [`cluster-example-projected-volume.yaml`](../samples/cluster-example-projected-volume.yaml)
+  a basic cluster with existing Secret and Configmap mounted into Postgres pod using projected volume mount.
+
+**Cluster with TDE enabled**
+: [`cluster-example-tde.yaml`](../samples/cluster-example-tde.yaml)
+  an EPAS 15 cluster with TDE. Note that you will need access credentials
+  to download the image used.
+
+## Backups
+
+**Customized storage class and backups**
+:   *Prerequisites*: bucket storage should be available. The sample config is for AWS,
     please change to suit your setup
 : [`cluster-storage-class-with-backup.yaml`](../samples/cluster-storage-class-with-backup.yaml) a cluster
    with backups configured
 
-Backup
-:   **Prerequisites**: [`cluster-storage-class-with-backup.yaml`](../samples/cluster-storage-class-with-backup.yaml)
+**Backup**
+:   *Prerequisites*: [`cluster-storage-class-with-backup.yaml`](../samples/cluster-storage-class-with-backup.yaml)
     applied and Healthy
 : [`backup-example.yaml`](../samples/backup-example.yaml):
   an example of a backup that runs against the previous sample
 
-Cluster with PVC (Persistent Volume Claim) configured
-: [`cluster-pvc-template.yaml`](../samples/cluster-pvc-template.yaml):
-   a basic cluster that with an explicit persistent volume claim template.
-
-Full example
-: [`cluster-example-full.yaml`](../samples/cluster-example-full.yaml):
-   a cluster that sets most of the available options.
-
-PostGIS example
-: [`postgis-example.yaml`](../samples/postgis-example.yaml):
-   an example of "PostGIS cluster" (see the [PostGIS section](postgis.md) for details.)
-
-Replica cluster via streaming (pg_basebackup)
-:   **Prerequisites**: [`cluster-example.yaml`](../samples/cluster-example.yaml)
-    applied and Healthy
-:   [`cluster-example-replica-streaming.yaml`](../samples/cluster-example-replica-streaming.yaml): a replica cluster following `cluster-example` with streaming replication.
-
-Simple cluster with backup configured
-:   **Prerequisites**: The configuration assumes `minio` is running and working.
+**Simple cluster with backup configured**
+:   *Prerequisites*: The configuration assumes `minio` is running and working.
     Please update `backup.barmanObjectStore` with your `minio` parameters or your cloud solution
 :  [`cluster-example-with-backup.yaml`](../samples/cluster-example-with-backup.yaml)
    a basic cluster with backups configured.
 
-Replica cluster via Backup from an object store
-:   **Prerequisites**:
+## Replica clusters
+
+**Replica cluster via Backup from an object store**
+:   *Prerequisites*:
     [`cluster-storage-class-with-backup.yaml`](../samples/cluster-storage-class-with-backup.yaml) applied and Healthy.
     And a backup
     [`cluster-example-trigger-backup.yaml`](../samples/cluster-example-trigger-backup.yaml)
@@ -68,8 +85,8 @@ Replica cluster via Backup from an object store
 : [`cluster-example-replica-from-backup-simple.yaml`](../samples/cluster-example-replica-from-backup-simple.yaml):
    a replica cluster following a cluster with backup configured.
 
-Replica cluster via Volume Snapshot
-:   **Prerequisites**:
+**Replica cluster via Volume Snapshot**
+:   *Prerequisites*:
     [`cluster-example-with-volume-snapshot.yaml`](../samples/cluster-example-with-volume-snapshot.yaml) applied and Healthy.
     And a volume snapshot
     [`backup-with-volume-snapshot.yaml`](../samples/backup-with-volume-snapshot.yaml)
@@ -77,26 +94,37 @@ Replica cluster via Volume Snapshot
 : [`cluster-example-replica-from-volume-snapshot.yaml`](../samples/cluster-example-replica-from-volume-snapshot.yaml):
    a replica cluster following a cluster with volume snapshot configured.
 
-Bootstrap cluster with SQL files
-: [`cluster-example-initdb-sql-refs.yaml`](../samples/cluster-example-initdb-sql-refs.yaml):
-   a cluster example that will execute a set of queries defined in a Secret and a ConfigMap right after the database is created.
+**Replica cluster via streaming (pg_basebackup)**
+:   *Prerequisites*: [`cluster-example.yaml`](../samples/cluster-example.yaml)
+    applied and Healthy
+:   [`cluster-example-replica-streaming.yaml`](../samples/cluster-example-replica-streaming.yaml): a replica cluster following `cluster-example` with streaming replication.
 
-Sample cluster with customized `pg_hba` configuration
-: [`cluster-example-pg-hba.yaml`](../samples/cluster-example-pg-hba.yaml):
-  a basic cluster that enables user `app` to authenticate using certificates.
+## PostGIS
 
-Sample cluster with Secret and Configmap mounted using projected volume template
-: [`cluster-example-projected-volume.yaml`](../samples/cluster-example-projected-volume.yaml)
-  a basic cluster with existing Secret and Configmap mounted into Postgres pod using projected volume mount.
+**PostGIS example**
+: [`postgis-example.yaml`](../samples/postgis-example.yaml):
+   an example of "PostGIS cluster" (see the [PostGIS section](postgis.md) for details.)
 
-Cluster with declarative role management
+## Managed roles
+
+**Cluster with declarative role management**
 : [`cluster-example-with-roles.yaml`](../samples/cluster-example-with-roles.yaml):
   declares a role with the `managed` stanza, includes password management with
   kubernetes secrets
 
-Cluster with TDE enabled
-: [`cluster-example-tde.yaml`](../samples/cluster-example-tde.yaml)
-  an EPAS 15 cluster with TDE. Note that you will need access credentials
-  to download the image used.
+## Declarative tablespaces
 
-For a list of available options, please refer to the ["API Reference" page](pg4k.v1.md).
+**Cluster with declarative tablespaces**
+: [`cluster-example-with-tablespaces.yaml`](../samples/cluster-example-with-tablespaces.yaml)
+
+**Cluster with declarative tablespaces and backup**
+: *Prerequisites*: The configuration assumes `minio` is running and working.
+    Please update `backup.barmanObjectStore` with your `minio` parameters or your cloud solution
+: [`cluster-example-with-tablespaces-backup.yaml`](../samples/cluster-example-with-tablespaces-backup.yaml)
+
+*Restored cluster with tablespaces from object store*
+: *Prerequisites*: the previous cluster applied and a base backup completed.
+    Remember to update `bootstrap.recovery.backup.name` with the backup name.
+: [`cluster-restore-with-tablespaces.yaml`](../samples/cluster-restore-with-tablespaces.yaml)
+
+For a list of available options, see the ["API Reference" page](cloudnative-pg.v1.md).

--- a/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-example-full.yaml
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-example-full.yaml
@@ -35,7 +35,7 @@ metadata:
   name: cluster-example-full
 spec:
   description: "Example of cluster"
-  imageName: quay.io/enterprisedb/postgresql:16.0
+  imageName: quay.io/enterprisedb/postgresql:16.1
   # imagePullSecret is only required if the images are located in a private registry
   # imagePullSecrets:
   #   - name: private_registry_access

--- a/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-example-with-tablespaces-backup.yaml
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-example-with-tablespaces-backup.yaml
@@ -1,0 +1,37 @@
+apiVersion: postgresql.k8s.enterprisedb.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-with-tablespaces
+spec:
+  instances: 3
+
+  storage:
+    size: 1Gi
+
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://backups/
+      endpointURL: http://minio:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+
+  tablespaces:
+    - name: atablespace
+      storage:
+        size: 1Gi
+        storageClass: standard
+    - name: another_tablespace
+      storage:
+        size: 2Gi
+        storageClass: standard
+    - name: tablespacea1
+      storage:
+        size: 2Gi
+        storageClass: standard

--- a/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-example-with-tablespaces.yaml
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-example-with-tablespaces.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgresql.k8s.enterprisedb.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-with-tablespaces
+spec:
+  instances: 3
+
+  storage:
+    size: 1Gi
+
+  tablespaces:
+    - name: atablespace
+      storage:
+        size: 1Gi
+        storageClass: standard
+      temporary: true
+    - name: another_tablespace
+      storage:
+        size: 2Gi
+        storageClass: standard
+      temporary: true
+    - name: tablespacea1
+      storage:
+        size: 2Gi
+        storageClass: standard

--- a/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-restore-with-tablespaces.yaml
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples/cluster-restore-with-tablespaces.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgresql.k8s.enterprisedb.io/v1
+kind: Cluster
+metadata:
+  name: cluster-restore-with-tablespaces
+spec:
+  instances: 3
+
+  storage:
+    size: 1Gi
+
+  bootstrap:
+    recovery:
+      backup:
+        name: cluster-example-with-tablespaces-20231128093940
+
+  tablespaces:
+    atablespace:
+      storage:
+        size: 1Gi
+        storageClass: standard
+    another_tablespace:
+      storage:
+        size: 2Gi
+        storageClass: standard
+    tablespacea1:
+      storage:
+        size: 2Gi
+        storageClass: standard

--- a/product_docs/docs/postgres_for_kubernetes/1/samples/k9s/plugin.yml
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples/k9s/plugin.yml
@@ -1,0 +1,124 @@
+# Move/add to $XDG_CONFIG_HOME/k9s/plugin.yml
+# Requires the cnp kubectl plugin. See https://cloudnative-pg.io/documentation/current/kubectl-plugin/
+#
+# Cluster actions:
+#   b         Request a new physical backup
+#   h         View hibernate status
+#   Shift-H   Hibernate cluster (this retains the data, but deletes everything else - including the cluster)
+#   l         View cluster logs
+#   p         Connect to the cluster via psql
+#   r         Reload the cluster
+#   Shift-R   Restart the cluster
+#   s         View cluster status
+#   Shift-S   View cluster status in verbose mode
+#
+# Namespace actions:
+#   Shift-H   Wake up Hibernated cluster in this namespace (assumes cluster name equals namespace name)
+
+plugin:
+  postgresql-operator-backup:
+    shortCut: b
+    description: Backup
+    scopes:
+      - cluster
+    command: bash
+    confirm: true
+    background: false
+    args:
+      - -c
+      - "kubectl cnp backup $NAME -n $NAMESPACE --context $CONTEXT |& less -R"
+  postgresql-operator-hibernate-status:
+    shortCut: h
+    description: Hibernate status
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp hibernate status $NAME -n $NAMESPACE --context $CONTEXT |& less -R"
+  postgresql-operator-hibernate:
+    shortCut: Shift-H
+    description: Hibernate
+    confirm: true
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp hibernate on $NAME -n $NAMESPACE --context $CONTEXT |& less -R"
+  postgresql-operator-hibernate-off:
+    shortCut: Shift-H
+    description: Wake up hibernated cluster in this namespace
+    confirm: true
+    scopes:
+      - namespace
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp hibernate off $NAME -n $NAME --context $CONTEXT |& less -R"
+
+  postgresql-operator-logs:
+    shortCut: l
+    description: Logs
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp logs cluster $NAME -f -n $NAMESPACE --context $CONTEXT"
+  postgresql-operator-psql:
+    shortCut: p
+    description: PSQL shell
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp psql $NAME -n $NAMESPACE --context $CONTEXT"
+  postgresql-operator-reload:
+    shortCut: r
+    description: Reload
+    confirm: true
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp reload $NAME -n $NAMESPACE --context $CONTEXT |& less -R"
+  postgresql-operator-restart:
+    shortCut: Ctrl-R
+    description: Restart
+    confirm: true
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp restart $NAME -n $NAMESPACE --context $CONTEXT |& less -R"
+  postgresql-operator-status:
+    shortCut: s
+    description: Status
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp status $NAME -n $NAMESPACE --context $CONTEXT |& less -R"
+  postgresql-operator-status-verbose:
+    shortCut: Shift-S
+    description: Status (verbose)
+    scopes:
+      - cluster
+    command: bash
+    background: false
+    args:
+      - -c
+      - "kubectl cnp status $NAME -n $NAMESPACE --context $CONTEXT --verbose |& less -R"

--- a/product_docs/docs/postgres_for_kubernetes/1/samples/monitoring/grafana-configmap.yaml
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples/monitoring/grafana-configmap.yaml
@@ -23,85 +23,6 @@ metadata:
 data:
   cnp.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "Prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
-      "__elements": {},
-      "__requires": [
-        {
-          "type": "panel",
-          "id": "alertlist",
-          "name": "Alert list",
-          "version": ""
-        },
-        {
-          "type": "panel",
-          "id": "bargauge",
-          "name": "Bar gauge",
-          "version": ""
-        },
-        {
-          "type": "panel",
-          "id": "gauge",
-          "name": "Gauge",
-          "version": ""
-        },
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "9.5.1"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph (old)",
-          "version": ""
-        },
-        {
-          "type": "panel",
-          "id": "heatmap",
-          "name": "Heatmap",
-          "version": ""
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "1.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "stat",
-          "name": "Stat",
-          "version": ""
-        },
-        {
-          "type": "panel",
-          "id": "table",
-          "name": "Table",
-          "version": ""
-        },
-        {
-          "type": "panel",
-          "id": "text",
-          "name": "Text",
-          "version": ""
-        },
-        {
-          "type": "panel",
-          "id": "timeseries",
-          "name": "Time series",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -127,7 +48,6 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "id": null,
       "links": [
         {
           "asDropdown": false,
@@ -147,6 +67,32 @@ data:
       "liveNow": false,
       "panels": [
         {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 563,
+          "panels": [],
+          "title": "Row title",
+          "type": "row"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 562,
+          "panels": [],
+          "title": "Summary",
+          "type": "row"
+        },
+        {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -155,7 +101,7 @@ data:
             "h": 7,
             "w": 3,
             "x": 0,
-            "y": 0
+            "y": 2
           },
           "id": 334,
           "options": {
@@ -188,7 +134,7 @@ data:
             "h": 1,
             "w": 15,
             "x": 3,
-            "y": 0
+            "y": 2
           },
           "id": 336,
           "options": {
@@ -200,7 +146,7 @@ data:
             "content": "",
             "mode": "markdown"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "title": "Overview",
           "type": "text"
         },
@@ -213,7 +159,7 @@ data:
             "h": 1,
             "w": 3,
             "x": 18,
-            "y": 0
+            "y": 2
           },
           "id": 352,
           "options": {
@@ -225,7 +171,7 @@ data:
             "content": "",
             "mode": "markdown"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "title": "Storage",
           "type": "text"
         },
@@ -238,7 +184,7 @@ data:
             "h": 1,
             "w": 3,
             "x": 21,
-            "y": 0
+            "y": 2
           },
           "id": 354,
           "options": {
@@ -250,7 +196,7 @@ data:
             "content": "",
             "mode": "markdown"
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "title": "Backups",
           "type": "text"
         },
@@ -283,7 +229,7 @@ data:
             "h": 3,
             "w": 2,
             "x": 3,
-            "y": 1
+            "y": 3
           },
           "id": 338,
           "options": {
@@ -299,9 +245,10 @@ data:
               "values": false
             },
             "text": {},
-            "textMode": "value"
+            "textMode": "value",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -351,7 +298,7 @@ data:
             "h": 6,
             "w": 3,
             "x": 5,
-            "y": 1
+            "y": 3
           },
           "id": 342,
           "interval": "1m",
@@ -367,9 +314,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -427,12 +375,14 @@ data:
             "h": 4,
             "w": 3,
             "x": 8,
-            "y": 1
+            "y": 3
           },
           "id": 344,
           "interval": "1m",
           "links": [],
           "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
             "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
@@ -444,7 +394,7 @@ data:
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -501,12 +451,14 @@ data:
             "h": 4,
             "w": 3,
             "x": 11,
-            "y": 1
+            "y": 3
           },
           "id": 348,
           "interval": "1m",
           "links": [],
           "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
             "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
@@ -518,7 +470,7 @@ data:
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -578,7 +530,7 @@ data:
             "h": 3,
             "w": 2,
             "x": 14,
-            "y": 1
+            "y": 3
           },
           "id": 465,
           "options": {
@@ -593,9 +545,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -652,7 +605,7 @@ data:
             "h": 3,
             "w": 2,
             "x": 16,
-            "y": 1
+            "y": 3
           },
           "id": 467,
           "options": {
@@ -667,9 +620,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -691,14 +645,14 @@ data:
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
+              "decimals": 2,
               "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -707,39 +661,43 @@ data:
                     "value": null
                   },
                   {
-                    "color": "orange",
-                    "value": 0.8
+                    "color": "#EAB839",
+                    "value": 60000000000
                   },
                   {
                     "color": "red",
-                    "value": 0.9
+                    "value": 80000000000
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "decbytes"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 4,
+            "h": 2,
             "w": 3,
             "x": 18,
-            "y": 1
+            "y": 3
           },
-          "id": 356,
+          "id": 358,
+          "links": [],
           "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "lastNotNull"
+                "sum"
               ],
               "fields": "",
               "values": false
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "textMode": "value",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -747,29 +705,36 @@ data:
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"}))",
-              "format": "time_series",
-              "interval": "",
-              "legendFormat": "DATA",
+              "exemplar": false,
+              "expr": "cnp_pg_database_size_bytes{namespace=\"$namespace\"}",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
               "range": true,
-              "refId": "DATA"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"}))",
-              "format": "time_series",
-              "interval": "",
-              "legendFormat": "WAL",
-              "range": true,
-              "refId": "WAL"
+              "refId": "A"
             }
           ],
-          "title": "Volume Space Usage",
-          "type": "gauge"
+          "title": "Database Size",
+          "transformations": [
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "Value": {
+                    "aggregations": [
+                      "max"
+                    ],
+                    "operation": "aggregate"
+                  },
+                  "datname": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "stat"
         },
         {
           "datasource": {
@@ -841,7 +806,7 @@ data:
             "h": 2,
             "w": 3,
             "x": 21,
-            "y": 1
+            "y": 3
           },
           "id": 360,
           "options": {
@@ -856,9 +821,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -885,6 +851,107 @@ data:
               "color": {
                 "mode": "thresholds"
               },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 18,
+            "y": 5
+          },
+          "id": 356,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"}))",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "DATA",
+              "range": true,
+              "refId": "DATA"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"}))",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "WAL",
+              "range": true,
+              "refId": "WAL"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max(\n    sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n    /\n    sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n    *\n    on(namespace, persistentvolumeclaim) group_left(volume)\n    kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$instances\"}\n)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Tablespaces (max)",
+              "range": true,
+              "refId": "Max Tablespace"
+            }
+          ],
+          "title": "Volume Space Usage",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Computes the time since the last known WAL archival in the primary.\nWe ensure to ignore the metric in the replicas by using (1 - cnp_pg_replication_in_recovery ) as a multiplicative factor. It will be 0 for replicas, 1 for the primary.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
               "mappings": [
                 {
                   "options": {
@@ -899,13 +966,13 @@ data:
                 },
                 {
                   "options": {
-                    "from": 0,
+                    "from": -1e+22,
                     "result": {
                       "color": "text",
                       "index": 1,
                       "text": "No data"
                     },
-                    "to": 1e+22
+                    "to": 0
                   },
                   "type": "range"
                 }
@@ -927,7 +994,7 @@ data:
             "h": 2,
             "w": 3,
             "x": 21,
-            "y": 3
+            "y": 5
           },
           "id": 362,
           "options": {
@@ -942,9 +1009,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -953,7 +1021,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "min((1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnp_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) -\ncnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}))",
+              "expr": "max((1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) +\ncnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}))",
               "format": "time_series",
               "interval": "",
               "legendFormat": "__auto",
@@ -993,7 +1061,7 @@ data:
             "h": 3,
             "w": 2,
             "x": 3,
-            "y": 4
+            "y": 6
           },
           "id": 340,
           "options": {
@@ -1009,9 +1077,10 @@ data:
               "values": false
             },
             "text": {},
-            "textMode": "value"
+            "textMode": "value",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "repeatDirection": "v",
           "targets": [
             {
@@ -1076,7 +1145,7 @@ data:
             "h": 3,
             "w": 2,
             "x": 14,
-            "y": 4
+            "y": 6
           },
           "id": 466,
           "options": {
@@ -1091,9 +1160,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -1150,7 +1220,7 @@ data:
             "h": 3,
             "w": 2,
             "x": 16,
-            "y": 4
+            "y": 6
           },
           "id": 468,
           "options": {
@@ -1165,9 +1235,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -1222,7 +1293,7 @@ data:
             "h": 2,
             "w": 3,
             "x": 8,
-            "y": 5
+            "y": 7
           },
           "id": 346,
           "links": [],
@@ -1238,9 +1309,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -1296,7 +1368,7 @@ data:
             "h": 2,
             "w": 3,
             "x": 11,
-            "y": 5
+            "y": 7
           },
           "id": 350,
           "links": [],
@@ -1312,9 +1384,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -1329,101 +1402,6 @@ data:
               "legendFormat": "Total",
               "range": true,
               "refId": "B"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 60000000000
-                  },
-                  {
-                    "color": "red",
-                    "value": 80000000000
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 18,
-            "y": 5
-          },
-          "id": 358,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "sum"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "cnp_pg_database_size_bytes{namespace=\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Database Size",
-          "transformations": [
-            {
-              "id": "groupBy",
-              "options": {
-                "fields": {
-                  "Value": {
-                    "aggregations": [
-                      "max"
-                    ],
-                    "operation": "aggregate"
-                  },
-                  "datname": {
-                    "aggregations": [],
-                    "operation": "groupby"
-                  }
-                }
-              }
             }
           ],
           "type": "stat"
@@ -1478,7 +1456,7 @@ data:
             "h": 2,
             "w": 3,
             "x": 21,
-            "y": 5
+            "y": 7
           },
           "id": 364,
           "options": {
@@ -1493,9 +1471,10 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.5.1",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "datasource": {
@@ -1516,7 +1495,7 @@ data:
           "type": "stat"
         },
         {
-          "collapsed": false,
+          "collapsed": true,
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
@@ -1524,10 +1503,1104 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 9
           },
           "id": 12,
-          "panels": [],
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 0,
+                "y": 20
+              },
+              "id": 191,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Instance",
+              "transparent": true,
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 2,
+                "x": 3,
+                "y": 20
+              },
+              "id": 192,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Status",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 5,
+                "y": 20
+              },
+              "id": 193,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Clustering / replicas",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 2,
+                "x": 8,
+                "y": 20
+              },
+              "id": 384,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Zone",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 4,
+                "x": 10,
+                "y": 20
+              },
+              "id": 195,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Connections",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 14,
+                "y": 20
+              },
+              "id": 196,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Max Connections",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 17,
+                "y": 20
+              },
+              "id": 197,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Wraparound",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 2,
+                "x": 20,
+                "y": 20
+              },
+              "id": 313,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Started",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 2,
+                "x": 22,
+                "y": 20
+              },
+              "id": 198,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Version",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 0,
+                "y": 21
+              },
+              "id": 61,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "Down"
+                        },
+                        "1": {
+                          "index": 1,
+                          "text": "Up"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-red"
+                      },
+                      {
+                        "color": "green",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 2,
+                "x": 3,
+                "y": 21
+              },
+              "id": 33,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": true,
+                  "expr": "min(kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "No"
+                        },
+                        "1": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "Yes"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "noValue": "-",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 2,
+                "x": 5,
+                "y": 21
+              },
+              "id": 60,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnp_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "transformations": [],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "noValue": "-",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 1,
+                "x": 7,
+                "y": 21
+              },
+              "id": 229,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "cnp_pg_replication_streaming_replicas{namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "transformations": [],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "This metric depends on exporting the: `topology.kubernetes.io/zone` label through kube-state-metrics (not enabled by default). Can be added by changing its configuration with:\n\n```yaml\nmetricLabelsAllowlist:\n  - nodes=[topology.kubernetes.io/zone]\n```",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 2,
+                "x": 8,
+                "y": 21
+              },
+              "id": 386,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "/^label_topology_kubernetes_io_zone$/",
+                  "values": false
+                },
+                "text": {
+                  "valueSize": 18
+                },
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": true,
+                  "expr": "kube_pod_info{namespace=~\"$namespace\",pod=~\"$instances\"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels",
+                  "format": "table",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "transformations": [],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 10,
+                "y": 21
+              },
+              "id": 58,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "mean"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "8.2.1",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"})",
+                  "instant": false,
+                  "interval": "",
+                  "legendFormat": "-",
+                  "refId": "A"
+                }
+              ],
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [],
+                  "max": 100,
+                  "min": 0,
+                  "noValue": "<1%",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 75
+                      },
+                      {
+                        "color": "red",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 14,
+                "y": 21
+              },
+              "id": 32,
+              "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "text": {}
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "100 * sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"}) / sum by (pod) (cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "gauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "max": 2147483647,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 200000000
+                      },
+                      {
+                        "color": "red",
+                        "value": 1000000000
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 17,
+                "y": 21
+              },
+              "id": 8,
+              "options": {
+                "displayMode": "lcd",
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "text": {},
+                "valueMode": "color"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "max by (pod) (cnp_pg_database_xid_age{namespace=~\"$namespace\",pod=~\"$instances\"})",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-blue"
+                      }
+                    ]
+                  },
+                  "unit": "dateTimeFromNow"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 2,
+                "x": 20,
+                "y": 21
+              },
+              "id": 314,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": false,
+                  "expr": "cnp_pg_postmaster_start_time{namespace=~\"$namespace\",pod=~\"$instances\"}*1000",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "transformations": [],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-blue"
+                      }
+                    ]
+                  },
+                  "unit": "string"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 2,
+                "x": 22,
+                "y": 21
+              },
+              "id": 42,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "/^full$/",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": false,
+                  "expr": "cnp_collector_postgres_version{namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "transformations": [],
+              "type": "stat"
+            }
+          ],
           "targets": [
             {
               "datasource": {
@@ -1540,1109 +2613,7 @@ data:
           "type": "row"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 0,
-            "y": 8
-          },
-          "id": 191,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Instance",
-          "transparent": true,
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 2,
-            "x": 3,
-            "y": 8
-          },
-          "id": 192,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Status",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 5,
-            "y": 8
-          },
-          "id": 193,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Clustering / replicas",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 2,
-            "x": 8,
-            "y": 8
-          },
-          "id": 384,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Zone",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 4,
-            "x": 10,
-            "y": 8
-          },
-          "id": 195,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Connections",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 14,
-            "y": 8
-          },
-          "id": 196,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Max Connections",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 17,
-            "y": 8
-          },
-          "id": 197,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Wraparound",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 2,
-            "x": 20,
-            "y": 8
-          },
-          "id": 313,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Started",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 2,
-            "x": 22,
-            "y": 8
-          },
-          "id": 198,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Version",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 0,
-            "y": 9
-          },
-          "id": 61,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "index": 0,
-                      "text": "Down"
-                    },
-                    "1": {
-                      "index": 1,
-                      "text": "Up"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 3,
-            "y": 9
-          },
-          "id": 33,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "min(kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "color": "red",
-                      "index": 1,
-                      "text": "No"
-                    },
-                    "1": {
-                      "color": "green",
-                      "index": 0,
-                      "text": "Yes"
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "noValue": "-",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 5,
-            "y": 9
-          },
-          "id": 60,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnp_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "transformations": [],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "-",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 1,
-            "x": 7,
-            "y": 9
-          },
-          "id": 229,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "cnp_pg_replication_streaming_replicas{namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "transformations": [],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "This metric depends on exporting the: `topology.kubernetes.io/zone` label through kube-state-metrics (not enabled by default). Can be added by changing its configuration with:\n\n```yaml\nmetricLabelsAllowlist:\n  - nodes=[topology.kubernetes.io/zone]\n```",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "blue",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 8,
-            "y": 9
-          },
-          "id": 386,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "/^label_topology_kubernetes_io_zone$/",
-              "values": false
-            },
-            "text": {
-              "valueSize": 18
-            },
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "kube_pod_info{namespace=~\"$namespace\",pod=~\"$instances\"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels",
-              "format": "table",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "transformations": [],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 4,
-            "x": 10,
-            "y": 9
-          },
-          "id": 58,
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "8.2.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"})",
-              "instant": false,
-              "interval": "",
-              "legendFormat": "-",
-              "refId": "A"
-            }
-          ],
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "max": 100,
-              "min": 0,
-              "noValue": "<1%",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 75
-                  },
-                  {
-                    "color": "red",
-                    "value": 90
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 14,
-            "y": 9
-          },
-          "id": 32,
-          "options": {
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "last"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "text": {}
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "100 * sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"}) / sum by (pod) (cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "gauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "max": 2147483647,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 200000000
-                  },
-                  {
-                    "color": "red",
-                    "value": 1000000000
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 17,
-            "y": 9
-          },
-          "id": 8,
-          "options": {
-            "displayMode": "lcd",
-            "minVizHeight": 10,
-            "minVizWidth": 0,
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "text": {},
-            "valueMode": "color"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "max by (pod) (cnp_pg_database_xid_age{namespace=~\"$namespace\",pod=~\"$instances\"})",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "bargauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-blue",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "dateTimeFromNow"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 20,
-            "y": 9
-          },
-          "id": 314,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": false,
-              "expr": "cnp_pg_postmaster_start_time{namespace=~\"$namespace\",pod=~\"$instances\"}*1000",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "transformations": [],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-blue",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "string"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 22,
-            "y": 9
-          },
-          "id": 42,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "/^full$/",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "cnp_collector_postgres_version{namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "transformations": [],
-          "type": "stat"
-        },
-        {
-          "collapsed": false,
+          "collapsed": true,
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
@@ -2650,10 +2621,944 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 18
+            "y": 10
           },
           "id": 41,
-          "panels": [],
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 0,
+                "y": 21
+              },
+              "id": 187,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Instance",
+              "transparent": true,
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 3,
+                "y": 21
+              },
+              "id": 183,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Max Connections",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 6,
+                "y": 21
+              },
+              "id": 184,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Shared Buffers",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 9,
+                "y": 21
+              },
+              "id": 185,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Effective Cache Size",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 12,
+                "y": 21
+              },
+              "id": 186,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Work Mem",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 15,
+                "y": 21
+              },
+              "id": 188,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Maintenance Work Mem",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 18,
+                "y": 21
+              },
+              "id": 189,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Random Page Cost",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 1,
+                "w": 3,
+                "x": 21,
+                "y": 21
+              },
+              "id": 190,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Sequential Page Cost",
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 0,
+                "y": 22
+              },
+              "id": 86,
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
+                "mode": "html"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "text"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 3,
+                "y": 22
+              },
+              "id": 30,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 6,
+                "y": 22
+              },
+              "id": 24,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "max by (pod) (cnp_pg_settings_setting{name=\"shared_buffers\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 9,
+                "y": 22
+              },
+              "id": 57,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "max by (pod) (cnp_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 12,
+                "y": 22
+              },
+              "id": 26,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "cnp_pg_settings_setting{name=\"work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 15,
+                "y": 22
+              },
+              "id": 47,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "cnp_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 18,
+                "y": 22
+              },
+              "id": 48,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "cnp_pg_settings_setting{name=\"random_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 3,
+                "x": 21,
+                "y": 22
+              },
+              "id": 56,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {},
+                "textMode": "value"
+              },
+              "pluginVersion": "10.1.5",
+              "repeat": "instances",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "cnp_pg_settings_setting{name=\"seq_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-purple"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 31
+              },
+              "id": 150,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true,
+                "sortBy": []
+              },
+              "pluginVersion": "10.1.5",
+              "repeatDirection": "v",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
+                  "exemplar": true,
+                  "expr": "cnp_pg_settings_setting{namespace=~\"$namespace\",pod=~\"$instances\"}",
+                  "format": "table",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Configurations",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "__name__": true,
+                      "container": true,
+                      "endpoint": true,
+                      "instance": true,
+                      "job": true,
+                      "name": false,
+                      "namespace": true,
+                      "pod": false
+                    },
+                    "indexByName": {
+                      "Time": 0,
+                      "Value": 9,
+                      "__name__": 1,
+                      "container": 2,
+                      "endpoint": 3,
+                      "instance": 4,
+                      "job": 5,
+                      "name": 7,
+                      "namespace": 8,
+                      "pod": 6
+                    },
+                    "renameByName": {
+                      "__name__": "",
+                      "name": "parameter"
+                    }
+                  }
+                },
+                {
+                  "id": "groupingToMatrix",
+                  "options": {
+                    "columnField": "pod",
+                    "rowField": "parameter",
+                    "valueField": "Value"
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                      "parameter\\pod": "parameter"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ],
           "targets": [
             {
               "datasource": {
@@ -2666,947 +3571,6 @@ data:
           "type": "row"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 0,
-            "y": 19
-          },
-          "id": 187,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Instance",
-          "transparent": true,
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 3,
-            "y": 19
-          },
-          "id": 183,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Max Connections",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 6,
-            "y": 19
-          },
-          "id": 184,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Shared Buffers",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 9,
-            "y": 19
-          },
-          "id": 185,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Effective Cache Size",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 12,
-            "y": 19
-          },
-          "id": 186,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Work Mem",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 15,
-            "y": 19
-          },
-          "id": 188,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Maintenance Work Mem",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 18,
-            "y": 19
-          },
-          "id": 189,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Random Page Cost",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 1,
-            "w": 3,
-            "x": 21,
-            "y": 19
-          },
-          "id": 190,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Sequential Page Cost",
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 0,
-            "y": 20
-          },
-          "id": 86,
-          "options": {
-            "code": {
-              "language": "plaintext",
-              "showLineNumbers": false,
-              "showMiniMap": false
-            },
-            "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
-            "mode": "html"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "text"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 3,
-            "y": 20
-          },
-          "id": 30,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 6,
-            "y": 20
-          },
-          "id": 24,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "max by (pod) (cnp_pg_settings_setting{name=\"shared_buffers\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 9,
-            "y": 20
-          },
-          "id": 57,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "max by (pod) (cnp_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 12,
-            "y": 20
-          },
-          "id": 26,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "cnp_pg_settings_setting{name=\"work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 15,
-            "y": 20
-          },
-          "id": 47,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "cnp_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 18,
-            "y": 20
-          },
-          "id": 48,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "cnp_pg_settings_setting{name=\"random_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 21,
-            "y": 20
-          },
-          "id": 56,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "value"
-          },
-          "pluginVersion": "9.5.1",
-          "repeat": "instances",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "cnp_pg_settings_setting{name=\"seq_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "auto"
-                },
-                "filterable": true,
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-purple",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 29
-          },
-          "id": 150,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": []
-          },
-          "pluginVersion": "9.5.1",
-          "repeatDirection": "v",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "cnp_pg_settings_setting{namespace=~\"$namespace\",pod=~\"$instances\"}",
-              "format": "table",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Configurations",
-          "transformations": [
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Time": true,
-                  "__name__": true,
-                  "container": true,
-                  "endpoint": true,
-                  "instance": true,
-                  "job": true,
-                  "name": false,
-                  "namespace": true,
-                  "pod": false
-                },
-                "indexByName": {
-                  "Time": 0,
-                  "Value": 9,
-                  "__name__": 1,
-                  "container": 2,
-                  "endpoint": 3,
-                  "instance": 4,
-                  "job": 5,
-                  "name": 7,
-                  "namespace": 8,
-                  "pod": 6
-                },
-                "renameByName": {
-                  "__name__": "",
-                  "name": "parameter"
-                }
-              }
-            },
-            {
-              "id": "groupingToMatrix",
-              "options": {
-                "columnField": "pod",
-                "rowField": "parameter",
-                "valueField": "Value"
-              }
-            },
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {},
-                "indexByName": {},
-                "renameByName": {
-                  "parameter\\pod": "parameter"
-                }
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
           "collapsed": true,
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
@@ -3615,7 +3579,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 38
+            "y": 11
           },
           "id": 10,
           "panels": [
@@ -3634,7 +3598,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 0,
-                "y": 39
+                "y": 47
               },
               "hiddenSeries": false,
               "id": 273,
@@ -3739,7 +3703,7 @@ data:
                 "h": 7,
                 "w": 12,
                 "x": 12,
-                "y": 39
+                "y": 47
               },
               "hiddenSeries": false,
               "id": 275,
@@ -3909,7 +3873,7 @@ data:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 46
+                "y": 54
               },
               "id": 39,
               "options": {
@@ -4012,7 +3976,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 54
+                "y": 62
               },
               "id": 50,
               "options": {
@@ -4117,7 +4081,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 54
+                "y": 62
               },
               "id": 4,
               "options": {
@@ -4209,7 +4173,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 62
+                "y": 70
               },
               "id": 55,
               "options": {
@@ -4303,7 +4267,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 62
+                "y": 70
               },
               "id": 54,
               "options": {
@@ -4347,7 +4311,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
@@ -4355,623 +4319,10 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 12
           },
           "id": 35,
-          "panels": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [],
-                  "max": 1,
-                  "min": 0,
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "#EAB839",
-                        "value": 0.7
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.8
-                      }
-                    ]
-                  },
-                  "unit": "percentunit"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 0,
-                "y": 48
-              },
-              "id": 424,
-              "options": {
-                "orientation": "auto",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showThresholdLabels": false,
-                "showThresholdMarkers": true,
-                "text": {}
-              },
-              "pluginVersion": "9.4.7",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
-                  "format": "time_series",
-                  "interval": "",
-                  "legendFormat": "{{persistentvolumeclaim}}",
-                  "range": true,
-                  "refId": "FREE_SPACE"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
-                  "format": "time_series",
-                  "interval": "",
-                  "legendFormat": "{{persistentvolumeclaim}}",
-                  "range": true,
-                  "refId": "FREE_SPACE_WAL"
-                }
-              ],
-              "title": "Volume Space Usage",
-              "transformations": [],
-              "type": "gauge"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "decimals": 2,
-                  "mappings": [],
-                  "max": 1,
-                  "min": 0,
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "#EAB839",
-                        "value": 0.8
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.9
-                      }
-                    ]
-                  },
-                  "unit": "percentunit"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 12,
-                "y": 48
-              },
-              "id": 426,
-              "options": {
-                "orientation": "auto",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showThresholdLabels": false,
-                "showThresholdMarkers": true
-              },
-              "pluginVersion": "9.4.7",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
-                  "format": "time_series",
-                  "interval": "",
-                  "legendFormat": "{{persistentvolumeclaim}}",
-                  "range": true,
-                  "refId": "FREE_INODES"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
-                  "format": "time_series",
-                  "interval": "",
-                  "legendFormat": "{{persistentvolumeclaim}}",
-                  "range": true,
-                  "refId": "FREE_INODES_WAL"
-                }
-              ],
-              "title": "Volume Inode Usage",
-              "transformations": [],
-              "type": "gauge"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": true,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 0,
-                "y": 56
-              },
-              "id": 44,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "sum(rate(cnp_pg_stat_database_tup_deleted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-                  "interval": "",
-                  "legendFormat": "deleted",
-                  "range": true,
-                  "refId": "A"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "sum(rate(cnp_pg_stat_database_tup_inserted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-                  "hide": false,
-                  "interval": "",
-                  "legendFormat": "inserted",
-                  "range": true,
-                  "refId": "B"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "sum(rate(cnp_pg_stat_database_tup_fetched{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-                  "hide": false,
-                  "interval": "",
-                  "legendFormat": "fetched",
-                  "range": true,
-                  "refId": "C"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "sum(rate(cnp_pg_stat_database_tup_returned{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-                  "hide": false,
-                  "interval": "",
-                  "legendFormat": "returned",
-                  "range": true,
-                  "refId": "D"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "sum(rate(cnp_pg_stat_database_tup_updated{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-                  "hide": false,
-                  "interval": "",
-                  "legendFormat": "updated",
-                  "range": true,
-                  "refId": "E"
-                }
-              ],
-              "title": "Tuple I/O [5m]",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": true,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 12,
-                "y": 56
-              },
-              "id": 46,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "rate(cnp_pg_stat_database_blks_hit{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
-                  "interval": "",
-                  "legendFormat": "hit ({{pod}})",
-                  "range": true,
-                  "refId": "A"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "rate(cnp_pg_stat_database_blks_read{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
-                  "hide": false,
-                  "interval": "",
-                  "legendFormat": "read ({{pod}})",
-                  "range": true,
-                  "refId": "B"
-                }
-              ],
-              "title": "Block I/O [5m]",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": true,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "unit": "decbytes"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 0,
-                "y": 64
-              },
-              "id": 22,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "8.0.5",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "editorMode": "code",
-                  "exemplar": true,
-                  "expr": "max by (datname) (cnp_pg_database_size_bytes{datname!~\"template.*\",datname!=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-                  "interval": "",
-                  "legendFormat": " {{pod}}: {{datname}}",
-                  "range": true,
-                  "refId": "A"
-                }
-              ],
-              "title": "Database Size",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": true,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "decbytes"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 12,
-                "y": 64
-              },
-              "id": 2,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
-                  },
-                  "exemplar": true,
-                  "expr": "rate(cnp_pg_stat_database_temp_bytes{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
-                  "instant": false,
-                  "interval": "",
-                  "legendFormat": "{{pod}}",
-                  "refId": "A"
-                }
-              ],
-              "title": "Temp Bytes [5m]",
-              "type": "timeseries"
-            }
-          ],
+          "panels": [],
           "targets": [
             {
               "datasource": {
@@ -4984,6 +4335,701 @@ data:
           "type": "row"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 424,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "range": true,
+              "refId": "FREE_SPACE"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "range": true,
+              "refId": "FREE_SPACE_WAL"
+            }
+          ],
+          "title": "Volume Space Usage: PGDATA and WAL",
+          "transformations": [],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 426,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "range": true,
+              "refId": "FREE_INODES"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "range": true,
+              "refId": "FREE_INODES_WAL"
+            }
+          ],
+          "title": "Volume Inode Usage: PGDATA and WAL",
+          "transformations": [],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 564,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "10.1.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n/\nsum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n*\non(namespace, persistentvolumeclaim) group_left(volume,pod)\nkube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$instances\"}",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{volume}}-{{pod}}",
+              "range": true,
+              "refId": "FREE_SPACE"
+            }
+          ],
+          "title": "Volume Space Usage: Tablespaces",
+          "transformations": [],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 44,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(rate(cnp_pg_stat_database_tup_deleted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+              "interval": "",
+              "legendFormat": "deleted",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(rate(cnp_pg_stat_database_tup_inserted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "inserted",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(rate(cnp_pg_stat_database_tup_fetched{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "fetched",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(rate(cnp_pg_stat_database_tup_returned{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "returned",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(rate(cnp_pg_stat_database_tup_updated{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "updated",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Tuple I/O [5m]",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 46,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(cnp_pg_stat_database_blks_hit{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
+              "interval": "",
+              "legendFormat": "hit ({{pod}})",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(cnp_pg_stat_database_blks_read{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "read ({{pod}})",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Block I/O [5m]",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 22,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.0.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max by (datname) (cnp_pg_database_size_bytes{datname!~\"template.*\",datname!=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "interval": "",
+              "legendFormat": " {{pod}}: {{datname}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Database Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "rate(cnp_pg_stat_database_temp_bytes{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Temp Bytes [5m]",
+          "type": "timeseries"
+        },
+        {
           "collapsed": true,
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
@@ -4992,7 +5038,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 44
           },
           "id": 37,
           "panels": [
@@ -5056,7 +5102,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 0,
-                "y": 49
+                "y": 57
               },
               "id": 6,
               "options": {
@@ -5159,7 +5205,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 8,
-                "y": 49
+                "y": 57
               },
               "id": 52,
               "options": {
@@ -5264,7 +5310,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 16,
-                "y": 49
+                "y": 57
               },
               "id": 53,
               "options": {
@@ -5316,7 +5362,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 41
+            "y": 45
           },
           "id": 18,
           "panels": [
@@ -5385,7 +5431,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 0,
-                "y": 13
+                "y": 21
               },
               "id": 16,
               "options": {
@@ -5478,7 +5524,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 6,
-                "y": 13
+                "y": 21
               },
               "id": 14,
               "options": {
@@ -5571,7 +5617,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 12,
-                "y": 13
+                "y": 21
               },
               "id": 59,
               "options": {
@@ -5665,7 +5711,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 18,
-                "y": 13
+                "y": 21
               },
               "id": 20,
               "options": {
@@ -5717,7 +5763,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 46
           },
           "id": 231,
           "panels": [
@@ -5754,7 +5800,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 51
+                "y": 59
               },
               "heatmap": {},
               "hideZeroBuckets": false,
@@ -5891,7 +5937,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 51
+                "y": 59
               },
               "id": 235,
               "options": {
@@ -5943,7 +5989,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 47
           },
           "id": 239,
           "panels": [
@@ -6008,7 +6054,7 @@ data:
                 "h": 6,
                 "w": 8,
                 "x": 0,
-                "y": 52
+                "y": 60
               },
               "id": 237,
               "options": {
@@ -6061,7 +6107,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 48
           },
           "id": 293,
           "panels": [
@@ -6127,7 +6173,7 @@ data:
                 "h": 6,
                 "w": 5,
                 "x": 0,
-                "y": 32
+                "y": 40
               },
               "id": 295,
               "options": {
@@ -6238,7 +6284,7 @@ data:
                 "h": 6,
                 "w": 5,
                 "x": 5,
-                "y": 32
+                "y": 40
               },
               "id": 296,
               "options": {
@@ -6303,7 +6349,6 @@ data:
       "refresh": "30s",
       "revision": 1,
       "schemaVersion": 38,
-      "style": "dark",
       "tags": [
         "cloudnativepg"
       ],
@@ -6329,7 +6374,12 @@ data:
             "type": "datasource"
           },
           {
-            "current": {},
+            "current": {
+              "isNone": true,
+              "selected": false,
+              "text": "None",
+              "value": ""
+            },
             "datasource": {
               "type": "prometheus",
               "uid": "${DS_PROMETHEUS}"
@@ -6351,7 +6401,12 @@ data:
             "type": "query"
           },
           {
-            "current": {},
+            "current": {
+              "isNone": true,
+              "selected": false,
+              "text": "None",
+              "value": ""
+            },
             "datasource": {
               "type": "prometheus",
               "uid": "${DS_PROMETHEUS}"
@@ -6373,7 +6428,15 @@ data:
             "type": "query"
           },
           {
-            "current": {},
+            "current": {
+              "selected": true,
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
+            },
             "datasource": {
               "type": "prometheus",
               "uid": "${DS_PROMETHEUS}"

--- a/product_docs/docs/postgres_for_kubernetes/1/samples/monitoring/grafana-dashboard.json
+++ b/product_docs/docs/postgres_for_kubernetes/1/samples/monitoring/grafana-dashboard.json
@@ -1,83 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "alertlist",
-      "name": "Alert list",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "bargauge",
-      "name": "Bar gauge",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "9.5.1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph (old)",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "heatmap",
-      "name": "Heatmap",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -103,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [
     {
       "asDropdown": false,
@@ -123,6 +43,32 @@
   "liveNow": false,
   "panels": [
     {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 563,
+      "panels": [],
+      "title": "Row title",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 562,
+      "panels": [],
+      "title": "Summary",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -131,7 +77,7 @@
         "h": 7,
         "w": 3,
         "x": 0,
-        "y": 0
+        "y": 2
       },
       "id": 334,
       "options": {
@@ -164,7 +110,7 @@
         "h": 1,
         "w": 15,
         "x": 3,
-        "y": 0
+        "y": 2
       },
       "id": 336,
       "options": {
@@ -176,7 +122,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "title": "Overview",
       "type": "text"
     },
@@ -189,7 +135,7 @@
         "h": 1,
         "w": 3,
         "x": 18,
-        "y": 0
+        "y": 2
       },
       "id": 352,
       "options": {
@@ -201,7 +147,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "title": "Storage",
       "type": "text"
     },
@@ -214,7 +160,7 @@
         "h": 1,
         "w": 3,
         "x": 21,
-        "y": 0
+        "y": 2
       },
       "id": 354,
       "options": {
@@ -226,7 +172,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "title": "Backups",
       "type": "text"
     },
@@ -259,7 +205,7 @@
         "h": 3,
         "w": 2,
         "x": 3,
-        "y": 1
+        "y": 3
       },
       "id": 338,
       "options": {
@@ -275,9 +221,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "value"
+        "textMode": "value",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -327,7 +274,7 @@
         "h": 6,
         "w": 3,
         "x": 5,
-        "y": 1
+        "y": 3
       },
       "id": 342,
       "interval": "1m",
@@ -343,9 +290,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -403,12 +351,14 @@
         "h": 4,
         "w": 3,
         "x": 8,
-        "y": 1
+        "y": 3
       },
       "id": 344,
       "interval": "1m",
       "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -420,7 +370,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -477,12 +427,14 @@
         "h": 4,
         "w": 3,
         "x": 11,
-        "y": 1
+        "y": 3
       },
       "id": 348,
       "interval": "1m",
       "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -494,7 +446,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -554,7 +506,7 @@
         "h": 3,
         "w": 2,
         "x": 14,
-        "y": 1
+        "y": 3
       },
       "id": 465,
       "options": {
@@ -569,9 +521,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -628,7 +581,7 @@
         "h": 3,
         "w": 2,
         "x": 16,
-        "y": 1
+        "y": 3
       },
       "id": 467,
       "options": {
@@ -643,9 +596,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -667,14 +621,14 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
+          "decimals": 2,
           "mappings": [],
-          "max": 1,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -683,39 +637,43 @@
                 "value": null
               },
               {
-                "color": "orange",
-                "value": 0.8
+                "color": "#EAB839",
+                "value": 60000000000
               },
               {
                 "color": "red",
-                "value": 0.9
+                "value": 80000000000
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "decbytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 2,
         "w": 3,
         "x": 18,
-        "y": 1
+        "y": 3
       },
-      "id": 356,
+      "id": 358,
+      "links": [],
       "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "sum"
           ],
           "fields": "",
           "values": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "textMode": "value",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -723,29 +681,36 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"}))",
-          "format": "time_series",
-          "interval": "",
-          "legendFormat": "DATA",
+          "exemplar": false,
+          "expr": "cnp_pg_database_size_bytes{namespace=\"$namespace\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
           "range": true,
-          "refId": "DATA"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"}))",
-          "format": "time_series",
-          "interval": "",
-          "legendFormat": "WAL",
-          "range": true,
-          "refId": "WAL"
+          "refId": "A"
         }
       ],
-      "title": "Volume Space Usage",
-      "type": "gauge"
+      "title": "Database Size",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "datname": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        }
+      ],
+      "type": "stat"
     },
     {
       "datasource": {
@@ -817,7 +782,7 @@
         "h": 2,
         "w": 3,
         "x": 21,
-        "y": 1
+        "y": 3
       },
       "id": 360,
       "options": {
@@ -832,9 +797,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -861,6 +827,107 @@
           "color": {
             "mode": "thresholds"
           },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 5
+      },
+      "id": 356,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"}))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "DATA",
+          "range": true,
+          "refId": "DATA"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"}))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "WAL",
+          "range": true,
+          "refId": "WAL"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(\n    sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n    /\n    sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n    *\n    on(namespace, persistentvolumeclaim) group_left(volume)\n    kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$instances\"}\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Tablespaces (max)",
+          "range": true,
+          "refId": "Max Tablespace"
+        }
+      ],
+      "title": "Volume Space Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Computes the time since the last known WAL archival in the primary.\nWe ensure to ignore the metric in the replicas by using (1 - cnp_pg_replication_in_recovery ) as a multiplicative factor. It will be 0 for replicas, 1 for the primary.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "options": {
@@ -875,13 +942,13 @@
             },
             {
               "options": {
-                "from": 0,
+                "from": -1e+22,
                 "result": {
                   "color": "text",
                   "index": 1,
                   "text": "No data"
                 },
-                "to": 1e+22
+                "to": 0
               },
               "type": "range"
             }
@@ -903,7 +970,7 @@
         "h": 2,
         "w": 3,
         "x": 21,
-        "y": 3
+        "y": 5
       },
       "id": 362,
       "options": {
@@ -918,9 +985,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -929,7 +997,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "min((1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnp_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) -\ncnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}))",
+          "expr": "max((1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) +\ncnp_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "__auto",
@@ -969,7 +1037,7 @@
         "h": 3,
         "w": 2,
         "x": 3,
-        "y": 4
+        "y": 6
       },
       "id": 340,
       "options": {
@@ -985,9 +1053,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "value"
+        "textMode": "value",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "repeatDirection": "v",
       "targets": [
         {
@@ -1052,7 +1121,7 @@
         "h": 3,
         "w": 2,
         "x": 14,
-        "y": 4
+        "y": 6
       },
       "id": 466,
       "options": {
@@ -1067,9 +1136,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -1126,7 +1196,7 @@
         "h": 3,
         "w": 2,
         "x": 16,
-        "y": 4
+        "y": 6
       },
       "id": 468,
       "options": {
@@ -1141,9 +1211,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -1198,7 +1269,7 @@
         "h": 2,
         "w": 3,
         "x": 8,
-        "y": 5
+        "y": 7
       },
       "id": 346,
       "links": [],
@@ -1214,9 +1285,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -1272,7 +1344,7 @@
         "h": 2,
         "w": 3,
         "x": 11,
-        "y": 5
+        "y": 7
       },
       "id": 350,
       "links": [],
@@ -1288,9 +1360,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -1305,101 +1378,6 @@
           "legendFormat": "Total",
           "range": true,
           "refId": "B"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 60000000000
-              },
-              {
-                "color": "red",
-                "value": 80000000000
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 18,
-        "y": 5
-      },
-      "id": 358,
-      "links": [],
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "cnp_pg_database_size_bytes{namespace=\"$namespace\"}",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Database Size",
-      "transformations": [
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "Value": {
-                "aggregations": [
-                  "max"
-                ],
-                "operation": "aggregate"
-              },
-              "datname": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
-            }
-          }
         }
       ],
       "type": "stat"
@@ -1454,7 +1432,7 @@
         "h": 2,
         "w": 3,
         "x": 21,
-        "y": 5
+        "y": 7
       },
       "id": 364,
       "options": {
@@ -1469,9 +1447,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -1492,7 +1471,7 @@
       "type": "stat"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "uid": "${DS_PROMETHEUS}"
       },
@@ -1500,10 +1479,1104 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 9
       },
       "id": 12,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 0,
+            "y": 20
+          },
+          "id": 191,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Instance",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 2,
+            "x": 3,
+            "y": 20
+          },
+          "id": 192,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Status",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 5,
+            "y": 20
+          },
+          "id": 193,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Clustering / replicas",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 2,
+            "x": 8,
+            "y": 20
+          },
+          "id": 384,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Zone",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 4,
+            "x": 10,
+            "y": 20
+          },
+          "id": 195,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Connections",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 14,
+            "y": 20
+          },
+          "id": 196,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Max Connections",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 17,
+            "y": 20
+          },
+          "id": 197,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Wraparound",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 2,
+            "x": 20,
+            "y": 20
+          },
+          "id": 313,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Started",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 2,
+            "x": 22,
+            "y": 20
+          },
+          "id": 198,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Version",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 0,
+            "y": 21
+          },
+          "id": 61,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "index": 0,
+                      "text": "Down"
+                    },
+                    "1": {
+                      "index": 1,
+                      "text": "Up"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 3,
+            "y": 21
+          },
+          "id": 33,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "min(kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "No"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "Yes"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "noValue": "-",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 5,
+            "y": 21
+          },
+          "id": 60,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnp_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "noValue": "-",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 1,
+            "x": 7,
+            "y": 21
+          },
+          "id": 229,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "cnp_pg_replication_streaming_replicas{namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "This metric depends on exporting the: `topology.kubernetes.io/zone` label through kube-state-metrics (not enabled by default). Can be added by changing its configuration with:\n\n```yaml\nmetricLabelsAllowlist:\n  - nodes=[topology.kubernetes.io/zone]\n```",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 8,
+            "y": 21
+          },
+          "id": 386,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^label_topology_kubernetes_io_zone$/",
+              "values": false
+            },
+            "text": {
+              "valueSize": 18
+            },
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "kube_pod_info{namespace=~\"$namespace\",pod=~\"$instances\"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 10,
+            "y": 21
+          },
+          "id": 58,
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.2.1",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "-",
+              "refId": "A"
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "noValue": "<1%",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 75
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 14,
+            "y": 21
+          },
+          "id": 32,
+          "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "100 * sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"}) / sum by (pod) (cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 2147483647,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 200000000
+                  },
+                  {
+                    "color": "red",
+                    "value": 1000000000
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 17,
+            "y": 21
+          },
+          "id": 8,
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "max by (pod) (cnp_pg_database_xid_age{namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-blue"
+                  }
+                ]
+              },
+              "unit": "dateTimeFromNow"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 20,
+            "y": 21
+          },
+          "id": 314,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "cnp_pg_postmaster_start_time{namespace=~\"$namespace\",pod=~\"$instances\"}*1000",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-blue"
+                  }
+                ]
+              },
+              "unit": "string"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 22,
+            "y": 21
+          },
+          "id": 42,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^full$/",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "cnp_collector_postgres_version{namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "transformations": [],
+          "type": "stat"
+        }
+      ],
       "targets": [
         {
           "datasource": {
@@ -1516,1109 +2589,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 0,
-        "y": 8
-      },
-      "id": 191,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Instance",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 2,
-        "x": 3,
-        "y": 8
-      },
-      "id": 192,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Status",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 5,
-        "y": 8
-      },
-      "id": 193,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Clustering / replicas",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 2,
-        "x": 8,
-        "y": 8
-      },
-      "id": 384,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Zone",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 4,
-        "x": 10,
-        "y": 8
-      },
-      "id": 195,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Connections",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 14,
-        "y": 8
-      },
-      "id": 196,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Max Connections",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 17,
-        "y": 8
-      },
-      "id": 197,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Wraparound",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 2,
-        "x": 20,
-        "y": 8
-      },
-      "id": 313,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Started",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 2,
-        "x": 22,
-        "y": 8
-      },
-      "id": 198,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Version",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 9
-      },
-      "id": 61,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "index": 0,
-                  "text": "Down"
-                },
-                "1": {
-                  "index": 1,
-                  "text": "Up"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 3,
-        "y": 9
-      },
-      "id": 33,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "min(kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "No"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "Yes"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "noValue": "-",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 5,
-        "y": 9
-      },
-      "id": 60,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "1 - cnp_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnp_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "transformations": [],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "-",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 1,
-        "x": 7,
-        "y": 9
-      },
-      "id": 229,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "cnp_pg_replication_streaming_replicas{namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "transformations": [],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "This metric depends on exporting the: `topology.kubernetes.io/zone` label through kube-state-metrics (not enabled by default). Can be added by changing its configuration with:\n\n```yaml\nmetricLabelsAllowlist:\n  - nodes=[topology.kubernetes.io/zone]\n```",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 8,
-        "y": 9
-      },
-      "id": 386,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^label_topology_kubernetes_io_zone$/",
-          "values": false
-        },
-        "text": {
-          "valueSize": 18
-        },
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "kube_pod_info{namespace=~\"$namespace\",pod=~\"$instances\"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "transformations": [],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 10,
-        "y": 9
-      },
-      "id": 58,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last",
-            "mean"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.2.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"})",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "-",
-          "refId": "A"
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "noValue": "<1%",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 75
-              },
-              {
-                "color": "red",
-                "value": 90
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 14,
-        "y": 9
-      },
-      "id": 32,
-      "options": {
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "text": {}
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "100 * sum by (pod) (cnp_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"}) / sum by (pod) (cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 2147483647,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 200000000
-              },
-              {
-                "color": "red",
-                "value": 1000000000
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 17,
-        "y": 9
-      },
-      "id": 8,
-      "options": {
-        "displayMode": "lcd",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "text": {},
-        "valueMode": "color"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "max by (pod) (cnp_pg_database_xid_age{namespace=~\"$namespace\",pod=~\"$instances\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "dateTimeFromNow"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 20,
-        "y": 9
-      },
-      "id": 314,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "cnp_pg_postmaster_start_time{namespace=~\"$namespace\",pod=~\"$instances\"}*1000",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "transformations": [],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "string"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 22,
-        "y": 9
-      },
-      "id": 42,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^full$/",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "cnp_collector_postgres_version{namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "transformations": [],
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "uid": "${DS_PROMETHEUS}"
       },
@@ -2626,10 +2597,944 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 10
       },
       "id": 41,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 0,
+            "y": 21
+          },
+          "id": 187,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Instance",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 3,
+            "y": 21
+          },
+          "id": 183,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Max Connections",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 6,
+            "y": 21
+          },
+          "id": 184,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Shared Buffers",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 9,
+            "y": 21
+          },
+          "id": 185,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Effective Cache Size",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 12,
+            "y": 21
+          },
+          "id": 186,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Work Mem",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 15,
+            "y": 21
+          },
+          "id": 188,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maintenance Work Mem",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 18,
+            "y": 21
+          },
+          "id": 189,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Random Page Cost",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 3,
+            "x": 21,
+            "y": 21
+          },
+          "id": 190,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Sequential Page Cost",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 0,
+            "y": 22
+          },
+          "id": 86,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 3,
+            "y": 22
+          },
+          "id": 30,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 6,
+            "y": 22
+          },
+          "id": 24,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "max by (pod) (cnp_pg_settings_setting{name=\"shared_buffers\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 9,
+            "y": 22
+          },
+          "id": 57,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "max by (pod) (cnp_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 12,
+            "y": 22
+          },
+          "id": 26,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "cnp_pg_settings_setting{name=\"work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 15,
+            "y": 22
+          },
+          "id": 47,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "cnp_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 18,
+            "y": 22
+          },
+          "id": 48,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "cnp_pg_settings_setting{name=\"random_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 21,
+            "y": 22
+          },
+          "id": 56,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value"
+          },
+          "pluginVersion": "10.1.5",
+          "repeat": "instances",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "cnp_pg_settings_setting{name=\"seq_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-purple"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 31
+          },
+          "id": 150,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "10.1.5",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "cnp_pg_settings_setting{namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Configurations",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "container": true,
+                  "endpoint": true,
+                  "instance": true,
+                  "job": true,
+                  "name": false,
+                  "namespace": true,
+                  "pod": false
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value": 9,
+                  "__name__": 1,
+                  "container": 2,
+                  "endpoint": 3,
+                  "instance": 4,
+                  "job": 5,
+                  "name": 7,
+                  "namespace": 8,
+                  "pod": 6
+                },
+                "renameByName": {
+                  "__name__": "",
+                  "name": "parameter"
+                }
+              }
+            },
+            {
+              "id": "groupingToMatrix",
+              "options": {
+                "columnField": "pod",
+                "rowField": "parameter",
+                "valueField": "Value"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "parameter\\pod": "parameter"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
       "targets": [
         {
           "datasource": {
@@ -2642,947 +3547,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 0,
-        "y": 19
-      },
-      "id": 187,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Instance",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 3,
-        "y": 19
-      },
-      "id": 183,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Max Connections",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 6,
-        "y": 19
-      },
-      "id": 184,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Shared Buffers",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 9,
-        "y": 19
-      },
-      "id": 185,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Effective Cache Size",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 12,
-        "y": 19
-      },
-      "id": 186,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Work Mem",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 15,
-        "y": 19
-      },
-      "id": 188,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Maintenance Work Mem",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 18,
-        "y": 19
-      },
-      "id": 189,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Random Page Cost",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 3,
-        "x": 21,
-        "y": 19
-      },
-      "id": 190,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Sequential Page Cost",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 20
-      },
-      "id": 86,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<table style=\"width:100%; height:100%;border:0px solid black;\">\n  <td style=\"text-align: center;vertical-align: middle;border:0px solid black; \"><p style=\"font-weight: bold;\">$instances</p>\n  </td>\n</table>",
-        "mode": "html"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 20
-      },
-      "id": 30,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "cnp_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 20
-      },
-      "id": 24,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "max by (pod) (cnp_pg_settings_setting{name=\"shared_buffers\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 20
-      },
-      "id": 57,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "max by (pod) (cnp_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnp_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 20
-      },
-      "id": 26,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "cnp_pg_settings_setting{name=\"work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 20
-      },
-      "id": 47,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "cnp_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 20
-      },
-      "id": 48,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "cnp_pg_settings_setting{name=\"random_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 20
-      },
-      "id": 56,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "value"
-      },
-      "pluginVersion": "9.5.1",
-      "repeat": "instances",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "cnp_pg_settings_setting{name=\"seq_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-purple",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 29
-      },
-      "id": 150,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "9.5.1",
-      "repeatDirection": "v",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "cnp_pg_settings_setting{namespace=~\"$namespace\",pod=~\"$instances\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Configurations",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "container": true,
-              "endpoint": true,
-              "instance": true,
-              "job": true,
-              "name": false,
-              "namespace": true,
-              "pod": false
-            },
-            "indexByName": {
-              "Time": 0,
-              "Value": 9,
-              "__name__": 1,
-              "container": 2,
-              "endpoint": 3,
-              "instance": 4,
-              "job": 5,
-              "name": 7,
-              "namespace": 8,
-              "pod": 6
-            },
-            "renameByName": {
-              "__name__": "",
-              "name": "parameter"
-            }
-          }
-        },
-        {
-          "id": "groupingToMatrix",
-          "options": {
-            "columnField": "pod",
-            "rowField": "parameter",
-            "valueField": "Value"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "parameter\\pod": "parameter"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
       "collapsed": true,
       "datasource": {
         "uid": "${DS_PROMETHEUS}"
@@ -3591,7 +3555,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 11
       },
       "id": 10,
       "panels": [
@@ -3610,7 +3574,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 47
           },
           "hiddenSeries": false,
           "id": 273,
@@ -3715,7 +3679,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 47
           },
           "hiddenSeries": false,
           "id": 275,
@@ -3885,7 +3849,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 46
+            "y": 54
           },
           "id": 39,
           "options": {
@@ -3988,7 +3952,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 54
+            "y": 62
           },
           "id": 50,
           "options": {
@@ -4093,7 +4057,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 54
+            "y": 62
           },
           "id": 4,
           "options": {
@@ -4185,7 +4149,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 70
           },
           "id": 55,
           "options": {
@@ -4279,7 +4243,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 70
           },
           "id": 54,
           "options": {
@@ -4323,7 +4287,7 @@
       "type": "row"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": {
         "uid": "${DS_PROMETHEUS}"
       },
@@ -4331,623 +4295,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 12
       },
       "id": 35,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 0.7
-                  },
-                  {
-                    "color": "red",
-                    "value": 0.8
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 48
-          },
-          "id": 424,
-          "options": {
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "text": {}
-          },
-          "pluginVersion": "9.4.7",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
-              "format": "time_series",
-              "interval": "",
-              "legendFormat": "{{persistentvolumeclaim}}",
-              "range": true,
-              "refId": "FREE_SPACE"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
-              "format": "time_series",
-              "interval": "",
-              "legendFormat": "{{persistentvolumeclaim}}",
-              "range": true,
-              "refId": "FREE_SPACE_WAL"
-            }
-          ],
-          "title": "Volume Space Usage",
-          "transformations": [],
-          "type": "gauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "decimals": 2,
-              "mappings": [],
-              "max": 1,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 0.8
-                  },
-                  {
-                    "color": "red",
-                    "value": 0.9
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 48
-          },
-          "id": 426,
-          "options": {
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true
-          },
-          "pluginVersion": "9.4.7",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
-              "format": "time_series",
-              "interval": "",
-              "legendFormat": "{{persistentvolumeclaim}}",
-              "range": true,
-              "refId": "FREE_INODES"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
-              "format": "time_series",
-              "interval": "",
-              "legendFormat": "{{persistentvolumeclaim}}",
-              "range": true,
-              "refId": "FREE_INODES_WAL"
-            }
-          ],
-          "title": "Volume Inode Usage",
-          "transformations": [],
-          "type": "gauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 56
-          },
-          "id": 44,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "sum(rate(cnp_pg_stat_database_tup_deleted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-              "interval": "",
-              "legendFormat": "deleted",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "sum(rate(cnp_pg_stat_database_tup_inserted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "inserted",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "sum(rate(cnp_pg_stat_database_tup_fetched{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "fetched",
-              "range": true,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "sum(rate(cnp_pg_stat_database_tup_returned{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "returned",
-              "range": true,
-              "refId": "D"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "sum(rate(cnp_pg_stat_database_tup_updated{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "updated",
-              "range": true,
-              "refId": "E"
-            }
-          ],
-          "title": "Tuple I/O [5m]",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 56
-          },
-          "id": 46,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(cnp_pg_stat_database_blks_hit{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
-              "interval": "",
-              "legendFormat": "hit ({{pod}})",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(cnp_pg_stat_database_blks_read{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "read ({{pod}})",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Block I/O [5m]",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 64
-          },
-          "id": 22,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "8.0.5",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "max by (datname) (cnp_pg_database_size_bytes{datname!~\"template.*\",datname!=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
-              "interval": "",
-              "legendFormat": " {{pod}}: {{datname}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Database Size",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 64
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "rate(cnp_pg_stat_database_temp_bytes{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Temp Bytes [5m]",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "targets": [
         {
           "datasource": {
@@ -4960,6 +4311,701 @@
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 424,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "FREE_SPACE"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "FREE_SPACE_WAL"
+        }
+      ],
+      "title": "Volume Space Usage: PGDATA and WAL",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 426,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "FREE_INODES"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "FREE_INODES_WAL"
+        }
+      ],
+      "title": "Volume Inode Usage: PGDATA and WAL",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 564,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n/\nsum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-tbs.*\"}) \n*\non(namespace, persistentvolumeclaim) group_left(volume,pod)\nkube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$instances\"}",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{volume}}-{{pod}}",
+          "range": true,
+          "refId": "FREE_SPACE"
+        }
+      ],
+      "title": "Volume Space Usage: Tablespaces",
+      "transformations": [],
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(cnp_pg_stat_database_tup_deleted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+          "interval": "",
+          "legendFormat": "deleted",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(cnp_pg_stat_database_tup_inserted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "inserted",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(cnp_pg_stat_database_tup_fetched{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "fetched",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(cnp_pg_stat_database_tup_returned{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "returned",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(cnp_pg_stat_database_tup_updated{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "updated",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Tuple I/O [5m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(cnp_pg_stat_database_blks_hit{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
+          "interval": "",
+          "legendFormat": "hit ({{pod}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(cnp_pg_stat_database_blks_read{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "read ({{pod}})",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Block I/O [5m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.0.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "max by (datname) (cnp_pg_database_size_bytes{datname!~\"template.*\",datname!=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+          "interval": "",
+          "legendFormat": " {{pod}}: {{datname}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "rate(cnp_pg_stat_database_temp_bytes{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Temp Bytes [5m]",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "datasource": {
         "uid": "${DS_PROMETHEUS}"
@@ -4968,7 +5014,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 44
       },
       "id": 37,
       "panels": [
@@ -5032,7 +5078,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 49
+            "y": 57
           },
           "id": 6,
           "options": {
@@ -5135,7 +5181,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 49
+            "y": 57
           },
           "id": 52,
           "options": {
@@ -5240,7 +5286,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 49
+            "y": 57
           },
           "id": 53,
           "options": {
@@ -5292,7 +5338,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 45
       },
       "id": 18,
       "panels": [
@@ -5361,7 +5407,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 13
+            "y": 21
           },
           "id": 16,
           "options": {
@@ -5454,7 +5500,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 13
+            "y": 21
           },
           "id": 14,
           "options": {
@@ -5547,7 +5593,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 13
+            "y": 21
           },
           "id": 59,
           "options": {
@@ -5641,7 +5687,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 13
+            "y": 21
           },
           "id": 20,
           "options": {
@@ -5693,7 +5739,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 46
       },
       "id": 231,
       "panels": [
@@ -5730,7 +5776,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 59
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -5867,7 +5913,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 59
           },
           "id": 235,
           "options": {
@@ -5919,7 +5965,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 47
       },
       "id": 239,
       "panels": [
@@ -5984,7 +6030,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 52
+            "y": 60
           },
           "id": 237,
           "options": {
@@ -6037,7 +6083,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 48
       },
       "id": 293,
       "panels": [
@@ -6103,7 +6149,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 32
+            "y": 40
           },
           "id": 295,
           "options": {
@@ -6214,7 +6260,7 @@
             "h": 6,
             "w": 5,
             "x": 5,
-            "y": 32
+            "y": 40
           },
           "id": 296,
           "options": {
@@ -6279,7 +6325,6 @@
   "refresh": "30s",
   "revision": 1,
   "schemaVersion": 38,
-  "style": "dark",
   "tags": [
     "cloudnativepg"
   ],
@@ -6305,7 +6350,12 @@
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
@@ -6327,7 +6377,12 @@
         "type": "query"
       },
       {
-        "current": {},
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
@@ -6349,7 +6404,15 @@
         "type": "query"
       },
       {
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"

--- a/product_docs/docs/postgres_for_kubernetes/1/scheduling.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/scheduling.mdx
@@ -14,7 +14,7 @@ the best node possible, based on several criteria.
     anti-affinity, node selectors, and so on.
 
 You can control how the EDB Postgres for Kubernetes cluster's instances should be
-scheduled through the [`affinity`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration)
+scheduled through the [`affinity`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration)
 section in the definition of the cluster, which supports:
 
 -   pod affinity/anti-affinity
@@ -61,7 +61,7 @@ metadata:
   name: cluster-example
 spec:
   instances: 3
-  imageName: quay.io/enterprisedb/postgresql:16.0
+  imageName: quay.io/enterprisedb/postgresql:16.1
 
   affinity:
     enablePodAntiAffinity: true #default value

--- a/product_docs/docs/postgres_for_kubernetes/1/scheduling.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/scheduling.mdx
@@ -14,7 +14,7 @@ the best node possible, based on several criteria.
     anti-affinity, node selectors, and so on.
 
 You can control how the EDB Postgres for Kubernetes cluster's instances should be
-scheduled through the [`affinity`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration)
+scheduled through the [`affinity`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-AffinityConfiguration)
 section in the definition of the cluster, which supports:
 
 -   pod affinity/anti-affinity

--- a/product_docs/docs/postgres_for_kubernetes/1/security.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/security.mdx
@@ -365,7 +365,7 @@ async streaming replication** with the current primary instance, with a special
 user called `streaming_replica`. The connection between nodes is **encrypted**
 and authentication is via **TLS client certificates** (please refer to the
 ["Client TLS/SSL Connections"]\(ssl_connections.md#"Client TLS/SSL Connections") page
-for details).
+for details). By default, the operator requires TLS v1.3 connections.
 
 Currently, the operator allows administrators to add `pg_hba.conf` lines directly in the manifest
 as part of the `pg_hba` section of the `postgresql` configuration. The lines defined in the

--- a/product_docs/docs/postgres_for_kubernetes/1/ssl_connections.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/ssl_connections.mdx
@@ -166,7 +166,24 @@ Output :
                                         version
 --------------------------------------------------------------------------------------
 ------------------
-PostgreSQL 16.0 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.3.1 20191121 (Red Hat
+PostgreSQL 16.1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.3.1 20191121 (Red Hat
 8.3.1-5), 64-bit
 (1 row)
 ```
+
+## About TLS protocol versions
+
+By default, the operator sets both [`ssl_min_protocol_version`](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-SSL-MIN-PROTOCOL-VERSION)
+and [`ssl_max_protocol_version`](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-SSL-MAX-PROTOCOL-VERSION)
+to `TLSv1.3`.
+
+!!! Important
+    In PostgreSQL 11 these two GUC doesn't exists hence, in these specific version
+    these values aren't set and will keep using the default ones.
+
+This assumes that the PostgreSQL operand images include an OpenSSL library that
+supports the `TLSv1.3` version.
+
+If not, or your client applications need a lower version number, you need to
+manually configure it in the PostgreSQL configuration as any other Postgres
+GUC.

--- a/product_docs/docs/postgres_for_kubernetes/1/storage.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/storage.mdx
@@ -95,12 +95,15 @@ information about this important security feature.
 The operator creates a persistent volume claim (PVC) for each PostgreSQL
 instance, with the goal to store the `PGDATA`, and then mounts it into each Pod.
 
-Additionally, it supports the creation of clusters with a separate PVC
-on which to store PostgreSQL Write-Ahead Log (WAL), as explained in the
-["Volume for WAL" section](#volume-for-wal) below.
+Additionally, it supports the creation of clusters with:
+
+-   a separate PVC on which to store PostgreSQL Write-Ahead Log (WAL), as
+    explained in the ["Volume for WAL" section](#volume-for-wal) below
+-   additional separate volumes reserved for PostgreSQL tablespaces, as explained
+    in the ["Tablespaces" section](tablespaces.md)
 
 In EDB Postgres for Kubernetes, the volumes attached to a single PostgreSQL instance
-are defined as **PVC group**.
+are defined as a **PVC group**.
 
 ## Configuration via a storage class
 
@@ -222,6 +225,12 @@ spec:
 !!! Important
     Removing `walStorage` is not supported: once added, a separate volume for
     WALs cannot be removed from an existing Postgres cluster.
+
+## Volumes for tablespaces
+
+EDB Postgres for Kubernetes supports declarative tablespaces. You can add one or more
+volumes, each dedicated to a single PostgreSQL tablespace.
+See ["Tablespaces" section](tablespaces.md) for details.
 
 ## Volume expansion
 

--- a/product_docs/docs/postgres_for_kubernetes/1/tablespaces.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/tablespaces.mdx
@@ -1,0 +1,358 @@
+---
+title: 'Tablespaces'
+originalFilePath: 'src/tablespaces.md'
+---
+
+A tablespace is a robust and widely embraced feature in database
+management systems. It offers a powerful means to enhance the vertical
+scalability of a database by decoupling the physical and logical modeling of
+data. Essentially, it serves as a technique for physical database modeling,
+enabling the efficient distribution of I/O operations across multiple volumes
+on distinct storage. It thereby optimizes performance through parallel on-disk
+read/write operations.
+
+In the context of the database industry, tablespaces play a strategic role,
+particularly when paired with table partitioning, a logical database modeling
+technique. They prove instrumental in managing large-scale databases and are
+also used for tasks such as separating tables from indexes or executing
+temporary operations.
+
+Tablespaces in PostgreSQL have been playing a pivotal role since 2005 (version
+8.0), while declarative partitioning was introduced in 2017 (version 10).
+Consequently, tablespaces are seamlessly integrated into all supported releases
+of PostgreSQL. Quoting from the
+[PostgreSQL documentation on tablespaces](https://www.postgresql.org/docs/current/manage-ag-tablespaces.html):
+
+> By using tablespaces, an administrator can control the disk layout of a
+> PostgreSQL installation. This is useful in at least two ways.
+>
+> -   First, if the partition or volume on which the cluster was initialized runs
+>     out of space and cannot be extended, a tablespace can be created on a
+>     different partition and used until the system can be reconfigured.
+> -   Second, tablespaces allow an administrator to use knowledge of the usage
+>     pattern of database objects to optimize performance.
+
+## Declarative tablespaces
+
+EDB Postgres for Kubernetes provides support for PostgreSQL tablespaces through *declarative
+tablespaces*, operating at two distinct levels:
+
+-   Kubernetes, managing persistent volume claims, identically to how PGDATA and
+    WAL volumes are handled
+-   PostgreSQL, managing the `TABLESPACE` global objects in the PostgreSQL
+    instance
+
+Being a part of the Kubernetes ecosystem, EDB Postgres for Kubernetes' declarative
+tablespaces are implemented by leveraging persistent volume claims (and persistent
+volumes). Each tablespace defined in the cluster is housed in its own
+persistent volume. EDB Postgres for Kubernetes takes care of generating the PVCs. It mounts
+the required volumes in the instance pods in normalized locations and ensures
+replicas are ready to support tablespaces before activating them in the
+primary.
+
+You can set up tablespaces when creating the cluster or add them later,
+provided the storage is available when requested. Currently, you can't
+remove them. However, this limitation will be addressed in a future minor or patch version
+of EDB Postgres for Kubernetes.
+
+## Using declarative tablespaces
+
+Using declarative tablespaces is straightforward. You can find a full example in
+[`cluster-example-with-tablespaces.yaml`](../samples/cluster-example-with-tablespaces.yaml).
+
+To use them, use the new `tablespaces` stanza on a new or existing `Cluster` resource:
+
+```yaml
+spec:
+  instances: 3
+
+  # ...
+
+  tablespaces:
+    - name: tbs1
+      storage:
+        size: 1Gi
+    - name: tbs2
+      storage:
+        size: 2Gi
+    - name: tbs3
+      storage:
+        size: 2Gi
+```
+
+Each tablespace has its own storage section where you can configure the size and the
+storage class of the generated PVC. The administrator can thus
+plan to use different storage classes for different kinds of workloads, as
+explained in [Storage classes and tablespaces](#storage-classes-and-tablespaces).
+
+EDB Postgres for Kubernetes creates the persistent volume claims for each instance
+in the high-availability Postgres cluster. It mounts them in each pod when they
+have been provisioned. Then, it ensures that the `tbs1`, `tbs2`, and `tbs3`
+tablespaces are created on the primary PostgreSQL instance using the `CREATE
+TABLESPACE` command. This process is quick, and you see this reflected in
+Postgres:
+
+```txt
+app=# SELECT oid, spcname FROM pg_tablespace;
+  oid  |      spcname       
+-------+--------------------
+  1663 | pg_default
+  1664 | pg_global
+ 16387 | tbs1
+ 16388 | tbs2
+ 16389 | tbs3
+(5 rows)
+```
+
+You can start using them right away:
+
+```txt
+app=# CREATE TABLE fibonacci(num INTEGER) TABLESPACE tbs1;
+CREATE TABLE
+```
+
+The cluster status has a section for tablespaces:
+
+```yaml
+status:
+
+  <- snipped ->
+  tablespacesStatus:
+  - name: atablespace
+    state: reconciled
+  - name: another_tablespace
+    state: reconciled
+  - name: tablespacea1
+    state: reconciled
+```
+
+## Storage classes and tablespaces
+
+You can use different storage classes for your tablespaces, just as you can for PGDATA and
+WAL volumes. This is a convenient way of optimizing your resources,
+balancing performance and costs of your storage based on data access usage and
+expectations.
+
+This example helps to explain the feature:
+
+```yaml
+apiVersion: postgresql.k8s.enterprisedb.io/v1
+kind: Cluster
+metadata:
+  name: yardbirds
+spec:
+  instances: 3
+
+  storage:
+    size: 10Gi
+  walStorage:
+    size: 10Gi
+  tablespaces:
+    - name: current
+      size: 100Gi
+      storageClass: fastest
+    - name: this_year
+      size: 500Gi
+      storageClass: balanced
+```
+
+The `yardbirds` cluster example requests 4 persistent volume claims using
+3 different storage classes:
+
+-   Default storage class – Used by the `PGDATA` and WAL volumes.
+-   `fastest` – Used by the `current` tablespace to store the most active and
+    demanding set of data in the database.
+-   `balanced` – Used by the `this_year` tablespace to store older partitions of
+    data that are rarely accessed by users and where performance expectations
+    aren't the highest.
+
+You can then take advantage of horizontal table partitioning and create
+the current month's table (for example, facts for December 2023) in the `current`
+tablespace:
+
+```sql
+CREATE TABLE facts_202312 PARTITION OF facts
+    FOR VALUES FROM ('2023-12-01') TO ('2024-01-01')
+    TABLESPACE current;
+```
+
+!!! Important
+    This example assumes you're familiar with
+    [PostgreSQL declarative partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html).
+
+## Tablespace ownership
+
+By default, unless otherwise specified, tablespaces are owned by the `app`
+application user, as defined in `.spec.bootstrap.initdb.owner`. See
+[Bootstrap a new cluster](bootstrap.md#bootstrap-an-empty-cluster-initdb) for
+details.
+This default behavior works in most microservice database use cases.
+
+You can set the owner of a tablespace in the `owner` stanza, for example
+the `postgres` user, like in the following excerpt:
+
+```yaml
+  # ...
+  tablespaces:
+    - name: clapton
+      owner:
+        name: postgres
+      storage:
+        size: 1Gi
+```
+
+!!! Important
+    If you change the ownership of a tablespace, make sure that you're using
+    an existing role. Otherwise, the status of the cluster reports the
+    issue and stops reconciling tablespaces until fixed. It's your responsibility
+    to monitor the status and the log and to promptly intervene by fixing the issue.
+
+If you define a tablespace with an owner that doesn't exist, EDB Postgres for Kubernetes can't
+create the tablespace and reflects this in the cluster status:
+
+```yaml
+spec:
+  instances: 3
+
+  # ...
+
+  tablespaces:
+    - name: tbs1
+      storage:
+        size: 1Gi
+    - name: tbs2
+      storage:
+        size: 2Gi
+    - name: tbs3
+      owner:
+        name: badhombre
+      storage:
+        size: 2Gi
+        status:
+
+  <- snipped ->
+  tablespacesStatus:
+  - name: tbs1
+    status: reconciled
+  - name: tbs2
+    status: reconciled
+  - error: 'while creating tablespace tbs3: ERROR: role "badhombre" does
+      not exist (SQLSTATE 42704)'
+    name: tbs3
+    status: pending
+```
+
+## Backup and recovery
+
+EDB Postgres for Kubernetes handles backup of tablespaces (and the relative
+tablespace map) both on object stores and volume snapshots.
+
+!!! Warning
+    By default, backups are taken from replica nodes. A backup taken immediately
+    after creating tablespaces in a cluster can result in an
+    incomplete view of the tablespaces from the replica and thus an incomplete
+    backup. The lag will be resolved in a maximum of 5 minutes, with the next
+    reconciliation.
+
+Once a cluster with tablespaces has a base backup, you can restore a
+new cluster from it. When it comes to the recovery side, it's your
+responsibility to ensure that the `Cluster` definition of the recovered
+database contains the exact list of tablespaces.
+
+## Replica clusters
+
+Replica clusters must have the same tablespace definition as their origin.
+The reason is that tablespace management commands like `CREATE TABLESPACE`
+are WAL logged and are replayed by any physical replication client (streaming or by way of WAL shipping).
+
+It's your responsibility to ensure that replica clusters have the same list of
+tablespaces, with the same name. Storage class and size might vary.
+
+For example:
+
+```yaml
+spec:
+
+  # ...
+  bootstrap:
+    recovery:
+      # ... your selected recovery method
+
+  tablespaces:
+    - name: tbs1
+      storage:
+        size: 1Gi
+    - name: tbs2
+      storage:
+        size: 2Gi
+    - name: tbs3
+      storage:
+        size: 2Gi
+```
+
+## Temporary tablespaces
+
+PostgreSQL allows you to define one or more temporary tablespaces to create
+temporary objects (temporary tables and indexes on temporary tables) when a
+`CREATE` command doesn't explicitly specify a tablespace, and to create temporary
+files for purposes such as sorting large data sets. When no temporary
+tablespace is specified, PostgreSQL uses the default tablespace of a database, which is
+currently the main `PGDATA` volume.
+
+When you specify more than one temporary tablespace, PostgreSQL randomly picks
+one the first time a temporary object needs to be created in a transaction.
+Then it sequentially iterates through the list.
+
+Temporary tablespaces also work like regular tablespaces with regard to backups.
+
+EDB Postgres for Kubernetes provides the `.spec.tablespaces[*].temporary` option to
+determine whether to add a tablespace to the `temp_tablespaces`
+PostgreSQL parameter and thus become eligible to store temporary data that
+doesn't have an explicit tablespace assignment.
+
+```yaml
+spec:
+  [...]
+  tablespaces:
+    - name: atablespace
+      storage:
+        size: 1Gi
+      temporary: true
+```
+
+They can be created at initialization time or added later, requiring a
+rolling update. The `temporary: true/false` option adds or removes the
+tablespace name to or from the list of tablespaces in the `temp_tablespaces`
+option. This change doesn't require a restart of PostgreSQL.
+
+Although temporary tablespaces can also work as regular tablespaces (meaning
+that users can also host regular data on them while using them for
+temporary operations), we recommend that you don't mix the two workloads.
+
+See the [PostgreSQL documentation on `temp_tablespaces`](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-TEMP-TABLESPACES)
+for details.
+
+## kubectl plugin support
+
+The [kubectl status](kubectl-plugin.md#status) plugin includes a section
+dedicated to tablespaces that offers a convenient overview, including
+tablespace status, owner, temporary flag, and any errors:
+
+```yaml
+[...]
+
+Tablespaces status
+Tablespace          Owner  Status      Temporary  Error
+----------          -----  ------      ---------  -----
+atablespace         app    reconciled  true       
+another_tablespace  app    reconciled  true       
+tablespacea1        app    reconciled  false 
+
+Instances status
+[...]
+```
+
+## Limitations
+
+Currently, you can't remove tablespaces from an existing EDB Postgres for Kubernetes
+cluster.

--- a/product_docs/docs/postgres_for_kubernetes/1/tde.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/tde.mdx
@@ -159,7 +159,6 @@ For example:
 -   wrap command: `openssl enc -aes-128-cbc -pass pass:temp-pass -e -out %p`
 -   unwrap command: `openssl enc -aes-128-cbc -pass pass:temp-pass -d -in %p`
 
-
 ## Example using HashiCorp Vault
 
 The following example shows how to use HashiCorp Vault to store the encryption
@@ -169,7 +168,7 @@ and is included by default in the EDB Postgres Advanced Server (EPAS) image.
 First, wherever you have vault running you must enable the Transit secrets 
 engine and create a key:
 
-``` shell
+```shell
 vault secrets enable transit
 vault write -f transit/keys/pg-tde
 ```
@@ -193,7 +192,7 @@ kubectl exec vault-0 -- vault operator init -key-shares=1 -key-threshold=1 -form
 cat cluster-keys.json | jq -r ".root_token"
 ```
 
-``` shell
+```shell
 kubectl create secret generic -o yaml vault-token \
     --from-literal=wrap="/bin/vault wrap --file %p --host http://vault:8200 --secret vault-token --key token --vault-endpoint pg-tde" \
     --from-literal=unwrap="/bin/vault unwrap --file %p --host http://vault:8200 --secret vault-token --key token --vault-endpoint pg-tde" \
@@ -202,7 +201,7 @@ kubectl create secret generic -o yaml vault-token \
 
 You can now create a Cluster that is referencing the secrets:
 
-``` yaml
+```yaml
 apiVersion: postgresql.k8s.enterprisedb.io/v1
 kind: Cluster
 metadata:

--- a/product_docs/docs/postgres_for_kubernetes/1/troubleshooting.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/troubleshooting.mdx
@@ -42,6 +42,44 @@ following plugins/utilities to be available in your system:
     If you are on Windows OS, you can use [`findstr`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/findstr) as an alternative to `grep` or directly use [`wsl`](https://docs.microsoft.com/en-us/windows/wsl/)
     and install your preferred \*nix distro and use the tools mentioned above.
 
+## First steps
+
+To quickly get an overview of the cluster or installation, the `kubectl` plugin
+is the primary tool to use:
+
+1.  the [status subcommand](kubectl-plugin.md#status) provides an overview of a
+    cluster
+2.  the [report subcommand](kubectl-plugin.md#report) provides the manifests
+    for clusters and the operator deployment. It can also include logs using
+    the `--logs` option.
+    The report generated via the plugin will include the full cluster manifest.
+
+The plugin can be installed on air-gapped systems via packages.
+Please refer to the [plugin document](kubectl-plugin.md) for complete instructions.
+
+## Are there backups?
+
+After getting the cluster manifest with the plugin, you should verify if backups
+are set up and working.
+
+In a cluster with backups set up, you will find, in the cluster Status, the fields
+`lastSuccessfulBackup` and `firstRecoverabilityPoint`. You should make sure
+there is a recent `lastSuccessfulBackup`.
+
+A cluster lacking the `.spec.backup` stanza won't have backups. 
+An insistent message will appear in the PostgreSQL logs:
+
+```
+Backup not configured, skip WAL archiving.
+```
+
+Before proceeding with troubleshooting operations, it may be advisable
+to perform an emergency backup depending on your findings regarding backups.
+Refer to the following section for instructions.
+
+It is **extremely risky** to operate a production database without keeping
+regular backups.
+
 ## Emergency backup
 
 In some emergency situations, you might need to take an emergency logical
@@ -95,7 +133,7 @@ kubectl exec -i new-cluster-example-1 -c postgres \
 
 The above steps might be integrated into the `cnp` plugin at some stage in the future.
 
-### Logs
+## Logs
 
 Every resource created and controlled by EDB Postgres for Kubernetes logs to
 standard output, as expected by Kubernetes, and directly in [JSON
@@ -183,7 +221,7 @@ Cluster in healthy state
 Name:               cluster-example
 Namespace:          default
 System ID:          7044925089871458324
-PostgreSQL Image:   quay.io/enterprisedb/postgresql:16.0-3
+PostgreSQL Image:   quay.io/enterprisedb/postgresql:16.1-3
 Primary instance:   cluster-example-1
 Instances:          3
 Ready instances:    3
@@ -259,7 +297,7 @@ kubectl describe cluster <CLUSTER_NAME> -n <NAMESPACE> | grep "Image Name"
 Output:
 
 ```shell
-  Image Name:    quay.io/enterprisedb/postgresql:16.0-3
+  Image Name:    quay.io/enterprisedb/postgresql:16.1-3
 ```
 
 !!! Note

--- a/product_docs/docs/postgres_for_kubernetes/1/wal_archiving.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/wal_archiving.mdx
@@ -16,7 +16,7 @@ the ["Backup on object stores" section](backup_barmanobjectstore.md) to set up
 the WAL archive.
 
 !!! Info
-    Please refer to [`BarmanObjectStoreConfiguration`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BarmanObjectStoreConfiguration)
+    Please refer to [`BarmanObjectStoreConfiguration`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-barmanobjectstoreconfiguration)
     in the API reference for a full list of options.
 
 If required, you can choose to compress WAL files as soon as they

--- a/product_docs/docs/postgres_for_kubernetes/1/wal_archiving.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/wal_archiving.mdx
@@ -16,7 +16,7 @@ the ["Backup on object stores" section](backup_barmanobjectstore.md) to set up
 the WAL archive.
 
 !!! Info
-    Please refer to [`BarmanObjectStoreConfiguration`](cloudnative-pg.v1.md#postgresql-k8s-enterprisedb-io-v1-barmanobjectstoreconfiguration)
+    Please refer to [`BarmanObjectStoreConfiguration`](pg4k.v1.md#postgresql-k8s-enterprisedb-io-v1-BarmanObjectStoreConfiguration)
     in the API reference for a full list of options.
 
 If required, you can choose to compress WAL files as soon as they


### PR DESCRIPTION
## What Changed?

- Postgres for Kubernetes: 1.22, 1.21.2, 1.20.5, 1.18.9
- Top-bar search: exclude pre-release products, limit searches to either latest versions or version being viewed (as appropriate)
- Bugfix for top-bar search introduced in ^