### PR TITLE
Add more information about efm startup log

### DIFF
--- a/product_docs/docs/efm/4/05_using_efm.mdx
+++ b/product_docs/docs/efm/4/05_using_efm.mdx
@@ -39,6 +39,8 @@ To start the Failover Manager cluster on RHEL/CentOS 7.x or RHEL/Rocky Linux/Alm
 
 `systemctl start edb-efm-4.<x>`
 
+!!! Note
+    If the agent fails to start, see the startup log `/var/log/efm-4.<x>/startup-efm.log` for more information.
 
 If the cluster properties file for the node specifies that `is.witness` is `true`, the node starts as a witness node.
 

--- a/product_docs/docs/efm/4/13_troubleshooting.mdx
+++ b/product_docs/docs/efm/4/13_troubleshooting.mdx
@@ -10,6 +10,10 @@ legacyRedirectsGenerated:
 
 <div id="troubleshooting" class="registered_link"></div>
 
+## The Failover Manager agent fails to start
+
+If an agent fails to start, see the startup log `/var/log/efm-<version>/startup-<cluster>.log` for more information.
+
 ## Authorization file not found. Is the local agent running?
 
 If you invoke an Failover Manager cluster management command and Failover Manager isn't running on the node, the `efm` command displays an error:


### PR DESCRIPTION
This changes adds notes in two places to tell the user to check the startup log if there is a problem starting efm. Too often the user only checks 'systemctl status' output, which does not contain the problem.

(I'd like to get rid of the startup log because users forget it's there and it's not needed any more. I don't know when it'll happen though: https://enterprisedb.atlassian.net/browse/EFM-1619)