### PR TITLE
Clarify that timestamp args of PWR accept input with or without time zone

### DIFF
--- a/product_docs/docs/pwr/1/using.mdx
+++ b/product_docs/docs/pwr/1/using.mdx
@@ -32,6 +32,10 @@ pwr execute --host-name myserver --sampling-start '2024-01-10 09:00+00' \
     --report-name 'Jan10_incident' my-oltp postgres 
 ```
 
+!!! Note
+`--sampling-start` and `--sampling-end` accept both timestamps with or without time zone. If no time zone is explicitly set in the timestamp(s), PWR uses the system time zone.
+!!!
+
 Run `pwr execute -h` to get the full list of options available.
 
 ## Example for the `report` option


### PR DESCRIPTION
When no time zone is explicitly set, PWR falls back to the local system time zone.

References: PGCP-71.

## What Changed?

Added a note to the PWR docs explaining that in the absence of a time zone in the timestamp arguments, PWR falls back to the system time zone.
