### PR TITLE
Docs/pem/installation updates and clarifications

### DIFF
--- a/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
@@ -52,7 +52,7 @@ After selecting a configuration option, the script prompts you for configuration
 /usr/edb/pem/bin/configure-pem-server.sh -help
 ```
 
-## Post-configuration steps for the web server and the PEM backend database separate installations
+## Post-configuration steps when web server and PEM backend database are installed separately
 
 If you choose to run the web application server on a separate host to the backend database, you need to perform some additional manual steps before PEM is fully operational.
 

--- a/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
@@ -52,24 +52,27 @@ After selecting a configuration option, the script prompts you for configuration
 /usr/edb/pem/bin/configure-pem-server.sh -help
 ```
 
-## Post-configuration steps for two-server installations
+## Post-configuration steps for the web server and the PEM backend database separate installations
 
-If you have chosen to run the PEM web application on a separate server to the backend database, you will need to perform some additional manual steps before PEM will be fully operational.
-Firstly, you must ensure that the backend Postgres instance accepts connections from any user permitted to login to PEM, from the web application server.
-You can do this by adding two lines to `pg_hba.conf` as follows, substituting `<web_app_ip>` for the IP address of the web application server.
+If you choose to run the web application server on a separate host to the backend database, you need to perform some additional manual steps before PEM is fully operational.
 
-```
+Make sure that the backend Postgres database accepts the connections from any user permitted to login to PEM, from the web application server. To achieve this add below entry to `pg_hba.conf`: 
+
+```ini
 host pem +pem_user <web_app_ip>/32 md5
-host postgres +pem_user <web_app_ip>/32 md56
+host postgres +pem_user <web_app_ip>/32 md5
 ```
 
-Additionally, if the IP address of the seb application server is not within the network address range specified when the script was executed,
-you must add two further lines to allow the PEM Agent on this server to connect.
+Where, `<web_app_ip>` is the IP address of the web application server.
 
-```
+Additionally, if the IP address of the web application server is not within the network address range specified when the script is executed, you must add two further entries to allow the PEM Agent on this server to connect:
+
+```ini
 host pem +pem_agent <web_app_ip>/32 md5
 host pem +pem_agent <web_app_ip>/32 cert
 ```
+
+Where, `<web_app_ip>` is the IP address of the web application server.
 
 ## Accessing the PEM application
 

--- a/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
@@ -52,6 +52,27 @@ After selecting a configuration option, the script prompts you for configuration
 /usr/edb/pem/bin/configure-pem-server.sh -help
 ```
 
+## Post-configuration steps for two-server installations
+
+If you have chosen to run the PEM web application on a separate server to the backend database, you will need to perform some additional manual steps before PEM will be fully operational.
+Firstly, you must ensure that the backend Postgres instance accepts connections from any user permitted to login to PEM, from the web application server.
+You can do this by adding two lines to `pg_hba.conf` as follows, substituting `<web_app_ip>` for the IP address of the web application server.
+
+```
+host pem +pem_user <web_app_ip>/32 md5
+host postgres +pem_user <web_app_ip>/32 md56
+```
+
+Additionally, if the IP address of the seb application server is not within the network address range specified when the script was executed,
+you must add two further lines to allow the PEM Agent on this server to connect.
+
+```
+host pem +pem_agent <web_app_ip>/32 md5
+host pem +pem_agent <web_app_ip>/32 cert
+```
+
+## Accessing the PEM application
+
 After configuring the PEM server, you can access the PEM web interface in your browser. Navigate to:
 
 ```text

--- a/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
@@ -54,7 +54,7 @@ After selecting a configuration option, the script prompts you for configuration
 
 ## Post-configuration steps when web server and PEM backend database are installed separately
 
-If you choose to run the web application server on a separate host to the backend database, you need to perform some additional manual steps before PEM is fully operational.
+If you choose to run the web application server on a separate host from the backend database, you need to perform some additional manual steps before PEM is fully operational.
 
 Make sure that the backend Postgres database accepts the connections from any user permitted to log in to PEM from the web application server. To achieve this, add this entry to `pg_hba.conf`: 
 

--- a/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
@@ -60,7 +60,6 @@ Make sure that the backend Postgres database accepts the connections from any us
 
 ```ini
 host pem +pem_user <web_app_ip>/32 md5
-host postgres +pem_user <web_app_ip>/32 md5
 ```
 
 Where `<web_app_ip>` is the IP address of the web application server.

--- a/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/8/installing/configuring_the_pem_server_on_linux.mdx
@@ -56,23 +56,23 @@ After selecting a configuration option, the script prompts you for configuration
 
 If you choose to run the web application server on a separate host to the backend database, you need to perform some additional manual steps before PEM is fully operational.
 
-Make sure that the backend Postgres database accepts the connections from any user permitted to login to PEM, from the web application server. To achieve this add below entry to `pg_hba.conf`: 
+Make sure that the backend Postgres database accepts the connections from any user permitted to log in to PEM from the web application server. To achieve this, add this entry to `pg_hba.conf`: 
 
 ```ini
 host pem +pem_user <web_app_ip>/32 md5
 host postgres +pem_user <web_app_ip>/32 md5
 ```
 
-Where, `<web_app_ip>` is the IP address of the web application server.
+Where `<web_app_ip>` is the IP address of the web application server.
 
-Additionally, if the IP address of the web application server is not within the network address range specified when the script is executed, you must add two further entries to allow the PEM Agent on this server to connect:
+Additionally, if the IP address of the web application server isn't within the network address range specified when the script is executed, you must add two entries to allow the PEM agent on this server to connect:
 
 ```ini
 host pem +pem_agent <web_app_ip>/32 md5
 host pem +pem_agent <web_app_ip>/32 cert
 ```
 
-Where, `<web_app_ip>` is the IP address of the web application server.
+Where `<web_app_ip>` is the IP address of the web application server.
 
 ## Accessing the PEM application
 

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -7,7 +7,7 @@ redirects:
 
 You can install PEM on a single server, or you can install the web application server and the backend database on two separate servers. You must prepare your servers for PEM installation. 
 
