### PR TITLE
Integrate CS and Sales articles into technical documentation

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_aws.mdx
@@ -11,6 +11,10 @@ Before connecting your cloud, make sure that you're assigned the following AWS m
 
 - arn:aws:iam::aws:policy/ServiceQuotasFullAccess
 
+!!! note
+    BigAnimal is deployed in a VPC within your Cloud Service Provider (CSP). To make changes or modify your BigAnimal clusters, use the BigAnimal Portal, the API, or CLI to manage and execute the activity. You can also open a support case if you need help. Making changes in the resources within those dedicated VPCs can impact EDB’s ability to deliver service.
+
+
 ## Connecting your cloud
 
 !!! tip

--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_azure.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_azure.mdx
@@ -6,6 +6,10 @@ navTitle: Azure
 !!! note
     The BigAnimal CLI commands used for connecting your cloud to BigAnimal register an application with Azure AD and create a service principal to delegate identity and access management functions to Azure Active Directory (AD). For more information, see for [Azure EDB cloud utilities](https://github.com/EnterpriseDB/cloud-utilities/tree/main/azure) in GitHub.
 
+!!! note
+    BigAnimal is deployed in a dedicated VNET within your Cloud Service Provider (CSP). To make changes or modify your BigAnimal clusters, use the BigAnimal Portal, the API, or CLI to manage and execute the activity. You can also open a support case if you need help. Making changes to the resources within those dedicated VPCs can impact EDB’s ability to deliver service.
+    
+
 ## Prerequisites
 Before connecting to your cloud, make sure that you're assigned either the Global Administrator role or the Privileged Role Administrator role in Azure AD and that you have the Owner role for your BigAnimal Azure subscription.
 

--- a/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_gcp.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/02_connecting_to_your_cloud/connecting_gcp.mdx
@@ -3,6 +3,10 @@ title: Connecting your Google Cloud
 navTitle: Google Cloud
 ---
 
+!!! note
+    BigAnimal is deployed in a VPC within your Cloud Service Provider (CSP). To make changes or modify your BigAnimal clusters, use the BigAnimal Portal, the API, or CLI to manage and execute the activity. You can also open a support case if you need help. Making changes in the resources within those dedicated VPCs can impact EDB’s ability to deliver service.
+
+
 ## Prerequisites
 
 Ensure you have at least the following combined roles:

--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -145,6 +145,9 @@ The following options aren't available when creating your cluster:
 
 3.  To optionally make updates to your database configuration parameters, select **Next: DB Configuration**.
 
+!!! note
+    Make changes to database or server parameters after cluster creation is complete. *Note that changing some parameters requires a restart*
+
 ## DB Configuration tab
 
 In the **Parameters** section, you can update the value of the database configuration parameters as needed. 

--- a/product_docs/docs/biganimal/release/getting_started/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/index.mdx
@@ -2,6 +2,7 @@
 title: "Getting started"
 indexCards: simple
 navigation:
+ - overview
  - 00_free_trial
  - identity_provider
  - 02_azure_market_setup

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -10,7 +10,7 @@ description: A high level description of the tasks needed to get started with Bi
 Use the following high-level steps to set up a BigAnimal account and begin using your new database.
 
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/). After setting up the account, you can access the BigAnimal portal, with all of its features and capabilities. 
-    
+
 1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
@@ -38,6 +38,18 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
 
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
 
+    1. Go to <https://portal.biganimal.com>.
+
+    1. Select **EDB Account**.
+
+    1. Under the login boxes, select **Create EDB account**. 
+
+    1. Complete the required information on the next page.
+        After providing the account request information, you will receive an email from EDB. Finish your account activation by clicking the activation link in the email. The activation link expires in 72 hours.
+
+    1. When prompted, create a password for your new EDB account. 
+    
+  
 1. Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).
     
 1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -4,70 +4,18 @@ navTitle: "Overview"
 description: A high level description of the tasks needed to get started with BigAnimal 
 ---
 
-I drafted two approaches
 
