### PR TITLE
PGD: fix description of bdr.node_group_type() function

### DIFF
--- a/product_docs/docs/pgd/5/reference/functions.mdx
+++ b/product_docs/docs/pgd/5/reference/functions.mdx
@@ -606,7 +606,7 @@ bdrdb=# SELECT bdr.local_group_slot_name();
 
 Returns the type of the given node group. Returned value is the same as what
 was passed to `bdr.create_node_group()` when the node group was created,
-except `normal` is returned if the `node_group_type` was passed as NULL
+except `global` is returned if the `node_group_type` was passed as NULL
 when the group was created.
 
 #### Example
@@ -615,7 +615,7 @@ when the group was created.
 bdrdb=# SELECT bdr.node_group_type('bdrgroup');
  node_group_type
 -----------------
- normal
+ global
 ```
 
 ### `bdr.alter_node_kind`


### PR DESCRIPTION
## What Changed?

From PGD 5, the default group name is "global", not "normal".

