### PR TITLE
Timestamp check fails with example

### DIFF
--- a/product_docs/docs/pwr/1/using.mdx
+++ b/product_docs/docs/pwr/1/using.mdx
@@ -27,8 +27,8 @@ This example generates a report on query waits for the Postgres server `myserver
 To get the report in HTML format, use the following command:
 
 ```shell
-pwr execute --host-name myserver --sampling-start '2024-01-10 09:00+00' \
-    --sampling-end '2024-01-10 13:00+00' --html \
+pwr execute --host-name myserver --sampling-start '2024-01-10 09:00:00+00:00' \
+    --sampling-end '2024-01-10 13:00:00+00:00' --html \
     --report-name 'Jan10_incident' my-oltp postgres 
 ```
 


### PR DESCRIPTION
The example fails with the timestamp check library we use. Added missing seconds to timestamp and minutes to timezone

## What Changed?

