### PR TITLE
Update pgpool_other_linux_9.mdx

### DIFF
--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_9.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+sudo dnf config-manager --enable crb
   ```
 
 ## Install the package


### PR DESCRIPTION
powertools is knows as `crb` in rocky 9 
```
[root@PG2 ~]# dnf config-manager --enable crb
[root@PG2 ~]# dnf install edb-pgpool44
Rocky Linux 9 - BaseOS           11 kB/s | 4.1 kB     00:00    
Rocky Linux 9 - AppStream        18 kB/s | 4.5 kB     00:00    
Rocky Linux 9 - CRB             2.0 MB/s | 2.3 MB     00:01    
Dependencies resolved.
================================================================
 Package      Arch   Version      Repository               Size
================================================================
Installing:
 edb-pgpool44 x86_64 4.4.3-1.el9  enterprisedb-enterprise 706 k
Installing dependencies:
 edb-pgpool44-libs
              x86_64 4.4.3-1.el9  enterprisedb-enterprise  59 k
 libmemcached-awesome
              x86_64 1.1.0-12.el9 crb                     110 k

Transaction Summary
================================================================
Install  3 Packages

Total download size: 874 k
Installed size: 3.7 M
Is this ok [y/N]: 

````

## What Changed?

