### PR TITLE
Updated supported EPAS versions for Migration Portal

### DIFF
--- a/product_docs/docs/migration_portal/4/02_supported_platforms.mdx
+++ b/product_docs/docs/migration_portal/4/02_supported_platforms.mdx
@@ -6,7 +6,7 @@ title: "Supported platforms"
 
 <div id="supported_platforms" class="registered_link"></div>
 
-The Migration Portal supports assessment and migration from Oracle 11g, 12c, 18c, and 19c to EDB Postgres Advanced Server 12 and later versions. Migration Portal is supported on the following browsers.
+The Migration Portal supports assessment and migration from Oracle 11g, 12c, 18c, and 19c to EDB Postgres Advanced Server 12, 13, 14, 15, and 16. Migration Portal is supported on the following browsers.
 
 ## Supported browsers
 

--- a/product_docs/docs/migration_portal/4/02_supported_platforms.mdx
+++ b/product_docs/docs/migration_portal/4/02_supported_platforms.mdx
@@ -6,7 +6,7 @@ title: "Supported platforms"
 
 <div id="supported_platforms" class="registered_link"></div>
 
-The Migration Portal supports assessment and migration from Oracle 11g, 12c, 18c, and 19c to EDB Postgres Advanced Server 11, 12, 13, or 14. Migration Portal is supported on the following browsers.
+The Migration Portal supports assessment and migration from Oracle 11g, 12c, 18c, and 19c to EDB Postgres Advanced Server 12 and later versions. Migration Portal is supported on the following browsers.
 
 ## Supported browsers
 


### PR DESCRIPTION
## What Changed?

Looking at the Migration Portal Web UI available at https://migration.enterprisedb.com/, it looks like the supported target EPAS versions have changed. (Dropped support for 11 and added 15 and 16)

Updating the docs to reflect that. I like to use the wording "and later versions" instead of explicitly calling out each version to avoid docs becoming outdated so quickly, but feel free to suggest otherwise. 

