### PR TITLE
PGD: fix name of bdr.seq_lastval() function

### DIFF
--- a/product_docs/docs/pgd/4/bdr/functions.mdx
+++ b/product_docs/docs/pgd/4/bdr/functions.mdx
@@ -920,7 +920,7 @@ interact with [BDR global sequences](sequences/#bdr-global-sequences).
 #### Notes
 
 The following are also internal BDR sequence manipulation functions.
-`bdr.seq_currval` and `bdr.sql_lastval` are used automatically.
+`bdr.seq_currval` and `bdr.seq_lastval` are used automatically.
 
 ### bdr.show_subscription_status
 

--- a/product_docs/docs/pgd/5/reference/functions-internal.mdx
+++ b/product_docs/docs/pgd/5/reference/functions-internal.mdx
@@ -105,7 +105,7 @@ interact with [PGD global sequences](../sequences/#pgd-global-sequences).
 #### Notes
 
 The following are also internal PGD sequence manipulation functions.
-`bdr.seq_currval` and `bdr.sql_lastval` are used automatically.
+`bdr.seq_currval` and `bdr.seq_lastval` are used automatically.
 
 ### `bdr.show_subscription_status`
 


### PR DESCRIPTION
## What Changed?

`bdr.seq_lastval()` was written incorrectly as `bdr.sql_lastval()` in two places.