### PR TITLE
Update extensions.mdx change index_advisor to query_advisor

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/extensions.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/extensions.mdx
@@ -60,7 +60,7 @@ PostgreSQL contrib extensions/modules:
 EDB extensions:
 - edb_dbo
 - sql-profiler
-- index_advisor
+- query_advisor
 - refdata
 - autocluster
 - edb_pg_tuner


### PR DESCRIPTION
The index_advisor extension has been renamed to query_advisor so this document needs to be updated to reflect that change.

Here is evidence from a BigAnimal cluster today:

edb_admin=> create extension index_advisor;
ERROR:  extension "index_advisor" is not available DETAIL:  Could not open extension control file "/usr/share/edb-as/16/extension/index_advisor.control": No such file or directory. HINT:  The extension must first be installed on the system where PostgreSQL is running.

edb_admin=> create extension query_advisor;
CREATE EXTENSION

edb_admin=> select * from pg_available_extensions where name like '%advisor%';
     name      | default_version | installed_version |            comment
---------------+-----------------+-------------------+--------------------------------
 query_advisor | 1.0             | 1.0               | An extension to advise indexes
(1 row)

## What Changed?

