### PR TITLE
Updating pgBouncer support table

### DIFF
--- a/product_docs/docs/pgbouncer/1/supported_platforms.mdx
+++ b/product_docs/docs/pgbouncer/1/supported_platforms.mdx
@@ -8,18 +8,21 @@ The EDB PgBouncer is supported on the same platforms as EDB Postgres Advanced Se
 
 This table lists the latest EDB PgBouncer versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions.
 
-| EDB PgBouncer | EPAS 15  | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 |   
-| ------------- | -------  | ------- | ------- | ------- | ------- |   
-| 1.19          | Y        | Y       | Y       | Y       | Y       |   
-| 1.18          | Y        | Y       | Y       | Y       | Y       |   
-| 1.17          | N        | Y       | Y       | Y       | Y       |   
-| 1.16          | N        | Y       | Y       | Y       | Y       |   
-| 1.15          | N        | N       | Y       | Y       | Y       |   
-| 1.14          | N        | N       | Y       | Y       | Y       |   
-| 1.13          | N        | N       | N       | Y       | N       |   
-| 1.12          | N        | N       | N       | Y       | N       |   
-| 1.9           | N        | N       | N       | N       | Y       |   
-| 1.7           |  N        | N       | N       | N       | N       |   
+| EDB PgBouncer | EPAS 16 | EPAS 15  | EPAS 14 | EPAS 13 | EPAS 12 |   
+| ------------- | ------- | -------  | ------- | ------- | ------- |   
+| 1.22          | Y       | Y        | Y       | Y       | Y       |
+| 1.21          | Y       | Y        | Y       | Y       | Y       |
+| 1.20          | Y       | Y        | Y       | Y       | Y       |
+| 1.19          | Y       | Y        | Y       | Y       | Y       |  
+| 1.18          | Y       | Y        | Y       | Y       | Y       | 
+| 1.17          | N       | N        | Y       | Y       | Y       | 
+| 1.16          | N       | N        | Y       | Y       | Y       |   
+| 1.15          | N       | N        | N       | Y       | Y       |   
+| 1.14          | N       | N        | N       | Y       | Y       |   
+| 1.13          | N       | N        | N       | N       | Y       |   
+| 1.12          | N       | N        | N       | N       | Y       |  
+| 1.9           | N       | N        | N       | N       | N       |  
+| 1.7           | N       | N        | N       | N       | N       |    
 
 
 The documented and supported functionality of each version of EDB PgBouncer is the same. The information in this documentation applies to all supported versions of EDB PgBouncer.


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/DOCS-207 

- Removed EPAS 11 from all rows
- Added EPAS 16 
- Added pgbouncer versions 1.20, 1.21, and 1.22

