### PR TITLE
Adding instructions for upgrading Postgres major versions in Big Animal using logical replication

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -5,6 +5,10 @@ navTitle: Upgrading Postgres major versions
 
 ## Using logical replication
 
+!!! Note
+This procedure does not work with distributed high-availability BigAnimal instances.
+!!!
+
 Logical replication offers a powerful method for upgrading major Postgres versions on BigAnimal instances, enabling a seamless transition with minimal downtime. 
 
 By replicating database changes in real-time from an older version to a newer one, this approach ensures data integrity and continuity. It's ideal for migrating data across different Postgres versions, providing a reliable upgrade path without sacrificing availability.
@@ -15,7 +19,7 @@ Depending on where your older and newer versioned BigAnimal instances are locate
 
 ### Create a new BigAnimal instance
 
-Migrating between major versions first requires creating a new BigAnimal instance with the newer version of Postgres. This procedure does not work for upgrading from a single node or standard high availability cluster to a distributed high-availability BigAnimal instance.
+Migrating between major versions first requires creating a new BigAnimal instance with the newer version of Postgres.
 
 The new instance must have sufficient storage to receive the data from the old instance, so ensure enough storage is provisioned when creating the new instance.
 
@@ -160,13 +164,13 @@ This slot tracks changes to the published tables on the old instance to ensure t
 Now, logged into the newer Postgres instance, create a subscription to the publication on the older instance in the following format:
 
 ```sql
-CREATE SUBSCRIPTION <name_of_subscription> CONNECTION 'user=<old_instance_username> host=<old_instance_read/write_host> port=<old_instance_port> dbname=<old_instance_dbname> password=<old_instance_password>' PUBLICATION <publication_name> WITH (enabled=true, copy_data = true, create_slot = false, slot_name=<slot_name>);
+CREATE SUBSCRIPTION <name_of_subscription> CONNECTION 'user=<old_instance_username> host=<old_instance_read/write_host> sslmode=require port=<old_instance_port> dbname=<old_instance_dbname> password=<old_instance_password>' PUBLICATION <publication_name> WITH (enabled=true, copy_data = true, create_slot = false, slot_name=<slot_name>);
 ```
 
 Specifically, in this example:
 
 ```sql
-CREATE SUBSCRIPTION v16_sub CONNECTION 'user=edb_admin host=p-x67kjhacc4.pg.biganimal.io port=5432 dbname=edb_admin password=XXX' PUBLICATION v12_pub WITH (enabled=true, copy_data = true, create_slot = false, slot_name=v12_pub);
+CREATE SUBSCRIPTION v16_sub CONNECTION 'user=edb_admin host=p-x67kjhacc4.pg.biganimal.io sslmode=require port=5432 dbname=edb_admin password=XXX' PUBLICATION v12_pub WITH (enabled=true, copy_data = true, create_slot = false, slot_name=v12_pub);
 ```
 
 Look for the expected output: `CREATE SUBSCRIPTION`.
