### PR TITLE
Updates list of object types

### DIFF
--- a/product_docs/docs/epas/16/reference/oracle_compatibility_reference/epas_compat_sql/35_create_synonym.mdx
+++ b/product_docs/docs/epas/16/reference/oracle_compatibility_reference/epas_compat_sql/35_create_synonym.mdx
@@ -29,8 +29,9 @@ CREATE [OR REPLACE] [PUBLIC] SYNONYM [<schema>.]<syn_name>
 -   Views
 -   Materialized views
 -   Sequences
--   Stored procedures
--   Stored functions
+-   Packages
+-   Procedures
+-   Functions
 -   Types
 -   Objects that are accessible through a database link
 -   Other synonyms


### PR DESCRIPTION
Added "Packages" to the list of database object types that synonyms can be create for.  Support for creating synonyms on packages was added in EPAS 16.

Also, changed "Stored procedures" and "Stored functions" to "Procedures" and "Functions".  The "Stored" qualifier isn't needed in this context since we are already talking about database object types here.

## What Changed?

