### PR TITLE
Update poolers.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/overview/poolers.mdx
+++ b/product_docs/docs/biganimal/release/overview/poolers.mdx
@@ -7,7 +7,7 @@ EDB PgBouncer can manage your connections to Postgres databases and help your wo
 BigAnimal provisions up to three instances per EDB PgBouncer-enabled cluster to ensure that performance is unaffected, so each availability zone receives its own instance of EDB PgBouncer. 
 
 !!!Note
-   Currently, you can't enable EDB PgBouncer when creating a distributed high-availability cluster using your cloud account.
+   Currently, you can't enable EDB PgBouncer when creating a distributed high-availability cluster.
 
 If you want to deploy and manage PgBouncer outside of BigAnimal, see the [How to configure EDB PgBouncer with BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/4848726654745-How-to-configure-PgBouncer-with-BigAnimal-Cluster) knowledge-base article.
 

--- a/product_docs/docs/biganimal/release/overview/poolers.mdx
+++ b/product_docs/docs/biganimal/release/overview/poolers.mdx
@@ -7,7 +7,7 @@ EDB PgBouncer can manage your connections to Postgres databases and help your wo
 BigAnimal provisions up to three instances per EDB PgBouncer-enabled cluster to ensure that performance is unaffected, so each availability zone receives its own instance of EDB PgBouncer. 
 
 !!!Note
-   Currently, you can't enable EDB PgBouncer when using BigAnimal's cloud account or when creating a distributed high-availability cluster using your cloud account.
+   Currently, you can't enable EDB PgBouncer when creating a distributed high-availability cluster using your cloud account.
 
 If you want to deploy and manage PgBouncer outside of BigAnimal, see the [How to configure EDB PgBouncer with BigAnimal cluster](https://support.biganimal.com/hc/en-us/articles/4848726654745-How-to-configure-PgBouncer-with-BigAnimal-Cluster) knowledge-base article.
 


### PR DESCRIPTION
## What Changed?

- The doc states that PgBouncer can't be enabled on BigAnimal's cloud account. In my testing, PgBouncer can be enabled on BAH.
- For a distributed high-availability cluster, PgBouncer can't be enabled on either BAH or customer cloud account.



<img width="1497" alt="Screenshot 2024-01-02 at 11 03 22" src="https://github.com/EnterpriseDB/docs/assets/95676424/614dd09d-d2ae-4ce5-be7d-6d2d8416e22d">