@@ -212,3 +216,10 @@ If logical replication is running correctly, each time you run `\dt+;` you see t
  public | pgbench_history  | table | edb_admin | permanent   | heap          | 0 bytes | 
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
 ```
+
+#### LiveCompare
+
+A final validation step to ensure the two databases are identical is to use [EDB's LiveCompare](https://www.enterprisedb.com/docs/livecompare/latest/). 
+
+LiveCompare compares the databases, generates a comparison report, and provides data manipulation language (DML) scripts so you can optionally apply the DML and fix any database inconsistencies.
+

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -9,11 +9,72 @@ Logical replication offers a powerful method for upgrading major Postgres versio
 
 By replicating database changes in real-time from an older version to a newer one, this approach ensures data integrity and continuity. It's ideal for migrating data across different Postgres versions, providing a reliable upgrade path without sacrificing availability.
 
+!!! Important
+Depending on where your older and newer versioned BigAnimal instances are located, this procedure may accrue ingress and egress costs from your cloud service provider (CSP) for the migrated data. Please consult your CSP's pricing documentation to see how ingress and egress fees are calculated to determine any extra costs.
+!!!
+
+### Create a new BigAnimal instance
+
+Migrating between major versions first requires creating a new BigAnimal instance with the newer version of Postgres. This procedure does not work for upgrading a distributed high-availability BigAnimal instance.
+
+The new instance must have sufficient storage to receive the data from the old instance, so ensure enough storage is provisioned when creating the new instance.
+
+Considering these caveats, [create the new BigAnimal instance](../getting_started/creating_a_cluster.mdx).
+
+### Gather instance information
+
+Next, information obtained from the BigAnimal console is necessary. For both the new instance and the old instance, you need the following:
+
+1. Read/write URI
+2. Database name
+3. Username 
+4. Read/write host
+
+To access this information, select the **Clusters** tab on the left-side navigation menu of the BigAnimal console, find the instance in question, and select it by name. Clusters are listed in alphabetical order.
+
+After selecting the instance in question, navigate to the **Connect** tab under the instance's name on its show page. The information needed for the procedure is listed there under **Connection Info**.
+
+### Confirm the Postgres versions before migration
+
+Next, from a machine with a Postgres client, confirm the current version of Postgres on both the old BigAnimal instance (the instance you are migrating *from*) and the new BigAnimal instance (the instance you are migrating *to*):
+
+```
+psql "<biganimal_read/write_uri>" -c "select version();"
+```
+
+Example output looks like the following for a version 16 instance:
+
+```
+                                                               version                                                               
+-------------------------------------------------------------------------------------------------------------------------------------
+ PostgreSQL 16.2 (Debian 16.2.0-3.buster) (BigAnimal Edition) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
+(1 row)
+```
+
+Check that both instances are the expected versions.
+
+### Migrate the database schema 
+
+Next, confirm the database schema you want to migrate. While logged into the old instance, use the following SQL to look at the table data:
+
+```sql
+/dt+
+```
+
+Here is an example database schema:
+
+```
+                                           List of relations
+ Schema |       Name       | Type  |   Owner   | Persistence | Access method |    Size    | Description 
+--------+------------------+-------+-----------+-------------+---------------+------------+-------------
+ public | pgbench_accounts | table | edb_admin | permanent   | heap          | 1572 MB    | 
+ public | pgbench_branches | table | edb_admin | permanent   | heap          | 8192 bytes | 
+ public | pgbench_history  | table | edb_admin | permanent   | heap          | 0 bytes    | 
+ public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 120 kB     | 
+```
 
 
-### Schema Migration 
-
-First, copy over the database schema from the old instance using the `pg_dump` command:
+Then, from a Postgres client, copy over the database schema from the old instance using the `pg_dump` command:
 
 ```
 pg_dump --schema-only  -h <old_biganimal_host> -U <old_biganimal_username> -d <old_biganimal_databasename> | psql -h <new_biganimal_host> -U <new_biganimal_username> -d <new_biganimal_databasename>
@@ -21,30 +82,108 @@ pg_dump --schema-only  -h <old_biganimal_host> -U <old_biganimal_username> -d <o
 
 The `pg_dump --schema-only` command exports the schema (structure) of the existing database without the data. It's then piped into `psql` to import this schema into the new Postgres 16 instance. This prepares the target database with the necessary structure to hold the data.
 
+Finally, log into the new instance and confirm that the database schema migrated correctly. Run `\dt+` again and you see the database schema migrated to the new instance as expected:
+
+```
+                                         List of relations
+ Schema |       Name       | Type  |   Owner   | Persistence | Access method |  Size   | Description 
+--------+------------------+-------+-----------+-------------+---------------+---------+-------------
+ public | pgbench_accounts | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_branches | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_history  | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
+```
+
+While the schema looks the same on the new instance, the "Size" column shows no data, confirming that only the schema has been migrated so far.
 
 ### Setting up Publication 
 
-On the Postgres 12 instance, a publication is created. This publication is configured to include specific tables, making their changes available for replication.
+To set up the publication, log into the old BigAnimal instance and create a publication:
 
 ```sql
--- Add tables to publication
+CREATE PUBLICATION v12_pub;
+```
+
+The expected output is `CREATE PUBLICATION`.
+
+Next, configure the publication to include specific tables, making any changes available for replication.
+
+```sql
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_accounts;
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_branches;
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_history;
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_tellers;
 ```
 
-### Creating Logical Replication Slot
+Each of these alterations creates `ALTER PUBLICATION` output upon success. 
 
-A replication slot named 'v12_pub' using the 'pgoutput' plugin is created on the version 12 instance. This slot tracks changes to the published tables to ensure they can be replicated to the subscriber without losing any data.
+### Creating the Logical Replication Slot
+
+Then, on the version 12 instance, create a replication slot named 'v12_pub' using the 'pgoutput' plugin:
 
 ```sql
 SELECT pg_create_logical_replication_slot('v12_pub','pgoutput');
 ```
-### Setting up Subscription
 
