### PR TITLE
PG4K: Perform API HTML+link corrections on import

### DIFF
--- a/scripts/fileProcessor/processors/cnp/cleanup-html.mjs
+++ b/scripts/fileProcessor/processors/cnp/cleanup-html.mjs
@@ -1,5 +1,5 @@
-// HTML comments (<!-- ... -->) are not valid in MDX
-// strip them out completely
+// HTML comments (<!-- ... -->) are not valid in MDX - strip them out completely
+// ensure tags are lowercase
 
 import toVFile from "to-vfile";
 import remarkParse from "remark-parse";
@@ -45,6 +45,9 @@ function stripComments() {
 
       // strip (potentially NON-EMPTY) HTML comments - these are not valid in JSX
       node.value = node.value.replace(/(?=<!--)([\s\S]*?)-->/g, "");
+
+      // lower-case HTML tags
+      node.value = node.value.replace(/<(\/*)(\w+)([^>]*)>/g, (match, close, tag, rest) => `<${close}${tag.toLowerCase()}${rest}>`)
     });
   };
 }

--- a/scripts/fileProcessor/processors/cnp/update-links.mjs
+++ b/scripts/fileProcessor/processors/cnp/update-links.mjs
@@ -44,6 +44,7 @@ function linkRewriter() {
     // - update links to release_notes to rel_notes
     // - update links to appendixes/* to /*
     // - update links *from* appendixes/* to /*
+    // - update links to cloudnative-pg.v1.md to pg4k.v1.md
     visit(tree, ["link", "yaml"], (node) => {
       if (node.type === "yaml")
       {
@@ -62,6 +63,8 @@ function linkRewriter() {
         node.url = "rel_notes";
       else if (node.url === "release_notes.md")
         node.url = "rel_notes";
+      else if (node.url.includes("cloudnative-pg.v1.md"))
+        node.url = node.url.replace("cloudnative-pg.v1.md", "pg4k.v1.md");
     });
   };
 }

--- a/scripts/source/process-pgd4k-docs.sh
+++ b/scripts/source/process-pgd4k-docs.sh
@@ -13,24 +13,35 @@ DESTINATION_CHECKOUT=`cd $2 && pwd`
 cd $DESTINATION_CHECKOUT/scripts/fileProcessor
 npm install --production
 
+cd $SOURCE_CHECKOUT
+
+# create a temporary worktree to avoid messing up source repo (for local work; CI doesn't care)
+git worktree add --detach ./docs-import
+
 cd $DESTINATION_CHECKOUT/product_docs/docs/postgres_distributed_for_kubernetes/1/
 node $DESTINATION_CHECKOUT/scripts/source/files-to-ignore.mjs \
   "$DESTINATION_CHECKOUT/product_docs/docs/postgres_distributed_for_kubernetes/1/" \
-  > $SOURCE_CHECKOUT/files-to-ignore.txt
+  > $SOURCE_CHECKOUT/docs-import/files-to-ignore.txt
 
-cd $SOURCE_CHECKOUT/docs
+cd $SOURCE_CHECKOUT/docs-import/docs
 
 node $DESTINATION_CHECKOUT/scripts/fileProcessor/main.mjs \
   -f "src/**/*.md" \
   -p "cnp/replace-github-urls" \
   -p "cnp/update-yaml-links" \
   -p "cnp/add-frontmatters" \
+  -p "cnp/cleanup-html" \
   -p "cnp/rename-to-mdx"
 
 node $DESTINATION_CHECKOUT/scripts/source/merge-indexes.mjs \
-  "$SOURCE_CHECKOUT/docs/src/index.mdx" \
+  "$SOURCE_CHECKOUT/docs-import/docs/src/index.mdx" \
   "$DESTINATION_CHECKOUT/product_docs/docs/postgres_distributed_for_kubernetes/1/index.mdx" \
-  "$SOURCE_CHECKOUT/docs/src/index.mdx" \
-  >> $SOURCE_CHECKOUT/files-to-ignore.txt
+  "$SOURCE_CHECKOUT/docs-import/docs/src/index.mdx" \
+  >> $SOURCE_CHECKOUT/docs-import/files-to-ignore.txt
 
-rsync -av --delete --exclude-from=$SOURCE_CHECKOUT/files-to-ignore.txt src/ $DESTINATION_CHECKOUT/product_docs/docs/postgres_distributed_for_kubernetes/1/
+rsync -av --delete --exclude-from=$SOURCE_CHECKOUT/docs-import/files-to-ignore.txt src/ $DESTINATION_CHECKOUT/product_docs/docs/postgres_distributed_for_kubernetes/1/
+
+# cleanup: remove worktree
+cd $SOURCE_CHECKOUT
+git worktree remove --force ./docs-import
+cd $CWD


### PR DESCRIPTION
## What Changed?

A few corrections that are easier to make on import than fix at the source.
Also use a worktree for the script to avoid messing up the source repo (can now re-run local import without side-effects)
