### PR TITLE
undo text->ini change

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
@@ -71,7 +71,7 @@ Use the properties in the `efm.properties` file to specify connection, administr
 | [user.email](#user_email)                                     |       |       |                                       | This value must be same for all the agents; can be left blank if using a notification script.                                                                  |
 | [from.email](#from_email).                                     |       |       | [efm@localhost](mailto:efm@localhost) | Leave blank to use the default [efm@localhost](mailto:efm@localhost).                                                                                           |
 | [notification.level](#notification_level)                     | Y     | Y     | INFO                                  | See the [list of notifications](../10_notifications/#notifications).                                                                                         |
-| [notification.ini.prefix](#notification_text_prefix)         |       |       |                                       |                                                                                                                                                                |
+| [notification.text.prefix](#notification_text_prefix)         |       |       |                                       |                                                                                                                                                                |
 | [script.notification](#script_notification)                   |       |       |                                       | Required if user.email property is not used; both parameters can be used together.                                                                              |
 | [bind.address](#bind_address)                                 | Y     | Y     |                                       | Example: &lt;ip_address>:&lt;port>                                                                                                                             |
 | [external.address](#external_address)                         |       |       |                                       | Example: &lt;ip_address/hostname>                                                                                                                              |
@@ -357,18 +357,18 @@ notification.level=INFO
 
 <div id="notification_text_prefix" class="registered_link"></div>
 
-Use the `notification.ini.prefix` property to specify the ini to add to the beginning of every notification.
+Use the `notification.text.prefix` property to specify the text to add to the beginning of every notification.
 
 ```ini
 # Text to add to the beginning of every notification. This could
 # be used to help identify what the cluster is used for, the role
 # of this node, etc. To use multiple lines, add a backslash \ to
-# the end of a line of ini. To include a newline use \n.
+# the end of a line of text. To include a newline use \n.
 # Example:
-# notification.ini.prefix=Development cluster for Example dept.\n\
+# notification.text.prefix=Development cluster for Example dept.\n\
 # Used by Dev and QA \
 # See Example group for questions.
-notification.ini.prefix=
+notification.text.prefix=
 ```
 
 <div id="script_notification" class="registered_link"></div>


### PR DESCRIPTION
Looks like someone did a bulk change of "text" to "ini" and it clobbered the information about one efm property. This change adds the proper name/text back in.

## What Changed?

