### PR TITLE
Add styling for the "info" admonition tag

### DIFF
--- a/src/styles/_admonitions.scss
+++ b/src/styles/_admonitions.scss
@@ -6,7 +6,8 @@
   @extend .alert-success;
 }
 .admonition-note,
-.admonition-seealso {
+.admonition-seealso,
+.admonition-info {
   @extend .alert-secondary;
 }
 .admonition-warning {
@@ -48,7 +49,7 @@
   opacity: 0.6;
 }
 
-.admonition-note {
+.admonition-note, .admonition-info {
   > .admonition-heading h5:before {
     content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"/></svg>');
   }

--- a/src/styles/_dark.scss
+++ b/src/styles/_dark.scss
@@ -154,7 +154,7 @@ html.dark {
       background-color: darken(#e7f1db, 70%) !important;
       color: darken($light, 10%) !important;
     }
-    .admonition-note, .admonition-seealso {
+    .admonition-note, .admonition-seealso, .admonition-info {
       background-color: darken(#e4eef5, 70%) !important;
       color: darken($light, 10%) !important;
     }


### PR DESCRIPTION
## What Changed?

This is almost exclusively used in the PG4K docs, where... Many should probably be SeeAlso instead. But regardless, in MkDocs the "info" styling is a dead ringer for "Note", so I've made them the same here too to avoid shock when writing for one system and then seeing it in the other.