### PR TITLE
Revise sqlpatch docs to sync with customer support content.

### DIFF
--- a/advocacy_docs/tools/edb_sqlpatch/index.mdx
+++ b/advocacy_docs/tools/edb_sqlpatch/index.mdx
@@ -47,7 +47,7 @@ Logical replicas may not replicate all changes to system objects. Therefore, eac
 
 ### PGD clusters
 
-PGD clusters are configured to replicate all changes. PGD clusters should have `edb_sqlpatch -f -a` run only once on a single node and then, when that is complete, each node should then have `edb_sqlpatch -a` run against it to ensure that it is fully and correctly patched. Do not run `edb_sqlpatch` concurrently on different nodes. 
+PGD clusters are configured to replicate all changes. PGD clusters should have `edb_sqlpatch -f -a` run on each node including all witness nodes. edb_sqlpatch should not be run in a mixed version cluster. Each node should be fully upgraded to the latest minor release version of EPAS before any of the nodes have edb_sqlpatch run against them. In addition, edb_sqlpatch should only be run on a single node at a time. Do not run `edb_sqlpatch` concurrently on different nodes. 
 
 ## Command line options
 


### PR DESCRIPTION
Making a change to the PGD cluster section to match that off the KB article:

https://techsupport.enterprisedb.com/kb/a/august-2023-advanced-server-security-update/

Customer in 103516 also was confused when they applied the edb_sqlpatch to the leader node and not all patches were applied to other nodes in the PGD cluster, like the documentation says.

## What Changed?

