### PR TITLE
Consistent use of tick formatting of variable names

### DIFF
--- a/product_docs/docs/pgd/5/durability/commit-scopes.mdx
+++ b/product_docs/docs/pgd/5/durability/commit-scopes.mdx
@@ -14,13 +14,13 @@ Every commit scope has a name (a `commit_scope_name`).
 
 Each commit scope has one or more rules.
 
-Each rule within the commit scope has an origin_node_group which together uniquely identify the commit scope rule.
+Each rule within the commit scope has an `origin_node_group` which together uniquely identify the commit scope rule.
 
-The origin_node_group is a PGD group and it defines the nodes which will apply this rule when they are the originators of a transaction.
+The `origin_node_group` is a PGD group and it defines the nodes which will apply this rule when they are the originators of a transaction.
 
 Finally there is the rule which defines what kind of commit scope or combination of commit scope kinds should be applied to those transactions.
 
-So if a commit scope has a rule that reads
+So if a commit scope has a rule that reads:
 
     origin_node_group := 'example_bdr_group',
     rule := 'ANY 2 (example_bdr_group) GROUP COMMIT',


### PR DESCRIPTION
And also consistent punctuation before a code sample.