### PR TITLE
Add `PWR_CONFIG_FILE` env variable to PWR documentation

### DIFF
--- a/product_docs/docs/pwr/1/configuring.mdx
+++ b/product_docs/docs/pwr/1/configuring.mdx
@@ -4,45 +4,45 @@ navTitle: "Configuring"
 description: "How to configure Postgres Workload Report after installation"
 ---
 
-## `pwr` configuration file
+## The Postgres Workload Report configuration file
 
 To reduce the number of command-line arguments needed when executing `pwr`, you can use a configuration file to specify options that always have the same value and whose values differ from the default.
 
-During execution, `pwr` looks for a configuration file in the following places, and uses the first one found:
+During execution, Postgres Workload Report looks for a configuration file in the following places, and uses the first one found:
 
-1. File pointed through `--config` command-line option, if given.
-2. File pointed by `PWR_CONFIG_FILE` environment variable, if set.
+1. The file named in the `--config` command-line option, if given.
+2. The file named in the `PWR_CONFIG_FILE` environment variable, if set.
 3. `~/.pwr.conf`.
 4. `/etc/pwr.conf`.
 
 The installation package creates a template for the configuration file in `/etc/pwr.conf.templ`. We recommend copying this file to one of the
-two places where `pwr` looks for a configuration file by default, that is locations `3.` and `4.` from the previous list, and editing the options in the template as necessary.
+two places where Postgres Workload Report looks for a configuration file by default (locations #3 or #4 in the previous list), and editing the options in the template as necessary.
 
 !!! Note
-If no configuration file is found, `pwr` assumes the default value for all options, which can still be override through the corresponding command-line options.
+If no configuration file is found, Postgres Workload Report assumes the default value for all options, which can still be overriden via the corresponding command-line options. See [Using Postgres Workload Report](using/) for more on using command-line options.
 !!!
 
-You can configure the following options.
+## Configuration file options
 
 ### `input_dir`
 
-Identifies an existing directory where the `edb_wait_states` contents of a Lasso report are located. This option is used mainly for `pwr report` execution (see [Using Postgres Workload Report](using)).
+An existing directory where the `edb_wait_states` portion of a Lasso report are located. This option is used mainly for `pwr report` execution (see [Using Postgres Workload Report](using)).
 
 ### `output_dir`
 
-Specifies where to output reports. During execution, Postgres Workload Report tries to create the directory if it doesn't exist.
+Location of the directory where Postgres Workload Report writes report files. Executing `pwr` will create this directory if it doesn't exist.
 
 ### `report_name`
 
-Provides the name of the report files generated. Usually, you specify this option from the command line because different reports typically have different names.
+The name of the report files generated (without a file type extension - that will be added based on the output format(s) specified on the command line). Usually, you would specify this option on the command line because different reports typically have different names.
 
 ### `log_file`
 
-Provides the full path to the file where PWR writes the `stdout` and `stderr` logs.
+The full path to the file where Postgres Workload Report writes the `stdout` and `stderr` logs.
 
 ### `log_level`
 
-Specifies the logging level to use when running Postgres Workload Report. The following are valid values, listed from more verbose to less verbose: 
+The logging level to use when running Postgres Workload Report. The following are valid values, listed from more verbose to less verbose: 
 
     `DEBUG`
     `INFO` (default if not specified)
@@ -54,8 +54,8 @@ See [the Python logging](https://docs.python.org/3/library/logging.html#logging-
 
 ### `log_format`
 
-Provides the format of the log messages that are written to the log file. See [the Python logging](https://docs.python.org/3/library/logging.html#logrecord-attributes) documentation for more information on log formatting.
+The format of the log messages that are written to the log file. See [the Python logging](https://docs.python.org/3/library/logging.html#logrecord-attributes) documentation for more information on log formatting.
 
 ### `assets_dir`
 
-Identifies the directory where you can find the Jinja templates used to format the HTML output and the CSS used for PDF output. Typically, the directory to use by default is `/usr/share/pwr/assets`, which contains the assets provided with the `edb-pwr` package.
+The directory containing the Jinja templates used to format the HTML output and the CSS used for PDF output. The default value is `/usr/share/pwr/assets`, which contains the assets provided with the `edb-pwr` package.

--- a/product_docs/docs/pwr/1/configuring.mdx
+++ b/product_docs/docs/pwr/1/configuring.mdx
@@ -4,11 +4,11 @@ navTitle: "Configuring"
 description: "How to configure Postgres Workload Report after installation"
 ---
 
-## The Postgres Workload Report configuration file
-
 To reduce the number of command-line arguments needed when executing `pwr`, you can use a configuration file to specify options that always have the same value and whose values differ from the default.
 
-During execution, Postgres Workload Report looks for a configuration file in the following places, and uses the first one found:
+## Configuration file locations
+
+Postgres Workload Report looks for a configuration file in the following places, and uses the first one found:
 
 1. The file named in the `--config` command-line option, if given.
 2. The file named in the `PWR_CONFIG_FILE` environment variable, if set.
@@ -34,7 +34,9 @@ Location of the directory where Postgres Workload Report writes report files. Ex
 
 ### `report_name`
 
-The name of the report files generated (without a file type extension - that will be added based on the output format(s) specified on the command line). Usually, you would specify this option on the command line because different reports typically have different names.
+The name of the report files generated. Usually, you would specify this option on the command line because different reports typically have different names.
+
+Don't include a file extension; an appropriate extension will be added will be added based on the output format(s) specified on the command line (`--pdf` adds `.pdf`, `--html` adds `.html`, and so on).
 
 ### `log_file`
 
@@ -44,11 +46,11 @@ The full path to the file where Postgres Workload Report writes the `stdout` and
 
 The logging level to use when running Postgres Workload Report. The following are valid values, listed from more verbose to less verbose: 
 
-    `DEBUG`
-    `INFO` (default if not specified)
-    `WARNING`
-    `ERROR`
-    `CRITICAL`
+- `DEBUG`
+- `INFO` (default if not specified)
+- `WARNING`
+- `ERROR`
+- `CRITICAL`
 
 See [the Python logging](https://docs.python.org/3/library/logging.html#logging-levels) documentation for more information about log levels.
 

--- a/product_docs/docs/pwr/1/configuring.mdx
+++ b/product_docs/docs/pwr/1/configuring.mdx
@@ -10,13 +10,13 @@ To reduce the number of command-line arguments needed when executing `pwr`, you 
 
 During execution, `pwr` looks for a configuration file in the following places, and uses the first one found:
 
-1. File pointed through `--config` command-line option, if given;
-2. File pointed by `PWR_CONFIG_FILE` environment variable, if set;
-3. `~/.pwr.conf`;
+1. File pointed through `--config` command-line option, if given.
+2. File pointed by `PWR_CONFIG_FILE` environment variable, if set.
+3. `~/.pwr.conf`.
 4. `/etc/pwr.conf`.
 
 The installation package creates a template for the configuration file in `/etc/pwr.conf.templ`. We recommend copying this file to one of the
-two places where `pwr` looks for a configuration file by default, i.e. locations `3.` and `4.` from the above list, and editing the options in the template as necessary.
+two places where `pwr` looks for a configuration file by default, that is locations `3.` and `4.` from the previous list, and editing the options in the template as necessary.
 
 **Note:** if no configuration file is found, `pwr` assumes the default value for all options, which can still be override through the corresponding command-line options.
 

--- a/product_docs/docs/pwr/1/configuring.mdx
+++ b/product_docs/docs/pwr/1/configuring.mdx
@@ -8,11 +8,17 @@ description: "How to configure Postgres Workload Report after installation"
 
 To reduce the number of command-line arguments needed when executing `pwr`, you can use a configuration file to specify options that always have the same value and whose values differ from the default.
 
-During execution, `pwr` looks for an existing configuration file in `~/.pwr.conf` and `/etc/pwr.conf`, in that order, and uses the first one found.
-However, if the `--config` option specifies a configuration file, that value overrides the default locations.
+During execution, `pwr` looks for a configuration file in the following places, and uses the first one found:
+
+1. File pointed through `--config` command-line option, if given;
+2. File pointed by `PWR_CONFIG_FILE` environment variable, if set;
+3. `~/.pwr.conf`;
+4. `/etc/pwr.conf`.
 
 The installation package creates a template for the configuration file in `/etc/pwr.conf.templ`. We recommend copying this file to one of the
-two places where `pwr` looks for a configuration file and editing the options in the template as necessary.
+two places where `pwr` looks for a configuration file by default, i.e. locations `3.` and `4.` from the above list, and editing the options in the template as necessary.
+
+**Note:** if no configuration file is found, `pwr` assumes the default value for all options, which can still be override through the corresponding command-line options.
 
 You can configure the following options.
 

--- a/product_docs/docs/pwr/1/configuring.mdx
+++ b/product_docs/docs/pwr/1/configuring.mdx
@@ -19,7 +19,7 @@ The installation package creates a template for the configuration file in `/etc/
 two places where `pwr` looks for a configuration file by default, that is locations `3.` and `4.` from the previous list, and editing the options in the template as necessary.
 
 !!! Note
-    If no configuration file is found, `pwr` assumes the default value for all options, which can still be override through the corresponding command-line options.
+If no configuration file is found, `pwr` assumes the default value for all options, which can still be override through the corresponding command-line options.
 !!!
 
 You can configure the following options.

--- a/product_docs/docs/pwr/1/configuring.mdx
+++ b/product_docs/docs/pwr/1/configuring.mdx
@@ -18,7 +18,9 @@ During execution, `pwr` looks for a configuration file in the following places, 
 The installation package creates a template for the configuration file in `/etc/pwr.conf.templ`. We recommend copying this file to one of the
 two places where `pwr` looks for a configuration file by default, that is locations `3.` and `4.` from the previous list, and editing the options in the template as necessary.
 
-**Note:** if no configuration file is found, `pwr` assumes the default value for all options, which can still be override through the corresponding command-line options.
+!!! Note
+    If no configuration file is found, `pwr` assumes the default value for all options, which can still be override through the corresponding command-line options.
+!!!
 
 You can configure the following options.
 


### PR DESCRIPTION
This commit modifies the PWR docs so it contains information about the environment variable `PWR_CONFIG_FILE`, which can be used to specify a config file for PWR.

References: PGCP-58.

## What Changed?

Add information about `PWR_CONFIG_FILE` environment variable to the PWR documentation. That variable has always been supported by PWR to specify the path to a configuration file, but the docs were missing that information.