-On the Postgres 16 instance, a subscription to the publication on the Postgres 12 instance is created. This subscription uses a connection string to specify the source database and includes options to copy existing data and to follow the publication identified by 'v12_pub'. The subscription mechanism pulls schema changes and data from the source to the target database, effectively replicating the data.
+If successful, the expected output is, in this example:
+
+```
+ pg_create_logical_replication_slot 
+------------------------------------
+ (v12_pub,0/AC003330)
+```
+
+This slot tracks changes to the published tables on the old instance to ensure they can be replicated to the subscriber on the new instance without losing any data.
+
+
+### Setting up the Subscription
+
+Now, logged into the Postgres 16 instance, create a subscription to the publication on the Postgres 12 instance:
 
 ```sql
 CREATE SUBSCRIPTION v16_sub CONNECTION 'user=edb_admin host=p-4bwwpm01u4.pg.biganimal.io port=5432 dbname=edb_admin password=XXX' PUBLICATION v12_pub WITH (enabled=true, copy_data = true, create_slot = false, slot_name=v12_pub);
+```
+
+Look for the expected output: `CREATE SUBSCRIPTION`.
+
+In this example, the subscription uses a connection string to specify the source database and includes options to copy existing data and to follow the publication identified by 'v12_pub'. 
+
+The subscription mechanism pulls schema changes and data from the source to the target database, effectively replicating the data.
+
+### Validate the migration
+
+Finally, you can follow the progression of the migration. First, use `\dt+` while logged into the older BigAnimal Postgres instance to see how much data is to be replicated. In this example:
+
+```
+                                           List of relations
+ Schema |       Name       | Type  |   Owner   | Persistence | Access method |    Size    | Description 
+--------+------------------+-------+-----------+-------------+---------------+------------+-------------
+ public | pgbench_accounts | table | edb_admin | permanent   | heap          | 1572 MB    | 
+ public | pgbench_branches | table | edb_admin | permanent   | heap          | 8192 bytes | 
+ public | pgbench_history  | table | edb_admin | permanent   | heap          | 0 bytes    | 
+ public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 120 kB     | 
+```
+
+Then run `\dt+` while logged into the new BigAnimal instance and compare:
+
+```
+                                         List of relations
+ Schema |       Name       | Type  |   Owner   | Persistence | Access method |  Size   | Description 
+--------+------------------+-------+-----------+-------------+---------------+---------+-------------
+ public | pgbench_accounts | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_branches | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_history  | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
+```
+
+If logical replication is running correctly, each time you run `\dt+` you see that more data has been migrated:
+
+```
+                                         List of relations
+ Schema |       Name       | Type  |   Owner   | Persistence | Access method |  Size   | Description 
+--------+------------------+-------+-----------+-------------+---------------+---------+-------------
+ public | pgbench_accounts | table | edb_admin | permanent   | heap          | 344 MB  | 
+ public | pgbench_branches | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_history  | table | edb_admin | permanent   | heap          | 0 bytes | 
+ public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
 ```

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -15,7 +15,7 @@ Depending on where your older and newer versioned BigAnimal instances are locate
 
 ### Create a new BigAnimal instance
 
-Migrating between major versions first requires creating a new BigAnimal instance with the newer version of Postgres. This procedure does not work for upgrading a distributed high-availability BigAnimal instance.
+Migrating between major versions first requires creating a new BigAnimal instance with the newer version of Postgres. This procedure does not work for upgrading from a single node or standard high availability cluster to a distributed high-availability BigAnimal instance.
 
 The new instance must have sufficient storage to receive the data from the old instance, so ensure enough storage is provisioned when creating the new instance.
 

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -1,0 +1,5 @@
+---
+title: Performing a rolling upgrade of Postgres major version on BigAnimal
+navTitle: Upgrading Postgres major versions
+---
+

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -80,7 +80,7 @@ Then, from a Postgres client, copy over the database schema from the old instanc
 pg_dump --schema-only  -h <old_biganimal_host> -U <old_biganimal_username> -d <old_biganimal_databasename> | psql -h <new_biganimal_host> -U <new_biganimal_username> -d <new_biganimal_databasename>
 ```
 
-The `pg_dump --schema-only` command exports the schema (structure) of the existing database without the data. It's then piped into `psql` to import this schema into the new Postgres 16 instance. This prepares the target database with the necessary structure to hold the data.
+The `pg_dump --schema-only` command exports the schema (structure) of the existing database without the data. It's then piped into `psql` to import this schema into the new Postgres instance. This prepares the target database with the necessary structure to hold the data.
 
 Finally, log into the new instance and confirm that the database schema migrated correctly. Run `\dt+;` in this example again and you see the database schema migrated to the new instance as expected:
 

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -1,5 +1,5 @@
 ---
-title: Performing a rolling upgrade of Postgres major version on BigAnimal
+title: Performing a major version upgrade of Postgres on BigAnimal
 navTitle: Upgrading Postgres major versions
 ---
 

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -1,6 +1,7 @@
 ---
 title: Performing a major version upgrade of Postgres on BigAnimal
 navTitle: Upgrading Postgres major versions
+deepToC: true
 ---
 
 ## Using logical replication
@@ -9,21 +10,35 @@ navTitle: Upgrading Postgres major versions
 This procedure does not work with distributed high-availability BigAnimal instances.
 !!!
 
-Logical replication offers a powerful method for upgrading major Postgres versions on BigAnimal instances, enabling a seamless transition with minimal downtime. 
+Logical replication is a common method for upgrading the Postgres major version on BigAnimal instances, enabling a transition with minimal downtime. 
 
-By replicating database changes in real-time from an older version to a newer one, this approach ensures data integrity and continuity. It's ideal for migrating data across different Postgres versions, providing a reliable upgrade path without sacrificing availability.
+By replicating changes in real-time from an older version (source instance) to a newer one (target instance), this method provides a reliable upgrade path while maintaining database availability.
 
 !!! Important
 Depending on where your older and newer versioned BigAnimal instances are located, this procedure may accrue ingress and egress costs from your cloud service provider (CSP) for the migrated data. Please consult your CSP's pricing documentation to see how ingress and egress fees are calculated to determine any extra costs.
 !!!
 
-### Create a new BigAnimal instance
+### Overview of upgrading
 
-To perform a major version upgrade, create a BigAnimal instance with your desired version of Postgres. This is your target instance.
+To perform a major version upgrade, use the following steps, explained in further detail below:
+
+1. [Create a BigAnimal instance](#create-a-biganimal-instance)
+1. [Gather instance information](#gather-instance-information)
+1. [Confirm the Postgres versions before migration](#confirm-the-postgres-versions-before-migration)
+1. [Migrate the database schema](#migrate-the-database-schema)
+1. [Create a publication](#create-a-publication)
+1. [Create a logical replication slot](#create-a-logical-replication-slot)
+1. [Create a subscription](#create-a-subscription)
+1. [Validate the migration](#validate-the-migration)
+
+
+### Create a BigAnimal instance
+
+To perform a major version upgrade, create a BigAnimal instance with your desired version of Postgres. This will be your target instance.
 
 Ensure your target instance is provisioned with a storage size equal to or greater than your source instance.
 
-Considering these caveats, [create your target BigAnimal instance](../getting_started/creating_a_cluster.mdx).
+For detailed steps on creating a BigAnimal instance, see [this guide](../getting_started/creating_a_cluster.mdx).
 
 ### Gather instance information
 
@@ -36,15 +51,13 @@ Use the BigAnimal console to obtain the following information for your source an
 
 Using the BigAnimal console:
 
-    1. Select the **Clusters** tab.
-    1. Select your source instance.
-    1. From the Connect tab, obtain the information from **Connection Info**.
-
-Repeat the steps for your target instance.
+1. Select the **Clusters** tab.
+1. Select your source instance.
+1. From the Connect tab, obtain the information from **Connection Info**.
 
 ### Confirm the Postgres versions before migration
 
-Confirm the Postgres version on both your source and target BigAnimal instances:
+Confirm the Postgres version of your source and target BigAnimal instances:
 
 ```
 psql "<biganimal_read/write_uri>" -c "select version();"
