### PR TITLE
Removed mention of DELETE from MERGE topic

### DIFF
--- a/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/65a_merge.mdx
+++ b/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/65a_merge.mdx
@@ -6,7 +6,7 @@ redirects:
 
 ## Name
 
-`MERGE` &mdash; conditionally insert, update, or delete rows of a table.
+`MERGE` &mdash; conditionally insert or update rows of a table.
 
 ## Synopsis
 
@@ -18,7 +18,6 @@ merge_update_clause merge_insert_clause
 -- where merge_update_clause is
 WHEN MATCHED THEN 
    UPDATE SET column = value, ... [ WHERE where_condition ]
-   [ DELETE WHERE where_condition ]
 
 -- and merge_insert_clause is
 WHEN NOT MATCHED THEN 
@@ -29,7 +28,7 @@ WHEN NOT MATCHED THEN
 
 `MERGE` allows you to select rows from one or more sources for update or insertion into a table. You specify the join condition to determine whether to update or insert into the target table. You specify conditional UPDATE and INSERT statements using the WHERE clause in the MERGE statement.
 
-`MERGE` provides a single SQL statement that can conditionally INSERT, UPDATE, or DELETE rows, a task which would otherwise require multiple procedural language statements.
+`MERGE` provides a single SQL statement that can conditionally INSERT or UPDATE rows, a task which would otherwise require multiple procedural language statements.
 
 For more information, see [MERGE statement](https://www.postgresql.org/docs/current/sql-merge.html).
 
@@ -61,8 +60,6 @@ For more information, see [MERGE statement](https://www.postgresql.org/docs/curr
  Specifies the new column values of the target table. It performs this update if the join_condition of the ON clause is true. 
 
  Specify the where_condition if you want the database to execute the update operation only if the specified condition is true. The condition can refer to either the data source or the target table. If the condition is not true, then the database skips the update operation when merging the row into the table.
-
- Specify the DELETE where_condition to clean up data in a table while populating or updating it. The only rows affected by this clause are those rows in the target table that are updated by the merge operation. The DELETE WHERE condition evaluates the updated value, not the original value that was evaluated by the UPDATE SET ... WHERE condition. If a row of the target table meets the DELETE condition but is not included in the join defined by the ON clause, then it is not deleted. 
 
  You can specify this clause by itself or with the merge_insert_clause. If you specify both, then they can be in either order.
 
@@ -113,30 +110,4 @@ WHEN MATCHED THEN
     UPDATE SET balance = s.delta
 WHEN NOT MATCHED THEN
     INSERT VALUES (s.sid, s.delta);
-```
-
-This example shows how to UPDATE, INSERT, and conditionally DELETE rows on the target table using MERGE statement:
-
-```sql
-MERGE INTO target t
-USING source s
-ON (t.tid = s.sid)
-WHEN MATCHED THEN
-    UPDATE SET t.balance = t.balance + 100
-    DELETE WHERE sid = 1
-WHEN NOT MATCHED THEN
-    INSERT VALUES (s.sid, s.delta);
-```
-
-This example shows how to UPDATE, INSERT, and DELETE rows on the target table conditionally using the MERGE statement:
-
-```sql
-MERGE INTO target t
-USING source s
-ON (t.tid = s.sid)
-WHEN MATCHED THEN
-    UPDATE SET balance = s.delta WHERE balance = 0
-    DELETE WHERE sid = 1
-WHEN NOT MATCHED THEN
-    INSERT VALUES (s.sid, s.delta) WHERE s.sid >= 5;
 ```

--- a/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/65a_merge.mdx
+++ b/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/65a_merge.mdx
@@ -115,7 +115,7 @@ WHEN NOT MATCHED THEN
     INSERT VALUES (s.sid, s.delta);
 ```
 
-This example shows how to INSERT and UDPATE rows on the target table conditionally using the MERGE statement:
+This example shows how to conditionally UPDATE and INSERT rows on the target table using the MERGE statement:
 
 ```sql
 MERGE INTO target t

--- a/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/65a_merge.mdx
+++ b/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/65a_merge.mdx
@@ -30,6 +30,9 @@ WHEN NOT MATCHED THEN
 
 `MERGE` provides a single SQL statement that can conditionally INSERT or UPDATE rows, a task which would otherwise require multiple procedural language statements.
 
+!!! Note:
+    In version 15, EDB Postgres Advanced Server provides only partial support for Oracle-compatible MERGE syntax.!!!
+
 For more information, see [MERGE statement](https://www.postgresql.org/docs/current/sql-merge.html).
 
 
@@ -110,4 +113,16 @@ WHEN MATCHED THEN
     UPDATE SET balance = s.delta
 WHEN NOT MATCHED THEN
     INSERT VALUES (s.sid, s.delta);
+```
+
+This example shows how to INSERT and UDPATE rows on the target table conditionally using the MERGE statement:
+
+```sql
+MERGE INTO target t
+USING source s
+ON (t.tid = s.sid)
+WHEN MATCHED THEN
+    UPDATE SET balance = s.delta WHERE balance = 0
+WHEN NOT MATCHED THEN
+    INSERT VALUES (s.sid, s.delta) WHERE s.sid >= 5;
 ```


### PR DESCRIPTION
Removed mention of DELETE from topic describing SQL-compatible MERGE command in version 15 of EPAS

