### PR TITLE
PGD: Removed physical standby reference

### DIFF
--- a/product_docs/docs/pgd/5/durability/limitations.mdx
+++ b/product_docs/docs/pgd/5/durability/limitations.mdx
@@ -6,10 +6,6 @@ The following limitations apply to the use of commit scopes and the various dura
 
 ## General limitations
 
--   Replacing a node with its physical standby doesn't work for nodes that use
-    CAMO/Eager/Group Commit. We don't recommend combining physical standbys and EDB Postgres
-    Distributed, even if it's possible.
-
 -   [Legacy synchronous replication](legacy-sync) uses a mechanism for transaction confirmation
     different from the one used by CAMO, Eager, and Group Commit. The two aren't
     compatible, so don't use them together. Whenever you use Group Commit, CAMO

--- a/product_docs/docs/pgd/5/durability/limitations.mdx
+++ b/product_docs/docs/pgd/5/durability/limitations.mdx
@@ -22,13 +22,14 @@ The following limitations apply to the use of commit scopes and the various dura
 [Group Commit](group-commit) enables configurable synchronous commits over 
 nodes in a group. If you use this feature, take the following limitations into account:
 
--   Not all DDL can run when you use Group Commit. If you use unsupported DDL, a warning is logged, and the transactions commit scope is set to local. The only supported DDL operations are:
+- Not all DDL can run when you use Group Commit. If you use unsupported DDL, a warning is logged, and the transactions commit scope is set to local. The only supported DDL operations are:
     - Nonconcurrent `CREATE INDEX`
     - Nonconcurrent `DROP INDEX`
     - Nonconcurrent `REINDEX` of an individual table or index
     - `CLUSTER` (of a single relation or index only)
     - `ANALYZE`
     - `TRUNCATE`
+
 
 - Explicit two-phase commit is not supported by Group Commit as it already uses two-phase commit.
 


### PR DESCRIPTION
## What Changed?

Removed limitations around physical standby from durability limitations (as physical standbys are no longer supported).