-After completing these steps, [install](/pem/8/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you're using two servers, install and configure PEM on both servers.
+After completing the prerequisites, [install](/pem/8/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you're using two servers, install and configure PEM on both servers.
 
 To install a PEM server on Linux, perform this preliminary configuration:
     

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -111,7 +111,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
           
         ```shell
         zypper install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
-
+        ```
 
     !!! Note For Debian and Ubuntu users               
         Debian 10 and Ubuntu 20 changed the requirements for accepting certificates.

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -33,7 +33,8 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
     !!!
 
-3.  Verify that the `sslutils` extension is installed on your Postgres server.
+3.  Verify that the `sslutils` extension is installed on your Postgres server. 
+    If you are using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you will also need to install the `hstore contrib` module.
 
     -   If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
 
@@ -61,18 +62,18 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         zypper install edb-as<x>-server-sslutils
         ```
 
-    -   If you're using PostgreSQL, you can install the `sslutils` extension as follows, where `<x>` is the PostgreSQL version.: 
+    -   If you're using PostgreSQL, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the PostgreSQL version.: 
 
         For RHEL/AlmaLinux/Rocky Linux 8/9:
           
         ```shell
-        dnf install sslutils_<x>
+        dnf install sslutils_<x> postgresql<x>-contrib
         ```
 
         For RHEL/OL/CentOS 7:
           
         ```shell
-        yum install sslutils_<x> 
+        yum install sslutils_<x> postgresql<x>-contrib
         ```
 
         For Debian/Ubuntu:
@@ -84,7 +85,32 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         For SLES:
           
         ```shell
-        zypper install sslutils_<x>
+        zypper install sslutils_<x> postgresql<x>-contrib
+    
+    -   If you're using EDB Postgres Extended Server, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version.: 
+
+        For RHEL/AlmaLinux/Rocky Linux 8/9:
+          
+        ```shell
+        dnf install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
+        ```
+
+        For RHEL/OL/CentOS 7:
+          
+        ```shell
+        yum install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
+        ```
+
+        For Debian/Ubuntu:
+          
+        ```shell
+        apt install edb-postgresextended-sslutils-<x>
+        ```
+
+        For SLES:
+          
+        ```shell
+        zypper install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
 
 
     !!! Note For Debian and Ubuntu users               
@@ -93,30 +119,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
           -   If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
           -   If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
 
-  4. If you are using PostgreSQL on RHEL/AlmaLinux/Rocky Linux or SLES. You will also need to install the `hstore contrib` module.
-     If you are using EDB Advanced Server on any platform, or PostgreSQL on Debian/Ubuntu you may skip this step.  
-     
-     First make sure you have access to the [PostgreSQL community repository](https://wiki.postgresql.org/wiki/Apt), then install the packages as follows, where `<x>` is the PostgreSQL version.
-        
-     For RHEL/AlmaLinux/Rocky Linux 8/9:
-        
-     ```shell
-     dnf install sslutils_<x> postgresql<x>-contrib
-     ```
-
-     For RHEL/OL/CentOS 7:
-        
-     ```shell
-     yum install sslutils_<x> postgresql<x>-contrib
-     ```
-
-     For SLES:
-        
-     ```shell
-     zypper install sslutils_<x> postgresql<x>-contrib
-     ```
-
-  5. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
+4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 
      For RHEL/Rocky Linux/AlmaLinux/OL/CentOS/SLES:
 
@@ -132,7 +135,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
     ```
 
-6. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
+5. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
 
      For RHEL/AlmaLinux/Rocky Linux 8:
 

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -12,12 +12,12 @@ After completing the prerequisites, [install](/pem/8/installing/linux_x86_64/ind
 To install a PEM server on Linux, perform this preliminary configuration:
     
 1.  Install a [supported Postgres instance](/pem/8/index/#postgres-compatibility) for PEM to use as a backend database. 
-
-You can install this instance on the same server as you plan to use for the PEM web application or on a separate server. You can also use an existing Postgres instance, providing you meet the conditions that follow.
+    You can install this instance on the same server as you will use for the PEM web application or a separate server. 
+    You can also use an existing Postgres instance providing it is configured as detailed in steps 2 and 3 below.
 
 2.  Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file. 
     
-You must make the following changes manually, prior to configuration. (Additional changes are made to this file during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+    You must make the following changes manually, prior to configuration. (Additional changes are made to this file during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
   
     - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you run the configuration script. In practice, this means the server on which the backend database is located and the server on which the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -5,27 +5,23 @@ redirects:
 - /pem/8/installing_pem_server/pem_server_inst_linux/prerequisites/
 ---
 
-You may install PEM on a single server, or you may install the web application and database components on two separate servers.
-This page explains how to prepare you server(s) for PEM installation. 
-After completing these steps you must follow the instructions to [install](/pem/8/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM.
-If you are using two servers, you must complete the installation and configuration steps on both servers.
+You may install PEM on a single server, or you may install the web application server and the backend database on two separate servers. This page explains how to prepare your server(s) for PEM installation. 
 
+After completing these steps you must follow the instructions to [install](/pem/8/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you are using two servers, you must complete the installation and configuration steps on both servers.
 
 To install a Postgres Enterprise Manager server on Linux, you need to perform some preliminary configuration:
     
-1.  Install a [supported Postgres instance](/pem/8/index/#postgres-compatibility) for PEM to use as a backend. 
-    You may install this instance on the same server as you will use for the PEM web application, or a separate server. 
-    You may also use an existing Postgres instance providing the conditions below are met.
+1.  Install a [supported Postgres instance](/pem/8/index/#postgres-compatibility) for PEM to use as a backend database. 
 
-2.  Configure authentication on the Postgres instance by updating the `pg_hba.conf` file. 
-    Further changes will be made to this file automatically during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually prior to configuration.
+You may install this instance on the same server as you will use for the PEM web application, or on a separate server. You may also use an existing Postgres instance providing the conditions below are met.
+
+2.  Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file. 
+    
+Further changes will be made to this file automatically during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually, prior to configuration.
   
-    - The PEM configuration script connects to the backend Postgres instance as a superuser of your choice using password authentication in order to create the relations required for PEM. 
-      This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. 
-      In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
+    - The PEM configuration script connects to the backend Postgres backend database as a superuser of your choice using password authentication in order to create the relations required for PEM. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
 
-    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication,
-      for example `host all superusername 127.0.0.1/32 scram-sha-256`.
+    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, for example `host all superusername 127.0.0.1/32 scram-sha-256`.
 
     !!! Note
     If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/8/managing_database_server/#modifying-the-pg_hbaconf-file).

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -33,17 +33,15 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
     !!!
 
-3.  Verify that the `sslutils` extension and `hstore contrib` module are installed on your Postgres server.
+3.  Verify that the `sslutils` extension is installed on your Postgres server.
 
-    -   If you're using EDB Postgres Advanced Server, the `hstore contrib` module is installed by default. You can install the `sslutils` extension:
+    -   If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
 
-        For RHEL/AlmaLinux/Rocky Linux 8:
+        For RHEL/AlmaLinux/Rocky Linux 8/9:
           
         ```shell
         dnf install edb-as<x>-server-sslutils
         ```
-
-        Where `<x>` is the EDB Postgres Advanced server version.
 
         For RHEL/OL/CentOS 7:
           
@@ -51,15 +49,11 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         yum install edb-as<x>-server-sslutils
         ```
 
-        Where `<x>` is the EDB Postgres Advanced server version.
-
         For Debian/Ubuntu:
           
         ```shell
         apt install edb-as<x>-server-sslutils
         ```
-
-        Where `<x>` is the EDB Postgres Advanced server version.
 
         For SLES:
           
@@ -67,25 +61,19 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         zypper install edb-as<x>-server-sslutils
         ```
 
-        Where `<x>` is the EDB Postgres Advanced server version.
+    -   If you're using PostgreSQL, you can install the `sslutils` extension as follows, where `<x>` is the PostgreSQL version.: 
 
-    -   If you're using PostgreSQL, make sure you have access to the PostgreSQL community repository ([yum](https://www.postgresql.org/download/linux/redhat/), [apt](https://wiki.postgresql.org/wiki/Apt)), and then install the `sslutils` extension and the `hstore contrib` module: 
-
-        For RHEL/AlmaLinux/Rocky Linux 8:
+        For RHEL/AlmaLinux/Rocky Linux 8/9:
           
         ```shell
-        dnf install sslutils_<x> postgresql<x>-contrib
+        dnf install sslutils_<x>
         ```
-
-        Where `<x>` is the Postgres server version.
 
         For RHEL/OL/CentOS 7:
           
         ```shell
-        yum install sslutils_<x> postgresql<x>-contrib
+        yum install sslutils_<x> 
         ```
-
-        Where `<x>` is the Postgres server version.
 
         For Debian/Ubuntu:
           
@@ -93,25 +81,42 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         apt install postgresql-<x>-sslutils
         ```
 
-        Where `<x>` is the Postgres server version.
-
         For SLES:
           
         ```shell
-        zypper install sslutils_<x> postgresql<x>-contrib
-        ```
+        zypper install sslutils_<x>
 
-        Where `<x>` is the Postgres server version.
 
-    !!! Note For Debian and Ubuntu users     
-        The postgres community repository for apt (used by Debian and Ubuntu) does not include `sslutils` and therefore this must be installed from the EDB repository along with PEM.
-          
+    !!! Note For Debian and Ubuntu users               
         Debian 10 and Ubuntu 20 changed the requirements for accepting certificates.
 
           -   If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
           -   If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
 
-  4.  If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
+  4. If you are using PostgreSQL on RHEL/AlmaLinux/Rocky Linux or SLES. You will also need to install the `hstore contrib` module.
+     If you are using EDB Advanced Server on any platform, or PostgreSQL on Debian/Ubuntu you may skip this step.  
+     
+     First make sure you have access to the [PostgreSQL community repository](https://wiki.postgresql.org/wiki/Apt), then install the packages as follows, where `<x>` is the PostgreSQL version.
+        
+     For RHEL/AlmaLinux/Rocky Linux 8/9:
+        
+     ```shell
+     dnf install sslutils_<x> postgresql<x>-contrib
+     ```
+
+     For RHEL/OL/CentOS 7:
+        
+     ```shell
+     yum install sslutils_<x> postgresql<x>-contrib
+     ```
+
+     For SLES:
+        
+     ```shell
+     zypper install sslutils_<x> postgresql<x>-contrib
+     ```
+
+  5. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 
      For RHEL/Rocky Linux/AlmaLinux/OL/CentOS/SLES:
 
@@ -127,7 +132,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
     ```
 
-5. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
+6. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
 
      For RHEL/AlmaLinux/Rocky Linux 8:
 

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -5,19 +5,35 @@ redirects:
 - /pem/8/installing_pem_server/pem_server_inst_linux/prerequisites/
 ---
 
-To install a Postgres Enterprise Manager server on Linux, you may need to perform some preliminary configuration:
+You may install PEM on a single server, or you may install the web application and database components on two separate servers.
+This page explains how to prepare you server(s) for PEM installation. 
+After completing these steps you must follow the instructions to [install](/pem/8/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM.
+If you are using two servers, you must complete the installation and configuration steps on both servers.
+
+
+To install a Postgres Enterprise Manager server on Linux, you need to perform some preliminary configuration:
     
-1. Configure authentication on the Postgres server by updating the `pg_hba.conf` file. The `pg_hba.conf` file manages connections. Verify that the `pg_hba.conf` file allows connections from the PEM server, the monitoring PEM agent, and the host of the Apache web server server. Pointers for configuring access:
+1.  Install a [supported Postgres instance](/pem/8/index/#postgres-compatibility) for PEM to use as a backend. 
+    You may install this instance on the same server as you will use for the PEM web application, or a separate server. 
+    You may also use an existing Postgres instance providing the conditions below are met.
+
+2.  Configure authentication on the Postgres instance by updating the `pg_hba.conf` file. 
+    Further changes will be made to this file automatically during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually prior to configuration.
   
-    - PEM server connects to the PEM backend database as a superuser using password authentication. On Linux platforms, this requires you to add a new superuser that authenticates using a password.
+    - The PEM configuration script connects to the backend Postgres instance as a superuser of your choice using password authentication in order to create the relations required for PEM. 
+      This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. 
+      In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
 
-    - To allow the new superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication.
+    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication,
+      for example `host all superusername 127.0.0.1/32 scram-sha-256`.
 
-    - If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/8/managing_database_server/#modifying-the-pg_hbaconf-file).
+    !!! Note
+    If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/8/managing_database_server/#modifying-the-pg_hbaconf-file).
 
-    - If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
+    If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
+    !!!
 
-2.  Verify that the `sslutils` extension and `hstore contrib` module are installed on your Postgres server.
+3.  Verify that the `sslutils` extension and `hstore contrib` module are installed on your Postgres server.
 
     -   If you're using EDB Postgres Advanced Server, the `hstore contrib` module is installed by default. You can install the `sslutils` extension:
 
@@ -95,7 +111,7 @@ To install a Postgres Enterprise Manager server on Linux, you may need to perfor
           -   If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
           -   If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
 
-  3.  If you're using a firewall, allow access to port 8443 on the Postgres server:
+  4.  If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 
      For RHEL/Rocky Linux/AlmaLinux/OL/CentOS/SLES:
 
@@ -111,7 +127,7 @@ To install a Postgres Enterprise Manager server on Linux, you may need to perfor
     iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
     ```
 
-4. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date: 
+5. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
 
      For RHEL/AlmaLinux/Rocky Linux 8:
 

--- a/product_docs/docs/pem/8/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/8/installing/prerequisites.mdx
@@ -5,23 +5,23 @@ redirects:
 - /pem/8/installing_pem_server/pem_server_inst_linux/prerequisites/
 ---
 
-You may install PEM on a single server, or you may install the web application server and the backend database on two separate servers. This page explains how to prepare your server(s) for PEM installation. 
+You can install PEM on a single server, or you can install the web application server and the backend database on two separate servers. You must prepare your servers for PEM installation. 
 
-After completing these steps you must follow the instructions to [install](/pem/8/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you are using two servers, you must complete the installation and configuration steps on both servers.
+After completing these steps, [install](/pem/8/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you're using two servers, install and configure PEM on both servers.
 
-To install a Postgres Enterprise Manager server on Linux, you need to perform some preliminary configuration:
+To install a PEM server on Linux, perform this preliminary configuration:
     
 1.  Install a [supported Postgres instance](/pem/8/index/#postgres-compatibility) for PEM to use as a backend database. 
 
-You may install this instance on the same server as you will use for the PEM web application, or on a separate server. You may also use an existing Postgres instance providing the conditions below are met.
+You can install this instance on the same server as you plan to use for the PEM web application or on a separate server. You can also use an existing Postgres instance, providing you meet the conditions that follow.
 
 2.  Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file. 
     
-Further changes will be made to this file automatically during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually, prior to configuration.
+You must make the following changes manually, prior to configuration. (Additional changes are made to this file during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
   
-    - The PEM configuration script connects to the backend Postgres backend database as a superuser of your choice using password authentication in order to create the relations required for PEM. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
+    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you run the configuration script. In practice, this means the server on which the backend database is located and the server on which the PEM web application is to be installed, if they're different.
 
-    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, for example `host all superusername 127.0.0.1/32 scram-sha-256`.
+    - To allow the chosen superuser to connect using password authentication, add a line to `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, for example, `host all superusername 127.0.0.1/32 scram-sha-256`.
 
     !!! Note
     If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/8/managing_database_server/#modifying-the-pg_hbaconf-file).
@@ -30,7 +30,7 @@ Further changes will be made to this file automatically during [configuration](/
     !!!
 
 3.  Verify that the `sslutils` extension is installed on your Postgres server. 
-    If you are using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you will also need to install the `hstore contrib` module.
+    If you're using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you also need to install the `hstore contrib` module.
 
     -   If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
 
@@ -58,7 +58,7 @@ Further changes will be made to this file automatically during [configuration](/
         zypper install edb-as<x>-server-sslutils
         ```
 
-    -   If you're using PostgreSQL, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the PostgreSQL version.: 
+    -   If you're using PostgreSQL, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the PostgreSQL version. 
 
         For RHEL/AlmaLinux/Rocky Linux 8/9:
           
@@ -83,7 +83,7 @@ Further changes will be made to this file automatically during [configuration](/
         ```shell
         zypper install sslutils_<x> postgresql<x>-contrib
     
-    -   If you're using EDB Postgres Extended Server, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version.: 
+    -   If you're using EDB Postgres Extended Server, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version. 
 
         For RHEL/AlmaLinux/Rocky Linux 8/9:
           

--- a/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
@@ -58,6 +58,27 @@ After selecting a configuration option, the script prompts you for configuration
 /usr/edb/pem/bin/configure-pem-server.sh -help
 ```
 
+## Post-configuration steps for two-server installations
+
+If you have chosen to run the PEM web application on a separate server to the backend database, you will need to perform some additional manual steps before PEM will be fully operational.
+Firstly, you must ensure that the backend Postgres instance accepts connections from any user permitted to login to PEM, from the web application server.
+You can do this by adding two lines to `pg_hba.conf` as follows, substituting `<web_app_ip>` for the IP address of the web application server.
+
+```
+host pem +pem_user <web_app_ip>/32 md5
+host postgres +pem_user <web_app_ip>/32 md56
+```
+
+Additionally, if the IP address of the seb application server is not within the network address range specified when the script was executed,
+you must add two further lines to allow the PEM Agent on this server to connect.
+
+```
+host pem +pem_agent <web_app_ip>/32 md5
+host pem +pem_agent <web_app_ip>/32 cert
+```
+
+## Accessing the PEM application
+
 After configuring the PEM server, you can access the PEM web interface in your browser. Navigate to:
 
 ```text

--- a/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
@@ -58,19 +58,19 @@ After selecting a configuration option, the script prompts you for configuration
 /usr/edb/pem/bin/configure-pem-server.sh -help
 ```
 
-## Post-configuration steps for the web server and the PEM backend database installations
+## Post-configuration steps when web server and PEM backend database are installed separately
 
 If you choose to run the web application server on a separate host to the backend database, you need to perform some additional manual steps before PEM is fully operational.
 
-Make sure that the backend Postgres database accepts the connections from any user permitted to login to PEM, from the web application server. To achieve this add below entry to `pg_hba.conf`:
+Make sure that the backend Postgres database accepts the connections from any user permitted to log in to PEM from the web application server. To achieve this, add this entry to `pg_hba.conf`: 
 
 ```ini
 host pem +pem_user <web_app_ip>/32 md5
 host postgres +pem_user <web_app_ip>/32 md56
 ```
-Where, `<web_app_ip>` is the IP address of the web application server.
+Where `<web_app_ip>` is the IP address of the web application server.
 
-Additionally, if the IP address of the web application server is not within the network address range specified when the script is executed, you must add two further entries to allow the PEM Agent on this server to connect:
+Additionally, if the IP address of the web application server isn't within the network address range specified when the script is executed, you must add two entries to allow the PEM agent on this server to connect:
 
 
 ```ini
@@ -78,7 +78,7 @@ host pem +pem_agent <web_app_ip>/32 md5
 host pem +pem_agent <web_app_ip>/32 cert
 ```
 
-Where, `<web_app_ip>` is the IP address of the web application server.
+Where `<web_app_ip>` is the IP address of the web application server.
 
 ## Accessing the PEM application
 

--- a/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
@@ -58,24 +58,27 @@ After selecting a configuration option, the script prompts you for configuration
 /usr/edb/pem/bin/configure-pem-server.sh -help
 ```
 
-## Post-configuration steps for two-server installations
+## Post-configuration steps for the web server and the PEM backend database installations
 
-If you have chosen to run the PEM web application on a separate server to the backend database, you will need to perform some additional manual steps before PEM will be fully operational.
-Firstly, you must ensure that the backend Postgres instance accepts connections from any user permitted to login to PEM, from the web application server.
-You can do this by adding two lines to `pg_hba.conf` as follows, substituting `<web_app_ip>` for the IP address of the web application server.
+If you choose to run the web application server on a separate host to the backend database, you need to perform some additional manual steps before PEM is fully operational.
 
-```
+Make sure that the backend Postgres database accepts the connections from any user permitted to login to PEM, from the web application server. To achieve this add below entry to `pg_hba.conf`:
+
+```ini
 host pem +pem_user <web_app_ip>/32 md5
 host postgres +pem_user <web_app_ip>/32 md56
 ```
+Where, `<web_app_ip>` is the IP address of the web application server.
 
-Additionally, if the IP address of the seb application server is not within the network address range specified when the script was executed,
-you must add two further lines to allow the PEM Agent on this server to connect.
+Additionally, if the IP address of the web application server is not within the network address range specified when the script is executed, you must add two further entries to allow the PEM Agent on this server to connect:
 
-```
+
+```ini
 host pem +pem_agent <web_app_ip>/32 md5
 host pem +pem_agent <web_app_ip>/32 cert
 ```
+
+Where, `<web_app_ip>` is the IP address of the web application server.
 
 ## Accessing the PEM application
 

--- a/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
+++ b/product_docs/docs/pem/9/installing/configuring_the_pem_server_on_linux.mdx
@@ -66,7 +66,6 @@ Make sure that the backend Postgres database accepts the connections from any us
 
 ```ini
 host pem +pem_user <web_app_ip>/32 md5
-host postgres +pem_user <web_app_ip>/32 md56
 ```
 Where `<web_app_ip>` is the IP address of the web application server.
 

--- a/product_docs/docs/pem/9/installing/dependencies.mdx
+++ b/product_docs/docs/pem/9/installing/dependencies.mdx
@@ -1,0 +1,141 @@
+---
+title: "Dependencies of the PEM Server and Agent on Linux"
+navTitle: "Linux dependencies"
+redirects:
+- /pem/latest/installing_pem_server/pem_server_inst_linux/dependencies/
+---
+
+The PEM Server and Agent packages for Linux have dependencies on various system libraries. 
+These dependencies are detailed below for reference. 
+
+!!! Note
+A PEM Agent is always installed alongside PEM Server, so all dependencies must be present on hosts where PEM Server (either the database or the web application) is installed.
+!!!
+
+Typically, PEM is built against the latest version of each dependency available from the vendor repository for a given platform and architecture.
+In some cases, PEM requires a newer version of a library than is available in the vendor repository.
+In these cases a newer version of the package, prefixed with `edb-` is sourced from EDB's repositories.
+
+!!! Note
+Because these dependencies are updated frequently, the tables below are valid only for the latest patch release of PEM.
+!!!
+
+## Python 3 and mod_wsgi
+
+Python 3 and mod_wsgi (a Python module for Apache HTTPD) are required for PEM Server.
+
+| Platform  | Architecture | Python/mod_wsgi package                | Python version | Python path                              |
+|-----------|--------------|----------------------------------------|----------------|------------------------------------------|
+| RHEL 7    | x86_64       | `edb-python39/edb-python39-mod-wsgi`   | 3.9            | `/usr/libexec/edb-python39/bin/python3`  |
+|           | ppc64le      | `edb-python39/edb-python39-mod-wsgi`   | 3.9            | `/usr/libexec/edb-python39/bin/python3`  |
+| RHEL 8    | x86_64       | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+|           | ppc64le      | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+|           | s390x        | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+| RHEL 9    | x86_64       | `python39/python39-mod_wsgi`           | 3.9            | `/usr/bin/python3`                       |
+|           | ppc64le      | `python39/python39-mod_wsgi`           | 3.9            | `/usr/bin/python3`                       |
+|           | s390x        | `python39/python39-mod_wsgi`           | 3.9            | `/usr/bin/python3`                       |
+| SLES 12   | x86_64       | `edb-python39/edb-python39-mod-wsgi`   | 3.9            | `/usr/libexec/edb-python39/bin/python3`  |
+|           | ppc64le      | `edb-python39/edb-python39-mod-wsgi`   | 3.9            | `/usr/libexec/edb-python39/bin/python3`  |
+|           | s390x        | `edb-python39/edb-python39-mod-wsgi`   | 3.9            | `/usr/libexec/edb-python39/bin/python3`  |
+| SLES 15   | x86_64       | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+|           | ppc64le      | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+|           | s390x        | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+| Ubuntu 20 | amd64        | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+| Ubuntu 22 | amd64        | `python310//libapache2-mod-wsgi-py3`   | 3.10           | `/usr/bin/python3`                       |
+| Debian 10 | amd64        | `edb-python310/edb-python310-mod-wsgi` | 3.10           | `/usr/libexec/edb-python310/bin/python3` |
+
+## OpenSSL
+
+The PEM Server and Agent require OpenSSL.
+
+| Platform  | Architecture |  package-version  |
+|-----------|--------------|-------------------|
+| RHEL 7    | x86_64       | `openssl-1.0.2k`  |
+|           | ppc64le      | `openssl-1.0.2k`  |
+| RHEL 8    | x86_64       | `openssl-1.1.1k`  |
+|           | ppc64le      | `openssl-1.1.1k`  |
+|           | s390x        | `openssl-1.1.1k`  |
+| RHEL 9    | x86_64       | `openssl-3.0.7`   |
+|           | ppc64le      | `openssl-3.0.7`   |
+|           | s390x        | `openssl-3.0.7`   |
+| SLES 12   | x86_64       | `openssl-1.0.2p`  |
+|           | ppc64le      | `openssl-1.0.2p`  |
+|           | s390x        | `openssl-1.0.2p`  |
+| SLES 15   | x86_64       | `openssl-1.1.1l`  |
+|           | ppc64le      | `openssl-1.1.1l`  |
+|           | s390x        | `openssl-1.1.1l`  |
+| Ubuntu 20 | amd64        | `openssl-1.1.1f`  |
+| Ubuntu 22 | amd64        | `openssl-3.0.2`   |
+| Debian 10 | amd64        | `openssl-1.1.1n`  |
+
+## Libcurl
+
+The PEM Agent requires libcurl.
+
+| Platform  | Architecture |  package-version    |
+|-----------|--------------|---------------------|
+| RHEL 7    | x86_64       | `libcurl-pem-8.4.0` |
+|           | ppc64le      | `libcurl-pem-8.4.0` |
+| RHEL 8    | x86_64       | `libcurl-pem-8.4.0` |
+|           | ppc64le      | `curl-7.61.1`       |
+|           | s390x        | `curl-7.61.1`       |
+| RHEL 9    | x86_64       | `curl-7.76.1`       |
+|           | ppc64le      | `curl-7.76.1`       |
+|           | s390x        | `curl-7.76.1`       |
+| SLES 12   | x86_64       | `curl-8.0.1`        |
+|           | ppc64le      | `curl-8.0.1`        |
+|           | s390x        | `curl-8.0.1`        |
+| SLES 15   | x86_64       | `curl-8.0.1`        |
+|           | ppc64le      | `curl-8.0.1`        |
+|           | s390x        | `curl-8.0.1`        |
+| Ubuntu 20 | amd64        | `libcurl4-7.68.0`   |
+| Ubuntu 22 | amd64        | `libcurl4-7.81.0`   |
+| Debian 10 | amd64        | `libcurl4-7.64.0`   |
+
+## SNMP++
+
+The PEM Agent requires SNMP++.
+
+| Platform  | Architecture |  package-version    |
+|-----------|--------------|---------------------|
+| RHEL 7    | x86_64       | `snmp++-3.4.2`      |
+|           | ppc64le      | `snmp++-3.4.2`      |
+| RHEL 8    | x86_64       | `snmp++-3.4.2`      |
+|           | ppc64le      | `edb-snmp++-3.4.10` |
+|           | s390x        | `edb-snmp++-3.4.7`  |
+| RHEL 9    | x86_64       | `edb-snmp++-3.4.10` |
+|           | ppc64le      | `edb-snmp++-3.4.10` |
+|           | s390x        | `edb-snmp++-3.4.10` |
+| SLES 12   | x86_64       | `edb-snmp++-3.4.10` |
+|           | ppc64le      | `edb-snmp++-3.4.10` |
+|           | s390x        | `edb-snmp++-3.4.7`  |
+| SLES 15   | x86_64       | `edb-snmp++-3.4.10` |
+|           | ppc64le      | `edb-snmp++-3.4.10` |
+|           | s390x        | `edb-snmp++-3.4.7`  |
+| Ubuntu 20 | amd64        | `edb-snmp++-3.4.10` |
+| Ubuntu 22 | amd64        | `edb-snmp++-3.4.10` |
+| Debian 10 | amd64        | `edb-snmp++-3.4.10` |
+
+## Boost libraries
+
+The PEM Agent requires the Boost libraries.
+
+| Platform  | Architecture |  package-version               |
+|-----------|--------------|--------------------------------|
+| RHEL 7    | x86_64       | `boost169-system-1.69.0`       |
+|           | ppc64le      | `None boost package`           |
+| RHEL 8    | x86_64       | `boost169-system-1.69.0`       |
+|           | ppc64le      | `boost-system-1.66.0`          |
+|           | s390x        | `boost-system-1.66.0`          |
+| RHEL 9    | x86_64       | `boost-system-1.75.0`          |
+|           | ppc64le      | `boost-system-1.75.0`          |
+|           | s390x        | `boost-system-1.75.0`          |
+| SLES 12   | x86_64       | `libboost_system1_54_0-1.54.0` |
+|           | ppc64le      | `libboost_system1_54_0-1.54.0` |
+|           | s390x        | `libboost_system1_54_0-1.54.0` |
+| SLES 15   | x86_64       | `libboost_regex1_66_1-1.66.0`  |
+|           | ppc64le      | `libboost_regex1_66_1-1.66.0`  |
+|           | s390x        | `libboost_regex1_66_1-1.66.0`  |
+| Ubuntu 20 | amd64        | `libboost-system1.71.0-1.71.0` |
+| Ubuntu 22 | amd64        | `libboost-system1.74.0-1.74.0` |
+| Debian 10 | amd64        | `libboost-system1.67.0-1.67.0` |

--- a/product_docs/docs/pem/9/installing/dependencies.mdx
+++ b/product_docs/docs/pem/9/installing/dependencies.mdx
@@ -17,6 +17,9 @@ In some cases, PEM requires a newer version of a library than is available in th
 In these cases a newer version of the package, prefixed with `edb-` is sourced from EDB's repositories.
 
 !!! Note
+This information is provided for reference. Packages from vendor repositories are not supported or patched by EDB. 
+Refer to your operating system documentation or support provider for details of these packages.  
+
 Because these dependencies are updated frequently, the tables below are valid only for the latest patch release of PEM.
 !!!
 

--- a/product_docs/docs/pem/9/installing/index.mdx
+++ b/product_docs/docs/pem/9/installing/index.mdx
@@ -16,6 +16,7 @@ redirects:
 
 navigation:
   - prerequisites
+  - dependencies
   - linux_x86_64
   - linux_ppc64le
   - windows

--- a/product_docs/docs/pem/9/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/9/installing/prerequisites.mdx
@@ -5,27 +5,22 @@ redirects:
 - /pem/latest/installing_pem_server/pem_server_inst_linux/prerequisites/
 ---
 
-You may install PEM on a single server, or you may install the web application and database components on two separate servers.
-This page explains how to prepare you server(s) for PEM installation. 
-After completing these steps you must follow the instructions to [install](/pem/latest/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM.
-If you are using two servers, you must complete the installation and configuration steps on both servers.
+You may install PEM on a single server, or you may install the web application server and the backend database on two separate servers. This page explains how to prepare your server(s) for PEM installation. 
+
+After completing these steps you must follow the instructions to [install](/pem/latest/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you are using two servers, you must complete the installation and configuration steps on both servers.
 
 
 To install a Postgres Enterprise Manager server on Linux, you need to perform some preliminary configuration:
     
-1.  Install a [supported Postgres instance](/pem/latest/index/#postgres-compatibility) for PEM to use as a backend. 
-    You may install this instance on the same server as you will use for the PEM web application, or a separate server. 
-    You may also use an existing Postgres instance providing the conditions below are met.
+1.  Install a [supported Postgres instance](/pem/latest/index/#postgres-compatibility) for PEM to use as a backend database.You may install this instance on the same server as you will use for the PEM web application, or a separate server. You may also use an existing Postgres instance providing the conditions below are met.
 
-2.  Configure authentication on the Postgres instance by updating the `pg_hba.conf` file. 
-    Further changes will be made to this file automatically during [configuration](/pem/latest/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually prior to configuration.
+2.  Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file. 
+    
+Further changes will be made to this file automatically during [configuration](/pem/latest/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually, prior to configuration.
   
-    - The PEM configuration script connects to the backend Postgres instance as a superuser of your choice using password authentication in order to create the relations required for PEM. 
-      This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. 
-      In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
+    - The PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication in order to create the relations required for PEM. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
 
-    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication,
-      for example `host all superusername 127.0.0.1/32 scram-sha-256`.
+    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, for example `host all superusername 127.0.0.1/32 scram-sha-256`.
 
     !!! Note
     If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/latest/managing_database_server/#modifying-the-pg_hbaconf-file).

--- a/product_docs/docs/pem/9/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/9/installing/prerequisites.mdx
@@ -131,7 +131,8 @@ To install a PEM server on Linux, perform this preliminary configuration:
     iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
     ```
 
-5. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
+5. Make sure the components Postgres Enterprise Manager depends on are up to date on all servers. You can do this by updating the whole system using your package manager as shown below.
+   If you prefer to update individual packages, a full list of dependencies is provided in [Dependencies of the PEM Server and Agent on Linux](dependencies.md).
 
      For RHEL/AlmaLinux/Rocky Linux 8:
 

--- a/product_docs/docs/pem/9/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/9/installing/prerequisites.mdx
@@ -111,7 +111,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
           
         ```shell
         zypper install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
-
+        ```
 
     !!! Note For Debian and Ubuntu users               
         Debian 10 and Ubuntu 20 changed the requirements for accepting certificates.

--- a/product_docs/docs/pem/9/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/9/installing/prerequisites.mdx
@@ -33,7 +33,8 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
     !!!
 
-3.  Verify that the `sslutils` extension is installed on your Postgres server.
+3.  Verify that the `sslutils` extension is installed on your Postgres server. 
+    If you are using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you will also need to install the `hstore contrib` module.
 
     -   If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
 
@@ -61,18 +62,18 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         zypper install edb-as<x>-server-sslutils
         ```
 
-    -   If you're using PostgreSQL, you can install the `sslutils` extension as follows, where `<x>` is the PostgreSQL version.: 
+    -   If you're using PostgreSQL, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the PostgreSQL version.: 
 
         For RHEL/AlmaLinux/Rocky Linux 8/9:
           
         ```shell
-        dnf install sslutils_<x>
+        dnf install sslutils_<x> postgresql<x>-contrib
         ```
 
         For RHEL/OL/CentOS 7:
           
         ```shell
-        yum install sslutils_<x> 
+        yum install sslutils_<x> postgresql<x>-contrib
         ```
 
         For Debian/Ubuntu:
@@ -84,7 +85,32 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         For SLES:
           
         ```shell
-        zypper install sslutils_<x>
+        zypper install sslutils_<x> postgresql<x>-contrib
+    
+    -   If you're using EDB Postgres Extended Server, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version.: 
+
+        For RHEL/AlmaLinux/Rocky Linux 8/9:
+          
+        ```shell
+        dnf install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
+        ```
+
+        For RHEL/OL/CentOS 7:
+          
+        ```shell
+        yum install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
+        ```
+
+        For Debian/Ubuntu:
+          
+        ```shell
+        apt install edb-postgresextended-sslutils-<x>
+        ```
+
+        For SLES:
+          
+        ```shell
+        zypper install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
 
 
     !!! Note For Debian and Ubuntu users               
@@ -93,30 +119,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
           -   If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
           -   If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
 
-  4. If you are using PostgreSQL on RHEL/AlmaLinux/Rocky Linux or SLES. You will also need to install the `hstore contrib` module.
-     If you are using EDB Advanced Server on any platform, or PostgreSQL on Debian/Ubuntu you may skip this step.  
-     
-     First make sure you have access to the [PostgreSQL community repository](https://wiki.postgresql.org/wiki/Apt), then install the packages as follows, where `<x>` is the PostgreSQL version.
-        
-     For RHEL/AlmaLinux/Rocky Linux 8/9:
-        
-     ```shell
-     dnf install sslutils_<x> postgresql<x>-contrib
-     ```
-
-     For RHEL/OL/CentOS 7:
-        
-     ```shell
-     yum install sslutils_<x> postgresql<x>-contrib
-     ```
-
-     For SLES:
-        
-     ```shell
-     zypper install sslutils_<x> postgresql<x>-contrib
-     ```
-
-  5. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
+4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 
      For RHEL/Rocky Linux/AlmaLinux/OL/CentOS/SLES:
 
@@ -132,7 +135,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
     ```
 
-6. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
+5. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
 
      For RHEL/AlmaLinux/Rocky Linux 8:
 

--- a/product_docs/docs/pem/9/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/9/installing/prerequisites.mdx
@@ -5,19 +5,35 @@ redirects:
 - /pem/latest/installing_pem_server/pem_server_inst_linux/prerequisites/
 ---
 
-To install a Postgres Enterprise Manager server on Linux, you may need to perform some preliminary configuration:
+You may install PEM on a single server, or you may install the web application and database components on two separate servers.
+This page explains how to prepare you server(s) for PEM installation. 
+After completing these steps you must follow the instructions to [install](/pem/latest/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM.
+If you are using two servers, you must complete the installation and configuration steps on both servers.
+
+
+To install a Postgres Enterprise Manager server on Linux, you need to perform some preliminary configuration:
     
-1. Configure authentication on the Postgres server by updating the `pg_hba.conf` file. The `pg_hba.conf` file manages connections. Verify that the `pg_hba.conf` file allows connections from the PEM server, the monitoring PEM agent, and the host of the Apache web server server. Pointers for configuring access:
+1.  Install a [supported Postgres instance](/pem/latest/index/#postgres-compatibility) for PEM to use as a backend. 
+    You may install this instance on the same server as you will use for the PEM web application, or a separate server. 
+    You may also use an existing Postgres instance providing the conditions below are met.
+
+2.  Configure authentication on the Postgres instance by updating the `pg_hba.conf` file. 
+    Further changes will be made to this file automatically during [configuration](/pem/latest/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually prior to configuration.
   
-    - PEM server connects to the PEM backend database as a superuser using password authentication. On Linux platforms, this requires you to add a new superuser that authenticates using a password.
+    - The PEM configuration script connects to the backend Postgres instance as a superuser of your choice using password authentication in order to create the relations required for PEM. 
+      This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. 
+      In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
 
-    - To allow the new superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication.
+    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication,
+      for example `host all superusername 127.0.0.1/32 scram-sha-256`.
 
-    - If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](../managing_database_server/#modifying-the-pg_hbaconf-file).
+    !!! Note
+    If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/latest/managing_database_server/#modifying-the-pg_hbaconf-file).
 
-    - If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
+    If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
+    !!!
 
-2.  Verify that the `sslutils` extension and `hstore contrib` module are installed on your Postgres server.
+3.  Verify that the `sslutils` extension and `hstore contrib` module are installed on your Postgres server.
 
     -   If you're using EDB Postgres Advanced Server, the `hstore contrib` module is installed by default. You can install the `sslutils` extension:
 
@@ -95,7 +111,7 @@ To install a Postgres Enterprise Manager server on Linux, you may need to perfor
           -   If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
           -   If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
 
-  3.  If you're using a firewall, allow access to port 8443 on the Postgres server:
+  4.  If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 
      For RHEL/Rocky Linux/AlmaLinux/OL/CentOS/SLES:
 
@@ -111,7 +127,7 @@ To install a Postgres Enterprise Manager server on Linux, you may need to perfor
     iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
     ```
 
-4. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date: 
+5. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
 
      For RHEL/AlmaLinux/Rocky Linux 8:
 

--- a/product_docs/docs/pem/9/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/9/installing/prerequisites.mdx
@@ -33,17 +33,15 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
     !!!
 
-3.  Verify that the `sslutils` extension and `hstore contrib` module are installed on your Postgres server.
+3.  Verify that the `sslutils` extension is installed on your Postgres server.
 
-    -   If you're using EDB Postgres Advanced Server, the `hstore contrib` module is installed by default. You can install the `sslutils` extension:
+    -   If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
 
-        For RHEL/AlmaLinux/Rocky Linux 8:
+        For RHEL/AlmaLinux/Rocky Linux 8/9:
           
         ```shell
         dnf install edb-as<x>-server-sslutils
         ```
-
-        Where `<x>` is the EDB Postgres Advanced server version.
 
         For RHEL/OL/CentOS 7:
           
@@ -51,15 +49,11 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         yum install edb-as<x>-server-sslutils
         ```
 
-        Where `<x>` is the EDB Postgres Advanced server version.
-
         For Debian/Ubuntu:
           
         ```shell
         apt install edb-as<x>-server-sslutils
         ```
-
-        Where `<x>` is the EDB Postgres Advanced server version.
 
         For SLES:
           
@@ -67,25 +61,19 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         zypper install edb-as<x>-server-sslutils
         ```
 
-        Where `<x>` is the EDB Postgres Advanced server version.
+    -   If you're using PostgreSQL, you can install the `sslutils` extension as follows, where `<x>` is the PostgreSQL version.: 
 
-    -   If you're using PostgreSQL, make sure you have access to the PostgreSQL community repository ([yum](https://www.postgresql.org/download/linux/redhat/), [apt](https://wiki.postgresql.org/wiki/Apt)), and then install the `sslutils` extension and the `hstore contrib` module: 
-
-        For RHEL/AlmaLinux/Rocky Linux 8:
+        For RHEL/AlmaLinux/Rocky Linux 8/9:
           
         ```shell
-        dnf install sslutils_<x> postgresql<x>-contrib
+        dnf install sslutils_<x>
         ```
-
-        Where `<x>` is the Postgres server version.
 
         For RHEL/OL/CentOS 7:
           
         ```shell
-        yum install sslutils_<x> postgresql<x>-contrib
+        yum install sslutils_<x> 
         ```
-
-        Where `<x>` is the Postgres server version.
 
         For Debian/Ubuntu:
           
@@ -93,25 +81,42 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
         apt install postgresql-<x>-sslutils
         ```
 
-        Where `<x>` is the Postgres server version.
-
         For SLES:
           
         ```shell
-        zypper install sslutils_<x> postgresql<x>-contrib
-        ```
+        zypper install sslutils_<x>
 
-        Where `<x>` is the Postgres server version.
 
-    !!! Note For Debian and Ubuntu users     
-        The postgres community repository for apt (used by Debian and Ubuntu) does not include `sslutils` and therefore this must be installed from the EDB repository along with PEM.
-          
+    !!! Note For Debian and Ubuntu users               
         Debian 10 and Ubuntu 20 changed the requirements for accepting certificates.
 
           -   If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
           -   If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
 
-  4.  If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
+  4. If you are using PostgreSQL on RHEL/AlmaLinux/Rocky Linux or SLES. You will also need to install the `hstore contrib` module.
+     If you are using EDB Advanced Server on any platform, or PostgreSQL on Debian/Ubuntu you may skip this step.  
+     
+     First make sure you have access to the [PostgreSQL community repository](https://wiki.postgresql.org/wiki/Apt), then install the packages as follows, where `<x>` is the PostgreSQL version.
+        
+     For RHEL/AlmaLinux/Rocky Linux 8/9:
+        
+     ```shell
+     dnf install sslutils_<x> postgresql<x>-contrib
+     ```
+
+     For RHEL/OL/CentOS 7:
+        
+     ```shell
+     yum install sslutils_<x> postgresql<x>-contrib
+     ```
+
+     For SLES:
+        
+     ```shell
+     zypper install sslutils_<x> postgresql<x>-contrib
+     ```
+
+  5. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 
      For RHEL/Rocky Linux/AlmaLinux/OL/CentOS/SLES:
 
@@ -127,7 +132,7 @@ To install a Postgres Enterprise Manager server on Linux, you need to perform so
     iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
     ```
 
-5. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
+6. Make sure the components Postgres Enterprise Manager depends on, such as python3, libboost, openssl (1.0.2k or later), snmp++, and libcurl, are up to date on all servers: 
 
      For RHEL/AlmaLinux/Rocky Linux 8:
 

--- a/product_docs/docs/pem/9/installing/prerequisites.mdx
+++ b/product_docs/docs/pem/9/installing/prerequisites.mdx
@@ -5,22 +5,23 @@ redirects:
 - /pem/latest/installing_pem_server/pem_server_inst_linux/prerequisites/
 ---
 
-You may install PEM on a single server, or you may install the web application server and the backend database on two separate servers. This page explains how to prepare your server(s) for PEM installation. 
+You can install PEM on a single server, or you can install the web application server and the backend database on two separate servers. You must prepare your servers for PEM installation. 
 
-After completing these steps you must follow the instructions to [install](/pem/latest/installing/linux_x86_64/index.mdx) and [configure](/pem/8/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you are using two servers, you must complete the installation and configuration steps on both servers.
+After completing the prerequisites, [install](/pem/9/installing/linux_x86_64/index.mdx) and [configure](/pem/9/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you're using two servers, install and configure PEM on both servers.
 
-
-To install a Postgres Enterprise Manager server on Linux, you need to perform some preliminary configuration:
+To install a PEM server on Linux, perform this preliminary configuration:
     
-1.  Install a [supported Postgres instance](/pem/latest/index/#postgres-compatibility) for PEM to use as a backend database.You may install this instance on the same server as you will use for the PEM web application, or a separate server. You may also use an existing Postgres instance providing the conditions below are met.
+1.  Install a [supported Postgres instance](/pem/latest/index/#postgres-compatibility) for PEM to use as a backend database.
+    You can install this instance on the same server as you will use for the PEM web application or a separate server. 
+    You can also use an existing Postgres instance providing it is configured as detailed in steps 2 and 3 below.
 
 2.  Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file. 
     
-Further changes will be made to this file automatically during [configuration](/pem/latest/installing/configuring_the_pem_server_on_linux.mdx) but the changes detailed here must be made manually, prior to configuration.
+    You must make the following changes manually, prior to configuration. (Additional changes are made to this file during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
   
-    - The PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication in order to create the relations required for PEM. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you will run the configuration script. In practice, this means the server on which the backend database is located, and the server on which the PEM web application is to be installed if this is different.
+    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location in which you run the configuration script. In practice, this means the server on which the backend database is located and the server on which the PEM web application is to be installed, if they're different.
 
-    - To allow the chosen superuser to connect using password authentication, add a line `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, for example `host all superusername 127.0.0.1/32 scram-sha-256`.
+    - To allow the chosen superuser to connect using password authentication, add a line to `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, for example, `host all superusername 127.0.0.1/32 scram-sha-256`.
 
     !!! Note
     If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/latest/managing_database_server/#modifying-the-pg_hbaconf-file).
@@ -29,7 +30,7 @@ Further changes will be made to this file automatically during [configuration](/
     !!!
 
 3.  Verify that the `sslutils` extension is installed on your Postgres server. 
-    If you are using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you will also need to install the `hstore contrib` module.
+    If you're using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you also need to install the `hstore contrib` module.
 
     -   If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
 
@@ -57,7 +58,7 @@ Further changes will be made to this file automatically during [configuration](/
         zypper install edb-as<x>-server-sslutils
         ```
 
-    -   If you're using PostgreSQL, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the PostgreSQL version.: 
+    -   If you're using PostgreSQL, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the PostgreSQL version. 
 
         For RHEL/AlmaLinux/Rocky Linux 8/9:
           
@@ -82,7 +83,7 @@ Further changes will be made to this file automatically during [configuration](/
         ```shell
         zypper install sslutils_<x> postgresql<x>-contrib
     
-    -   If you're using EDB Postgres Extended Server, you can install the `sslutils` and (if required) `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version.: 
+    -   If you're using EDB Postgres Extended Server, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version. 
 
         For RHEL/AlmaLinux/Rocky Linux 8/9:
           


### PR DESCRIPTION
## What Changed?
Added clarification that you need a Postgres instance before installing PEM, and added lots of extra detail and corrections to the hba rules needed on that intance.
