### PR TITLE
Edits for DOCS-138 - BA repo token instructions.

### DIFF
--- a/product_docs/docs/pgd/5/cli/installing_cli.mdx
+++ b/product_docs/docs/pgd/5/cli/installing_cli.mdx
@@ -11,7 +11,7 @@ By default, Trusted Postgres Architect installs and configures PGD CLI on each P
 
 ## Installing manually on Linux
 
-PGD CLI is installable from the EDB repositories, which you have access to with your EDB account and within the free trial. These repositories require a token to enable downloads from them. Log in to [EDB Repos 2.0](https://www.enterprisedb.com/repos-downloads) to obtain your token. Then execute the command shown for your operating system, substituting
+PGD CLI is installable from the EDB repositories, which you have access to with your EDB account and within the free trial. These repositories require a token to enable downloads from them. Log in to [EDB Repos 2.0](https://www.enterprisedb.com/repos-downloads) to obtain your token. You may need to click 'Request Access' in order to see the token. Then execute the command shown for your operating system, substituting
 your token for `<your-token>`. 
 
 ### Add repository and install PGD CLI on Debian or Ubuntu

--- a/product_docs/docs/pgd/5/cli/installing_cli.mdx
+++ b/product_docs/docs/pgd/5/cli/installing_cli.mdx
@@ -11,8 +11,8 @@ By default, Trusted Postgres Architect installs and configures PGD CLI on each P
 
 ## Installing manually on Linux
 
-PGD CLI is installable from the EDB repositories. These repositories require a token to enable downloads from them. Log in to [EDB Repos 2.0](https://www.enterprisedb.com/repos-downloads) to obtain your token. Then execute the command shown for your operating system, substituting
-your token for `<your-token>`.
+PGD CLI is installable from the EDB repositories, which you have access to with your EDB account and within the free trial. These repositories require a token to enable downloads from them. Log in to [EDB Repos 2.0](https://www.enterprisedb.com/repos-downloads) to obtain your token. Then execute the command shown for your operating system, substituting
+your token for `<your-token>`. 
 
 ### Add repository and install PGD CLI on Debian or Ubuntu
 

--- a/product_docs/docs/pgd/5/cli/installing_cli.mdx
+++ b/product_docs/docs/pgd/5/cli/installing_cli.mdx
@@ -11,7 +11,11 @@ By default, Trusted Postgres Architect installs and configures PGD CLI on each P
 
 ## Installing manually on Linux
 
-PGD CLI is installable from the EDB repositories, which you have access to with your EDB account and within the free trial. These repositories require a token to enable downloads from them. Log in to [EDB Repos 2.0](https://www.enterprisedb.com/repos-downloads) to obtain your token. You may need to click 'Request Access' in order to see the token. Then execute the command shown for your operating system, substituting
+PGD CLI is installable from the EDB repositories, which you can access with your EDB account. Both PGD users and BigAnimal users, including those on a free trial, will have an EDB account and access to PGD CLI.
+
+ These repositories require a token to enable downloads from them. To obtain your token, log in to [EDB Repos 2.0](https://www.enterprisedb.com/repos-downloads). If this is your first time visiting the EDB Repos 2.0 page, you must click 'Request Access' to generate your token. Once a generated token is available, click on the copy icon to copy it directly to your clipboard or click on the eye icon to view it.
+
+Once you have the token, execute the command shown for your operating system, substituting
 your token for `<your-token>`. 
 
 ### Add repository and install PGD CLI on Debian or Ubuntu


### PR DESCRIPTION
Need to make it clear that BA free trial customers can also access the token from the EDB Repos

## What Changed?