@@ -61,7 +74,7 @@ Output using Postgres 16:
 
 ### Migrate the database schema 
 
-On your source instance, view the details of the schema to be migrated:
+On your source instance, use the `dt` command to view the details of the schema to be migrated:
 
 ```sql
 /dt+;
@@ -85,7 +98,7 @@ Use pg_dump with the `--schema-only` flag to copy the schema from your source to
 pg_dump --schema-only  -h <source_biganimal_host> -U <source_biganimal_username> -d <source_biganimal_databasename> | psql -h <target_biganimal_host> -U <target_biganimal_username> -d <target_biganimal_databasename>
 ```
 
-On the target instance, confirm the schema is migrated:
+On the target instance, confirm the schema was migrated:
 
 ```
                                          List of relations
@@ -101,9 +114,9 @@ On the target instance, confirm the schema is migrated:
 A successful schema-only copy shows the tables with zero bytes.
 !!!
 
-### Setting up Publication 
+### Create a publication 
 
-Create a publication from your source instance:
+Use the `CREATE PUBLICATION` command to create a publication on your source instance. For more information on using `CREATE PUBLICATION`, see [the Posgres documentation](https://www.postgresql.org/docs/current/sql-createpublication.html).
 
 ```sql
 CREATE PUBLICATION <pub_name>;
@@ -157,9 +170,9 @@ The expected output returns the `slot_name` and `lsn`.
 
 The replication slot tracks changes to the published tables from the source instance and replicates changes to the subscriber on the target instance.
 
-### Setting up the Subscription
+### Create a subscription
 
