### PR TITLE
Added more information about upgrade-conf source flag

### DIFF
--- a/product_docs/docs/efm/4/07_using_efm_utility.mdx
+++ b/product_docs/docs/efm/4/07_using_efm_utility.mdx
@@ -173,9 +173,9 @@ This command must be invoked by efm, a member of the efm group, or root.
 
 `efm upgrade-conf <cluster_name> [-source <directory>]`
 
-Invoke the `efm upgrade-conf` command to copy the configuration files from an existing Failover Manager installation and add parameters required by a Failover Manager installation. Provide the name of the previous cluster when invoking the utility. This command must be invoked with root privileges.
+Invoke the `efm upgrade-conf` command to copy the configuration files from an existing Failover Manager installation and add parameters required by a Failover Manager installation. Provide the name of the previous cluster when invoking the utility. If you're running Failover Manager in the default mode, this command must be invoked with root privileges.
 
-If you're upgrading from a Failover Manager configuration that doesn't use sudo, include the `-source` flag and specify the name of the directory in which the configuration files reside when invoking `upgrade-conf`.
+For information on the optional `-source` flag, or if you're upgrading from a Failover Manager configuration that doesn't use sudo, see [Upgrading Failover Manager](upgrading) for more information.
 
 ## efm node-status-json
 

--- a/product_docs/docs/efm/4/upgrading.mdx
+++ b/product_docs/docs/efm/4/upgrading.mdx
@@ -22,7 +22,7 @@ Failover Manager provides a utility to assist you when upgrading a cluster manag
    efm upgrade-conf <cluster_name>
    ```
 
-   The efm `upgrade-conf` utility locates the `.properties` and `.nodes` files of preexisting clusters and copies the parameter values to a new configuration file for use by Failover Manager. The utility saves the updated copy of the configuration files in the `/etc/edb/efm-4.8` directory.
+   The `efm upgrade-conf` utility locates the `.properties` and `.nodes` files of preexisting clusters and copies the parameter values to a new configuration file for use by Failover Manager. The utility saves the updated copy of the configuration files in the `/etc/edb/efm-4.8` directory.
 
 3.  Modify the `.properties` and `.nodes` files for Failover Manager 4.8, specifying any new preferences. Use your choice of editor to modify any additional properties in the properties file (located in the `/etc/edb/efm-4.8` directory) before starting the service for that node. For detailed information about property settings, see [The cluster properties file](04_configuring_efm/01_cluster_properties/#cluster_properties).
 
@@ -34,7 +34,7 @@ Failover Manager provides a utility to assist you when upgrading a cluster manag
    /usr/efm-4.7/bin/efm stop-cluster efm
    ```
 !!! Note
-    The primary agent will not drop the virtual IP address (if used) when it is stopped; the database will remain up and accessible on the VIP during the EFM upgrade. See also: [Using Failover Manager with virtual IP addresses](04_configuring_efm/05_using_vip_addresses.mdx) 
+    The primary agent will not drop the virtual IP address (if used) when it is stopped; the database will remain up and accessible on the VIP during the EFM upgrade. See also: [Using Failover Manager with virtual IP addresses](04_configuring_efm/05_using_vip_addresses.mdx)
 
 6. Start the new [Failover Manager service](08_controlling_efm_service/#controlling_efm_service) (`edb-efm-4.8`) on each node of the cluster.
 
@@ -51,7 +51,20 @@ Upgrade of files is finished. The owner and group for properties and nodes files
 [root@hostname ~]#
 ```
 
-If you're [using a Failover Manager configuration without sudo](04_configuring_efm/04_extending_efm_permissions/#running_efm_without_sudo), include the `-source` flag and specify the name of the directory in which the configuration files reside when invoking `upgrade-conf`. If the directory isn't the configuration default directory, the upgraded files are created in the directory from which the `upgrade-conf` command was invoked.
+### The optional `-source` flag
+
+
+The `-source` flag can be used to explicitly specify the directory containing the files to be processed. If the directory is a Failover Manager configuration location, i.e. `/etc/edb/efm-<earlier_version>`, the utility will write the new files in the default location. This allows upgrading from a specific earlier version if desired.
+
+If the source directory is any other directory, the utility will create the new files in the directory where the command was invoked. The files will be owned by the user who ran the command. This is typically used when [using a Failover Manager configuration without sudo](04_configuring_efm/04_extending_efm_permissions/#running_efm_without_sudo), and does not require root privileges.
+
+Summary:
+1.  The `-source` is not used: the utility will search previous installation directories for configuration files. The new files will be generated in the current default configuration directory and will be owned by `efm` user. The command must be invoked with root privileges.
+2.  The `-source` flag is set to a previous installation's configuration directory: the utility will only look in the specified directory for configuration files. The new files will be generated in the current default configuration directory and will be owned by the `efm` user. The command must be invoked with root privileges.
+3.  The `-source` flag is set to any other directory: the utility will only look in the specified directory for configuration files. The new files will be generated in the directory from which the command was invoked and will be owned by the user invoking the command. Root privileges are not required.
+
+!!! Note
+    In all cases, if a `<cluster_name>.properties` or `<cluster_name>.nodes` file already exists in the target directory, it is renamed with a timestamp before the new file is saved.
 
 ## Uninstalling Failover Manager
 


### PR DESCRIPTION
This removes a little information from the general 'efm' utility page and adds a note to see the upgrade page for more info instead. Hopefully this is better than having incomplete information spread out across pages. On the upgrade page there is now a whole section on the -source parameter and when root privileges are not required to run it.

There is also a note about what happens when files already exist in the target location.

The above changes are in response to a customer confused about when root privileges were required or not, and what happened when files are upgraded into the same directory as the source files (source files renamed). Any suggestions are welcome -- the "summary" could possibly be a table but that might be overkill.



