### PR TITLE
Replace use of recovery.conf outside of PGD 3.7

### DIFF
--- a/product_docs/docs/pgd/3.7/bdr/backup.mdx
+++ b/product_docs/docs/pgd/3.7/bdr/backup.mdx
@@ -164,7 +164,7 @@ would also include changes from other nodes that have been committed
 by `T1`, even though they were not applied on `N1` until later.
 
 To request multi-origin PITR, use the standard syntax in
-the recovery.conf file:
+the postgresql.conf file:
 
 ```
 recovery_target_time = T1
@@ -222,7 +222,7 @@ of a single BDR node, optionally plus WAL archives:
 -   Restore a single PostgreSQL node from a physical backup of one of
     the BDR nodes.
 -   If you have WAL archives associated with the backup, create a suitable
-    `recovery.conf` and start PostgreSQL in recovery to replay up to the latest
+    `postgresql.conf` and start PostgreSQL in recovery to replay up to the latest
     state. You can specify a alternative `recovery_target` here if needed.
 -   Start the restored node, or promote it to read/write if it was in standby
     recovery. Keep it fenced from any surviving nodes!

--- a/product_docs/docs/pgd/4/backup.mdx
+++ b/product_docs/docs/pgd/4/backup.mdx
@@ -164,7 +164,7 @@ would also include changes from other nodes that have been committed
 by `T1`, even though they were not applied on `N1` until later.
 
 To request multi-origin PITR, use the standard syntax in
-the recovery.conf file:
+the postgresql.conf file:
 
 ```
 recovery_target_time = T1
@@ -222,7 +222,7 @@ of a single BDR node, optionally plus WAL archives:
 -   Restore a single PostgreSQL node from a physical backup of one of
     the BDR nodes.
 -   If you have WAL archives associated with the backup, create a suitable
-    `recovery.conf` and start PostgreSQL in recovery to replay up to the latest
+    `postgresql.conf` and start PostgreSQL in recovery to replay up to the latest
     state. You can specify a alternative `recovery_target` here if needed.
 -   Start the restored node, or promote it to read/write if it was in standby
     recovery. Keep it fenced from any surviving nodes!

--- a/product_docs/docs/pgd/4/bdr/nodes.mdx
+++ b/product_docs/docs/pgd/4/bdr/nodes.mdx
@@ -312,10 +312,9 @@ BDR:
 -   The connection between BDR primary and standby uses streaming
     replication through a physical replication slot.
 -   The standby has:
-    -   `recovery.conf` (for PostgreSQL &lt;12, for PostgreSQL 12+ these settings are in `postgres.conf`):
+    -   `postgresql.conf`:
         -   `primary_conninfo` pointing to the primary
         -   `primary_slot_name` naming a physical replication slot on the primary to be used only by this standby
-    -   `postgresql.conf`:
         -   `shared_preload_libraries = 'bdr'`, there can be other plugins in the list as well, but don't include pglogical
         -   `hot_standby = on`
         -   `hot_standby_feedback = on`

--- a/product_docs/docs/pgd/5/backup.mdx
+++ b/product_docs/docs/pgd/5/backup.mdx
@@ -165,7 +165,7 @@ also includes changes from other nodes that were committed
 by `T1`, even though they weren't applied on `N1` until later.
 
 To request multi-origin PITR, use the standard syntax in
-the `recovery.conf` file:
+the `postgresql.conf` file:
 
 ```
 recovery_target_time = T1
@@ -223,7 +223,7 @@ of a single PGD node, optionally plus WAL archives:
 -   Restore a single PostgreSQL node from a physical backup of one of
     the PGD nodes.
 -   If you have WAL archives associated with the backup, create a suitable
-    `recovery.conf` and start PostgreSQL in recovery to replay up to the latest
+    `postgresql.conf` and start PostgreSQL in recovery to replay up to the latest
     state. You can specify an alternative `recovery_target` here if needed.
 -   Start the restored node, or promote it to read/write if it was in standby
     recovery. Keep it fenced from any surviving nodes!


### PR DESCRIPTION
## What Changed?

Bare minimum fixes for #5035 - remove references to recovery.conf except in PGD 3.7 where it is still nominally supported 

(Note: originally contained a somewhat iffy change to PGD 5 in a now-eliminated file.)