### PR TITLE
Add information about slot privileges needed

### DIFF
--- a/product_docs/docs/efm/4/installing/prerequisites.mdx
+++ b/product_docs/docs/efm/4/installing/prerequisites.mdx
@@ -102,6 +102,12 @@ If the `reconfigure.num.sync` or `reconfigure.sync.primary` property is set to `
 
 For detailed information about each of these functions, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/index.html).
 
+If the `update.physical.slots.period` property is used, then the db.user requires the `REPLICATION` privilege. A database superuser can provide the permissions needed:
+
+```sql
+ALTER USER <user_name> REPLICATION;
+```
+
 The user must also have permissions to read the values of configuration variables. A database superuser can use the PostgreSQL `GRANT` command to provide the permissions needed:
 
 ```sql


### PR DESCRIPTION
If using physical replication slots, the database user efm uses must have permissions for creating and advancing slots. This commit adds a note about it and the command needed to grant the privileges.