### PR TITLE
docs/pgd/fix/BDR-4594-docs-add-missing-terminology-terms

### DIFF
--- a/product_docs/docs/pgd/5/terminology.mdx
+++ b/product_docs/docs/pgd/5/terminology.mdx
@@ -98,6 +98,10 @@ A consensus algorithm that uses votes from a quorum of machines in a distributed
 
 The ability of a system to handle increasing read workloads. For example, PGD can introduce one or more read replica nodes to a cluster and have the application direct writes to the primary node and reads to the replica nodes. As the read workload grows, you can increase the number of read replica nodes to maintain performance.
 
+#### Subscription
+
+PGD nodes will publish changes being made to data to nodes that are interested. Other PGD nodes will ask to subscribe to those changes. This creates a subscription and is the mechanism by which each node is updated. PGD nodes bidirectionally subscribe to other PGD node's changes.
+
 #### Switchover
 
 A planned change in connection between the application or proxies and the active database node in a cluster, typically done for maintenance.
@@ -133,3 +137,8 @@ Witness nodes primarily serve to help the cluster establish a consensus. An odd 
 #### Write leader
 
 In an Always-On architecture, a node is selected as the correct connection endpoint for applications. This node is called the write leader. Once selected, proxy nodes route queries and updates to it. With only one node receiving writes, unintended multi-node writes can be avoided. The write leader is selected by consensus of a quorum of data nodes. If the write leader becomes unavailable, the data nodes select another node to become write leader. Nodes that aren't the write leader are referred to as *shadow nodes*.
+
+#### Writer
+
+ When a [subscription](#subscription) delivers data changes to a PGD node, the database server tasks a worker process called a writer with getting those changes recorded.
+

--- a/product_docs/docs/pgd/5/terminology.mdx
+++ b/product_docs/docs/pgd/5/terminology.mdx
@@ -140,5 +140,5 @@ In an Always-On architecture, a node is selected as the correct connection endpo
 
 #### Writer
 
- When a [subscription](#subscription) delivers data changes to a PGD node, the database server tasks a worker process called a writer with getting those changes recorded.
+ When a [subscription](#subscription) delivers data changes to a PGD node, the database server tasks a worker process called a writer with getting those changes applied.
 


### PR DESCRIPTION
## What Changed?

Subscription and writer added to the terminology