### PR TITLE
Limitations to partitioning commands

### DIFF
--- a/product_docs/docs/epas/16/reference/oracle_compatibility_reference/04_partitioning_commands_compatible_with_oracle_databases/limitations.mdx
+++ b/product_docs/docs/epas/16/reference/oracle_compatibility_reference/04_partitioning_commands_compatible_with_oracle_databases/limitations.mdx
@@ -1,0 +1,6 @@
+---
+title: "Limitations for partitioning commands compatible with Oracle Databases"
+indexCards: simple
+navTitle: Limitations
+---
+

--- a/product_docs/docs/epas/16/reference/oracle_compatibility_reference/04_partitioning_commands_compatible_with_oracle_databases/limitations.mdx
+++ b/product_docs/docs/epas/16/reference/oracle_compatibility_reference/04_partitioning_commands_compatible_with_oracle_databases/limitations.mdx
@@ -1,6 +1,44 @@
 ---
-title: "Limitations for partitioning commands compatible with Oracle Databases"
+title: "Limitations for partitioning commands compatible with Oracle databases"
 indexCards: simple
 navTitle: Limitations
 ---
+
+## Limitations for primary or unique keys
+
+For Oracle compatibility, EDB Postgres Advanced Server allows you to use a `CREATE TABLE` statement to create a unique or primary key constraint on a partitioned table that includes a non-partitioned key column. This capability differs from PostgreSQL, and it has the following limitations:
+
+- The primary or unique key is only created on a child table. The key isn't created on a parent or root table.
+
+- When using an `ALTER` statement to create a new partition, the primary or unique key isn't created automatically. You must create it manually.
+
+- The uniqueness of the key is limited to the child partition. The unique key doesn't apply across the partitioning hierarchy. 
+
+## Interval partitioning limitations
+
+Interval partitioning is a useful capability, but it has the following limitations: 
+
+- Interval partitioning is restricted to a single partition key. If you try to create or alter an existing partitioned table having a multi-column partitioned key, it will fail.
+
+- The supported key must be a numerical or date range type.
+
+- You can't define `DEFAULT` and `MAXVALUE` for an interval partitioned table.
+
+- Data to be inserted can't have `NULL`, `Not-a-Number`, or `Infinity` values specified in the partitioning key column.
+
+- The interval partitioning expression must yield a constant value and can't be a negative value.
+
+- For the interval partitioned table, at least one partition should be defined first.
+
+## Automatic partitioning limitations
+
+Automatic partitioning has the following limitations:
+
+- Like interval partitioning, automatic partitioning is restricted to a single partition key.
+
+- An automatic partitioned table can't have a `DEFAULT` partition.
+
+
+
+
 

--- a/product_docs/docs/epas/16/reference/oracle_compatibility_reference/04_partitioning_commands_compatible_with_oracle_databases/limitations.mdx
+++ b/product_docs/docs/epas/16/reference/oracle_compatibility_reference/04_partitioning_commands_compatible_with_oracle_databases/limitations.mdx
@@ -16,7 +16,7 @@ For Oracle compatibility, EDB Postgres Advanced Server allows you to use a `CREA
 
 ## Interval partitioning limitations
 
-Interval partitioning is a useful capability, but it has the following limitations: 
+Interval range partitioning is a useful capability, but it has the following limitations: 
 
 - Interval partitioning is restricted to a single partition key. If you try to create or alter an existing partitioned table having a multi-column partitioned key, it will fail.
 
@@ -32,7 +32,7 @@ Interval partitioning is a useful capability, but it has the following limitatio
 
 ## Automatic partitioning limitations
 
-Automatic partitioning has the following limitations:
+Automatic list partitioning has the following limitations:
 
 - Like interval partitioning, automatic partitioning is restricted to a single partition key.
 


### PR DESCRIPTION
Limitations when creating a partitioned table that includes non-partition key column.

Also describes interval and automatic partitioning limitations.

Addresses https://enterprisedb.atlassian.net/browse/DB-2584
