### PR TITLE
Change name of powertools to crb for Rocky and Alma Linux 9

### DIFF
--- a/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_other_linux_9.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_other_linux_9.mdx
@@ -40,7 +40,7 @@ Before you begin the installation process:
 - Enable additional repositories to resolve dependencies:
 
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 - Disable the built-in PostgreSQL module:

--- a/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_other_linux_9.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_other_linux_9.mdx
@@ -40,7 +40,7 @@ Before you begin the installation process:
 - Enable additional repositories to resolve dependencies:
 
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 - Disable the built-in PostgreSQL module:

--- a/install_template/templates/platformBase/almalinux-9-or-rocky-linux-9.njk
+++ b/install_template/templates/platformBase/almalinux-9-or-rocky-linux-9.njk
@@ -6,6 +6,6 @@
 {{ super() }}
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 {% endblock prerequisites %}

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_other_linux_9.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_other_linux_9.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -111,7 +111,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_centos_7.mdx
@@ -103,7 +103,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_10.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_11.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.2.0, server 15.2.0)
+psql (11.1.0, server 11.1.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_7.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_8.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_9.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -111,7 +111,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_centos_7.mdx
@@ -103,7 +103,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_10.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_11.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.2.0, server 15.2.0)
+psql (12.1.0, server 12.1.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_7.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_8.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_9.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -111,7 +111,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_centos_7.mdx
@@ -103,7 +103,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_10.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_11.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.2.0, server 15.2.0)
+psql (13.1.0, server 13.1.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_7.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_8.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_9.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -111,7 +111,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_centos_7.mdx
@@ -103,7 +103,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_10.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_11.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.2.0, server 15.2.0)
+psql (14.1.0, server 14.1.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_7.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_8.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_9.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -111,7 +111,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -118,7 +118,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_centos_7.mdx
@@ -103,7 +103,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_10.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_11.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.2.0, server 15.2.0)
+psql (15.1.0, server 15.1.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_7.mdx
@@ -109,7 +109,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_8.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_9.mdx
@@ -116,7 +116,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_15.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -88,7 +88,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.1.0, server 16.1.0)
+psql (15.2.0, server 15.2.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -42,7 +42,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_other_linux_9.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_other_linux_9.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_9.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_9.mdx
@@ -51,7 +51,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_9.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_9.mdx
@@ -51,7 +51,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_other_linux_9.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_other_linux_9.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_other_linux_9.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_other_linux_9.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/ocl_connector/14/installing/linux_x86_64/ocl_other_linux_9.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_x86_64/ocl_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/ocl_connector/14/installing/linux_x86_64/ocl_other_linux_9.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_x86_64/ocl_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/ocl_connector/15/installing/linux_x86_64/ocl_other_linux_9.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_x86_64/ocl_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/ocl_connector/15/installing/linux_x86_64/ocl_other_linux_9.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_x86_64/ocl_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/ocl_connector/16/installing/linux_x86_64/ocl_other_linux_9.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/linux_x86_64/ocl_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/ocl_connector/16/installing/linux_x86_64/ocl_other_linux_9.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/linux_x86_64/ocl_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/odbc_connector/13/installing/linux_x86_64/odbc_other_linux_9.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_x86_64/odbc_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/odbc_connector/13/installing/linux_x86_64/odbc_other_linux_9.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_x86_64/odbc_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_9.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_9.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/odbc_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_other_linux_9.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_other_linux_9.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_other_linux_9.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_other_linux_9.mdx
@@ -40,7 +40,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/pge/15/installing/linux_x86_64/pge_other_linux_9.mdx
+++ b/product_docs/docs/pge/15/installing/linux_x86_64/pge_other_linux_9.mdx
@@ -40,7 +40,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/pge/16/installing/linux_x86_64/pge_other_linux_9.mdx
+++ b/product_docs/docs/pge/16/installing/linux_x86_64/pge_other_linux_9.mdx
@@ -40,7 +40,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/pge/16/installing/linux_x86_64/pge_other_linux_9.mdx
+++ b/product_docs/docs/pge/16/installing/linux_x86_64/pge_other_linux_9.mdx
@@ -40,7 +40,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_9.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_9.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_other_linux_9.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_other_linux_9.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package

--- a/product_docs/docs/postgis/3.2/installing/linux_x86_64/postgis_other_linux_9.mdx
+++ b/product_docs/docs/postgis/3.2/installing/linux_x86_64/postgis_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled powertools
+  sudo dnf config-manager --set-enabled crb
   ```
 
 ## Install the package

--- a/product_docs/docs/postgis/3.2/installing/linux_x86_64/postgis_other_linux_9.mdx
+++ b/product_docs/docs/postgis/3.2/installing/linux_x86_64/postgis_other_linux_9.mdx
@@ -47,7 +47,7 @@ Before you begin the installation process:
 
 - Enable additional repositories to resolve dependencies:
   ```shell
-  sudo dnf config-manager --set-enabled crb
+  sudo dnf config-manager --set-enabled powertools
   ```
 
 ## Install the package


### PR DESCRIPTION
Changes the command for enabling powertools from "powertools" to "crb" for all products installed on Rocky or Alma Linux 9.

This PR also picks up a change to EPAS that must have been made in the templates but never propagated to all the versions of EPAS. I'm including it in this PR so all the templatized output is consistent.

This PR responds to [PR-5197](https://github.com/EnterpriseDB/docs/pull/5197) but I don't have access to that branch.