### PR TITLE
Update `pg-backup-api` docs to cover all supported operations

### DIFF
--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
@@ -71,9 +71,9 @@ This operation is used to request a remote execution of `barman config-update` c
 The JSON payload of the request must contain the following keys:
 
  * `type`: set as `config_update` to request that operation
- * `changes`: an array of documents to be used as argument for `barman config-update`
+ * `changes`: an array of documents in JSON format to be used as an argument for `barman config-update`
 
-As an example, you could request pg-backup-api to update the configuration of a couple Barman servers plus a Barman model with a payload like this:
+As an example, you could request pg-backup-api to update the configuration of a couple of Barman servers plus a Barman model with a payload like this:
 
 ```json
 {
@@ -101,10 +101,10 @@ As an example, you could request pg-backup-api to update the configuration of a 
 }
 ```
 
-Assume the above JSON content is stored in a file named `payload-pg-backup-api.json`, you could issue a request to the API like this:
+Assume the above JSON content is stored in a file named `payload-pg-backup-api.json`, you could issue a request to the API using `curl` in the following way:
 
 ```bash
-curl -X POST http://barman-server.my.org/operations -H "content-type: application/json" -d@payload-pg-backup-api.json
+curl -X POST http://barman-server.my.org/operations -H "content-type: application/json" -d @payload-pg-backup-api.json
 {
   "operation_id": "20240118T104231"
 }
@@ -182,7 +182,7 @@ As an example, you could request pg-backup-api to restore the latest backup of B
 ```
 
 ```bash
-curl -X POST http://barman-server.my.org/servers/db_server_two/operations -H "content-type: application/json" -d@payload-pg-backup-api.json
+curl -X POST http://barman-server.my.org/servers/db_server_two/operations -H "content-type: application/json" -d @payload-pg-backup-api.json
 {
   "operation_id": "20240118T140951"
 }
@@ -213,7 +213,7 @@ As an example, you could request pg-backup-api to apply the model `my-model` to 
 ```
 
 ```bash
-curl -X POST http://barman-server.my.org/servers/db_server_two/operations -H "content-type: application/json" -d@payload-pg-backup-api.json
+curl -X POST http://barman-server.my.org/servers/db_server_two/operations -H "content-type: application/json" -d @payload-pg-backup-api.json
 {
   "operation_id": "20240118T141135"
 }

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
@@ -20,68 +20,222 @@ tags:
 
 ### Available endpoints
 
- * /servers/NAME/operations/
- * /servers/NAME/operations/OPERATION_ID
+ * Instance level operations:
+   * `/operations/`
+   * `/operations/OPERATION_ID`
+ * Server level operations:
+   * `/servers/NAME/operations/`
+   * `/servers/NAME/operations/OPERATION_ID`
 
-NAME is an available Barman server configuration. Usually in a file like /etc/barman.d/myserver.conf
+`NAME` is an available Barman server configuration. Usually in a file like `/etc/barman.d/myserver.conf`
 
-OPERATION_ID is a short string that represents the ID of an operation created by the API.
+`OPERATION_ID` is a short string that represents the ID of an operation created by the API.
 
 You can find out how to fetch operations created by the API below
 
 ### Available operations
 
-#### GET: /servers/NAME/operations
+#### GET: /operations
 
-Returns all tasks created by the API, if any.
+Returns all instance level tasks created by the API, if any.
 
 ```bash
