### PR TITLE
pgd: fixes for bdr.node_summary documentation

### DIFF
--- a/product_docs/docs/pgd/3.7/bdr/catalogs.mdx
+++ b/product_docs/docs/pgd/3.7/bdr/catalogs.mdx
@@ -600,7 +600,6 @@ node.
 | node_local_dbname      | name    | Database name of the node                                                   |
 | pub_repsets            | text\[] | Deprecated column, always NULL, will be removed in 4.0                      |
 | sub_repsets            | text\[] | Deprecated column, always NULL, will be removed in 4.0                      |
-| set_repl_ops           | text    | Which operations does the default replication set replicate                 |
 | node_id                | oid     | The OID of the node                                                         |
 | node_group_id          | oid     | The OID of the BDR node group                                               |
 | if_id                  | oid     | The OID of the connection interface used by the node                        |

--- a/product_docs/docs/pgd/4/bdr/catalogs.mdx
+++ b/product_docs/docs/pgd/4/bdr/catalogs.mdx
@@ -616,7 +616,6 @@ node.
 | peer_target_state_name | text | State that the node is trying to reach (during join or promotion)           |
 | node_seq_id            | int4 | Sequence identifier of the node used for generating unique sequence numbers |
 | node_local_dbname      | name | Database name of the node                                                   |
-| set_repl_ops           | text | Which operations does the default replication set replicate                 |
 | node_id                | oid  | The OID of the node                                                         |
 | node_group_id          | oid  | The OID of the BDR node group                                               |
 


### PR DESCRIPTION
## What Changed?

The field "set_repl_ops" is not present from PGC 3.7 onwards, so remove this from the 3.7 and 4 documentation (it is not in the PGD 5 docs).

BDR-4774.



