### PR TITLE
pgd: add "node_kind" parameter to bdr.create_node() reference documentation

### DIFF
--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -235,7 +235,9 @@ This function creates a node.
 ### Synopsis
 
 ```sql
-bdr.create_node(node_name text, local_dsn text)
+bdr.create_node(node_name text,
+                local_dsn text,
+                node_kind DEFAULT NULL)
 ```
 
 ### Parameters
@@ -244,6 +246,9 @@ bdr.create_node(node_name text, local_dsn text)
       database. Valid node names consist of lowercase letters, numbers,
       hyphens, and underscores.
 -   `local_dsn` &mdash; Connection string to the node.
+-   `node_kind` &mdash; One of `data` (the default), `standby`, `subscriber-only`
+      or `witness`. If this parameter is not set, or `NULL` is provided,
+      the default `data` node kind is used.
 
 ### Notes
 
@@ -254,7 +259,7 @@ created, the function reports an error if run again.
 This function is a transactional function. You can roll it back and the
 changes made by it are visible to the current transaction.
 
-The function holds lock on the newly created bdr node until the end of
+The function holds lock on the newly created node until the end of
 the transaction.
 
 ## `bdr.create_node_group`


### PR DESCRIPTION
## What Changed?

`bdr.create_node()`: https://www.enterprisedb.com/docs/pgd/latest/reference/nodes-management-interfaces/#bdrcreate_node

- added missing `node_kind` parameter, present from BDR 5.0.