-curl http://barman-server.my.org/servers/db_server_two/operations
+curl http://barman-server.my.org/operations
 {
   "operations": [
-    "20230223T092433",
-    "20230223T092630"
+    {
+      "id": "20240118T104231",
+      "type": "config_update"
+    },
+    {
+      "id": "20240118T103947",
+      "type": "config_update"
+    }
+  ]
+}
+```
+
+#### POST: /operations
+
+Request pg-backup-api to create instance level operations.
+
+Currently pg-backup-api supports only the `config_update` operation.
+
+!!! Note
+    You need to set the `content-type` header as `application/json` when executing `POST` requests to this endpoint, otherwise you will receive a `400 Bad Request error`.
+
+##### config_update
+
+This operation is used to request a remote execution of `barman config-update` command.
+
+The JSON payload of the request must contain the following keys:
+
+ * `type`: set as `config_update` to request that operation
+ * `changes`: an array of documents to be used as argument for `barman config-update`
+
+As an example, you could request pg-backup-api to update the configuration of a couple Barman servers plus a Barman model with a payload like this:
+
+```json
+{
+  "type": "config_update",
+  "changes": [
+    {
+      "scope": "server",
+      "server_name": "my-server-a",
+      "archiver": "on",
+      "streaming_archiver": "off"
+    },
+    {
+      "scope": "server",
+      "server_name": "my-other-server-b",
+      "conninfo": "some_conn_info",
+      "streaming_conninfo": "some_streaming_conninfo",
+      "streaming_archiver": "on"
+    },
+    {
+      "scope": "model",
+      "model_name": "some-model",
+      "streaming_conninfo": "some_streaming_conn_info"
+    }
+  ]
+}
+```
+
+Assume the above JSON content is stored in a file named `payload-pg-backup-api.json`, you could issue a request to the API like this:
+
+```bash
+curl -X POST http://barman-server.my.org/operations -H "content-type: application/json" -d@payload-pg-backup-api.json
+{
+  "operation_id": "20240118T104231"
+}
+```
+
+The `operation_id` in the response is the ID of the operation that has been created in by the API.
+
+#### GET: /operations/OPERATION_ID
+
+This endpoint allows you to check the status of an instance level operation with ID `OPERATION_ID`, which can be either of these:
+
+ * `DONE`: if the operation finished successfully
+ * `FAILED`: if the operation finished with errors
+ * `IN_PROGRESS`: if the operation is still ongoing
+
+ Please find an example below:
+
+ ```bash
+ curl http://barman-server.my.org/operations/20240118T104231
+ {
+  "operation_id": "20240118T104231",
+  "status": "DONE"
+}
+ ```
+
+#### GET: /servers/NAME/operations
+
+Returns all server level tasks created by the API for Barman server `NAME`, if any.
+
+```bash
+curl http://barman-server.my.org/servers/my-barman-server/operations
+{
+  "operations": [
+    {
+      "id": "20240118T140951",
+      "type": "recovery"
+    },
+    {
+      "id": "20240118T141135",
+      "type": "config_switch"
+    }
   ]
 }
 ```
 
 #### POST: /servers/NAME/operations
 
-This method is one of the most important ones, because it is where you ask pg-backup-api to create operations. Pay attention on the response below because we will use the ID to query its status later.
+Request pg-backup-api to create server level operations.
 
-You need to send instructions about the operation you want to be created. This step is done by a json message (payload) which should look like this:
-
-The first supported (and only for the moment) operation type is "recover".
-
-```
-{"operation_type": "recover",
- "backup_id": "20230221T155931",
- "remote_ssh_command": "ssh postgres@db_server_two.my.org",
- "destination_directory": "/var/lib/pgdata"}
-```
+Currently pg-backup-api supports `recovery` and `config_switch` operations.
 
 !!! Note
-    You need to set the "content-type" header as "application/json" like the example below, otherwise you will receive a 400 Bad Request error.
+    You need to set the `content-type` header as `application/json` when executing `POST` requests to this endpoint, otherwise you will receive a `400 Bad Request error`.
 
+##### recovery
+
+This operation is used to request a remote execution of `barman recover` command.
+
+The JSON payload of the request must contain the following keys:
+
+ * `type`: set as `recovery` to request that operation;
+ * `backup_id`: ID of the backup to be restored from Barman server `NAME`. Supports whatever `barman recover` supports, including `latest` for example;
+ * `remote_ssh_command`: the SSH command to be used to connect to the target Postgres server where the backup will be restored;
+ * `destination_directory`: the path in the target server where the backup will be restored.
+
+As an example, you could request pg-backup-api to restore the latest backup of Barman server `db_server_two` with a payload like this:
+
+```json
+{
+  "type": "recovery",
+  "backup_id": "latest",
+  "remote_ssh_command": "ssh postgres@db_server_two.my.org",
+  "destination_directory": "/var/lib/pgdata"
+}
+```
 
 ```bash
 curl -X POST http://barman-server.my.org/servers/db_server_two/operations -H "content-type: application/json" -d@payload-pg-backup-api.json
 {
-  "operation_id": {  "20230223T093201" },
+  "operation_id": "20240118T140951"
 }
 ```
 
-In the response above, "20230223T093201" is the OPERATION_ID which we will use next to check its status.
+The `operation_id` in the response is the ID of the operation that has been created in by the API.
+
+##### config_switch
+
+This operation is used to request a remote execution of `barman config-switch` command.
+
+The JSON payload of the request must contain the following key:
+
+ * `type`: set as `config_switch` to request that operation.
+
+Besides that, it may contain either of the following keys:
+
+ * `model_name`: the name of a model, if you want to apply it to the Barman server `NAME`; or
+ * `reset`: set with `true` if you want to unapply the currently active model of the Barman server `NAME`
+
+As an example, you could request pg-backup-api to apply the model `my-model` to the Barman server with a payload like this:
+
+```json
+{
+  "type": "config_switch",
+  "model_name": "my-model"
+}
+```
+
+```bash
+curl -X POST http://barman-server.my.org/servers/db_server_two/operations -H "content-type: application/json" -d@payload-pg-backup-api.json
+{
+  "operation_id": "20240118T141135"
+}
+```
+
+The `operation_id` in the response is the ID of the operation that has been created in by the API.
 
 
 #### GET: /servers/NAME/operations/OPERATION_ID
 
-This method allows you to check if an operation is: DONE, SUCCESS or IN_PROGRESS.
+This endpoint allows you to check the status of an server level operation for server `NAME` with ID `OPERATION_ID`, which can be either of these:
 
-```bash
-curl http://barman-server.my.org/servers/db_server_two/operations/20230223T093201
-{
-  "recovery_id": "20230223T093201",
+ * `DONE`: if the operation finished successfully
+ * `FAILED`: if the operation finished with errors
+ * `IN_PROGRESS`: if the operation is still ongoing
+
+ Please find an example below:
+
+ ```bash
+ curl http://barman-server.my.org/servers/db_server_two/operations/20240118T140951
+ {
+  "operation_id": "20240118T140951",
   "status": "DONE"
 }
-```
+ ```

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
@@ -168,7 +168,7 @@ This operation is used to request a remote execution of `barman recover` command
 The JSON payload of the request must contain the following keys:
 
  * `type`: set as `recovery` to request that operation;
- * `backup_id`: ID of the backup to be restored from Barman server `NAME`. Supports whatever `barman recover` supports, including `latest` for example;
+ * `backup_id`: ID of the backup to be restored from Barman server `NAME`. You could use Barman shortcuts or anything that `barman recover` supports, including `latest` for example;
  * `remote_ssh_command`: the SSH command to be used to connect to the target Postgres server where the backup will be restored;
  * `destination_directory`: the path in the target server where the backup will be restored.
 
@@ -226,7 +226,7 @@ The `operation_id` in the response is the ID of the operation that has been crea
 
 #### GET: /servers/NAME/operations/OPERATION_ID
 
-This endpoint allows you to check the status of an server level operation for server `NAME` with ID `OPERATION_ID`, which can be either of these:
+This endpoint allows you to check the status of a server level operation for server `NAME` with ID `OPERATION_ID`, which can be either of these:
 
  * `DONE`: if the operation finished successfully
  * `FAILED`: if the operation finished with errors

--- a/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
+++ b/advocacy_docs/supported-open-source/barman/pg-backup-api/03-tasks.mdx
@@ -134,6 +134,8 @@ This endpoint allows you to check the status of an instance level operation with
 
 Returns all server level tasks created by the API for Barman server `NAME`, if any.
 
+The following example shows the two tasks created on the `my-barman-server` Barman server.
+
 ```bash
 curl http://barman-server.my.org/servers/my-barman-server/operations
 {


### PR DESCRIPTION
## What Changed?

The page that describes the available operations of `pg-backup-api`.

`pg-backup-api` now has not only server level operations, but also instance level operations. With these changes, a couple more endpoints were made available in the API to handle the instance level operaitons.

Besides that, `pg-backup-api` has been changed in a few fronts:

* Slight changes to output format of `GET` requests, so they include not only the operation ID, but also the operation type
* Slight changes made on the payload for requesting recovery operations
* Introduced a new server level operation: `config_switch`
* Introduced an instance level operation: `config_update`

This commit updates the `pg-backup-api` docs so it contains all the supported endpoints and operations.

References: BAR-144.