### PR TITLE
Add AES-256 usage notes to "How does TDE encrypt data?"

### DIFF
--- a/product_docs/docs/tde/15/index.mdx
+++ b/product_docs/docs/tde/15/index.mdx
@@ -78,7 +78,7 @@ Starting with version 16, EDB TDE introduces the option to choose between AES-12
 
 TDE uses AES-128-XTS or AES-256-XTS algorithms for encrypting data files. XTS uses a second value, known as the *tweak value*, to enhance the encryption. The XTS tweak value with TDE uses the database OID, the relfilenode, and the block number. 
 
-For Write-Ahead Log (WAL) files, TDE utilizes AES-128-CTR or AES-256-CTR, incorporating the WAL's Log Sequence Number (LSN) as the counter component. 
+For write-ahead log (WAL) files, TDE uses AES-128-CTR or AES-256-CTR, incorporating the WAL's log sequence number (LSN) as the counter component. 
 
 Temporary files that are accessed by block are also encrypted using AES-128-XTS or AES-256-XTS. Other temporary files are encrypted using AES-128-CBC or AES-256-CBC.
 

--- a/product_docs/docs/tde/15/index.mdx
+++ b/product_docs/docs/tde/15/index.mdx
@@ -76,7 +76,7 @@ EDB Postgres Advanced Server and EDB Postgres Extended Server provide hooks to k
 
 Starting with version 16, EDB TDE introduces the option to choose between AES-128 and AES-256 encryption algorithms during the initialization of the Postgres cluster. The choice between AES-128 and AES-256 hinges on balancing performance and security requirements. AES-128 is commonly advised for environments where performance efficiency and lower power consumption are pivotal, making it suitable for most applications. Conversely, AES-256 is recommended for scenarios demanding the highest level of security, often driven by regulatory mandates.
 
-TDE employs AES-128-XTS or AES-256-XTS algorithms for the encryption of data files. The XTS tweak uses the database OID, the relfilenode, and the block number. 
+TDE employs AES-128-XTS or AES-256-XTS algorithms for the encryption of data files. XTS uses a second value, known as the "tweak value", to enhance the encryption. The XTS tweak value with TDE uses the database OID, the relfilenode, and the block number. 
 
 For Write-Ahead Log (WAL) files, TDE utilizes AES-128-CTR or AES-256-CTR, incorporating the WAL's Log Sequence Number (LSN) as the counter component. 
 

--- a/product_docs/docs/tde/15/index.mdx
+++ b/product_docs/docs/tde/15/index.mdx
@@ -76,7 +76,7 @@ EDB Postgres Advanced Server and EDB Postgres Extended Server provide hooks to k
 
 Starting with version 16, EDB TDE introduces the option to choose between AES-128 and AES-256 encryption algorithms during the initialization of the Postgres cluster. The choice between AES-128 and AES-256 hinges on balancing performance and security requirements. AES-128 is commonly advised for environments where performance efficiency and lower power consumption are pivotal, making it suitable for most applications. Conversely, AES-256 is recommended for scenarios demanding the highest level of security, often driven by regulatory mandates.
 
-TDE employs AES-128-XTS or AES-256-XTS algorithms for the encryption of data files. XTS uses a second value, known as the "tweak value", to enhance the encryption. The XTS tweak value with TDE uses the database OID, the relfilenode, and the block number. 
+TDE uses AES-128-XTS or AES-256-XTS algorithms for encrypting data files. XTS uses a second value, known as the *tweak value*, to enhance the encryption. The XTS tweak value with TDE uses the database OID, the relfilenode, and the block number. 
 
 For Write-Ahead Log (WAL) files, TDE utilizes AES-128-CTR or AES-256-CTR, incorporating the WAL's Log Sequence Number (LSN) as the counter component. 
 

--- a/product_docs/docs/tde/15/index.mdx
+++ b/product_docs/docs/tde/15/index.mdx
@@ -74,13 +74,13 @@ EDB Postgres Advanced Server and EDB Postgres Extended Server provide hooks to k
 
 ### How does TDE encrypt data? 
 
-TDE encrypts the data files using AES-128-XTS. The XTS “tweak” uses the database OID, the relfilenode, and the block number.
-<!-- Can you be more explicit? I see that "tweak is an XTS term, but I'm not sure this sentence will be clear to all. Or can you just remove the quote marks around "tweak"?-->
+Starting with version 16, EDB TDE introduces the option to choose between AES-128 and AES-256 encryption algorithms during the initialization of the Postgres cluster. The choice between AES-128 and AES-256 hinges on balancing performance and security requirements. AES-128 is commonly advised for environments where performance efficiency and lower power consumption are pivotal, making it suitable for most applications. Conversely, AES-256 is recommended for scenarios demanding the highest level of security, often driven by regulatory mandates.
 
-The WAL is encrypted using AES-128-CTR. The “counter” includes the WAL LSN.
-<!-- Are quote marks needed around "counter"?-->
+TDE employs AES-128-XTS or AES-256-XTS algorithms for the encryption of data files. The XTS tweak uses the database OID, the relfilenode, and the block number. 
 
-Temporary files that are accessed by block are also encrypted using AES-128-XTS. Other temporary files are encrypted using AES-128-CBC.
+For Write-Ahead Log (WAL) files, TDE utilizes AES-128-CTR or AES-256-CTR, incorporating the WAL's Log Sequence Number (LSN) as the counter component. 
+
+Temporary files that are accessed by block are also encrypted using AES-128-XTS or AES-256-XTS. Other temporary files are encrypted using AES-128-CBC or AES-256-CBC.
 
 ### How is data stored on disk with TDE?
 


### PR DESCRIPTION
Starting with v16, we added the option for AES 256 encryption. Updating the 'How does TDE encrypt data?' section to include the updated choice and algorithms.

## What Changed?

Before: 
TDE encrypts the data files using AES-128-XTS. The XTS “tweak” uses the database OID, the relfilenode, and the block number.

The WAL is encrypted using AES-128-CTR. The “counter” includes the WAL LSN.

Temporary files that are accessed by block are also encrypted using AES-128-XTS. Other temporary files are encrypted using AES-128-CBC.

After: 
Starting with version 16, EDB TDE introduces the option to choose between AES-128 and AES-256 encryption algorithms during the initialization of the Postgres cluster. The choice between AES-128 and AES-256 hinges on balancing performance and security requirements. AES-128 is commonly advised for environments where performance efficiency and lower power consumption are pivotal, making it suitable for most applications. Conversely, AES-256 is recommended for scenarios demanding the highest level of security, often driven by regulatory mandates.

TDE employs AES-128-XTS or AES-256-XTS algorithms for the encryption of data files. The XTS "tweak" uses the database OID, the relfilenode, and the block number. 

For Write-Ahead Log (WAL) files, TDE utilizes AES-128-CTR or AES-256-CTR, incorporating the WAL's Log Sequence Number (LSN) as the counter component. 

Temporary files that are accessed by block are also encrypted using AES-128-XTS or AES-256-XTS. Other temporary files are encrypted using AES-128-CBC or AES-256-CBC.
