### PR TITLE
update jdbc.properties note

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
@@ -304,7 +304,7 @@ jdbc.sslmode=disable
 <div id="jdbc_note" class="registered_link"></div>
 
 !!! Note
-    If you set the value of `jdbc.sslmode` to `verify-ca` and you want to use Java trust store for certificate validation, you need to set the following value:
+    If you set the value of `jdbc.sslmode` to `verify-ca` and you want to use Java trust store for certificate validation, you need to set the following value. This line can be added anywhere in the cluster properties file:
 
     `jdbc.properties=sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory`
 


### PR DESCRIPTION
Instead of adding this property to the efm properties file template, we're updating the note about how to use it instead. This is the only case that the property is used without working with EDB first for instructions on what to use for the property information.



