### PR TITLE
pgd: fix "bdr.raft_keep_min_entries" reference entry

### DIFF
--- a/product_docs/docs/pgd/5/reference/pgd-settings.mdx
+++ b/product_docs/docs/pgd/5/reference/pgd-settings.mdx
@@ -601,11 +601,11 @@ is disabled. It defaults to -1.
 
 ## Internal settings - Other Raft values
 
-###   `bdr.raft_keep_min_entries`
+### `bdr.raft_keep_min_entries`
 
-The minimum number of entries to keep in the Raft log when doing log compaction 
-(default 100). The value of 0 disables log compaction. You can set this only at 
-Postgres server start.
+The minimum number of entries to keep in the Raft log when doing log compaction
+(default `1000`; PGD 5.3 and earlier: `100`). The value of `0` disables log
+compaction. You can set this only at Postgres server start.
 
 !!! Warning
 If log compaction is disabled, the log grows in size forever.


### PR DESCRIPTION
## What Changed?

The default value was changed from 100 to 1000 with PGD 5.4 (BDR commit 2588f022) but the reference entry wasn't updated.
