### PR TITLE
DOCS-223: ensure every page has a rel="canonical" header

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -27,6 +27,7 @@ const Layout = ({
   const { baseUrl, imageUrl, title: siteTitle } = useSiteMetadata();
   const meta = pageMeta || {};
   const url = meta.path ? baseUrl + meta.path : baseUrl;
+  const canonicalUrl = meta.canonicalPath ? baseUrl + meta.canonicalPath : url;
   const title = meta.title ? `EDB Docs - ${meta.title}` : siteTitle;
 
   const [dark, setDark] = useState(false);
@@ -122,9 +123,7 @@ const Layout = ({
         )}
         <meta property="og:image" content={imageUrl} />
         <meta property="og:url" content={url} />
-        {meta.canonicalPath && (
-          <link rel="canonical" href={baseUrl + meta.canonicalPath} />
-        )}
+        <link rel="canonical" href={canonicalUrl} />
         <meta name="twitter:card" content="summary_large_image" />
         <body className={`bg-${background} fixed-container`} />
       </Helmet>


### PR DESCRIPTION
## What Changed?

Always render the canonical header. If no other version of a given page is known, it should be considered the canonical path and rendered in the header with http://www.enterprisedb.com/docs/ as the base URL.

## Background 

It appears we are not rendering the canonical header for unversioned pages (this includes all content under advocacy_docs, as well as the homepage, special status pages, and potentially a tiny handful of product pages contained within normally versioned products in exceptional circumstances). Most importantly, this includes most of our documentation for extensions.

Example: https://www.enterprisedb.com/docs/pg_extensions/pg_squeeze/using/ does not have a rel="canonical" header. https://deploy-preview-5402--edb-docs-staging.netlify.app/docs/pg_extensions/pg_squeeze/using/ (same page but built with this PR) does.