### PR TITLE
Release: 2024/03/01a

### DIFF
--- a/advocacy_docs/pg_extensions/pg_failover_slots/configuring.mdx
+++ b/advocacy_docs/pg_extensions/pg_failover_slots/configuring.mdx
@@ -9,8 +9,8 @@ You must add the extension to `shared_preload_libraries` on both the primary ins
 
 The following settings are required: 
 
-- `hot_standby_feedback` should be `on`.
-- `primary_slot_name` should be non-empty.
+- `hot_standby_feedback` must be `on`.
+- `primary_slot_name` must be non-empty.
 
 These settings are necessary to connect to the primary so it can send the `xmin` and `catalog_xmin` separately over `hot_standby_feedback`.
 

--- a/product_docs/docs/efm/4/07_using_efm_utility.mdx
+++ b/product_docs/docs/efm/4/07_using_efm_utility.mdx
@@ -173,9 +173,9 @@ This command must be invoked by efm, a member of the efm group, or root.
 
 `efm upgrade-conf <cluster_name> [-source <directory>]`
 
-Invoke the `efm upgrade-conf` command to copy the configuration files from an existing Failover Manager installation and add parameters required by a Failover Manager installation. Provide the name of the previous cluster when invoking the utility. This command must be invoked with superuser privileges if you are running Failover Manager in the default mode.
+Invoke the `efm upgrade-conf` command to copy the configuration files from an existing Failover Manager installation and add parameters required by a Failover Manager installation. Provide the name of the previous cluster when invoking the utility. This command must be invoked with superuser privileges if you're running Failover Manager in the default mode.
 
-For information on the optional `-source` flag, or if you're upgrading from a Failover Manager configuration that doesn't use sudo, see [Upgrading Failover Manager](upgrading) for more information.
+For information on the optional `-source` flag, or if you're upgrading from a Failover Manager configuration that doesn't use sudo, see [Upgrading Failover Manager](upgrading).
 
 ## efm node-status-json
 