-## Option 1 - Consolidated instructions
-
-Use the following high-level steps to connect BigAnimal to your cloud account and begin using your new database. The steps vary depending on whether you are using your own cloud account or the BigAnimal portal.
-
-1. *If using your own cloud account:* Ensure you have the correct access permissions for your cloud account. 
-    - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner
-
-    - AWS&mdash;IAMFullAccess policy and ServiceQuotasFullAccess policy
-
-    - Google Cloud&mdash;roles/owner or at least the following combined roles:
-
-        - roles/iam.serviceAccountCreator
-
-        - roles/iam.serviceAccountKeyAdmin
-
-        - roles/iam.roleAdmin
-
-        - roles/resourcemanager.projectIamAdmin
-        
-        - roles/compute.viewer
-
-1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
-
-1. After signing into your EDB account for the first time, take one of the following steps:
-    - Continue to use BigAnimal as your portal and skip to the next step.
-
-    - Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).
-    
-1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
-   Although we recommend using a CLI, it is not essential.
-
-1. *If using your own cloud account:* Prepare your cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
-    - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
-
-    - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
-
-    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
-
-1. *If using your own cloud account:* Connect to your cloud. See [Connecting to your cloud](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/02_connecting_to_your_cloud/).
-
-1. *If using your own cloud account:* Activate and manage regions. See [Managing regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/). 
-
-1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
-
-1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
-
-## Option 2 - Two procedures based on cloud approach
-
-### Getting started using the Big Animal portal 
+## Getting started using Big Animal's cloud account 
 
 Use the following high-level steps to set up a BigAnimal account and begin using your new database.
 
-1. Create an EDB account. After setting up the account, you can continue to use BigAnimal as your portal. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
+1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/). After setting up the account, you can access the BigAnimal portal, with all of its features and capabilities. 
     
-1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
-   Although we recommend using a CLI, it is not essential.
-
 1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
 
-### Getting started using your own cloud account
+## Getting started using your own cloud account
 
 Use the following high-level steps to connect BigAnimal to your own cloud account and begin using your new database. 
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -20,6 +20,7 @@ Use the following high-level steps to set up a BigAnimal account and begin using
 Use the following high-level steps to connect BigAnimal to your own cloud account and begin using your new database. 
 
 1. Ensure you have the correct access permissions for your cloud account. 
+
     - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner
 
     - AWS&mdash;IAMFullAccess policy and ServiceQuotasFullAccess policy
@@ -56,6 +57,7 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
    Although we recommend using a CLI, it is not essential.
 
 1. Prepare your cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
+
     - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
 
     - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
@@ -73,7 +75,9 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
 1. Optionally, set up private networking to allow you to connect to your cluster from other applications. Depending on your cloud service provider, see one of the following:
 
 - [Connecting from Azure](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/)
+
 - [Connecting from AWS](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/)
+
 - [Connecting from Google Cloud](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/connecting_from_gcp/)
 
 1. Provide access to other users. See [Managing user access](https://www.enterprisedb.com/docs/biganimal/latest/administering_cluster/01_portal_access/).

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -1,0 +1,43 @@
+---
+title: "Getting started overview"
+navTitle: "Overview"
+description: A high level description of the tasks needed to get started with BigAnimal 
+---
+
+Follow the steps below to connect BigAnimal to your cloud account and begin using your new database.
+
+1. Ensure you have the correct access permissions for your cloud account. 
+    - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner.
+    - AWS&mdash;IAMFullAccess policy AND ServiceQuotasFullAccess policy
+    - Google Cloud&mdash;roles/owner or at least the following combined roles:
+        - roles/iam.serviceAccountCreator
+        - roles/iam.serviceAccountKeyAdmin
+        - roles/iam.roleAdmin
+        - roles/resourcemanager.projectIamAdmin
+        - roles/compute.viewer
+
+1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
+
+1. After signing into your EDB account for the first time you can take one of the following steps:
+    - Continue to use BigAnimal as your portal and skip to the next step.
+    - Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).$
+
+1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
+    We recommend using a CLI but it is not essential.
+
+1. If you are not using BigAnimal's cloud account, you must prepare your cloud to work with BigAnimal. Do this every time you create a new cluster. The required steps vary by cloud provider:
+    - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
+    - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
+    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/03_preparing_gcp/).
+
+1. Connect to your cloud. See [Connecting to your cloud](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/02_connecting_to_your_cloud/).
+
+1. Activate and manage regions. See [Managing regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/). 
+
+1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
+
+1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/).
+
+
+
+

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -68,7 +68,15 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
 
 1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
 
