### PR TITLE
Corrections to install templates

### DIFF
--- a/install_template/templates/products/edb-jdbc-connector/base.njk
+++ b/install_template/templates/products/edb-jdbc-connector/base.njk
@@ -10,7 +10,7 @@
 #}
 deployPath: jdbc_connector/{{ product.version }}/installing/linux_{{platform.arch}}/jdbc_{{deploy.map_platform[platform.name]}}.mdx
 redirects:
-  - jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/{{deploy.expand_arch[platform.arch]}}/jdbc42_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
+  - jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/{{deploy.expand_arch[platform.arch]}}/jdbc42_{{deploy.map_platform_old[platform.name]}}_{{platform.arch | replace(r/_?64/g, "")}}.mdx
 {% endblock frontmatter %}
 
 

--- a/install_template/templates/products/edb-postgres-advanced-server/base.njk
+++ b/install_template/templates/products/edb-postgres-advanced-server/base.njk
@@ -77,7 +77,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql ({{ product.version }}.x.x, server {{ product.version }}.x.x)
+psql ({{ product.version }}.0.0, server {{ product.version }}.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -110,7 +110,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_centos_7.mdx
@@ -102,7 +102,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_10.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_debian_11.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_7.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_8.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_rhel_9.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (11.x.x, server 11.x.x)
+psql (11.0.0, server 11.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -110,7 +110,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_centos_7.mdx
@@ -102,7 +102,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_10.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_debian_11.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_7.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_8.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_rhel_9.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (12.x.x, server 12.x.x)
+psql (12.0.0, server 12.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -110,7 +110,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_centos_7.mdx
@@ -102,7 +102,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_10.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_debian_11.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_7.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_8.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_rhel_9.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (13.x.x, server 13.x.x)
+psql (13.0.0, server 13.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -110,7 +110,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_centos_7.mdx
@@ -102,7 +102,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_10.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_debian_11.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_7.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_8.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_rhel_9.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (14.x.x, server 14.x.x)
+psql (14.0.0, server 14.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -110,7 +110,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_centos_7.mdx
@@ -102,7 +102,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_10.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_debian_11.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_7.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_8.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_rhel_9.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (15.x.x, server 15.x.x)
+psql (15.0.0, server 15.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_ppc64le/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/16/installing/linux_ppc64le/epas_rhel_7.mdx
@@ -110,7 +110,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_ppc64le/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/16/installing/linux_ppc64le/epas_rhel_8.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_ppc64le/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/16/installing/linux_ppc64le/epas_rhel_9.mdx
@@ -117,7 +117,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/16/installing/linux_ppc64le/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_ppc64le/epas_sles_15.mdx
+++ b/product_docs/docs/epas/16/installing/linux_ppc64le/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_centos_7.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_centos_7.mdx
@@ -102,7 +102,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_debian_10.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_debian_10.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_debian_11.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_debian_11.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_8.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_8.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_9.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_other_linux_9.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_rhel_7.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_rhel_7.mdx
@@ -108,7 +108,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_rhel_8.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_rhel_8.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_rhel_9.mdx
@@ -115,7 +115,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_sles_12.mdx
@@ -106,7 +106,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_sles_15.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_sles_15.mdx
@@ -107,7 +107,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_ubuntu_20.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_ubuntu_20.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_ubuntu_22.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_ubuntu_22.mdx
@@ -87,7 +87,7 @@ Connect to the `hr` database inside psql:
 ```
 \c hr
 __OUTPUT__
-psql (16.x.x, server 16.x.x)
+psql (16.0.0, server 16.0.0)
 You are now connected to database "hr" as user "enterprisedb".
 ```
 

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_rhel_8.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 8 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel8_ppcle
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel8_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_rhel_9.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_rhel_9.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 9 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel9_ppcle
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_rhel9_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_sles_12.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 12 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_sles_15.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 15 ppc64le
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles15_ppcle
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_centos_7.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_centos_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on CentOS 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_centos7_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_centos7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_debian_10.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_debian_10.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Debian 10 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb10_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb10_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_debian_11.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_debian_11.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Debian 11 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb11_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_deb11_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_8.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on AlmaLinux 8 or Rocky Linux 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux8_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_9.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_other_linux_9.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on AlmaLinux 9 or Rocky Linux 9 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux9_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_other_linux9_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_rhel_7.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_rhel_7.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 7 or OL 7 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel7_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel7_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_rhel_8.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_rhel_8.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 8 or OL 8 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel8_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel8_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_rhel_9.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_rhel_9.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on RHEL 9 or OL 9 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel9_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_rhel9_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_sles_12.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_sles_12.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 12 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_sles_15.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_sles_15.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on SLES 15 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles15_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_ubuntu_20.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_ubuntu_20.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Ubuntu 20.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu20_x86
 ---
 
 ## Prerequisites

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_ubuntu_22.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_ubuntu_22.mdx
@@ -6,7 +6,7 @@ title: Installing EDB JDBC Connector on Ubuntu 22.04 x86_64
 # the documentation team will update the templates accordingly.
 
 redirects:
-  - /jdbc_connector/latest/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu22_x86
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_ubuntu22_x86
 ---
 
 ## Prerequisites


### PR DESCRIPTION
Fix to install example for all versions of EPAS so the output shows the correct version number.

Changed config file to show current version of JDBC connector. 
