### PR TITLE
PGD: add missing columns to "bdr.nodes" reference

### DIFF
--- a/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
+++ b/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
@@ -435,22 +435,26 @@ Information about status of either subscription or table synchronization process
 
 This table lists all the PGD nodes in the cluster.
 
+The view [`bdr.node_summary`](#bdrnode_summary) provides a human-readable version of most of the columns from `bdr.node`.
+
 #### `bdr.node` columns
 
-| Name                  | Type    | Description                                                                 |
-| --------------------- | ------- | --------------------------------------------------------------------------- |
-| node_id               | oid     | ID of the node                                                              |
-| node_name             | name    | Name of the node                                                            |
-| node_group_id         | oid     | ID of the node group                                                        |
-| source_node_id        | oid     | ID of the source node                                                       |
-| synchronize_structure | "char"  | Schema synchronization done during the join                                 |
-| node_state            | oid     | Consistent state of the node                                                |
-| target_state          | oid     | State that the node is trying to reach (during join or promotion)           |
-| seq_id                | int4    | Sequence identifier of the node used for generating unique sequence numbers |
-| dbname                | name    | Database name of the node                                                   |
-| node_dsn              | char    | Connection string for the node                                              |
-| proto_version_ranges  | int\[]  | Supported protocol version ranges by the node                               |
-| node_join_finished    | boolean | Check if the join is finished                                               |
+| Name                  | Type     | Description                                                                   |
+| --------------------- | -------- | ----------------------------------------------------------------------------- |
+| node_id               | oid      | ID of the node                                                                |
+| node_name             | name     | Name of the node                                                              |
+| node_group_id         | oid      | ID of the node group                                                          |
+| source_node_id        | oid      | ID of the source node                                                         |
+| synchronize_structure | "char"   | Schema synchronization done during the join                                   |
+| node_state            | oid      | Consistent state of the node                                                  |
+| target_state          | oid      | State that the node is trying to reach (during join or promotion)             |
+| seq_id                | int4     | Sequence identifier of the node used for generating unique sequence numbers   |
+| dbname                | name     | Database name of the node                                                     |
+| node_dsn              | char     | Connection string for the node                                                |
+| proto_version_ranges  | int\[]   | Supported protocol version ranges by the node                                 |
+| generation            | smallint | A counter incremented when a node joins with the same name as a previous node |
+| node_kind             | oid      | The ID of the node kind                                                       |
+| node_join_finished    | boolean  | Check if the join is finished                                                 |
 
 ### `bdr.node_catchup_info`
 


### PR DESCRIPTION
## What Changed?

Added descriptions for following columns:

- `generated`
- `node_kind`

Also add a link to the human-readable `bdr.node_summary` view.

BDR-4743.



