### PR TITLE
Update 1_18_8_rel_notes.mdx

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_18_8_rel_notes.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/rel_notes/1_18_8_rel_notes.mdx
@@ -11,16 +11,11 @@ This release of EDB Postgres for Kubernetes includes the following:
 
 | Type | Description |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| Enhancement | Enhanced the `status` command of the `cnp` plugin for `kubectl` with progress
-information on active streaming base backups. |
-| Enhancement | Allowed the configuration of `max_prepared_statements` with the pgBouncer
-`Pooler` resource. |
+| Enhancement | Enhanced the `status` command of the `cnp` plugin for `kubectl` with progress information on active streaming base backups. |
+| Enhancement | Allowed the configuration of `max_prepared_statements` with the pgBouncer `Pooler` resource. |
 | Technical Enhancement | Use extended query protocol for PostgreSQL in the instance manager. |
 | Bug fix | Suspend WAL archiving during a switchover and resume it when it is completed. |
-| Bug fix | Ensured that the instance manager always uses `synchronous_commit = local`
-when managing the PostgreSQL cluster. |
-| Bug fix | Custom certificates for streaming replication user through
-`.spec.certificates.replicationTLSSecret` are now working. |
+| Bug fix | Ensured that the instance manager always uses `synchronous_commit = local` when managing the PostgreSQL cluster. |
+| Bug fix | Custom certificates for streaming replication user through `.spec.certificates.replicationTLSSecret` are now working. |
 | Bug fix | Set the `k8s.enterprisedb.io/cluster` label to the `Pooler` pods. |
-| Change | Stopped using the `postgresql.auto.conf` file inside PGDATA to control Postgres
-replication settings, and replace it with a file named `override.conf`. |
+| Change | Stopped using the `postgresql.auto.conf` file inside PGDATA to control Postgres replication settings, and replace it with a file named `override.conf`. |


### PR DESCRIPTION
## What Changed?

Fix for:

"Hopefully this is the correct place to report this. On the EDB Postgres for Kubernetes release notes for 1.18.8,
https://www.enterprisedb.com/docs/postgres_for_kubernetes/latest/rel_notes/1_18_8_rel_notes/
some of the Description text is spilling into the Type column:"
