### PR TITLE
pgd: fixes for bdr.create_node_group() reference documentation

### DIFF
--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -264,7 +264,9 @@ the transaction.
 
 ## `bdr.create_node_group`
 
-This function creates a PGD group with the local node as the only member of the group.
+This function creates a PGD node group. By default, the local node will join the
+group as the only member. Additional nodes can be added to the group with
+[`bdr.join_node_group()`](#bdrjoin_node_group).
 
 ### Synopsis
 
@@ -280,20 +282,19 @@ bdr.create_node_group(node_group_name text,
 -   `node_group_name` &mdash; Name of the new PGD group. As with the node
       name, valid group names must consist of only lowercase letters, numbers,
       and underscores.
--   `parent_group_name` &mdash; The name of the parent group for the subgroup.
--   `join_node_group` &mdash; This parameter helps a node to decide whether to join
-     the group being created by it. The default value is `true`. This is used
-     when a node is creating a shard group that it doesn't want to join.
-     This can be `false` only if you specify `parent_group_name`.
--   `node_group_type` &mdash; The valid values are `NULL`, `subscriber-only`, `datanode`,
-     `read coordinator`, and `write coordinator`. `subscriber-only` type is
-     used to create a group of nodes that receive changes only from the
-     fully joined nodes in the cluster, but they never send replication
-     changes to other nodes. See [Subscriber-only groups](../node_management/subscriber_only/) for more details.
-     `Datanode` implies that the group represents a shard, whereas the other
-     values imply that the group represents respective coordinators.
-     Except for `subscriber-only`, the other values are reserved for future use.
-     `NULL` implies a normal general-purpose node group is created.
+-   `parent_group_name` &mdash; If a node subgroup is being created, this must be the
+      name of the parent group. Provide `NULL` (the default) when creating the main
+      node group for the cluster.
+-   `join_node_group` &mdash; This parameter determines whether the node should
+      join the group being created. The default value is `true`. `false` may
+      be provided when creating a subgroup which the local node will not join.
+      In this case, `parent_group_name` must be specified.
+-   `node_group_type` &mdash; The valid values are `NULL`, `subscriber-only`,
+      and `shard`. `NULL` (the default) is for creating a normal, general-purpose
+      node group. `subscriber-only` is for creating [Subscriber-only groups](../node_management/subscriber_only/)
+      whose members receive changes only from the fully joined nodes in the cluster,
+      but which never send changes to other nodes.
+      `shard` is reserved for future use.
 
 ### Notes
 


### PR DESCRIPTION
## What Changed?

The values for the `node_group_type` parameter were changed in BDR 5.0 (commit 205c6aa1) but the documentation still describes the values valid for BDR 4.x and earlier.

Also while I was at it, generally improved the reference entry wording.

BDR-4554.

