### PR TITLE
Fix: Update cve-2024-1597.mdx

### DIFF
--- a/advocacy_docs/security/assessments/cve-2024-1597.mdx
+++ b/advocacy_docs/security/assessments/cve-2024-1597.mdx
@@ -1,19 +1,19 @@
 ---
 title: CVE-2024-1597 - SQL Injection via line comment generation
 navTitle: CVE-2024-1597
-affectedProducts: pgJDBC all versions prior to 42.7.2, 42.6.1, 42.5.5, 42.4.4, 42.3.9, and 42.2.8 and EDB pgJDBC all versions prior to 42.5.5
+affectedProducts: pgJDBC all versions prior to 42.7.2, 42.6.1, 42.5.5, 42.4.4, 42.3.9, and 42.2.28 and EDB pgJDBC all versions prior to 42.5.5
 ---
 
 First Published: 2024/02/26
 
-Last Updated: 2024/02/26
+Last Updated: 2024/03/08
 
 Important: This is an assessment of the impact of CVE-2024-1597 on EDB products and services. It links to and details the CVE and supplements that information with EDB's own assessment.
 
 
 ## Summary 
 
-pgjdbc, the PostgreSQL JDBC Driver, allows attacker to inject SQL if using PreferQueryMode=SIMPLE. Note this is not the default. In the default mode there is no vulnerability. A placeholder for a numeric value must be immediately preceded by a minus. There must be a second placeholder for a string value after the first placeholder; both must be on the same line. By constructing a matching string payload, the attacker can inject SQL to alter the query,bypassing the protections that parameterized queries bring against SQL Injection attacks. Versions before 42.7.2, 42.6.1, 42.5.5, 42.4.4, 42.3.9, and 42.2.8 are affected.
+pgjdbc, the PostgreSQL JDBC Driver, allows attacker to inject SQL if using PreferQueryMode=SIMPLE. Note this is not the default. In the default mode there is no vulnerability. A placeholder for a numeric value must be immediately preceded by a minus. There must be a second placeholder for a string value after the first placeholder; both must be on the same line. By constructing a matching string payload, the attacker can inject SQL to alter the query,bypassing the protections that parameterized queries bring against SQL Injection attacks. Versions before 42.7.2, 42.6.1, 42.5.5, 42.4.4, 42.3.9, and 42.2.28 are affected.
 
 
 ## Vulnerability details
@@ -36,7 +36,7 @@ CVSS Vector:  CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
 * All versions prior to 42.6.1
 * All versions prior to 42.5.5
 * All versions prior to 42.3.9
-* All versions prior to 42.2.8
+* All versions prior to 42.2.28
 
 ### EnterpriseDB pgJDBC
 


### PR DESCRIPTION
## What Changed?

According to the official pgjdbc repo, the vulnerable versions are not those below 4.2.8 but those below 4.2.28: https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56

So here's the modification I'd suggest. I have also sent a request for a modification to https://www.cve.org/.

Regards,
Simon
![CVE-2024-1597](https://github.com/EnterpriseDB/docs/assets/48290387/7f5b170b-5a71-4749-b146-f45b9c57a68a)


