### PR TITLE
Document bdr.alter_node_group_option

### DIFF
--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -131,7 +131,7 @@ The group creation doesn't hold any locks.
 ## `bdr.alter_node_group_config`
 
 !!! Warning
-    This function only exists for compatibility with PGD4 and 3.7
+    This function only exists for compatibility with PGD4 and 3.7. 
     Please use [`bdr.alter_node_group_option`](#bdralter_node_group_option) instead.
 
 This function changes the configuration parameters of an existing PGD group.

--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -213,6 +213,9 @@ This function doesn't hold any locks.
     This restriction has little consequence on production
     use because this value normally isn't used outside of testing.
 
+!!! Warning this function only exists for compatibility with PGD4 and 3.7
+    Please use [`bdr.alter_node_group_option`](#bdralter_node_group_option) instead.
+
 ## `bdr.join_node_group`
 
 This function joins the local node to an already existing PGD group.
@@ -535,6 +538,43 @@ bdr.alter_node_group_option(node_group_name text,
 -   `config_key` &mdash; Key of the option in the node group to be changed.
 -   `config_value` &mdash; New value to be set for the given key.
 
+The group options which can be changed using this function are:
+-   `location` &mdash; Information about node location, this is purely metadata for monitoring.
+-   `apply_delay` &mdash; How long nodes wait to apply incoming changes. This is useful mainly to setup a special sub-group with delayed subscriber-only nodes. Don't set this on groups which contain data nodes or on top-level group. The value is in Postgres interval format. Default is `0s`.
+-   `check_constraints` &mdash; Whether the apply process checks the constraints when writing replicated data. It's recommended to keep this to default value, otherwise you risk data loss. Valid values are either `on` or `off`. Default is `on`.
+-   `num_writers` &mdash; Number of parallel apply writers.
+-   `enable_wal_decoder` &mdash; Number of parallel writers for subscription backing this node group. Valid values are either -1 or a positive integer. The -1 is the default.
+-   `enable_wal_decoder` &mdash; Enables/disables the decoding worker process. You can't enable the decoding worker process if `streaming_mode` is already enabled. Valid values are either `on` or `off`. Default is `off`.
+-   `streaming_mode` &mdash; Enables/disables streaming of large transactions.
+     When set to `off`, streaming is disabled. When set to any other value,
+     large transactions are decoded while they're still in progress, and the
+     changes are sent to the downstream. If the value is set to `file`,
+     then the incoming changes of streaming transactions are stored in a file
+     and applied only after the transaction is committed on upstream. If the
+     value is set to `writer`, then the incoming changes are directly sent to
+     one of the writers, if available. If parallel apply is disabled or no
+     writer is free to handle streaming transaction, then the changes are
+     written to a file and applied after the transaction is committed. If the
+     value is set to `auto`, PGD tries to intelligently pick between
+     `file` and `writer`, depending on the transaction property and available
+     resources. You can't enable `streaming_mode` if the WAL
+     decoder is already enabled. Default is `auto`
+
+     For more details, see [Transaction streaming](../transaction-streaming).
+-   `default_commit_scope` &mdash; The commit scope to use by default,
+     initially the `local` commit scope. This applies only to the
+     top-level node group. You can use individual rules for different
+     origin groups of the same commit scope. See
+     [Origin groups](../durability/commit-scopes/#origin-groups) for more details.
+-   `enable_proxy_routing` &mdash; Where routing through leader is enabled for given group.
+     Valid values are `on` or `off`. Default is `off`.
+-   `route_writer_max_lag` &mdash; Maximum lag in bytes of the new write candidate to be
+     selected as write leader. If no candidate passes this, no writer is
+     selected automatically.
+-   `route_reader_max_lag` &mdash; Maximum lag in bytes for a node to be considered a viable
+  read-only node. Currently reserved for future use.
+-   `enable_raft` &mdash; Whether group has it's own Raft consensus. This is necessary for
+     setting `enable_proxy_routing` to `on`. This is always `on` for top-level group. Valid values are `on` or `off`. Default is `off` for subgroups.
 
 ## `bdr.alter_node_option`
 

--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -130,6 +130,10 @@ The group creation doesn't hold any locks.
 
 ## `bdr.alter_node_group_config`
 
+!!! Warning 
+    This function only exists for compatibility with PGD4 and 3.7
+    Please use [`bdr.alter_node_group_option`](#bdralter_node_group_option) instead.
+
 This function changes the configuration parameters of an existing PGD group.
 Options with NULL value (default for all of them) aren't modified.
 
@@ -212,9 +216,6 @@ This function doesn't hold any locks.
     group.
     This restriction has little consequence on production
     use because this value normally isn't used outside of testing.
-
-!!! Warning this function only exists for compatibility with PGD4 and 3.7
-    Please use [`bdr.alter_node_group_option`](#bdralter_node_group_option) instead.
 
 ## `bdr.join_node_group`
 

--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -130,7 +130,7 @@ The group creation doesn't hold any locks.
 
 ## `bdr.alter_node_group_config`
 
-!!! Warning 
+!!! Warning
     This function only exists for compatibility with PGD4 and 3.7
     Please use [`bdr.alter_node_group_option`](#bdralter_node_group_option) instead.
 


### PR DESCRIPTION
Document bdr.alter_node_group_option so that we can expose apply_delay option

BDR-4396

## What Changed?

Added warning to alter_node_group_config about being deprecated in favor of bdr.alter_node_group_option and properly documented options that bdr.alter_node_group_option can set.

This is for PGD 5.4 release.
