### PR TITLE
Correct PEM compatibility table

### DIFF
--- a/product_docs/docs/pem/8/index.mdx
+++ b/product_docs/docs/pem/8/index.mdx
@@ -65,8 +65,8 @@ Supported versions of Postgres for PEM 8.x:
 
 |                                          |**Monitored Instance** |**Backend Instance** |
 |:-----------------------------------------|:----------------------|:--------------------|
-|**EDB Postgres Advanced Server (EPAS)**   |11, 12, 13, 14         |11, 12, 13, 14       |
-|**PostgreSQL (PG)**                       |11, 12, 13, 14         |11, 12, 13, 14       |
-|**EDB Postgres Extended Server (PGE)**    |11, 12, 13, 14         |Note[^1]              
+|**EDB Postgres Advanced Server (EPAS)**   |12, 13, 14             |12, 13, 14           |
+|**PostgreSQL (PG)**                       |12, 13, 14             |12, 13, 14           |
+|**EDB Postgres Extended Server (PGE)**    |12, 13, 14             |13, 14[^1]           |
 
-Note[^1]: PEM will support PGE as a backend when `sslutils` is available for this server distribution. It is expected to be available in the second quarter of 2023.
+[^1]: sslutils isn't available for RHEL 7 on IBM Power, so this distribution can't use PGE as a backend.


### PR DESCRIPTION
PGE is supported as a backend for 13 and 14

11 is now out of support

