### PR TITLE
PGD: add "bdr.node_group_summary" reference entry.

### DIFF
--- a/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
+++ b/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
@@ -490,7 +490,9 @@ Currently configured conflict resolution for all known conflict types.
 
 ### `bdr.node_group`
 
-This catalog table lists all the PGD node groups.
+This catalog table lists all the PGD node groups. See also
+[`bdr.node_group_summary`](#bdrnode_group_summary) for a view containing
+user-readable details.
 
 #### `bdr.node_group` columns
 
@@ -508,9 +510,9 @@ This catalog table lists all the PGD node groups.
 | node_group_num_writers          | int      | Number of writers to use for subscriptions backing this node group                            |
 | node_group_enable_wal_decoder   | bool     | Whether the group has enable_wal_decoder set                                                  |
 | node_group_streaming_mode       | char     | Transaction streaming setting: 'O' - off, 'F' - file, 'W' - writer, 'A' - auto, 'D' - default |
-| node_group_location             | char     | Name of the location associated with the node group |
-| node_group_enable_proxy_routing | char     | Whether the node group allows routing from `pgd-proxy` |
-| node_group_enable_raft | bool | Whether the node group allows Raft Consensus |
+| node_group_location             | char     | Name of the location associated with the node group                                           |
+| node_group_enable_proxy_routing | char     | Whether the node group allows routing from `pgd-proxy`                                        |
+| node_group_enable_raft          | bool     | Whether the node group allows Raft Consensus                                                  |
 
 ### `bdr.node_group_replication_sets`
 
@@ -526,6 +528,33 @@ A view showing default replication sets create for PGD groups. See also
 | def_repset_ops     | text\[] | Actions replicated by the default repset                                             |
 | def_repset_ext     | name    | Name of the default "external" repset (usually same as def_repset)                   |
 | def_repset_ext_ops | text\[] | Actions replicated by the default "external" repset (usually same as def_repset_ops) |
+
+
+### `bdr.node_group_summary`
+
+A view containing user-readable details about node groups. See also
+[`bdr.node_group`](#bdrnode_group).
+
+#### `bdr.node_group_summary` columns
+
+| Name                    | Type     | Description                                                                    |
+| ----------------------- | -------- | ------------------------------------------------------------------------------ |
+| node_group_name         | name     | Name of the node group                                                         |
+| default_repset          | name     | Default replication set for this node group                                    |
+| parent_group_name       | name     | Name of parent group (NULL if this is a root group)                            |
+| node_group_type         | text     | Type of the node group (one of "global", "data", "shard" or "subscriber-only") |
+| apply_delay             | interval | How long a subscriber waits before applying changes from the provider          |
+| check_constraints       | boolean  | Whether the apply process checks constraints when applying data                |
+| num_writers             | integer  | Number of writers to use for subscriptions backing this node group             |
+| enable_wal_decoder      | boolean  | Whether the group has enable_wal_decoder set                                   |
+| streaming_mode          | text     | Transaction streaming setting: "off", "file", "writer", "auto" or "default"    |
+| default_commit_scope    | name     | Name of the node group's default commit scope                                  |
+| location                | name     | Name of the location associated with the node group                            |
+| enable_proxy_routing    | boolean  | Whether the node group allows routing from `pgd-proxy`                         |
+| enable_raft             | boolean  | Whether the node group allows Raft Consensus                                   |
+| route_writer_max_lag    | bigint   | Maximum write lag accepted                                                     |
+| route_reader_max_lag    | bigint   | Maximum read lag accepted                                                      |
+| route_writer_wait_flush | boolean  | Switch if we need to wait for the flush                                        |
 
 ### `bdr.node_local_info`
 


### PR DESCRIPTION
## What Changed?

Added "bdr.node_group_summary" reference entry, which has been missing since the view was added in BDR 5.0.0.

Cross-reference from "bdr.node_group" added too (and cleaned up the column formatting there).

BDR-4467


