### PR TITLE
pgd: remove deprecation notices for "check_constraints" node group option

### DIFF
--- a/product_docs/docs/pgd/3.7/bdr/nodes.mdx
+++ b/product_docs/docs/pgd/3.7/bdr/nodes.mdx
@@ -1022,8 +1022,6 @@ bdr.alter_node_group_config(node_group_name text,
 -   `apply_delay` - Reserved for backwards compatibility reasons
 -   `check_constraints` - Whether the apply process will check the constraints
       when writing replicated data.
-      **This option is deprecated and may be disabled or removed in future
-      versions of BDR.**
 -   `num_writers` - number of parallel writers for subscription backing
      this node group, -1 means the default (as specified by the pglogical
      GUC pglogical.writers_per_subscription) will be used. Valid values

--- a/product_docs/docs/pgd/4/bdr/nodes.mdx
+++ b/product_docs/docs/pgd/4/bdr/nodes.mdx
@@ -987,8 +987,6 @@ bdr.alter_node_group_config(node_group_name text,
 -   `apply_delay` &mdash; Reserved for backward compatibility.
 -   `check_constraints` &mdash; Whether the apply process checks the constraints
       when writing replicated data.
-      This option is deprecated and will be disabled or removed in future
-      versions of BDR.
 -   `num_writers` &mdash; Number of parallel writers for subscription backing
      this node group. -1 means the default (as specified by the
      GUC `bdr.writers_per_subscription`) is used. Valid values

--- a/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5/reference/nodes-management-interfaces.mdx
@@ -40,8 +40,6 @@ bdr.alter_node_group_config(node_group_name text,
 -   `apply_delay` &mdash; Reserved for backward compatibility.
 -   `check_constraints` &mdash; Whether the apply process checks the constraints
       when writing replicated data.
-      This option is deprecated and will be disabled or removed in future
-      versions of PGD.
 -   `num_writers` &mdash; Number of parallel writers for subscription backing
      this node group. -1 means the default (as specified by the
      GUC `bdr.writers_per_subscription`) is used. Valid values


### PR DESCRIPTION
## What Changed?

This option was removed in BDR 3.7, but hastily reinstated with a deprecation notice as it turned out it was in use by at least one customer. Since then, the customer has continued using the option but no action has been or is likely to be taken to remove, replace or otherwise modify the behaviour of the option, and the presence of the deprecation notices over multiple major releases is causing ongoing confusion, so remove the notices.

BDR-4424.