-1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
+1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/).
+
+1. Optionally, set up private networking to allow you to connect to your cluster from other applications. Depending on your cloud service provider, see one of the following:
+
+- [Connecting from Azure](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/)
+- [Connecting from AWS](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/)
+- [Connecting from Google Cloud](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/connecting_from_gcp/)
+
+1. Provide access to other users. See [Managing user access](https://www.enterprisedb.com/docs/biganimal/latest/administering_cluster/01_portal_access/).
 
 
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -4,9 +4,13 @@ navTitle: "Overview"
 description: A high level description of the tasks needed to get started with BigAnimal 
 ---
 
-Use the following high-level steps to connect BigAnimal to your cloud account and begin using your new database.
+I drafted two approaches
 
-1. Ensure you have the correct access permissions for your cloud account. 
+## Option 1 - Consolidated instructions
+
+Use the following high-level steps to connect BigAnimal to your cloud account and begin using your new database. The steps vary depending on whether you are using your own cloud account or the BigAnimal portal.
+
+1. *If using your own cloud account:* Ensure you have the correct access permissions for your cloud account. 
     - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner
 
     - AWS&mdash;IAMFullAccess policy and ServiceQuotasFullAccess policy
@@ -33,7 +37,65 @@ Use the following high-level steps to connect BigAnimal to your cloud account an
 1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
    Although we recommend using a CLI, it is not essential.
 
-1. If you are not using BigAnimal's cloud account, prepare your own cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
+1. *If using your own cloud account:* Prepare your cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
+    - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
+
+    - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
+
+    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
+
+1. *If using your own cloud account:* Connect to your cloud. See [Connecting to your cloud](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/02_connecting_to_your_cloud/).
+
+1. *If using your own cloud account:* Activate and manage regions. See [Managing regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/). 
+
+1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
+
+1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
+
+## Option 2 - Two procedures based on cloud approach
+
+### Getting started using the Big Animal portal 
+
+Use the following high-level steps to set up a BigAnimal account and begin using your new database.
+
+1. Create an EDB account. After setting up the account, you can continue to use BigAnimal as your portal. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
+    
+1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
+   Although we recommend using a CLI, it is not essential.
+
+1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
+
+1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
+
+### Getting started using your own cloud account
+
+Use the following high-level steps to connect BigAnimal to your own cloud account and begin using your new database. 
+
+1. Ensure you have the correct access permissions for your cloud account. 
+    - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner
+
+    - AWS&mdash;IAMFullAccess policy and ServiceQuotasFullAccess policy
+
+    - Google Cloud&mdash;roles/owner or at least the following combined roles:
+
+        - roles/iam.serviceAccountCreator
+
+        - roles/iam.serviceAccountKeyAdmin
+
+        - roles/iam.roleAdmin
+
+        - roles/resourcemanager.projectIamAdmin
+        
+        - roles/compute.viewer
+
+1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
+
+1. Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).
+    
+1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
+   Although we recommend using a CLI, it is not essential.
+
+1. Prepare your cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
     - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
 
     - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
@@ -47,6 +109,7 @@ Use the following high-level steps to connect BigAnimal to your cloud account an
 1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
+
 
 
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -8,30 +8,37 @@ Use the following high-level steps to connect BigAnimal to your cloud account an
 
 1. Ensure you have the correct access permissions for your cloud account. 
     - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner
