### PR TITLE
Added information about lock levels to pg_squeeze docs

### DIFF
--- a/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
+++ b/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
@@ -5,19 +5,22 @@ navTitle: Using
 
 ## Understanding lock levels while using `pg_squeeze`
 
-While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place locks on data, as described below. The table being squeezed is available for both read and write operations by other transactions most of the time. 
+While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place locks on data, as described in the following steps. The table being squeezed is available for both read and write operations by other transactions most of the time. 
 
-When squeezing a table, `pg_squeeze':
+When squeezing a table, the extension:
 
-1. Creates a transient table and copies the contents of the source table using the snapshot. 
+1. Creates a transient table and copies the contents of the source table using the snapshot.
+
     `pg_squeeze` holds an `ACCESS SHARE` lock on the source table during this step. 
 
 1. Builds indexes on the transient table.
+
     `pg_squeeze` holds an `ACCESS SHARE` lock on the source table during this step. 
 
-1. Decodes and applies the concurrent changes that occurred on the source table while the initial load was in progress.
+1. Decodes and applies the concurrent changes that occurred on the source table while the initial load is in progress.
 
-1. Applies any concurrent changes that took place while waiting for the lock and swaps the storage of the transient and the source table. 
+1. Applies any concurrent changes that take place while waiting for the lock and swaps the storage of the transient and the source table.
+ 
     `pg_squeeze` holds an `ACCESS EXCLUSIVE` lock for a short period during this step.
 
 1. Drops the transient table

--- a/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
+++ b/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
@@ -2,6 +2,9 @@
 title: Using pg_squeeze
 navTitle: Using
 ---
+
+The following sections explain how to use `pg_squeeze`.
+
 ## Understanding lock levels while using `pg_squeeze`
 
 While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place locks on tables, as described in the following steps. The table being squeezed is available for both read and write operations by other transactions most of the time. 

--- a/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
+++ b/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
@@ -3,7 +3,7 @@ title: Using pg_squeeze
 navTitle: Using
 ---
 
-The following sections explain how to use `pg_squeeze`.
+Use `pg_squeeze` to remove unused space from a table and optionally sort tuples according to a particular index.
 
 ## Understanding lock levels while using `pg_squeeze`
 

--- a/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
+++ b/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
@@ -2,10 +2,9 @@
 title: Using pg_squeeze
 navTitle: Using
 ---
-
 ## Understanding lock levels while using `pg_squeeze`
 
-While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place locks on data, as described in the following steps. The table being squeezed is available for both read and write operations by other transactions most of the time. 
+While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place locks on tables, as described in the following steps. The table being squeezed is available for both read and write operations by other transactions most of the time. 
 
 When squeezing a table, the extension:
 
@@ -23,7 +22,7 @@ When squeezing a table, the extension:
  
     `pg_squeeze` holds an `ACCESS EXCLUSIVE` lock for a short period during this step.
 
-1. Drops the transient table
+1. Drops the transient table.
 
 
 ## Registering a table for regular processing

--- a/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
+++ b/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
@@ -3,9 +3,29 @@ title: Using pg_squeeze
 navTitle: Using
 ---
 
+## Understanding lock levels while using `pg_squeeze`
+
+While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place locks on data, as described below. The table being squeezed is available for both read and write operations by other transactions most of the time. 
+
+When squeezing a table, `pg_squeeze':
+
+1. Creates a transient table and copies the contents of the source table using the snapshot. 
+    `pg_squeeze` holds an `ACCESS SHARE` lock on the source table during this step. 
+
+1. Builds indexes on the transient table.
+    `pg_squeeze` holds an `ACCESS SHARE` lock on the source table during this step. 
+
+1. Decodes and applies the concurrent changes that occurred on the source table while the initial load was in progress.
+
+1. Applies any concurrent changes that took place while waiting for the lock and swaps the storage of the transient and the source table. 
+    `pg_squeeze` holds an `ACCESS EXCLUSIVE` lock for a short period during this step.
+
+1. Drops the transient table
+
+
 ## Registering a table for regular processing
 
-First, ensure that your table has either a primary key or a unique constraint. This is necessary to process changes resulting from other transactions  while `pg_squeeze` is doing its work.
+Before using `pg_squeeze`, ensure that your table has either a primary key or a replica identity. This is necessary to process changes resulting from other transactions  while `pg_squeeze` is doing its work.
 
 To make the `pg_squeeze` extension aware of the table, you must insert a record into the `squeeze.tables` table. After it is added, table statistics are checked periodically. When the table meets the necessary criteria to be squeezed, a task is added to a queue. The tasks are processed sequentially, in the order they are created.
 

--- a/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
+++ b/advocacy_docs/pg_extensions/pg_squeeze/using.mdx
@@ -7,7 +7,7 @@ The following sections explain how to use `pg_squeeze`.
 
 ## Understanding lock levels while using `pg_squeeze`
 
-While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place locks on tables, as described in the following steps. The table being squeezed is available for both read and write operations by other transactions most of the time. 
+While using `pg_squeeze`, the extension performs a series of actions, and some of these actions place a lock on the squeezed table, as described in the following steps. The table being squeezed is available for both read and write operations by other transactions most of the time. 
 
 When squeezing a table, the extension:
 


### PR DESCRIPTION
Added an introduction to Using section describing when lock levels are applied.

Also one small change to registering section.

Addresses information request in https://github.com/EnterpriseDB/docs/issues/5278.