### PR TITLE
docs/pgd/fix/BDR-4575-docs-document-which-kinds-of-commit-scope-rules-m

### DIFF
--- a/product_docs/docs/pgd/5/consistency/eager.mdx
+++ b/product_docs/docs/pgd/5/consistency/eager.mdx
@@ -40,6 +40,8 @@ SELECT bdr.add_commit_scope(
 !!! note Upgrading?
     The old `global` commit scope doesn't exist anymore. The above command creates a scope that's the same as the old `global` scope with `bdr.global_commit_timeout` set to `60s`.
 
+The commit scope group for the eager conflict resolution rule can only be `ALL` or `MAJORITY`. Where `ALL` is used, the `commit_decision` setting must also be set to `raft`.
+
 ## Error handling
 
 Given that PGD manages the transaction, the client needs to check only the result of the `COMMIT`. This is advisable in any case, including single-node Postgres.

--- a/product_docs/docs/pgd/5/durability/group-commit.mdx
+++ b/product_docs/docs/pgd/5/durability/group-commit.mdx
@@ -76,9 +76,7 @@ to commit something. This approach requires application changes to use
 the CAMO transaction protocol to work correctly, as the application is in some way
 part of the consensus. For more on this approach, see [CAMO](camo).
 
-The `raft` option is for backwards compatibility only. It uses PGD's built-in Raft
-consensus for commit decisions. It is slow and only useful with eager conflict
-resolution.
+The `raft` decision used PGDs built-in raft consensus for commit decisions. It can have low performance and is currently only required when doing eager conflict resolution with an ALL commit scope group.
 
 ### Conflict resolution
 
@@ -93,9 +91,9 @@ conflict resolution works.
 Eager means that conflicts are resolved eagerly (as part of agreement on
 COMMIT), and conflicting transactions get aborted with a serialization error.
 This approach provides greater isolation than the asynchronous resolution at the
-price of performance. When `eager` resolution is used with an `ALL` commit
-scope group, the `GROUP COMMIT` commit decision setting must be set to `raft` to avoid reconciliation issues.
-
+price of performance. Using eager with an ALL commit scope group requires that 
+the [commit decision](#commit-decisions) must be set to `raft` to avoid 
+reconciliation issues.
 
 For the details about how Eager conflict resolution works,
 see [Eager conflict resolution](../consistency/eager). 
@@ -108,4 +106,5 @@ transaction abort is requested. If the transaction is already
 decided to be committed at the time the abort request is sent, the transaction
 does eventually COMMIT even though the client might receive an abort message.
 
-See also [Limitations](limitations).
+
+See also [Limitations](limitations). 

--- a/product_docs/docs/pgd/5/durability/group-commit.mdx
+++ b/product_docs/docs/pgd/5/durability/group-commit.mdx
@@ -76,7 +76,7 @@ to commit something. This approach requires application changes to use
 the CAMO transaction protocol to work correctly, as the application is in some way
 part of the consensus. For more on this approach, see [CAMO](camo).
 
-The `raft` decision used PGDs built-in raft consensus for commit decisions. It can have low performance and is currently only required when doing eager conflict resolution with an ALL commit scope group.
+The `raft` decision uses PGDs built-in raft consensus for commit decisions. It can have low performance and is currently only required when doing eager conflict resolution with an ALL commit scope group.
 
 ### Conflict resolution
 

--- a/product_docs/docs/pgd/5/durability/group-commit.mdx
+++ b/product_docs/docs/pgd/5/durability/group-commit.mdx
@@ -93,8 +93,8 @@ conflict resolution works.
 Eager means that conflicts are resolved eagerly (as part of agreement on
 COMMIT), and conflicting transactions get aborted with a serialization error.
 This approach provides greater isolation than the asynchronous resolution at the
-price of performance. Eager resolution should only be used with an `ALL` commit
-scope group, which in turn requires the GROUP COMMIT commit decision set to `raft`.
+price of performance. When `eager` resolution is used with an `ALL` commit
+scope group, the `GROUP COMMIT` commit decision setting must be set to `raft` to avoid reconciliation issues.
 
 
 For the details about how Eager conflict resolution works,

--- a/product_docs/docs/pgd/5/durability/group-commit.mdx
+++ b/product_docs/docs/pgd/5/durability/group-commit.mdx
@@ -76,7 +76,7 @@ to commit something. This approach requires application changes to use
 the CAMO transaction protocol to work correctly, as the application is in some way
 part of the consensus. For more on this approach, see [CAMO](camo).
 
-The `raft` decision uses PGDs built-in raft consensus for commit decisions. It can have low performance and is currently only required when doing eager conflict resolution with an ALL commit scope group.
+The `raft` decision uses PGDs built-in raft consensus for commit decisions. It can have low performance and is currently only required when using GROUP COMMIT with an ALL commit scope group.
 
 ### Conflict resolution
 
@@ -91,9 +91,11 @@ conflict resolution works.
 Eager means that conflicts are resolved eagerly (as part of agreement on
 COMMIT), and conflicting transactions get aborted with a serialization error.
 This approach provides greater isolation than the asynchronous resolution at the
-price of performance. Using eager with an ALL commit scope group requires that 
-the [commit decision](#commit-decisions) must be set to `raft` to avoid 
-reconciliation issues.
+price of performance. 
+
+Using an ALL commit scope group requires that the [commit
+decision](#commit-decisions) must be set to `raft` to avoid reconciliation
+issues.
 
 For the details about how Eager conflict resolution works,
 see [Eager conflict resolution](../consistency/eager). 

--- a/product_docs/docs/pgd/5/durability/group-commit.mdx
+++ b/product_docs/docs/pgd/5/durability/group-commit.mdx
@@ -93,8 +93,12 @@ conflict resolution works.
 Eager means that conflicts are resolved eagerly (as part of agreement on
 COMMIT), and conflicting transactions get aborted with a serialization error.
 This approach provides greater isolation than the asynchronous resolution at the
-price of performance. For the details about how Eager conflict resolution works,
-see [Eager conflict resolution](../consistency/eager).
+price of performance. Eager resolution should only be used with an `ALL` commit
+scope group, which in turn requires the GROUP COMMIT commit decision set to `raft`.
+
+
+For the details about how Eager conflict resolution works,
+see [Eager conflict resolution](../consistency/eager). 
 
 ### Aborts
 

--- a/product_docs/docs/pgd/5/reference/commit-scopes.mdx
+++ b/product_docs/docs/pgd/5/reference/commit-scopes.mdx
@@ -149,7 +149,9 @@ When set to true, two-phase commit transactions:
 
 The value `async` means resolve conflicts asynchronously during replication using the conflict resolution policy.
 
-The value `eager` means that conflicts are resolved eagerly during COMMIT by aborting one of the conflicting transactions. The `eager` conflict_resolution setting must only be used with the `ALL` commit scope group, and in turn must be used with a [`commit_decision`](#commit_decision-settings) set to `raft`.
+The value `eager` means that conflicts are resolved eagerly during COMMIT by aborting one of the conflicting transactions. 
+
+When this option is used with the `ALL` commit scope group, the [`commit_decision`](#commit_decision-settings) must be set to `raft` to avoid reconcilation issue.
 
 See ["Conflict resolution" in Group Commit](../durability/group-commit/#conflict-resolution).
 
@@ -159,7 +161,9 @@ The value `group` means the preceding `commit_scope_group` specification also af
 
 The value `partner` means the partner node decides whether transactions can be committed. This value is allowed only on groups with 2 data nodes. 
 
-The value `raft` means the COMMIT decision is noted using Raft consensus of all nodes, after the nodes in the `commit_scope_group` have confirmed. This ensures that all nodes have a consensus on the decision. This option must be used when the `ALL` commit scope group is being used to ensure no divergence between the nodes over the decision. This option may have low performance.
+The value `raft` means the COMMIT decision is noted using Raft consensus of all nodes, after the nodes in the `commit_scope_group` have confirmed. This ensures that all nodes have a consensus on the decision. 
+
+This option must be used when the `ALL` commit scope group is being used with `eager` conflict resolution to ensure no divergence between the nodes over the decision. This option may have low performance.
 
 See ["Commit decisions" in Group Commit](../durability/group-commit/#commit-decisions).
 

--- a/product_docs/docs/pgd/5/reference/commit-scopes.mdx
+++ b/product_docs/docs/pgd/5/reference/commit-scopes.mdx
@@ -163,7 +163,7 @@ The value `partner` means the partner node decides whether transactions can be c
 
 The value `raft` means the COMMIT decision is noted using Raft consensus of all nodes, after the nodes in the `commit_scope_group` have confirmed. This ensures that all nodes have a consensus on the decision. 
 
-This option must be used when the `ALL` commit scope group is being used with `eager` conflict resolution to ensure no divergence between the nodes over the decision. This option may have low performance.
+This option must be used when the `ALL` commit scope group is being used to ensure no divergence between the nodes over the decision. This option may have low performance.
 
 See ["Commit decisions" in Group Commit](../durability/group-commit/#commit-decisions).
 

--- a/product_docs/docs/pgd/5/reference/commit-scopes.mdx
+++ b/product_docs/docs/pgd/5/reference/commit-scopes.mdx
@@ -151,7 +151,11 @@ The value `async` means resolve conflicts asynchronously during replication usin
 
 The value `eager` means that conflicts are resolved eagerly during COMMIT by aborting one of the conflicting transactions. 
 
-When this option is used with the `ALL` commit scope group, the [`commit_decision`](#commit_decision-settings) must be set to `raft` to avoid reconcilation issue.
+Eager is only available with `MAJORITY` or `ALL` commit scope groups.
+
+When used with the `ALL` commit scope group, the [`commit_decision`](#commit_decision-settings) must be set to `raft` to avoid reconcilation issue.
+
+
 
 See ["Conflict resolution" in Group Commit](../durability/group-commit/#conflict-resolution).
 
@@ -161,7 +165,7 @@ The value `group` means the preceding `commit_scope_group` specification also af
 
 The value `partner` means the partner node decides whether transactions can be committed. This value is allowed only on groups with 2 data nodes. 
 
-The value `raft` means the COMMIT decision is noted using Raft consensus of all nodes, after the nodes in the `commit_scope_group` have confirmed. This ensures that all nodes have a consensus on the decision. 
+The value `raft` means the decision makes use of PGD's built-in Raft consensus. Once all the nodes in the selected commit scope group have confirmed the transaction, to ensure that all the nodes in the PGD cluster have noted the transaction, it is noted with the all-node Raft.
 
 This option must be used when the `ALL` commit scope group is being used to ensure no divergence between the nodes over the decision. This option may have low performance.
 

--- a/product_docs/docs/pgd/5/reference/commit-scopes.mdx
+++ b/product_docs/docs/pgd/5/reference/commit-scopes.mdx
@@ -74,7 +74,9 @@ A transaction under this commit scope group will be considered committed if a ma
 
 Example: `ALL (left_dc)`
 
-A transaction under this commit scope group will be considered committed if all of the nodes in the `left_dc` group confirm they processed the transaction.
+A transaction under this commit scope group will be considered committed if all of the nodes in the `left_dc` group confirm they processed the transaction. 
+
+When `ALL` is used with [`GROUP COMMIT`](#group-commit), the [`commit_decision`](#commit_decision-settings) setting must be set to `raft` to avoid reconciliation issues.
 
 ### ALL NOT
 
@@ -147,7 +149,7 @@ When set to true, two-phase commit transactions:
 
 The value `async` means resolve conflicts asynchronously during replication using the conflict resolution policy.
 
-The value `eager` means that conflicts are resolved eagerly during COMMIT by aborting one of the conflicting transactions.
+The value `eager` means that conflicts are resolved eagerly during COMMIT by aborting one of the conflicting transactions. The `eager` conflict_resolution setting must only be used with the `ALL` commit scope group, and in turn must be used with a [`commit_decision`](#commit_decision-settings) set to `raft`.
 
 See ["Conflict resolution" in Group Commit](../durability/group-commit/#conflict-resolution).
 
@@ -157,11 +159,9 @@ The value `group` means the preceding `commit_scope_group` specification also af
 
 The value `partner` means the partner node decides whether transactions can be committed. This value is allowed only on groups with 2 data nodes. 
 
-The value `raft` means the COMMIT decision is done using Raft consensus of all the nodes in the cluster, independent of any `commit_scope_group` consensus. This option has low performance and is for backward compatibility only.
+The value `raft` means the COMMIT decision is noted using Raft consensus of all nodes, after the nodes in the `commit_scope_group` have confirmed. This ensures that all nodes have a consensus on the decision. This option must be used when the `ALL` commit scope group is being used to ensure no divergence between the nodes over the decision. This option may have low performance.
 
 See ["Commit decisions" in Group Commit](../durability/group-commit/#commit-decisions).
-
-
 
 ## CAMO
 


### PR DESCRIPTION
## What Changed?

Additional notes on the interactions between ALL, GROUP COMMIT, eager and raft.