### PR TITLE
Update 06_demonstration_oracle_compatibility.mdx

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/06_demonstration_oracle_compatibility.mdx
@@ -259,7 +259,7 @@ If you want to try these examples on your own BigAnimal cluster, follow these in
 3.  Create a limited-privilege user for connecting to this database:
 
     ```sql
-    CREATE USER demo WITH PASSWORD 'password';
+    CREATE USER demo WITH PASSWORD 'password1';
     ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO demo;
     ```
 


### PR DESCRIPTION
While testing this code with the password set to "password", I encountered the following error message:

chinook=> CREATE USER demo WITH PASSWORD 'password'; ERROR:  password must contain both letters and nonletters

Adding a number succeeded:

chinook=> CREATE USER demo WITH PASSWORD 'password1'; CREATE ROLE

## What Changed?