-On the target instance, create a subscription:
+Use the `CREATE SUBSCRIPTION` command to create a subscription on your target instance. For more information on using `CREATE SUBSCRIPTION`, see [the Postgres documentation](https://www.postgresql.org/docs/current/sql-createsubscription.html).
 
 ```sql
 CREATE SUBSCRIPTION <name_of_subscription> CONNECTION 'user=<source_instance_username> host=<source_instance_read/write_host> sslmode=require port=<source_instance_port> dbname=<source_instance_dbname> password=<source_instance_password>' PUBLICATION <publication_name> WITH (enabled=true, copy_data = true, create_slot = false, slot_name=<slot_name>);
@@ -175,12 +188,12 @@ The expected output is: `CREATE SUBSCRIPTION`.
 
 In this example, the subscription uses a connection string to specify the source database and includes options to copy existing data and to follow the publication identified by 'v12_pub'. 
 
-The subscription mechanism pulls schema changes (with some exceptions, as noted in the PostgreSQL documentation on Limitations of Logical Replication: https://www.postgresql.org/docs/current/logical-replication-restrictions.html) and data from the source to the target database, effectively replicating the data.
+The subscriber pulls schema changes (with some exceptions, as noted in the PostgreSQL [documentation on Limitations of Logical Replication](https://www.postgresql.org/docs/current/logical-replication-restrictions.html)) and data from the source to the target database, effectively replicating the data.
 
 ### Validate the migration
 
-Finally, you can follow the progression of the migration. First, use `\dt+;` while logged into the older BigAnimal Postgres instance to see how much data is to be replicated. In this example:
-
+To validate the progress of the data migration, use `dt+` from the source and target BigAnimal instances to compare the size of each table.
+ 
 ```
                                            List of relations
  Schema |       Name       | Type  |   Owner   | Persistence | Access method |    Size    | Description 
@@ -190,8 +203,6 @@ Finally, you can follow the progression of the migration. First, use `\dt+;` whi
  public | pgbench_history  | table | edb_admin | permanent   | heap          | 0 bytes    | 
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 120 kB     | 
 ```
-
-Then run `\dt+;` while logged into the new BigAnimal instance and compare:
 
 ```
                                          List of relations
@@ -215,9 +226,9 @@ If logical replication is running correctly, each time you run `\dt+;` you see t
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
 ```
 
-#### LiveCompare
+!!! Note
+You can optionally use [LiveCompare](https://www.enterprisedb.com/docs/livecompare/latest/) to generate a comparison report of the source and target databases to validate that all database objects and data are consistent.
+!!!
 
-A final validation step to ensure the two databases are identical is to use [EDB's LiveCompare](https://www.enterprisedb.com/docs/livecompare/latest/). 
 
-LiveCompare compares the databases, generates a comparison report, and provides data manipulation language (DML) scripts so you can optionally apply the DML and fix any database inconsistencies.
 

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -58,10 +58,10 @@ Check that both instances are the expected versions.
 Next, confirm the database schema you want to migrate. While logged into the old instance, use the following SQL to look at the table data:
 
 ```sql
-/dt+
+/dt+;
 ```
 
-Here is an example database schema:
+Here is a sample database schema for this example:
 
 ```
                                            List of relations
@@ -82,7 +82,7 @@ pg_dump --schema-only  -h <old_biganimal_host> -U <old_biganimal_username> -d <o
 
 The `pg_dump --schema-only` command exports the schema (structure) of the existing database without the data. It's then piped into `psql` to import this schema into the new Postgres 16 instance. This prepares the target database with the necessary structure to hold the data.
 
-Finally, log into the new instance and confirm that the database schema migrated correctly. Run `\dt+` again and you see the database schema migrated to the new instance as expected:
+Finally, log into the new instance and confirm that the database schema migrated correctly. Run `\dt+;` in this example again and you see the database schema migrated to the new instance as expected:
 
 ```
                                          List of relations
@@ -94,11 +94,18 @@ Finally, log into the new instance and confirm that the database schema migrated
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
 ```
 
-While the schema looks the same on the new instance, the "Size" column shows no data, confirming that only the schema has been migrated so far.
+While the schema looks the same on the new instance, the "Size" column shows 0 bytes of data, confirming that only the schema has been migrated so far.
 
 ### Setting up Publication 
 
 To set up the publication, log into the old BigAnimal instance and create a publication:
+
+```sql
+CREATE PUBLICATION <pub_name>;
+```
+
+In this example:
+
 
 ```sql
 CREATE PUBLICATION v12_pub;
@@ -106,7 +113,13 @@ CREATE PUBLICATION v12_pub;
 
 The expected output is `CREATE PUBLICATION`.
 
-Next, configure the publication to include specific tables, making any changes available for replication.
+Next, configure the publication to include the specific tables you want replicated on the new instance:
+
+```sql
+ALTER PUBLICATION <pub_name> ADD TABLE <table_name>;
+```
+
+Which in the current example is:
 
 ```sql
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_accounts;
@@ -115,17 +128,23 @@ ALTER PUBLICATION v12_pub ADD TABLE pgbench_history;
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_tellers;
 ```
 
-Each of these alterations creates `ALTER PUBLICATION` output upon success. 
+Each of these alterations produces `ALTER PUBLICATION` output upon success. 
 
 ### Creating the Logical Replication Slot
 
-Then, on the version 12 instance, create a replication slot named 'v12_pub' using the 'pgoutput' plugin:
+Then, on the older versioned instance, create a replication slot using the 'pgoutput' plugin:
+
+```sql
+SELECT pg_create_logical_replication_slot('<slot_name>','pgoutput');
+```
+
+In the current example:
 
 ```sql
 SELECT pg_create_logical_replication_slot('v12_pub','pgoutput');
 ```
 
-If successful, the expected output is, in this example:
+If successful, the expected output is something like the following:
 
 ```
  pg_create_logical_replication_slot 
@@ -138,10 +157,16 @@ This slot tracks changes to the published tables on the old instance to ensure t
 
 ### Setting up the Subscription
 
-Now, logged into the Postgres 16 instance, create a subscription to the publication on the Postgres 12 instance:
+Now, logged into the newer Postgres instance, create a subscription to the publication on the older instance in the following format:
 
 ```sql
-CREATE SUBSCRIPTION v16_sub CONNECTION 'user=edb_admin host=p-4bwwpm01u4.pg.biganimal.io port=5432 dbname=edb_admin password=XXX' PUBLICATION v12_pub WITH (enabled=true, copy_data = true, create_slot = false, slot_name=v12_pub);
+CREATE SUBSCRIPTION <name_of_subscription> CONNECTION 'user=<old_instance_username> host=<old_instance_read/write_host> port=<old_instance_port> dbname=<old_instance_dbname> password=<old_instance_password>' PUBLICATION <publication_name> WITH (enabled=true, copy_data = true, create_slot = false, slot_name=<slot_name>);
+```
+
+Specifically, in this example:
+
+```sql
+CREATE SUBSCRIPTION v16_sub CONNECTION 'user=edb_admin host=p-x67kjhacc4.pg.biganimal.io port=5432 dbname=edb_admin password=XXX' PUBLICATION v12_pub WITH (enabled=true, copy_data = true, create_slot = false, slot_name=v12_pub);
 ```
 
 Look for the expected output: `CREATE SUBSCRIPTION`.
@@ -152,7 +177,7 @@ The subscription mechanism pulls schema changes and data from the source to the 
 
 ### Validate the migration
 
-Finally, you can follow the progression of the migration. First, use `\dt+` while logged into the older BigAnimal Postgres instance to see how much data is to be replicated. In this example:
+Finally, you can follow the progression of the migration. First, use `\dt+;` while logged into the older BigAnimal Postgres instance to see how much data is to be replicated. In this example:
 
 ```
                                            List of relations
@@ -164,7 +189,7 @@ Finally, you can follow the progression of the migration. First, use `\dt+` whil
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 120 kB     | 
 ```
 
-Then run `\dt+` while logged into the new BigAnimal instance and compare:
+Then run `\dt+;` while logged into the new BigAnimal instance and compare:
 
 ```
                                          List of relations
@@ -176,7 +201,7 @@ Then run `\dt+` while logged into the new BigAnimal instance and compare:
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
 ```
 
-If logical replication is running correctly, each time you run `\dt+` you see that more data has been migrated:
+If logical replication is running correctly, each time you run `\dt+;` you see that more data has been migrated:
 
 ```
                                          List of relations

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -19,34 +19,38 @@ Depending on where your older and newer versioned BigAnimal instances are locate
 
 ### Create a new BigAnimal instance
 
-Migrating between major versions first requires creating a new BigAnimal instance with the newer version of Postgres.
+To perform a major version upgrade, create a BigAnimal instance with your desired version of Postgres. This is your target instance.
 
-The new instance must have sufficient storage to receive the data from the old instance, so ensure enough storage is provisioned when creating the new instance.
+Ensure your target instance is provisioned with a storage size equal to or greater than your source instance.
 
-Considering these caveats, [create the new BigAnimal instance](../getting_started/creating_a_cluster.mdx).
+Considering these caveats, [create your target BigAnimal instance](../getting_started/creating_a_cluster.mdx).
 
 ### Gather instance information
 
-Next, information obtained from the BigAnimal console is necessary. For both the new instance and the old instance, you need the following:
+Use the BigAnimal console to obtain the following information for your source and target instance:
 
-1. Read/write URI
-2. Database name
-3. Username 
-4. Read/write host
+- Read/write URI
+- Database name
+- Username 
+- Read/write host
 
-To access this information, select the **Clusters** tab on the left-side navigation menu of the BigAnimal console, find the instance in question, and select it by name. Clusters are listed in alphabetical order.
+Using the BigAnimal console:
 
-After selecting the instance in question, navigate to the **Connect** tab under the instance's name on its show page. The information needed for the procedure is listed there under **Connection Info**.
+    1. Select the **Clusters** tab.
+    1. Select your source instance.
+    1. From the Connect tab, obtain the information from **Connection Info**.
+
+Repeat the steps for your target instance.
 
 ### Confirm the Postgres versions before migration
 
-Next, from a machine with a Postgres client, confirm the current version of Postgres on both the old BigAnimal instance (the instance you are migrating *from*) and the new BigAnimal instance (the instance you are migrating *to*):
+Confirm the Postgres version on both your source and target BigAnimal instances:
 
 ```
 psql "<biganimal_read/write_uri>" -c "select version();"
 ```
 
-Example output looks like the following for a version 16 instance:
+Output using Postgres 16:
 
 ```
                                                                version                                                               
@@ -55,11 +59,9 @@ Example output looks like the following for a version 16 instance:
 (1 row)
 ```
 
-Check that both instances are the expected versions.
-
 ### Migrate the database schema 
 
-Next, confirm the database schema you want to migrate. While logged into the old instance, use the following SQL to look at the table data:
+On your source instance, view the details of the schema to be migrated:
 
 ```sql
 /dt+;
@@ -77,16 +79,13 @@ Here is a sample database schema for this example:
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 120 kB     | 
 ```
 
-
-Then, from a Postgres client, copy over the database schema from the old instance using the `pg_dump` command:
+Use pg_dump with the `--schema-only` flag to copy the schema from your source to your target instance. For more information on using `pg_dump`, [see the Postgres documentation](https://www.postgresql.org/docs/current/app-pgdump.html).
 
 ```
-pg_dump --schema-only  -h <old_biganimal_host> -U <old_biganimal_username> -d <old_biganimal_databasename> | psql -h <new_biganimal_host> -U <new_biganimal_username> -d <new_biganimal_databasename>
+pg_dump --schema-only  -h <source_biganimal_host> -U <source_biganimal_username> -d <source_biganimal_databasename> | psql -h <target_biganimal_host> -U <target_biganimal_username> -d <target_biganimal_databasename>
 ```
 
-The `pg_dump --schema-only` command exports the schema (structure) of the existing database without the data. It's then piped into `psql` to import this schema into the new Postgres instance. This prepares the target database with the necessary structure to hold the data.
-
-Finally, log into the new instance and confirm that the database schema migrated correctly. Run `\dt+;` in this example again and you see the database schema migrated to the new instance as expected:
+On the target instance, confirm the schema is migrated:
 
 ```
                                          List of relations
@@ -98,11 +97,13 @@ Finally, log into the new instance and confirm that the database schema migrated
  public | pgbench_tellers  | table | edb_admin | permanent   | heap          | 0 bytes | 
 ```
 
-While the schema looks the same on the new instance, the "Size" column shows 0 bytes of data, confirming that only the schema has been migrated so far.
+!!! Note
+A successful schema-only copy shows the tables with zero bytes.
+!!!
 
 ### Setting up Publication 
 
-To set up the publication, log into the old BigAnimal instance and create a publication:
+Create a publication from your source instance:
 
 ```sql
 CREATE PUBLICATION <pub_name>;
@@ -115,15 +116,13 @@ In this example:
 CREATE PUBLICATION v12_pub;
 ```
 
-The expected output is `CREATE PUBLICATION`.
+The expected output is: `CREATE PUBLICATION`.
 
-Next, configure the publication to include the specific tables you want replicated on the new instance:
+Add tables that you want to replicate to your target instance:
 
 ```sql
 ALTER PUBLICATION <pub_name> ADD TABLE <table_name>;
 ```
-
-Which in the current example is:
 
 ```sql
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_accounts;
@@ -132,11 +131,11 @@ ALTER PUBLICATION v12_pub ADD TABLE pgbench_history;
 ALTER PUBLICATION v12_pub ADD TABLE pgbench_tellers;
 ```
 
-Each of these alterations produces `ALTER PUBLICATION` output upon success. 
+The expected output is: `ALTER PUBLICATION`.
 
 ### Creating the Logical Replication Slot
 
-Then, on the older versioned instance, create a replication slot using the 'pgoutput' plugin:
+Then, on the source instance, create a replication slot using the `pgoutput` plugin:
 
 ```sql
 SELECT pg_create_logical_replication_slot('<slot_name>','pgoutput');
@@ -148,7 +147,7 @@ In the current example:
 SELECT pg_create_logical_replication_slot('v12_pub','pgoutput');
 ```
 
-If successful, the expected output is something like the following:
+The expected output returns the `slot_name` and `lsn`.
 
 ```
  pg_create_logical_replication_slot 
@@ -156,24 +155,23 @@ If successful, the expected output is something like the following:
  (v12_pub,0/AC003330)
 ```
 
-This slot tracks changes to the published tables on the old instance to ensure they can be replicated to the subscriber on the new instance without losing any data.
-
+The replication slot tracks changes to the published tables from the source instance and replicates changes to the subscriber on the target instance.
 
 ### Setting up the Subscription
 
-Now, logged into the newer Postgres instance, create a subscription to the publication on the older instance in the following format:
+On the target instance, create a subscription:
 
 ```sql
-CREATE SUBSCRIPTION <name_of_subscription> CONNECTION 'user=<old_instance_username> host=<old_instance_read/write_host> sslmode=require port=<old_instance_port> dbname=<old_instance_dbname> password=<old_instance_password>' PUBLICATION <publication_name> WITH (enabled=true, copy_data = true, create_slot = false, slot_name=<slot_name>);
+CREATE SUBSCRIPTION <name_of_subscription> CONNECTION 'user=<source_instance_username> host=<source_instance_read/write_host> sslmode=require port=<source_instance_port> dbname=<source_instance_dbname> password=<source_instance_password>' PUBLICATION <publication_name> WITH (enabled=true, copy_data = true, create_slot = false, slot_name=<slot_name>);
 ```
 
-Specifically, in this example:
+Creating a subscription on a Postgres 16 instance to a publication on a Postgres 12 instance:
 
 ```sql
 CREATE SUBSCRIPTION v16_sub CONNECTION 'user=edb_admin host=p-x67kjhacc4.pg.biganimal.io sslmode=require port=5432 dbname=edb_admin password=XXX' PUBLICATION v12_pub WITH (enabled=true, copy_data = true, create_slot = false, slot_name=v12_pub);
 ```
 
-Look for the expected output: `CREATE SUBSCRIPTION`.
+The expected output is: `CREATE SUBSCRIPTION`.
 
 In this example, the subscription uses a connection string to specify the source database and includes options to copy existing data and to follow the publication identified by 'v12_pub'. 
 

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -173,7 +173,7 @@ Look for the expected output: `CREATE SUBSCRIPTION`.
 
 In this example, the subscription uses a connection string to specify the source database and includes options to copy existing data and to follow the publication identified by 'v12_pub'. 
 
-The subscription mechanism pulls schema changes and data from the source to the target database, effectively replicating the data.
+The subscription mechanism pulls schema changes (with some exceptions, as noted in the PostgreSQL documentation on Limitations of Logical Replication: https://www.postgresql.org/docs/current/logical-replication-restrictions.html) and data from the source to the target database, effectively replicating the data.
 
 ### Validate the migration
 

--- a/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05c_upgrading_log_rep.mdx
@@ -3,3 +3,48 @@ title: Performing a rolling upgrade of Postgres major version on BigAnimal
 navTitle: Upgrading Postgres major versions
 ---
 
+## Using logical replication
+
+Logical replication offers a powerful method for upgrading major Postgres versions on BigAnimal instances, enabling a seamless transition with minimal downtime. 
+
+By replicating database changes in real-time from an older version to a newer one, this approach ensures data integrity and continuity. It's ideal for migrating data across different Postgres versions, providing a reliable upgrade path without sacrificing availability.
+
+
+
+### Schema Migration 
+
+First, copy over the database schema from the old instance using the `pg_dump` command:
+
+```
+pg_dump --schema-only  -h <old_biganimal_host> -U <old_biganimal_username> -d <old_biganimal_databasename> | psql -h <new_biganimal_host> -U <new_biganimal_username> -d <new_biganimal_databasename>
+```
+
+The `pg_dump --schema-only` command exports the schema (structure) of the existing database without the data. It's then piped into `psql` to import this schema into the new Postgres 16 instance. This prepares the target database with the necessary structure to hold the data.
+
+
+### Setting up Publication 
+
+On the Postgres 12 instance, a publication is created. This publication is configured to include specific tables, making their changes available for replication.
+
+```sql
+-- Add tables to publication
+ALTER PUBLICATION v12_pub ADD TABLE pgbench_accounts;
+ALTER PUBLICATION v12_pub ADD TABLE pgbench_branches;
+ALTER PUBLICATION v12_pub ADD TABLE pgbench_history;
+ALTER PUBLICATION v12_pub ADD TABLE pgbench_tellers;
+```
+
+### Creating Logical Replication Slot
+
+A replication slot named 'v12_pub' using the 'pgoutput' plugin is created on the version 12 instance. This slot tracks changes to the published tables to ensure they can be replicated to the subscriber without losing any data.
+
+```sql
+SELECT pg_create_logical_replication_slot('v12_pub','pgoutput');
+```
+### Setting up Subscription
+
+On the Postgres 16 instance, a subscription to the publication on the Postgres 12 instance is created. This subscription uses a connection string to specify the source database and includes options to copy existing data and to follow the publication identified by 'v12_pub'. The subscription mechanism pulls schema changes and data from the source to the target database, effectively replicating the data.
+
+```sql
+CREATE SUBSCRIPTION v16_sub CONNECTION 'user=edb_admin host=p-4bwwpm01u4.pg.biganimal.io port=5432 dbname=edb_admin password=XXX' PUBLICATION v12_pub WITH (enabled=true, copy_data = true, create_slot = false, slot_name=v12_pub);
+```

--- a/product_docs/docs/biganimal/release/using_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/index.mdx
@@ -11,6 +11,7 @@ navigation:
 - 05_monitoring_and_logging
 - fault_injection_testing
 - 05a_deleting_your_cluster
+- 05c_upgrading_log_rep
 - 06_analyze_with_superset
 - 06_demonstration_oracle_compatibility
 - terraform_provider


### PR DESCRIPTION
## Added the instructions to upgrade major Postgres versions on BigAnimal by migrating via logical replication.

Tracked in [JIRA](https://enterprisedb.atlassian.net/browse/DOCS-147).