-    - AWS&mdash;IAMFullAccess policy and ServiceQuotasFullAccess policy
-    - Google Cloud&mdash;roles/owner or at least the following combined roles:
-        - roles/iam.serviceAccountCreator
-        - roles/iam.serviceAccountKeyAdmin
-        - roles/iam.roleAdmin
-        - roles/resourcemanager.projectIamAdmin
-        - roles/compute.viewer
 
+    - AWS&mdash;IAMFullAccess policy and ServiceQuotasFullAccess policy
+
+    - Google Cloud&mdash;roles/owner or at least the following combined roles:
+
+        - roles/iam.serviceAccountCreator
+
+        - roles/iam.serviceAccountKeyAdmin
+
+        - roles/iam.roleAdmin
+
+        - roles/resourcemanager.projectIamAdmin
+        
+        - roles/compute.viewer
 
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
 
 1. After signing into your EDB account for the first time, take one of the following steps:
     - Continue to use BigAnimal as your portal and skip to the next step.
+
     - Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).
-
-
+    
 1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
    Although we recommend using a CLI, it is not essential.
 
 1. If you are not using BigAnimal's cloud account, prepare your own cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
     - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
-    - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
-    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
 
+    - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
+
+    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
 
 1. Connect to your cloud. See [Connecting to your cloud](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/02_connecting_to_your_cloud/).
 
@@ -39,7 +46,7 @@ Use the following high-level steps to connect BigAnimal to your cloud account an
 
 1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
 
-1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/).
+1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
 
 
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -13,7 +13,7 @@ Use the following high-level steps to set up a BigAnimal account and begin using
 
 1. Create a cluster. When prompted for **Where to deploy**, select **BigAnimal**. See [Creating a cluster](/creating_a_cluster/). 
 
-1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
+1. Use your cluster. See [Using your cluster](../using_cluster/)
 
 ## Getting started using your own cloud account
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -11,7 +11,7 @@ Use the following high-level steps to set up a BigAnimal account and begin using
 
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/). After setting up the account, you can access the BigAnimal portal, with all of its features and capabilities. 
 
-1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). When prompted for **Where to deploy**, select **BigAnimal**.
+1. Create a cluster. When prompted for **Where to deploy**, select **BigAnimal**. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). 
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
 
@@ -37,7 +37,7 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
         
         - roles/compute.viewer
 
