### PR TITLE
Add the description of `barman_home`

### DIFF
--- a/product_docs/docs/tpa/23/reference/barman.mdx
+++ b/product_docs/docs/tpa/23/reference/barman.mdx
@@ -33,14 +33,17 @@ the previous 4 weeks.
 
 ## Barman configuration
 
+The Barman home directory on the Barman server can be set using the 
+cluster variable `barman_home`; its default value is `/var/lib/barman`.
+
 On each Barman server, a global configuration file is created
 as `/etc/barman.conf`. This file contains default values for many Barman
 configuration variables. For each Postgres server being backed up,
 an additional Barman configuration file is created. For example, to back up the
 server `one`, the file is `/etc/barman.d/one.conf`, and the backups
-are stored in `/var/lib/barman/one`. The file and directory names
-are taken from the backed-up instance's `backup_name` setting. The default for this setting
-is the instance name.
+are stored in the subdirectory `one` in the Barman home directory. The 
+configuration file and directory names are taken from the backed-up instance's 
+`backup_name` setting. The default for this setting is the instance name.
 
 You can set the following variables on the backed-up instance. They are
 passed through into Barman's configuration with the prefix `barman_`


### PR DESCRIPTION
Barman home directory can be overridden using this variable.

## What Changed?

Added the description for `barman_home`