### PR TITLE
pgd: add missing field to "bdr.node_group" reference entry

### DIFF
--- a/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
+++ b/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
@@ -514,6 +514,7 @@ user-readable details.
 | node_group_num_writers          | int      | Number of writers to use for subscriptions backing this node group                            |
 | node_group_enable_wal_decoder   | bool     | Whether the group has enable_wal_decoder set                                                  |
 | node_group_streaming_mode       | char     | Transaction streaming setting: 'O' - off, 'F' - file, 'W' - writer, 'A' - auto, 'D' - default |
+| node_group_default_commit_scope | oid      | ID of the node group's default commit scope                                                   |
 | node_group_location             | char     | Name of the location associated with the node group                                           |
 | node_group_enable_proxy_routing | char     | Whether the node group allows routing from `pgd-proxy`                                        |
 | node_group_enable_raft          | bool     | Whether the node group allows Raft Consensus                                                  |


### PR DESCRIPTION
## What Changed?

Column `node_group_default_commit_scope`, added in PGD 5.0, was missing, so added. The corresponding entry in `bdr.node_group_summary` is present.