--- a/product_docs/docs/efm/4/upgrading.mdx
+++ b/product_docs/docs/efm/4/upgrading.mdx
@@ -34,7 +34,7 @@ Failover Manager provides a utility to assist you when upgrading a cluster manag
    /usr/efm-4.7/bin/efm stop-cluster efm
    ```
 !!! Note
-    The primary agent will not drop the virtual IP address (if used) when it is stopped; the database will remain up and accessible on the VIP during the EFM upgrade. See also: [Using Failover Manager with virtual IP addresses](04_configuring_efm/05_using_vip_addresses.mdx)
+    The primary agent doesn't drop the virtual IP address (if used) when it's stopped. The database remains up and accessible on the VIP during the EFM upgrade. See also [Using Failover Manager with virtual IP addresses](04_configuring_efm/05_using_vip_addresses.mdx).
 
 6. Start the new [Failover Manager service](08_controlling_efm_service/#controlling_efm_service) (`edb-efm-4.8`) on each node of the cluster.
 
@@ -53,18 +53,20 @@ Upgrade of files is finished. The owner and group for properties and nodes files
 
 ### The optional `-source` flag
 
+You can use the `-source` flag to explicitly specify the directory containing the files to process. If the directory is a Failover Manager configuration location, that is, `/etc/edb/efm-<earlier_version>`, the utility writes the new files in the default configuration directory. This behavior allows upgrading from a specific earlier version if desired.
 
-The `-source` flag can be used to explicitly specify the directory containing the files to be processed. If the directory is a Failover Manager configuration location, i.e. `/etc/edb/efm-<earlier_version>`, the utility will write the new files in the default configuration directory. This allows upgrading from a specific earlier version if desired.
-
-If the source directory is any other directory, the utility will create the new files in the directory where the command was invoked. The files will be owned by the user who ran the command. This is typically used when [using a Failover Manager configuration without sudo](04_configuring_efm/04_extending_efm_permissions/#running_efm_without_sudo), and does not require root privileges.
+If the source directory is any other directory, the utility creates the new files in the directory where the command was invoked. The files are owned by the user who ran the command. This approach is typically used when [using a Failover Manager configuration without sudo](04_configuring_efm/04_extending_efm_permissions/#running_efm_without_sudo), and doesn't require root privileges.
 
 Summary:
-1.  The `-source` flag is not used: the utility will search previous installation directories for configuration files. The new files will be generated in the current default configuration directory and will be owned by `efm` user. The command must be invoked with root privileges.
-2.  The `-source` flag is set to a previous installation's configuration directory: the utility will only look in the specified directory for configuration files. The new files will be generated in the current default configuration directory and will be owned by the `efm` user. The command must be invoked with root privileges.
-3.  The `-source` flag is set to any other directory: the utility will only look in the specified directory for configuration files. The new files will be generated in the directory from which the command was invoked and will be owned by the user invoking the command. Root privileges are not required.
+
+-  **The `-source` flag isn't used.** The utility searches previous installation directories for configuration files. The new files are generated in the current default configuration directory and are owned by the efm user. Root privileges are required.
+
+-  **The `-source` flag is set to a previous installation's configuration directory.** The utility looks only in the specified directory for configuration files. The new files are generated in the current default configuration directory and are owned by the efm user. Root privileges are required.
+
+-  **The `-source` flag is set to any other directory.** The utility looks only in the specified directory for configuration files. The new files are generated in the directory from which the command was invoked and are owned by the user invoking the command. Root privileges aren't required.
 
 !!! Note
-    In all cases, if a `<cluster_name>.properties` or `<cluster_name>.nodes` file already exists in the target directory, it is renamed with a timestamp before the new file is saved.
+    In all cases, if a `<cluster_name>.properties` or `<cluster_name>.nodes` file already exists in the target directory, it's renamed with a timestamp before the new file is saved.
 
 ## Uninstalling Failover Manager
 

--- a/product_docs/docs/pgd/5/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/5/upgrades/upgrade_paths.mdx
@@ -26,7 +26,7 @@ release before upgrading to the latest version 5 release. After upgrading to
 
 ## Upgrading from version 3.7 to version 5
 
-You can upgrade from version 3.7.23 onwards to version 5.3.0 or later. 
+Starting with version 3.7.23, you can upgrade directly to version 5.3.0 or later. 
 For earlier versions, upgrade to 3.7.23 before upgrading to 5. 
 See [Upgrading within version 3.7](/pgd/3/upgrades/upgrade_paths/#upgrading-within-version-37) 
 for more information. 

--- a/product_docs/docs/postgres_for_kubernetes/1/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/index.mdx
@@ -80,6 +80,8 @@ and OpenShift. It is designed, developed, and supported by EDB and covers the
 full lifecycle of a highly available Postgres database clusters with a
 primary/standby architecture, using native streaming replication.
 
+EDB Postgres for Kubernetes was made generally available on February 4, 2021. Earlier versions were made available to selected customers prior to the GA release. 
+
 !!! Note
     The operator has been renamed from Cloud Native PostgreSQL. Existing users
     of Cloud Native PostgreSQL will not experience any change, as the underlying

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_0_1_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_0_1_rel_notes.mdx
@@ -1,0 +1,19 @@
+---
+title: "EDB Postgres for Kubernetes 0.0.1 release notes"
+navTitle: "Version 0.0.1"
+---
+
+Released: 5 Mar 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | PostgreSQL 12.2 container image.           |
+| Feature | Self-Healing capability, through failover of the primary instance, by promoting the most aligned replica.             |
+| Feature | Self-Healing capability, through automated recreation of a replica.             |
+| Feature | Planned switchover of the primary instance, by promoting a selected replica.                                                                    |
+| Feature | Scale up/down capabilities.           |
+| Feature | Definition of an arbitrary number of instances (minimum 1 - one primary server).           |
+| Feature | Definition of the *read-write* service, to connect your applications to the only primary server of the cluster.           |
+| Feature | Definition of the *read-only* service, to connect your applications to any of the instances for read workloads.           |
+| Feature | Support for Local Persistent Volumes with PVC templates.           |
+| Feature | Standard output logging of PostgreSQL error messages.           |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_1_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_1_0_rel_notes.mdx
@@ -1,0 +1,20 @@
+---
+title: "EDB Postgres for Kubernetes 0.1 release notes"
+navTitle: "Version 0.1"
+---
+
+Released: 3 Apr 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | Reuse of existing persistent storage with Pods (required for rolling updates).           |
+| Feature | Independence between operator container image and PostgreSQL container image (required by rolling updates) - this enables usage of Community PostgreSQL images.             |
+| Feature | Rolling updates for the update of the operator and the entire cluster to a new version of PostgreSQL, by updating all the replicas first; switchover can be entirely managed by Kubernetes once replicas have been updated (`unsupervised` option), or manually triggered by the user (`supervised` option).                                                                    |
+| Feature | Check framework for update-in-progress of a Pod.           |
+| Enhancement | Improvements in cluster status information.           |
+| Enhancement | E2E tests for Kubernetes 1.18.           |
+| Enhancement | E2E performance tests for failover (< 5 seconds).           |
+| Enhancement | Improvements in E2E tests for switchover.           |
+| Feature | Support for PostgreSQL's `cluster_name` GUC.           |
+| Feature | New documentation section `Exposing Postgres services`.           |
+| Feature | New documentation section `Security`.           |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_2_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_2_0_rel_notes.mdx
@@ -1,0 +1,15 @@
+---
+title: "EDB Postgres for Kubernetes 0.2 release notes"
+navTitle: "Version 0.2"
+---
+
+Released: 11 Aug 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | PostgreSQL 10 and 11 are now supported, in addition to PostgreSQL 12.           |
+| Feature | Usage of UBI as base image of the operator (OpenShift support).             |
+| Feature | New Backup and ScheduledBackup CRD, allowing users to take a physical backup of the cluster in an object store that complies with the S3 protocol (such as AWS S3, MinIO, MinIO Gateway).                                                                    |
+| Feature | Support for WAL archiving to an object store that complies with the S3 protocol.           |
+| Enhancement | Improvements in the E2e tests infrastructure.           |
+| Fix | Bug fixes and minor improvements.           |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_3_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_3_0_rel_notes.mdx
@@ -1,0 +1,20 @@
+---
+title: "EDB Postgres for Kubernetes 0.3 release notes"
+navTitle: "Version 0.3"
+---
+
+Released: 25 Sep 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | Support for PostgreSQL 13.           |
+| Feature | Remove `emptyDir` volume storage support.             |
+| Feature | Node maintenance support for PostgreSQL clusters with local storage through the `nodeMaintenanceWindow` parameter.                                                                    |
+| Enhancement | Improve PostgreSQL configuration management through the usage of a dictionary supporting default, required and fixed values.                                                  |
+| Feature | Use MD5 as authentication method for inter-cluster communication, with automated password creation in a secret.           |
+| Feature | Remove need for "trust" authentication method.           |
+| Feature | `spec.postgresql.pg_hba` is now optional, defaulting to MD5 authentication required for communication between Pods and `peer` for in-Pod communication.           |
+| Feature | Remove "unusable" annotation support, now PVC can just be removed followed by a deletion of the corresponding Pod.           |
+| Feature | Support for license keys, including implicit 30 day trial version.           |
+| Fix | Bug fixes and minor improvements.           |
+| Feature | Update from an earlier version not supported.           |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_4_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_4_0_rel_notes.mdx
@@ -1,0 +1,17 @@
+---
+title: "EDB Postgres for Kubernetes 0.4 release notes"
+navTitle: "Version 0.4"
+---
+
+Released: 5 Nov 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | Support for full recovery from a backup.           |
+| Feature | Add `bootstrap` section to configure how to initiate a cluster: `initDB` or `fullRecovery`.             |
+| Feature | Introduce defaulting and validating webhooks.                                                                    |
+| Feature | Simplify configuration (convention over configuration).                                                  |
+| Feature | Constrain rolling upgrades to the same PostgreSQL major version.           |
+| Feature | End-to-end tests run on GKE, AKS and GKS.           |
+| Enhancement | Documentation improvements.           |
+| Enhancement | Bug fixes and minor improvements.           |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_5_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_5_0_rel_notes.mdx
@@ -1,0 +1,19 @@
+---
+title: "EDB Postgres for Kubernetes 0.5 release notes"
+navTitle: "Version 0.5"
+---
+
+Released: 20 Nov 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | Automated provisioning of an independent Certification Authority (CA) for each PostgreSQL cluster.           |
+| Feature | Transparent and native support for TLS/SSL connections to encrypt client/server communications.             |
+| Enhancement | Improve the security of the standby streaming replication channel through a dedicated and fixed database user called `streaming_replica` with sole `REPLICATION` privileges and II. an automatically managed X.509 TLS certificate signed by the cluster Certification Authority to authenticate the `streaming_replica` user.         |
+| Enhancement | Improve the security of the standby streaming replication channel through an automatically managed X.509 TLS certificate signed by the cluster Certification Authority to authenticate the `streaming_replica` user.         |
+| Enhancement | Improve PostgreSQL configuration capability through a mutating webhook that prevents users from changing those parameters that are directly managed by the operator.                                                                    |
+| Enhancement | Improve PostgreSQL configuration capability through a defaulting webhook that integrates the users' supplied configuration options with default values in the cluster state.                                                                    |
+| Enhancement | Improve PostgreSQL configuration capability through automated management of the PostgreSQL instances reload and restart.                                                                    |
+| Feature | Enable custom and independent configuration of a PostgreSQL cluster following a recovery from a backup.                                                                    |
+| Feature | Convey the current status of the cluster (i.e. healthy, failover in progress, switchover in progress).                                                  |
+| Feature | API change from k8s.2ndq.io to k8s.enterprisedb.io.           |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_6_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_6_0_rel_notes.mdx
@@ -1,0 +1,21 @@
+---
+title: "EDB Postgres for Kubernetes 0.6 release notes"
+navTitle: "Version 0.6"
+---
+
+Released: 4 Dec 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | Add Point-In-Time Recovery based on timestamp, target name, or transaction Id, as well as the specification of the timeline, through a new bootstrap method option called `recoveryTarget`. |
+| Feature | Add Synchronous Streaming Replication support through the `minSyncReplicas` and `maxSyncReplicas` cluster options, defining respectively the expected minimum and maximum number of synchronous standby servers at any time (disabled by default)                                  |
+| Feature | Support EDB Postgres Advanced Server (EPAS).                                                                 |
+| Feature | Configure `initdb` options for the bootstrap of an empty cluster (`initDb`).                                 |
+| Feature | Enable/Disable Redwood compatibility level with EPAS.                                                        |
+| Feature | Extend the instance manager with a new framework for the export of metrics for Prometheus - currently supporting pg_stat_archiver only.                                                  |
+| Feature | Use Kubernetes jobs instead of init containers to perform cluster initialization procedures (including standby creation and recovery) and improve their observability.                                                  |
+| Feature | Record Kubernetes events to be used by `kubectl describe` and `kubectl get events`.                          |
+| Feature | Introduce Kubernetes expectations for Pods, PVCs, and Jobs to prevent race conditions.                       |
+| Feature | Set `application_name` in PostgreSQL to the name of the Pod/instance.                                        |
+| Feature | The `fullRecovery` bootstrap mode has been renamed to `recovery` to address also Point-In-Time Recovery      |
+| Fix     | Bug fixes and code improvements.                                                                             |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_7_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_7_0_rel_notes.mdx
@@ -1,0 +1,16 @@
+---
+title: "EDB Postgres for Kubernetes 0.7 release notes"
+navTitle: "Version 0.7"
+---
+
+Released: 31 Dec 2020
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | Support `pg_rewind` if needed following a failover or switchover to let the former primary act as a standby. |
+| Feature | Add persistent volume expansion support, if permitted by the storage class.                                  |
+| Enhancement | Enhance metrics exporter for PostgreSQL.                                                                     |
+| Feature | Add support for Kubernetes version 1.20.                                                                     |
+| Feature | Drop support for Kubernetes version 1.15.                                                                    |
+| Feature | Refactor E2E tests, including conversion to Github actions.                                                  |
+| Fix     | Bug fixes and code improvements.                                                                             |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_8_0_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/0_8_0_rel_notes.mdx
@@ -1,0 +1,17 @@
+---
+title: "EDB Postgres for Kubernetes 0.8 release notes"
+navTitle: "Version 0.8"
+---
+
+Released: 29 Jan 2021
+
+| Type    | Description                                                                                                  |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| Feature | Upgraded API version to v1.                                                                                  |
+| Feature | Implement node affinity via `nodeSelector`.                                                                  |
+| Feature | Activate `AntiAffinity` by default.                                                                          |
+| Feature | Remove completed `Jobs` from the cluster.                                                                    |
+| Feature | Upgrade controller-runtime to v0.8.1.                                                                        |
+| Change  | Build container images using schema version 2.                                                               |
+| Change  | Enhance E2E tests by covering more cases, robustness, and reliability improvements.                          |
+| Fix     | Bug fixes and code improvements.                                                                             |

--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/index.mdx
@@ -73,6 +73,15 @@ navigation:
 - 1_2_rel_notes
 - 1_1_rel_notes
 - 1_0_rel_notes
+- 0_8_0_rel_notes
+- 0_7_0_rel_notes
+- 0_6_0_rel_notes
+- 0_5_0_rel_notes
+- 0_4_0_rel_notes
+- 0_3_0_rel_notes
+- 0_2_0_rel_notes
+- 0_1_0_rel_notes
+- 0_0_1_rel_notes
 ---
 
 The EDB Postgres for Kubernetes documentation describes the major version of EDB Postgres for Kubernetes, including minor releases and patches. The release notes provide information on what is new in each release. For new functionality introduced in a minor or patch release, the content also indicates the release that introduced the feature.
@@ -149,5 +158,20 @@ The EDB Postgres for Kubernetes documentation describes the major version of EDB
 | [1.1.0](1_1_rel_notes)     | 03 Mar 2021 | NA                                                                                          |
 | [1.0.0](1_0_rel_notes)     | 04 Feb 2021 | NA                                                                                          |
 
+
+EDB Postgres for Kubernetes was made generally available on February 4, 2021. Earlier versions were made available to selected customers prior to the GA release. 
+
+
+|          Version           | Release date |                                       Upstream merges                                       |
+| -------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| [0.8.0](0_8_0_rel_notes)   | 29 Jan 2021 | NA |
+| [0.7.0](0_7_0_rel_notes)   | 31 Dec 2020 | NA |
+| [0.6.0](0_6_0_rel_notes)   | 04 Dec 2020 | NA |
+| [0.5.0](0_5_0_rel_notes)   | 20 Nov 2020 | NA |
+| [0.4.0](0_4_0_rel_notes)   | 05 Nov 2020 | NA |
+| [0.3.0](0_3_0_rel_notes)   | 25 Sep 2020 | NA |
+| [0.2.0](0_2_0_rel_notes)   | 11 Aug 2020 | NA |
+| [0.1.0](0_1_0_rel_notes)   | 03 Apr 2020 | NA |
+| [0.0.1](0_0_1_rel_notes)   | 05 Mar 2020 | NA |
 
 


### PR DESCRIPTION
## What Changed?

EDB Postgres for Kubernetes
- Release Notes for versions earlier than 1.0

Edits to pg_failover and efm

