### PR TITLE
Remove note on Faraway support from southeastasia row - no longer applies

### DIFF
--- a/product_docs/docs/biganimal/release/overview/03a_region_support/index.mdx
+++ b/product_docs/docs/biganimal/release/overview/03a_region_support/index.mdx
@@ -54,7 +54,7 @@ When using Azure, you can create clusters in the following regions.
 | Australia East       | australiaeast      |                                                      |
 | Central India        | centralindia       |                                                      |
 | Japan East           | japaneast          |                                                      |
-| Southeast Asia       | southeastasia      | Does not support the creation of faraway replicas    |
+| Southeast Asia       | southeastasia      |     |
 
 
 ### AWS regions 


### PR DESCRIPTION
## What Changed?

Remove the southeastasia notes, the Faraway is already supported there.