### PR TITLE
pgd: update output columns for bdr.lag_control()

### DIFF
--- a/product_docs/docs/pgd/5/reference/functions.mdx
+++ b/product_docs/docs/pgd/5/reference/functions.mdx
@@ -975,25 +975,29 @@ bdr.lag_control()
 
 #### Output columns
 
-- `commit_delay` &mdash; Current runtime commit delay, in fractional milliseconds.
+- `commit_scope_id` &mdash; OID of the commit scope (see [`bdr.commit_scopes`](catalogs-visible/#bdr.commit_scopes))
 
-- `commit_delay_maximum` &mdash; Configured maximum commit delay, in fractional milliseconds.
+- `sessions` &mdash; Number of sessions referencing the lag control entry
 
-- `commit_delay_adjustment` &mdash; Change to runtime commit delay possible during
+- `current_commit_delay` &mdash; Current runtime commit delay, in fractional milliseconds.
+
+- `maximum_commit_delay` &mdash; Configured maximum commit delay, in fractional milliseconds.
+
+- `commit_delay_adjust` &mdash; Change to runtime commit delay possible during
   a sample interval, in fractional milliseconds.
 
-- `conforming_nodes` &mdash; Current runtime number of nodes conforming to lag measures.
+- `curent_conforming_nodes` &mdash; Current runtime number of nodes conforming to lag measures.
 
-- `conforming_nodes_minimum` &mdash; Configured minimum number of nodes required to
+- `minimum_conforming_nodes` &mdash; Configured minimum number of nodes required to
   conform to lag measures, below which a commit delay adjustment is applied.
 
 - `lag_bytes_threshold` &mdash; Lag size at which a commit delay is applied, in kilobytes.
 
-- `lag_bytes_maximum` &mdash; Configured maximum lag size, in kilobytes.
+- `maximum_lag_bytes` &mdash; Configured maximum lag size, in kilobytes.
 
 - `lag_time_threshold` &mdash; Lag time at which a commit delay is applied, in milliseconds.
 
-- `lag_time_maximum` &mdash; Configured maximum lag time, in milliseconds.
+- `maximum_lag_time` &mdash; Configured maximum lag time, in milliseconds.
 
 - `sample_interval` &mdash; Configured minimum time between lag samples and possible
   commit delay adjustments, in milliseconds.


### PR DESCRIPTION
## What Changed?

The fields in the record emitted by this function were partially renamed and two new ones added in BDR 5.0.0 (see commit [d346c453](https://github.com/EnterpriseDB/bdr/commit/d346c4536fdc0bbc2c7c8d2b2f2960dbcb652750)).