### PR TITLE
pgd: format fixes for bdr.join_node_group() reference documentation

### DIFF
--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -389,12 +389,12 @@ bdr.join_node_group (
 !!! Warning
     `pause_in_standby` is deprecated since BDR 5.0. The recommended way to create
     a logical standby is to set `node_kind` to `standby` when creating the node
-    with `[bdr.create_node](#bdrcreate_node)`.
+    with [`bdr.create_node`](#bdrcreate_node).
 
 If `wait_for_completion` is specified as `false`, the function call will return
 as soon as the joining procedure starts. Progress of the join can be viewed in
-the log files and the `[bdr.event_summary](catalogs-internal.mdx#bdrevent_summary)`
-information view. The function `[bdr.wait_for_join_completion()](#bdrwait_for_join_completion)`
+the log files and the [`bdr.event_summary`](catalogs-internal.mdx#bdrevent_summary)
+information view. The function [`bdr.wait_for_join_completion()`](#bdrwait_for_join_completion)
 can be called after `bdr.join_node_group()` to wait for the join operation to complete,
 and can emit progress information if called with `verbose_progress` set to `true`.
 


### PR DESCRIPTION
## What Changed?

In a4328ef54, I applied backtick formatting incorrectly to the Markdown links, meaning the enclosed text was rendered literally.