-1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
+1. Create an EDB account. See [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
 
     1. Go to [https://portal.biganimal.com](https://portal.biganimal.com).
 
@@ -58,27 +58,27 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
 
 1. Prepare your cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
 
-    - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
+    - [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
 
-    - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
+    - [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
 
-    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
+    - [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
 
 1. Connect to your cloud. See [Connecting to your cloud](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/02_connecting_to_your_cloud/).
 
 1. Activate and manage regions. See [Managing regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/). 
 
-1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). When prompted for **Where to deploy**, select **Your Cloud Account**.
+1. Create a cluster. When prompted for **Where to deploy**, select **Your Cloud Account**. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). 
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/).
 
 1. Optionally, set up private networking to allow you to connect to your cluster from other applications. Depending on your cloud service provider, see one of the following:
 
-- [Connecting from Azure](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/)
+    - [Connecting from Azure](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/)
 
-- [Connecting from AWS](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/)
+    - [Connecting from AWS](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/)
 
-- [Connecting from Google Cloud](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/connecting_from_gcp/)
+    - [Connecting from Google Cloud](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/connecting_from_gcp/)
 
 1. Provide access to other users. See [Managing user access](https://www.enterprisedb.com/docs/biganimal/latest/administering_cluster/01_portal_access/).
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -11,7 +11,7 @@ Use the following high-level steps to set up a BigAnimal account and begin using
 
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/). After setting up the account, you can access the BigAnimal portal, with all of its features and capabilities. 
 
-1. Create a cluster. When prompted for **Where to deploy**, select **BigAnimal**. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). 
+1. Create a cluster. When prompted for **Where to deploy**, select **BigAnimal**. See [Creating a cluster](/creating_a_cluster/). 
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -4,14 +4,19 @@ navTitle: "Overview"
 description: A high level description of the tasks needed to get started with BigAnimal 
 ---
 
+BigAnimal provides two options for setting up and accessing a cloud account for your new database:
 
-## Getting started using Big Animal's cloud account 
+- [Using BigAnimal's cloud account](#getting-started-using-a-biganimal-cloud-account)
+
+- [Using your own cloud account with BigAnimal](#getting-started-using-your-own-cloud-account)
+
+## Getting started using a BigAnimal cloud account 
 
 Use the following high-level steps to set up a BigAnimal account and begin using your new database.
 
-1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/). After setting up the account, you can access the BigAnimal portal, with all of its features and capabilities. 
+1. Create an EDB account. For more information see [Create an EDB account](../free_trial/detail/create_an_account/). After setting up the account, you can access the BigAnimal portal, with all of its features and capabilities. 
 
-1. Create a cluster. When prompted for **Where to deploy**, select **BigAnimal**. See [Creating a cluster](/creating_a_cluster/). 
+1. Create a cluster. When prompted for **Where to deploy**, select **BigAnimal**. See [Creating a cluster](../creating_a_cluster/). 
 
 1. Use your cluster. See [Using your cluster](../using_cluster/)
 
@@ -37,7 +42,7 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
         
         - roles/compute.viewer
 
-1. Create an EDB account. See [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
+1. Create an EDB account. See [Create an EDB account](../free_trial/detail/create_an_account/).
 
     1. Go to [https://portal.biganimal.com](https://portal.biganimal.com).
 
@@ -51,36 +56,36 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
     1. When prompted, create a password for your new EDB account. 
     
   
-1. Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).
+1. Set up your own identity provider. For more information see [Setting up your identity provider](identity_provider/).
     
-1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
+1. Set up a CLI. See [Using the BigAnimal CLI](../reference/cli/). 
    Although we recommend using a CLI, it is not essential.
 
 1. Prepare your cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
 
-    - [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
+    - [Preparing your Azure account](preparing_cloud_account/01_preparing_azure/).
 
-    - [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
+    - [Preparing your AWS account](preparing_cloud_account/02_preparing_aws/).
 
-    - [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
+    - [Preparing your Google Cloud account](preparing_cloud_account/preparing_gcp/).
 
-1. Connect to your cloud. See [Connecting to your cloud](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/02_connecting_to_your_cloud/).
+1. Connect to your cloud. See [Connecting to your cloud](02_connecting_to_your_cloud/).
 
-1. Activate and manage regions. See [Managing regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/). 
+1. Activate and manage regions. See [Managing regions](activating_regions/). 
 
-1. Create a cluster. When prompted for **Where to deploy**, select **Your Cloud Account**. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). 
+1. Create a cluster. When prompted for **Where to deploy**, select **Your Cloud Account**. See [Creating a cluster](../creating_a_cluster/). 
 
-1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/).
+1. Use your cluster. See [Using your cluster](../using_cluster/).
 
 1. Optionally, set up private networking to allow you to connect to your cluster from other applications. Depending on your cloud service provider, see one of the following:
 
-    - [Connecting from Azure](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/01_connecting_from_azure/)
+    - [Connecting from Azure](../using_cluster/02_connecting_your_cluster/01_connecting_from_azure/)
 
-    - [Connecting from AWS](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/02_connecting_from_aws/)
+    - [Connecting from AWS](../using_cluster/02_connecting_your_cluster/02_connecting_from_aws/)
 
-    - [Connecting from Google Cloud](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/02_connecting_your_cluster/connecting_from_gcp/)
+    - [Connecting from Google Cloud](../using_cluster/02_connecting_your_cluster/connecting_from_gcp/)
 
-1. Provide access to other users. See [Managing user access](https://www.enterprisedb.com/docs/biganimal/latest/administering_cluster/01_portal_access/).
+1. Provide access to other users. See [Managing user access](../administering_cluster/01_portal_access/).
 
 
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -4,11 +4,11 @@ navTitle: "Overview"
 description: A high level description of the tasks needed to get started with BigAnimal 
 ---
 
-Follow the steps below to connect BigAnimal to your cloud account and begin using your new database.
+Use the following high-level steps to connect BigAnimal to your cloud account and begin using your new database.
 
 1. Ensure you have the correct access permissions for your cloud account. 
-    - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner.
-    - AWS&mdash;IAMFullAccess policy AND ServiceQuotasFullAccess policy
+    - Azure&mdash;Global Administrator or Privileged Role Administrator and you must be a Subscription Owner
+    - AWS&mdash;IAMFullAccess policy and ServiceQuotasFullAccess policy
     - Google Cloud&mdash;roles/owner or at least the following combined roles:
         - roles/iam.serviceAccountCreator
         - roles/iam.serviceAccountKeyAdmin
@@ -16,19 +16,22 @@ Follow the steps below to connect BigAnimal to your cloud account and begin usin
         - roles/resourcemanager.projectIamAdmin
         - roles/compute.viewer
 
+
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
 
-1. After signing into your EDB account for the first time you can take one of the following steps:
+1. After signing into your EDB account for the first time, take one of the following steps:
     - Continue to use BigAnimal as your portal and skip to the next step.
-    - Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).$
+    - Set up your own identity provider. For more information see [Setting up your identity provider](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/identity_provider/).
+
 
 1. Set up a CLI. See [Using the BigAnimal CLI](https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/). 
-    We recommend using a CLI but it is not essential.
+   Although we recommend using a CLI, it is not essential.
 
-1. If you are not using BigAnimal's cloud account, you must prepare your cloud to work with BigAnimal. Do this every time you create a new cluster. The required steps vary by cloud provider:
+1. If you are not using BigAnimal's cloud account, prepare your own cloud to work with BigAnimal. You must do this every time you create a new cluster. The required steps vary by cloud provider:
     - Azure&mdash;see [Preparing your Azure account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/01_preparing_azure/).
     - AWS&mdash;see [Preparing your AWS account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/02_preparing_aws/).
-    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/03_preparing_gcp/).
+    - Google Cloud&mdash;see [Preparing your Google Cloud account](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/preparing_cloud_account/preparing_gcp/).
+
 
 1. Connect to your cloud. See [Connecting to your cloud](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/02_connecting_to_your_cloud/).
 

--- a/product_docs/docs/biganimal/release/getting_started/overview.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/overview.mdx
@@ -11,7 +11,7 @@ Use the following high-level steps to set up a BigAnimal account and begin using
 
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/). After setting up the account, you can access the BigAnimal portal, with all of its features and capabilities. 
 
-1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
+1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). When prompted for **Where to deploy**, select **BigAnimal**.
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/)
 
