### PR TITLE
Release: 2024-03-28b

### DIFF
--- a/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
+++ b/product_docs/docs/biganimal/release/getting_started/creating_a_cluster/index.mdx
@@ -73,6 +73,8 @@ The following options aren't available when creating your cluster:
 
         -   **[EDB Postgres Advanced Server](/epas/latest/)** is EDB's Oracle-compatible database offering. View [a quick demonstration of Oracle compatibility on BigAnimal](../../using_cluster/06_demonstration_oracle_compatibility). EDB Postgres Advanced Server is compatible with all three cluster types.
 
+        -   **[EDB Postgres Extended Server](/pge/latest/)** is EDB's PostgreSQL-compatible database offering that uses advanced logical replication.
+
         -   **[PostgreSQL](/supported-open-source/postgresql/)** is the open-source, object-relational database management system. PostgreSQL is compatible with single-node and primary/standby high-availability cluster types.
     
     1.  In the **Postgres Version** list, select the version of Postgres that you want to use. See [Database version policy](../../overview/05_database_version_policy) for more information.

--- a/product_docs/docs/postgres_for_kubernetes/1/images/grafana-local.png
+++ b/product_docs/docs/postgres_for_kubernetes/1/images/grafana-local.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b6fd7597138faadf132fd13dce4df89bbef2e771a45241d2defa32607f029a5
-size 241795
+oid sha256:6a3f34d6c747cba079665d94b19db1e562ca11526ff442e5a85a5e80b78cef14
+size 398383

