### PR TITLE
BA - Reorganize left nav to lower known issues - DOCS-248

### DIFF
--- a/product_docs/docs/biganimal/release/index.mdx
+++ b/product_docs/docs/biganimal/release/index.mdx
@@ -8,8 +8,6 @@ directoryDefaults:
   hideKBLink: true
 
 navigation:
-  - release_notes
-  - known_issues
   - free_trial
   - overview
   - planning
@@ -19,6 +17,8 @@ navigation:
   - pricing_and_billing
   - migration
   - reference
+  - release_notes
+  - known_issues
   - knowledge_base
 ---
 


### PR DESCRIPTION

## What Changed?

Move release notes *and* known issues down the left nav
