### PR TITLE
Adding Dependencies topic to navigation for PEM server

### DIFF
--- a/install_template/templates/products/postgres-enterprise-manager-server/index.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/index.njk
@@ -18,6 +18,7 @@ redirects:
 {% endblock frontmatter %}
 {% block navigation %}
 - prerequisites
+- dependencies
 - linux_x86_64
 - linux_ppc64le
 - windows


### PR DESCRIPTION
Recently a "Linux dependencies" topic was added for PEM 9. This change adds to the navigation for the index page for "Installing the PEM server". 

