### PR TITLE
pgd/sql monitoring: Updated for relevance

### DIFF
--- a/product_docs/docs/pgd/5/monitoring/sql.mdx
+++ b/product_docs/docs/pgd/5/monitoring/sql.mdx
@@ -686,10 +686,9 @@ One of the following status summaries is returned:
 
 ## Monitoring transaction COMMITs
 
-By default, PGD transactions commit only on the local node. In that case,
-transaction `COMMIT` is processed quickly.
+By default, PGD transactions are only committed to the local node. In that case, a transaction's `COMMIT` is processed quickly.
 
-PGD's commit scopes offer a range of [commit scopes](../durability/commit-scopes) with synchrnous options for transactions that allow you to balance durability, consistency and performance for your particular queries. 
-These transactions can be monitored by examining the [`bdr.stat_activity`](/pgd/latest/reference/catalogs-visible#bdrstat_activity) catalog, where processes report different `wait_event` states as transactions are committed. This only covers transactions in progress and does not provide historical timing information.
+PGD's commit scopes offer a range of [commit scopes](../durability/commit-scopes) with synchronous transaction options that allow you to balance durability, consistency, and performance for your particular queries. 
+You can monitor these transactions by examining the [`bdr.stat_activity`](/pgd/latest/reference/catalogs-visible#bdrstat_activity) catalog. The processes will report different `wait_event` states as a transaction is committed. This monitoring only covers transactions in progress and does not provide historical timing information.
  
 

--- a/product_docs/docs/pgd/5/monitoring/sql.mdx
+++ b/product_docs/docs/pgd/5/monitoring/sql.mdx
@@ -689,12 +689,7 @@ One of the following status summaries is returned:
 By default, PGD transactions commit only on the local node. In that case,
 transaction `COMMIT` is processed quickly.
 
-You can use PGD with standard PostgreSQL synchronous replication. 
-PGD also provides two new transaction commit modes: CAMO and eager
-replication. Each of these modes adds robustness
-features, though at the expense of additional latency at `COMMIT`.
-You can monitor the additional time at `COMMIT` dynamically using the
-`bdr.stat_activity` catalog, where processes report different `wait_event`
-states. A transaction in `COMMIT` waiting for confirmations from one or
-more synchronous standbys reports a `SyncRep` wait event, whereas the
-two new modes report `EagerRep`.
+PGD's commit scopes offer a range of [commit scopes](../durability/commit-scopes) with synchrnous options for transactions that allow you to balance durability, consistency and performance for your particular queries. 
+These transactions can be monitored by examining the [`bdr.stat_activity`](/pgd/latest/reference/catalogs-visible#bdrstat_activity) catalog, where processes report different `wait_event` states as transactions are committed. This only covers transactions in progress and does not provide historical timing information.
+ 
+


### PR DESCRIPTION
## What Changed?

Reworked Monitoring transaction COMMITs section to reflect the current status of transaction monitoring.