### PR TITLE
Clarify in the docs that PWR configuration file should be in YAML format

### DIFF
--- a/product_docs/docs/pwr/1/configuring.mdx
+++ b/product_docs/docs/pwr/1/configuring.mdx
@@ -22,6 +22,10 @@ two places where Postgres Workload Report looks for a configuration file by defa
 If no configuration file is found, Postgres Workload Report assumes the default value for all options, which you can still override using the corresponding command-line options. See [Using Postgres Workload Report](using/) for more on using command-line options.
 !!!
 
+!!! Note
+Although the configuration file extension is `.conf`, its content must be in **valid** YAML format.
+!!!
+
 ## Configuration file options
 
 ### `input_dir`


### PR DESCRIPTION
Although the PWR configuration file is named with a `.conf` suffix, its content must be in YAML format.

This commit adds a note with that information, so we avoid having users to face config parsing issues.

References: PGCP-63.

## What Changed?

Adds a note that PWR config file content must be in YAML format.
