### PR TITLE
PGD: clarify bdr.join_node_group()'s synchronize_structure parameter

### DIFF
--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -245,9 +245,10 @@ bdr.join_node_group (
 -   `wait_for_completion` &mdash; Wait for the join process to complete before
     returning. Defaults to `true`.
 -   `synchronize_structure` &mdash; Set the kind of structure (schema) synchronization
-    to do during the join. Valid options are `all`, which synchronizes
-    the complete database structure, and `none`, which doesn't synchronize any
-    structure. However, it still synchronizes data.
+    to do during the join.  The default setting is `all`, which synchronizes
+    the complete database structure, The other available setting is `none`, which doesn't
+    synchronize any structure. However, it still synchronizes data (except for witness
+    nodes, which by design do not synchronize data).
 
 If `wait_for_completion` is specified as `false`,
 this is an asynchronous call that returns as soon as the joining procedure starts.


### PR DESCRIPTION
## What Changed?

Current state: https://www.enterprisedb.com/docs/pgd/latest/reference/nodes-management-interfaces/#bdrjoin_node_group

This patch:
- explicitly states the default value (`all`) -> see https://github.com/EnterpriseDB/bdr/blob/5a247059b06984a7e2d50dcaee7aaa58abc2720f/bdr_functions.c#L2358
- notes that data is not synchronized for witness nodes -> see https://www.enterprisedb.com/docs/pgd/latest/node_management/witness_nodes/

BDR-4520.