--- a/product_docs/docs/postgres_for_kubernetes/1/installation_upgrade.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/installation_upgrade.mdx
@@ -23,7 +23,7 @@ You can install the [latest operator manifest](https://get.enterprisedb.io/cnp/p
 for this minor release as follows:
 
 ```sh
-kubectl apply -f \
+kubectl apply --server-side -f \
   https://get.enterprisedb.io/cnp/postgresql-operator-1.22.2.yaml
 ```
 
@@ -75,8 +75,8 @@ For example, you can install the latest snapshot of the operator with:
 
 ```sh
 curl -sSfL \
-  https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-1.22/manifests/operator-manifest.yaml | \
-  kubectl apply -f -
+  https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/manifests/operator-manifest.yaml | \
+  kubectl apply --server-side -f -
 ```
 
 If you are instead looking for the latest snapshot of the operator for this

--- a/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
@@ -34,52 +34,67 @@ them in your systems.
 
 #### Debian packages
 
-For example, let's install the 1.18.1 release of the plugin, for an Intel based
+For example, let's install the 1.22.2 release of the plugin, for an Intel based
 64 bit server. First, we download the right `.deb` file.
 
 ```sh
-$ wget https://github.com/EnterpriseDB/kubectl-cnp/releases/download/v1.18.1/kubectl-cnp_1.18.1_linux_x86_64.deb
+wget https://github.com/EnterpriseDB/kubectl-cnp/releases/download/v1.22.2/kubectl-cnp_1.22.2_linux_x86_64.deb
 ```
 
 Then, install from the local file using `dpkg`:
 
 ```sh
-$ dpkg -i kubectl-cnp_1.18.1_linux_x86_64.deb
+dpkg -i kubectl-cnp_1.22.2_linux_x86_64.deb 
+__OUTPUT__
 (Reading database ... 16102 files and directories currently installed.)
-Preparing to unpack kubectl-cnp_1.18.1_linux_x86_64.deb ...
-Unpacking cnp (1.18.1) over (1.18.1) ...
-Setting up cnp (1.18.1) ...
+Preparing to unpack kubectl-cnp_1.22.2_linux_x86_64.deb ...
+Unpacking cnp (1.22.2) over (1.22.2) ...
+Setting up cnp (1.22.2) ...
 ```
 
 #### RPM packages
 
-As in the example for `.deb` packages, let's install the 1.18.1 release for an
+As in the example for `.deb` packages, let's install the 1.22.2 release for an
 Intel 64 bit machine. Note the `--output` flag to provide a file name.
 
-```sh
-curl -L https://github.com/EnterpriseDB/kubectl-cnp/releases/download/v1.18.1/kubectl-cnp_1.18.1_linux_x86_64.rpm --output cnp-plugin.rpm
+``` sh
+curl -L https://github.com/EnterpriseDB/kubectl-cnp/releases/download/v1.22.2/kubectl-cnp_1.22.2_linux_x86_64.rpm \
+  --output kube-plugin.rpm
 ```
 
 Then install with `yum`, and you're ready to use:
 
 ```sh
-$ yum --disablerepo=* localinstall cnp-plugin.rpm
-yum --disablerepo=* localinstall cnp-plugin.rpm
-Failed to set locale, defaulting to C.UTF-8
+yum --disablerepo=* localinstall kube-plugin.rpm    
+__OUTPUT__
 Dependencies resolved.
-====================================================================================================
- Package            Architecture         Version                   Repository                  Size
-====================================================================================================
+========================================================================================================================
+ Package                       Architecture             Version                    Repository                      Size
+========================================================================================================================
 Installing:
- cnpg               x86_64               1.18.1-1                  @commandline                14 M
+ kubectl-cnp                   x86_64                   1.22.2-1                   @commandline                    17 M
 
 Transaction Summary
-====================================================================================================
+========================================================================================================================
 Install  1 Package
 
-Total size: 14 M
-Installed size: 43 M
+Total size: 17 M
+Installed size: 62 M
 Is this ok [y/N]: y
+Downloading Packages:
+Running transaction check
+Transaction check succeeded.
+Running transaction test
+Transaction test succeeded.
+Running transaction
+  Preparing        :                                                                                                1/1
+  Installing       : kubectl-cnp-1.22.2-1.x86_64                                                                    1/1
+  Verifying        : kubectl-cnp-1.22.2-1.x86_64                                                                    1/1
+
+Installed:
+  kubectl-cnp-1.22.2-1.x86_64
+
+Complete!
 ```
 
 ### Supported Architectures
@@ -101,6 +116,29 @@ operating system and architectures:
     -   amd64
     -   arm 5/6/7
     -   arm64
+
+### Configuring auto-completion
+
+To configure [auto-completion](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_completion/) for the plugin, a helper shell script needs to be
+installed into your current PATH. Assuming the latter contains `/usr/local/bin`,
+this can be done with the following commands:
+
+```shell
+cat > kubectl_complete-cnp <<EOF
+#!/usr/bin/env sh
+
+# Call the __complete command passing it all arguments
+kubectl cnp __complete "\$@"
+EOF
+
+chmod +x kubectl_complete-cnp
+
+# Important: the following command may require superuser permission
+sudo mv kubectl_complete-cnp /usr/local/bin
+```
+
+!!! Important
+    The name of the script needs to be exactly the one provided since is used by the kubectl auto-complete process
 
 ## Use
 
@@ -127,10 +165,7 @@ The main options are:
 
 -   `-n`: the namespace in which to install the operator (by default: `postgresql-operator-system`)
 -   `--replicas`: number of replicas in the deployment
--   `--version`: minor version of the operator to be installed, such as `1.17`.
-    If a minor version is specified, the plugin will install the latest patch
-    version of that minor version. If no version is supplied the plugin will
-    install the latest `MAJOR.MINOR.PATCH` version of the operator.
+-   `--version`: version of the operator to be installed, specified in the `<major>.<minor>.<patch>` format (e.g. `1.22.2`). The default empty value installs the version of the operator that matches the version of the plugin.
 -   `--watch-namespace`: comma separated string containing the namespaces to
     watch (by default all namespaces)
 
@@ -140,7 +175,7 @@ will install the operator, is as follows:
 ```shell
 kubectl cnp install generate \
   -n king \
-  --version 1.17 \
+  --version 1.22.2 \
   --replicas 3 \
   --watch-namespace "albert, bb, freddie" \
   > operator.yaml
@@ -149,9 +184,9 @@ kubectl cnp install generate \
 The flags in the above command have the following meaning:
 
 -   `-n king` install the CNP operator into the `king` namespace
--   `--version 1.17` install the latest patch version for minor version 1.17
+-   `--version 1.22.2` install operator version 1.22.2
 -   `--replicas 3` install the operator with 3 replicas
--   `--watch-namespaces "albert, bb, freddie"` have the operator watch for
+-   `--watch-namespace "albert, bb, freddie"` have the operator watch for
     changes in the `albert`, `bb` and `freddie` namespaces only
 
 ### Status
@@ -187,7 +222,7 @@ Cluster in healthy state
 Name:               sandbox
 Namespace:          default
 System ID:          7039966298120953877
-PostgreSQL Image:   quay.io/enterprisedb/postgresql:15.3
+PostgreSQL Image:   quay.io/enterprisedb/postgresql:16.2
 Primary instance:   sandbox-2
 Instances:          3
 Ready instances:    3
@@ -232,7 +267,7 @@ Cluster in healthy state
 Name:               sandbox
 Namespace:          default
 System ID:          7039966298120953877
-PostgreSQL Image:   quay.io/enterprisedb/postgresql:15.3
+PostgreSQL Image:   quay.io/enterprisedb/postgresql:16.2
 Primary instance:   sandbox-2
 Instances:          3
 Ready instances:    3
@@ -722,6 +757,89 @@ items:
             "apiVersion": "postgresql.k8s.enterprisedb.io/v1",
 ```
 
+### Logs
+
+The `kubectl cnp logs` command allows to follow the logs of a collection
+of pods related to EDB Postgres for Kubernetes in a single go.
+
+It has at the moment one available sub-command: `cluster`.
+
+#### Cluster logs
+
+The `cluster` sub-command gathers all the pod logs for a cluster in a single
+stream or file.
+This means that you can get all the pod logs in a single terminal window, with a
+single invocation of the command.
+
+As in all the cnp plugin sub-commands, you can get instructions and help with
+the `-h` flag:
+
+`kubectl cnp logs cluster -h`
+
+The `logs` command will display logs in  JSON-lines format, unless the
+`--timestamps` flag is used, in which case, a human readable timestamp will be
+prepended to each line. In this case, lines will no longer be valid JSON,
+and tools such as `jq` may not work as desired.
+
+If the `logs cluster` sub-command is given the `-f` flag (aka `--follow`), it
+will follow the cluster pod logs, and will also watch for any new pods created
+in the cluster after the command has been invoked.
+Any new pods found, including pods that have been restarted or re-created,
+will also have their pods followed.
+The logs will be displayed in the terminal's standard-out.
+This command will only exit when the cluster has no more pods left, or when it
+is interrupted by the user.
+
+If `logs` is called without the `-f` option, it will read the logs from all
+cluster pods until the time of invocation and display them in the terminal's
+standard-out, then exit.
+The `-o` or `--output` flag can be provided, to specify the name
+of the file where the logs should be saved, instead of displaying over
+standard-out.
+The `--tail` flag can be used to specify how many log lines will be retrieved
+from each pod in the cluster. By default, the `logs cluster` sub-command will
+display all the logs from each pod in the cluster. If combined with the "follow"
+flag `-f`, the number of logs specified by `--tail` will be retrieved until the
+current time, and and from then the new logs will be followed.
+
+NOTE: unlike other `cnp` plugin commands, the `-f` is used to denote "follow"
+rather than specify a file. This keeps with the convention of `kubectl logs`,
+which takes `-f` to mean the logs should be followed.
+
+Usage:
+
+```shell
+kubectl cnp logs cluster <clusterName> [flags]
+```
+
+Using the `-f` option to follow:
+
+```shell
+kubectl cnp report cluster cluster-example -f
+```
+
+Using `--tail` option to display 3 lines from each pod and the `-f` option
+to follow:
+
+```shell
+kubectl cnp report cluster cluster-example -f --tail 3
+```
+
+``` json
+{"level":"info","ts":"2023-06-30T13:37:33Z","logger":"postgres","msg":"2023-06-30 13:37:33.142 UTC [26] LOG:  ending log output to stderr","source":"/controller/log/postgres","logging_pod":"cluster-example-3"}
+{"level":"info","ts":"2023-06-30T13:37:33Z","logger":"postgres","msg":"2023-06-30 13:37:33.142 UTC [26] HINT:  Future log output will go to log destination \"csvlog\".","source":"/controller/log/postgres","logging_pod":"cluster-example-3"}
+…
+…
+```
+
+With the `-o` option omitted, and with `--output` specified:
+
+``` sh
+kubectl cnp logs cluster cluster-example --output my-cluster.log
+
+Successfully written logs to "my-cluster.log"
+```
+
 ### Destroy
 
 The `kubectl cnp destroy` command helps remove an instance and all the
@@ -826,10 +944,15 @@ kubectl cnp fio <fio-job-name> -n <namespace>
 
 Refer to the [Benchmarking fio section](benchmarking.md#fio) for more details.
 
-### Requesting a new base backup
+### Requesting a new physical backup
 
 The `kubectl cnp backup` command requests a new physical base backup for
 an existing Postgres cluster by creating a new `Backup` resource.
+
+!!! Info
+    From release 1.21, the `backup` command accepts a new flag, `-m`
+    to specify the backup method.
+    To request a backup using volume snapshots, set `-m volumeSnapshot`
 
 The following example requests an on-demand backup for a given cluster:
 
@@ -844,10 +967,17 @@ kubectl cnp backup cluster-example
 backup/cluster-example-20230121002300 created
 ```
 
-By default, new created backup will use the backup target policy defined
-in cluster to choose which instance to run on. You can also use `--backup-target`
-option to override this policy. please refer to [Backup and Recovery](backup_recovery.md)
-for more information about backup target.
+By default, a newly created backup will use the backup target policy defined
+in the cluster to choose which instance to run on.
+However, you can override this policy with the `--backup-target` option.
+
+In the case of volume snapshot backups, you can also use the `--online` option
+to request an online/hot backup or an offline/cold one: additionally, you can
+also tune online backups by explicitly setting the `--immediate-checkpoint` and
+`--wait-for-archive` options.
+
+The ["Backup" section](./backup.md#backup) contains more information about
+the configuration settings.
 
 ### Launching psql
 
@@ -862,7 +992,7 @@ it from the actual pod. This means that you will be using the `postgres` user.
 ```shell
 kubectl cnp psql cluster-example
 
-psql (15.3)
+psql (16.2 (Debian 16.2-1.pgdg110+1))
 Type "help" for help.
 
 postgres=#
@@ -873,7 +1003,7 @@ select to work against a replica by using the `--replica` option:
 
 ```shell
 kubectl cnp psql --replica cluster-example
-psql (15.3)
+psql (16.2 (Debian 16.2-1.pgdg110+1))
 
 Type "help" for help.
 
@@ -901,44 +1031,335 @@ kubectl cnp psql cluster-example -- -U postgres
 
 ### Snapshotting a Postgres cluster
 
-The `kubectl cnp snapshot` creates consistent snapshots of a Postgres
-`Cluster` by:
-
-1.  choosing a replica Pod to work on
-2.  fencing the replica
-3.  taking the snapshot
-4.  unfencing the replica
-
 !!! Warning
-    A cluster already having a fenced instance cannot be snapshotted.
+    The `kubectl cnp snapshot` command has been removed.
+    Please use the [`backup` command](#requesting-a-new-backup) to request
+    backups using volume snapshots.
 
-At the moment, this command can be used only for clusters having at least one
-replica: that replica will be shut down by the fencing procedure to ensure the
-snapshot to be consistent (cold backup). As the development of
-declarative support for Kubernetes' `VolumeSnapshot` API continues,
-this limitation will be removed, allowing you to take online backups
-as business continuity requires.
+### Using pgAdmin4 for evaluation/demonstration purposes only
+
+[pgAdmin](https://www.pgadmin.org/) stands as the most popular and feature-rich
+open-source administration and development platform for PostgreSQL.
+For more information on the project, please refer to the official
+[documentation](https://www.pgadmin.org/docs/).
+
+Given that the pgAdmin Development Team maintains official Docker container
+images, you can install pgAdmin in your environment as a standard
+Kubernetes deployment.
 
 !!! Important
-    Even if the procedure will shut down a replica, the primary
-    Pod will not be involved.
+    Deployment of pgAdmin in Kubernetes production environments is beyond the
+    scope of this document and, more broadly, of the EDB Postgres for Kubernetes project.
 
-The `kubectl cnp snapshot` command requires the cluster name:
+However, **for the purposes of demonstration and evaluation**, EDB Postgres for Kubernetes
+offers a suitable solution. The `cnp` plugin implements the `pgadmin4`
+command, providing a straightforward method to connect to a given database
+`Cluster` and navigate its content in a local environment such as `kind`.
 
-```shell
-kubectl cnp snapshot cluster-example
+For example, you can install a demo deployment of pgAdmin4 for the
+`cluster-example` cluster as follows:
 
-waiting for cluster-example-3 to be fenced
-waiting for VolumeSnapshot cluster-example-3-1682539624 to be ready to use
-unfencing pod cluster-example-3
+```sh
+kubectl cnp pgadmin4 cluster-example
 ```
 
-The `VolumeSnapshot` resource will be created with an empty
-`VolumeSnapshotClass` reference. That resource is intended by be used by the
-`VolumeSnapshotClass` configured as default.
+This command will produce:
 
-A specific `VolumeSnapshotClass` can be requested via the `-c` option:
+```output
+ConfigMap/cluster-example-pgadmin4 created
+Deployment/cluster-example-pgadmin4 created
+Service/cluster-example-pgadmin4 created
+Secret/cluster-example-pgadmin4 created
 
-```shell
-kubectl cnp snapshot cluster-example -c longhorn
+[...]
 ```
+
+After deploying pgAdmin, forward the port using kubectl and connect
+through your browser by following the on-screen instructions.
+
+![Screenshot of desktop installation of pgAdmin](images/pgadmin4.png)
+
+As usual, you can use the `--dry-run` option to generate the YAML file:
+
+```sh
+kubectl cnp pgadmin4 --dry-run cluster-example
+```
+
+pgAdmin4 can be installed in either desktop or server mode, with the default
+being server.
+
+In `server` mode, authentication is required using a randomly generated password,
+and users must manually specify the database to connect to.
+
+On the other hand, `desktop` mode initiates a pgAdmin web interface without
+requiring authentication. It automatically connects to the `app` database as the
+`app` user, making it ideal for quick demos, such as on a local deployment using
+`kind`:
+
+```sh
+kubectl cnp pgadmin4 --mode desktop cluster-example
+```
+
+After concluding your demo, ensure the termination of the pgAdmin deployment by
+executing:
+
+```sh
+kubectl cnp pgadmin4 --dry-run cluster-example | kubectl delete -f -
+```
+
+!!! Warning
+    Never deploy pgAdmin in production using the plugin.
+
+### Logical Replication Publications
+
+The `cnp publication` command group is designed to streamline the creation and
+removal of [PostgreSQL logical replication publications](https://www.postgresql.org/docs/current/logical-replication-publication.html).
+Be aware that these commands are primarily intended for assisting in the
+creation of logical replication publications, particularly on remote PostgreSQL
+databases.
+
+!!! Warning
+    It is crucial to have a solid understanding of both the capabilities and
+    limitations of PostgreSQL's native logical replication system before using
+    these commands.
+    In particular, be mindful of the [logical replication restrictions](https://www.postgresql.org/docs/current/logical-replication-restrictions.html).
+
+#### Creating a new publication
+
+To create a logical replication publication, use the `cnp publication create`
+command. The basic structure of this command is as follows:
+
+```sh
+kubectl cnp publication create \
+  --publication <PUBLICATION_NAME> \
+  [--external-cluster <EXTERNAL_CLUSTER>]
+  <LOCAL_CLUSTER> [options]
+```
+
+There are two primary use cases:
+
+- With `--external-cluster`: Use this option to create a publication on an
+  external cluster (i.e. defined in the `externalClusters` stanza). The commands
+  will be issued from the `<LOCAL_CLUSTER>`, but the publication will be for the
+  data in `<EXTERNAL_CLUSTER>`.
+
+- Without `--external-cluster`: Use this option to create a publication in the
+  `<LOCAL_CLUSTER>` PostgreSQL `Cluster` (by default, the `app` database).
+
+!!! Warning
+    When connecting to an external cluster, ensure that the specified user has
+    sufficient permissions to execute the `CREATE PUBLICATION` command.
+
+You have several options, similar to the [`CREATE PUBLICATION`](https://www.postgresql.org/docs/current/sql-createpublication.html)
+command, to define the group of tables to replicate. Notable options include:
+
+- If you specify the `--all-tables` option, you create a publication `FOR ALL TABLES`.
+- Alternatively, you can specify multiple occurrences of:
+  - `--table`: Add a specific table (with an expression) to the publication.
+  - `--schema`: Include all tables in the specified database schema (available
+    from PostgreSQL 15).
+
+The `--dry-run` option enables you to preview the SQL commands that the plugin
+will execute.
+
+For additional information and detailed instructions, type the following
+command:
+
+```sh
+kubectl cnp publication create --help
+```
+
+##### Example
+
+Given a `source-cluster` and a `destination-cluster`, we would like to create a
+publication for the data on `source-cluster`.
+The `destination-cluster` has an entry in the `externalClusters` stanza pointing
+to `source-cluster`.
+
+We can run:
+
+``` sh
+kubectl cnp publication create destination-cluster  \
+  --external-cluster=source-cluster --all-tables
+```
+
+which will create a publication for all tables on `source-cluster`, running
+the SQL commands on the `destination-cluster`.
+
+Or instead, we can run:
+
+``` sh
+kubectl cnp publication create source-cluster \
+  --publication=app --all-tables
+```
+
+which will create a publication named `app` for all the tables in the
+`source-cluster`, running the SQL commands on the source cluster.
+
+!!! Info
+    There are two sample files that have been provided for illustration and inspiration:
+    [logical-source](../samples/cluster-example-logical-source.yaml) and
+    [logical-destination](../samples/cluster-example-logical-destination.yaml).
+
+#### Dropping a publication
+
+The `cnp publication drop` command seamlessly complements the `create` command
+by offering similar key options, including the publication name, cluster name,
+and an optional external cluster. You can drop a `PUBLICATION` with the
+following command structure:
+
+```sh
+kubectl cnp publication drop \
+  --publication <PUBLICATION_NAME> \
+  [--external-cluster <EXTERNAL_CLUSTER>]
+  <LOCAL_CLUSTER> [options]
+```
+
+To access further details and precise instructions, use the following command:
+
+```sh
+kubectl cnp publication drop --help
+```
+
+### Logical Replication Subscriptions
+
+The `cnp subscription` command group is a dedicated set of commands designed
+to simplify the creation and removal of
+[PostgreSQL logical replication subscriptions](https://www.postgresql.org/docs/current/logical-replication-subscription.html).
+These commands are specifically crafted to aid in the establishment of logical
+replication subscriptions, especially when dealing with remote PostgreSQL
+databases.
+
+!!! Warning
+    Before using these commands, it is essential to have a comprehensive
+    understanding of both the capabilities and limitations of PostgreSQL's
+    native logical replication system.
+    In particular, be mindful of the [logical replication restrictions](https://www.postgresql.org/docs/current/logical-replication-restrictions.html).
+
+In addition to subscription management, we provide a helpful command for
+synchronizing all sequences from the source cluster. While its applicability
+may vary, this command can be particularly useful in scenarios involving major
+upgrades or data import from remote servers.
+
+#### Creating a new subscription
+
+To create a logical replication subscription, use the `cnp subscription create`
+command. The basic structure of this command is as follows:
+
+```sh
+kubectl cnp subscription create \
+  --subscription <SUBSCRIPTION_NAME> \
+  --publication <PUBLICATION_NAME> \
+  --external-cluster <EXTERNAL_CLUSTER> \
+  <LOCAL_CLUSTER> [options]
+```
+
+This command configures a subscription directed towards the specified
+publication in the designated external cluster, as defined in the
+`externalClusters` stanza of the `<LOCAL_CLUSTER>`.
+
+For additional information and detailed instructions, type the following
+command:
+
+```sh
+kubectl cnp subscription create --help
+```
+
+##### Example
+
+As in the section on publications, we have a `source-cluster` and a
+`destination-cluster`, and we have already created a publication called
+`app`.
+
+The following command:
+
+``` sh
+kubectl cnp subscription create destination-cluster \
+  --external-cluster=source-cluster \
+  --publication=app --subscription=app
+```
+
+will create a subscription for `app` on the destination cluster.
+
+!!! Warning
+    Prioritize testing subscriptions in a non-production environment to ensure
+    their effectiveness and identify any potential issues before implementing them
+    in a production setting.
+
+!!! Info
+    There are two sample files that have been provided for illustration and inspiration:
+    [logical-source](../samples/cluster-example-logical-source.yaml) and
+    [logical-destination](../samples/cluster-example-logical-destination.yaml).
+
+#### Dropping a subscription
+
+The `cnp subscription drop` command seamlessly complements the `create` command.
+You can drop a `SUBSCRIPTION` with the following command structure:
+
+```sh
+kubectl cnp subcription drop \
+  --subscription <SUBSCRIPTION_NAME> \
+  <LOCAL_CLUSTER> [options]
+```
+
+To access further details and precise instructions, use the following command:
+
+```sh
+kubectl cnp subscription drop --help
+```
+
+#### Synchronizing sequences
+
+One notable constraint of PostgreSQL logical replication, implemented through
+publications and subscriptions, is the lack of sequence synchronization. This
+becomes particularly relevant when utilizing logical replication for live
+database migration, especially to a higher version of PostgreSQL. A crucial
+step in this process involves updating sequences before transitioning
+applications to the new database (*cutover*).
+
+To address this limitation, the `cnp subscription sync-sequences` command
+offers a solution. This command establishes a connection with the source
+database, retrieves all relevant sequences, and subsequently updates local
+sequences with matching identities (based on database schema and sequence
+name).
+
+You can use the command as shown below:
+
+```sh
+kubectl cnp subscription sync-sequences \
+  --subscription <SUBSCRIPTION_NAME> \
+  <LOCAL_CLUSTER>
+```
+
+For comprehensive details and specific instructions, utilize the following
+command:
+
+```sh
+kubectl cnp subscription sync-sequences --help
+```
+
+##### Example
+
+As in the previous sections for publication and subscription, we have
+a `source-cluster` and a `destination-cluster`. The publication and the
+subscription, both called `app`, are already present.
+
+The following command will synchronize the sequences involved in the
+`app` subscription, from the source cluster into the destination cluster.
+
+``` sh
+kubectl cnp subscription sync-sequences destination-cluster \
+  --subscription=app
+```
+
+!!! Warning
+    Prioritize testing subscriptions in a non-production environment to
+    guarantee their effectiveness and detect any potential issues before deploying
+    them in a production setting.
+
+## Integration with K9s
+
+The `cnp` plugin can be easily integrated in [K9s](https://k9scli.io/), a
+popular terminal-based UI to interact with Kubernetes clusters.
+
+See [`k9s/plugins.yml`](../samples/k9s/plugins.yml) for details.

--- a/product_docs/docs/postgres_for_kubernetes/1/monitoring.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/monitoring.mdx
@@ -752,8 +752,7 @@ section for context:
 In addition, we provide the "raw" sources for the Prometheus alert rules in the
 `alerts.yaml` file.
 
-The [Grafana dashboard](https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/monitoring/grafana-dashboard.json)
-is now part of the official Helm Chart project.
+The [Grafana dashboard](https://github.com/cloudnative-pg/grafana-dashboards/blob/main/charts/cluster/grafana-dashboard.json) has a dedicated repository now.
 
 Note that, for the configuration of `kube-prometheus-stack`, other fields and
 settings are available over what we provide in `kube-stack-config.yaml`.

--- a/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/quickstart.mdx
@@ -349,8 +349,8 @@ And access Grafana locally at [`http://localhost:3000/`](http://localhost:3000/)
 providing the credentials `admin` as username, `prom-operator` as password (defined in `kube-stack-config.yaml`).
 
 EDB Postgres for Kubernetes provides a default dashboard for Grafana as part of the official
-[Helm chart](https://github.com/cloudnative-pg/charts). You can download the
-[grafana-dashboard.json](https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/monitoring/grafana-dashboard.json)
+[Helm chart](https://github.com/cloudnative-pg/charts). You can also download the
+[grafana-dashboard.json](https://github.com/cloudnative-pg/grafana-dashboards/blob/main/charts/cluster/grafana-dashboard.json)
 file and manually importing it via the GUI.
 
 !!! Warning


### PR DESCRIPTION
## What Changed?

PR 5451: Updates BA docs such that the option to use PGE when creating a cluster is now highlighted.
PR 5455: Re-import of PG4K 1.22.2 - Fixes missing --server side flag in installation instructions, some other small ommisions.
PR 5442: Sync PG4K plugin docs with upstream - corrects out of date information by syncing with upstream cloudnativepg version.