@@ -38,7 +38,7 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
 
 1. Create an EDB account. For more information see [Create an EDB account](https://www.enterprisedb.com/docs/biganimal/latest/free_trial/detail/create_an_account/).
 
-    1. Go to <https://portal.biganimal.com>.
+    1. Go to [https://portal.biganimal.com](https://portal.biganimal.com).
 
     1. Select **EDB Account**.
 
@@ -66,7 +66,7 @@ Use the following high-level steps to connect BigAnimal to your own cloud accoun
 
 1. Activate and manage regions. See [Managing regions](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/activating_regions/). 
 
-1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/).
+1. Create a cluster. See [Creating a cluster](https://www.enterprisedb.com/docs/biganimal/latest/getting_started/creating_a_cluster/). When prompted for **Where to deploy**, select **Your Cloud Account**.
 
 1. Use your cluster. See [Using your cluster](https://www.enterprisedb.com/docs/biganimal/latest/using_cluster/).
 

--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/01_preparing_azure/index.mdx
@@ -8,11 +8,12 @@ BigAnimal requires you to check the readiness of your Azure subscription before 
 
 -   Are the necessary Azure resource providers registered for your subscription?
 -   Is there a restriction on SKUs for the standard Esv3 family and standard D2_v4 VM size?
--   Is there a sufficient limit on the number of vCPU or public IP addresses in your region?
+-   Is there a sufficient limit on the number of vCPU or public IP addresses in your region?    
 
+## Prerequisites
+When preparing your Azure account, make sure that you're assigned either the Global Administrator role or the Privileged Role Administrator role in Azure AD and that you have the Owner role for your BigAnimal Azure subscription.
 
-!!! Note
-    Before proceeding, see [Understanding requirements in Azure](01_understanding_qotas_in_azure) for details on planning for your clusters' requirements and resource limits in Azure.
+Before proceeding, see [Understanding requirements in Azure](01_understanding_qotas_in_azure) for details on planning for your clusters' requirements and resource limits in Azure.
 
 ## Check for readiness
 

--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/02_preparing_aws.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/02_preparing_aws.mdx
@@ -2,7 +2,14 @@
 title: "Preparing your AWS account"
 ---
 
-   
+## Prerequisites
+
+Before preparing your cloud account, make sure that you're assigned the following AWS managed policies or an equivalent custom policy granting full access to resources:
+
+- arn:aws:iam::aws:policy/IAMFullAccess
+
+- arn:aws:iam::aws:policy/ServiceQuotasFullAccess
+
 BigAnimal requires you to check the readiness of your AWS account before you deploy your clusters. (You don't need to perform this check if you're using BigAnimal's cloud account as your [deployment option](/biganimal/release/planning/deployment_options).) The checks that you perform ensure that your AWS account is prepared to meet your clusters' requirements and resource limits, such as:
 
    - Is the AWS CLI configured to access your AWS account?

--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/preparing_gcp/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/preparing_gcp/index.mdx
@@ -4,9 +4,15 @@ title: Preparing your Google Cloud account
 
 BigAnimal requires you to check the readiness of your Google Cloud (GCP) account before you deploy your clusters. (You don't need to perform this check if you're using BigAnimal's cloud account as your [deployment option](/biganimal/release/planning/deployment_options).) The checks that you perform ensure that your Google Cloud account is prepared to meet your clusters' requirements and resource limits.
 
-!!! Note
-    Before proceeding, see [Understanding requirements in Google Cloud](understanding_quotas_in_gcp) for details on planning for your clusters' requirements and resource limits in Google Cloud.
+## Prerequisites
 
+Before preparing your cloud account, make sure that you're assigned the following AWS managed policies or an equivalent custom policy granting full access to resources:
+
+- arn:aws:iam::aws:policy/IAMFullAccess
+
+- arn:aws:iam::aws:policy/ServiceQuotasFullAccess
+
+Before proceeding, see [Understanding requirements in Google Cloud](understanding_quotas_in_gcp) for details on planning for your clusters' requirements and resource limits in Google Cloud.
 
 ## Required roles
 

--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/preparing_gcp/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/preparing_gcp/index.mdx
@@ -2,19 +2,7 @@
 title: Preparing your Google Cloud account 
 ---
 
-BigAnimal requires you to check the readiness of your Google Cloud (GCP) account before you deploy your clusters. (You don't need to perform this check if you're using BigAnimal's cloud account as your [deployment option](/biganimal/release/planning/deployment_options).) The checks that you perform ensure that your Google Cloud account is prepared to meet your clusters' requirements and resource limits.
-
 ## Prerequisites
-
-Before preparing your cloud account, make sure that you're assigned the following AWS managed policies or an equivalent custom policy granting full access to resources:
-
-- arn:aws:iam::aws:policy/IAMFullAccess
-
-- arn:aws:iam::aws:policy/ServiceQuotasFullAccess
-
-Before proceeding, see [Understanding requirements in Google Cloud](understanding_quotas_in_gcp) for details on planning for your clusters' requirements and resource limits in Google Cloud.
-
-## Required roles
 
 Ensure you have at least the following combined roles:
 - roles/iam.serviceAccountCreator
@@ -25,6 +13,8 @@ Ensure you have at least the following combined roles:
 
 Alternatively, you can have an equivalent single role, such as:
 - roles/owner
+
+BigAnimal requires you to check the readiness of your Google Cloud (GCP) account before you deploy your clusters. (You don't need to perform this check if you're using BigAnimal's cloud account as your [deployment option](/biganimal/release/planning/deployment_options).) The checks that you perform ensure that your Google Cloud account is prepared to meet your clusters' requirements and resource limits.
 
 ## Required APIs and services
 

--- a/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/preparing_gcp/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/preparing_cloud_account/preparing_gcp/index.mdx
@@ -14,7 +14,7 @@ Ensure you have at least the following combined roles:
 Alternatively, you can have an equivalent single role, such as:
 - roles/owner
 
-BigAnimal requires you to check the readiness of your Google Cloud (GCP) account before you deploy your clusters. (You don't need to perform this check if you're using BigAnimal's cloud account as your [deployment option](/biganimal/release/planning/deployment_options).) The checks that you perform ensure that your Google Cloud account is prepared to meet your clusters' requirements and resource limits.
+BigAnimal requires you to check the readiness of your Google Cloud (GCP) account before you deploy your clusters. (You don't need to perform this check if you're using BigAnimal's cloud account as your [deployment option](../planning/deployment_options). The checks that you perform ensure that your Google Cloud account is prepared to meet your clusters' requirements and resource limits.
 
 ## Required APIs and services
 

--- a/product_docs/docs/biganimal/release/overview/additional_tools.mdx
+++ b/product_docs/docs/biganimal/release/overview/additional_tools.mdx
@@ -1,0 +1,5 @@
+---
+title: "Additional EDB tools"
+---
+
+Based on your subscription, you may be entitled to a subset of EDB tools that you can access via the EDB Repository. For instructions on using the EDB Repository, see [EDB Repository Access](https://info.enterprisedb.com/rs/069-ALB-339/images/Repository%20Access%2004-09-2019.pdf).

--- a/product_docs/docs/biganimal/release/overview/index.mdx
+++ b/product_docs/docs/biganimal/release/overview/index.mdx
@@ -13,6 +13,7 @@ navigation:
 - 04_responsibility_model
 - 05_database_version_policy
 - updates
+- additional_tools
 - support
 ---
 

--- a/product_docs/docs/biganimal/release/overview/support/index.mdx
+++ b/product_docs/docs/biganimal/release/overview/support/index.mdx
@@ -55,7 +55,14 @@ See [Managing your Support cases](01_case_management) for more information.
 | Severity 1 | The cloud service is down, or there's an error with critical impact on your production environment. Covers urgent problems including database service outage, data loss, and cluster provisioning failure.                                 |
 | Severity 2 | There's a cloud service error or an issue significantly impacting your production environment. The system is functioning but in a severely reduced capacity. Covers problems including database service interruption and backup failures. |
 | Severity 3 | There's an error or issue that doesn't have a significant impact on your production environment. Covers problems including API issues, monitoring metrics, and logging issues.                                                            |
-| Severity 4 | General questions, inquiries, or nontechnical requests.                                                                                                                                                                                   |
+| Severity 4 | General questions, inquiries, or nontechnical requests.   
+
+## Best practices
+
+- Have at least two account owners assigned to your BigAnimal and cloud service provider accounts.
+
+- Add cloudsupport@enterprisedb.com to your email allowed list to avoid missing emails from the BigAnimal support team.
+
 ## For more information
 - [BigAnimal Terms](https://www.enterprisedb.com/biganimal-terms)
 - [Service Level Agreement (SLA) - BigAnimal](https://www.enterprisedb.com/service-level-agreement-sla-biganimal)


### PR DESCRIPTION
This is a collection of edits and new material based on documents Sales and CS uses for new customers. Most of the information in the sales/CS docs already appears in the BigAnimal technical documentation, but I've added a few pieces in information here and there. The main change is that I created a new overview topic in the "Getting started" section to supplement some of the existing getting started information, which seems a big disjointed.

Addresses: https://enterprisedb.atlassian.net/browse/DOCS-155
