### PR TITLE
pgd: update bdr_read_all_stats / bdr_monitor documentation

### DIFF
--- a/product_docs/docs/pgd/5/security/pgd-predefined-roles.mdx
+++ b/product_docs/docs/pgd/5/security/pgd-predefined-roles.mdx
@@ -16,53 +16,96 @@ in multiple databases on the same PostgreSQL instance without problem.
 
 SELECT privilege on:
 
--   [`bdr.conflict_history_summary`](/pgd/latest/reference/catalogs-visible#bdrconflict_history_summary)
+-   `bdr.autopartition_partitions`
+-   `bdr.autopartition_rules`
 -   [`bdr.ddl_epoch`](/pgd/latest/reference/catalogs-internal#bdrddl_epoch)
 -   [`bdr.ddl_replication`](/pgd/latest/reference/pgd-settings#bdrddl_replication)
 -   [`bdr.global_consensus_journal_details`](/pgd/latest/reference/catalogs-visible#bdrglobal_consensus_journal_details)
 -   [`bdr.global_lock`](/pgd/latest/reference/catalogs-visible#bdrglobal_lock)
 -   [`bdr.global_locks`](/pgd/latest/reference/catalogs-visible#bdrglobal_locks)
+-   [`bdr.group_camo_details`](/pgd/latest/reference/catalogs-visible#bdrgroup_camo_details)
 -   [`bdr.local_consensus_state`](/pgd/latest/reference/catalogs-visible#bdrlocal_consensus_state)
 -   [`bdr.local_node_summary`](/pgd/latest/reference/catalogs-visible#bdrlocal_node_summary)
 -   [`bdr.node`](/pgd/latest/reference/catalogs-visible#bdrnode)
 -   [`bdr.node_catchup_info`](/pgd/latest/reference/catalogs-visible#bdrnode_catchup_info)
+-   [`bdr.node_catchup_info_details`](/pgd/latest/reference/catalogs-visible#bdrnode_catchup_info_details)
 -   [`bdr.node_conflict_resolvers`](/pgd/latest/reference/catalogs-visible#bdrnode_conflict_resolvers)
 -   [`bdr.node_group`](/pgd/latest/reference/catalogs-visible#bdrnode_group)
 -   [`bdr.node_local_info`](/pgd/latest/reference/catalogs-visible#bdrnode_local_info)
 -   [`bdr.node_peer_progress`](/pgd/latest/reference/catalogs-visible#bdrnode_peer_progress)
+-   [`bdr.node_replication_rates`](/pgd/latest/reference/catalogs-visible#bdrnode_replication_rates)
 -   [`bdr.node_slots`](/pgd/latest/reference/catalogs-visible#bdrnode_slots)
 -   [`bdr.node_summary`](/pgd/latest/reference/catalogs-visible#bdrnode_summary)
 -   [`bdr.replication_sets`](/pgd/latest/reference/catalogs-visible#bdrreplication_sets)
+-   `bdr.replication_status`
 -   [`bdr.sequences`](/pgd/latest/reference/catalogs-visible#bdrsequences)
+-   [`bdr.stat_activity`](/pgd/latest/reference/catalogs-visible#bdrstat_activity)
 -   [`bdr.stat_relation`](/pgd/latest/reference/catalogs-visible#bdrstat_relation)
--   [`bdr.stat_subscription`](/pgd/latest/reference/catalogs-visible#bdrstat_subscription)
+-   [`bdr.stat_subscription`](/pgd/latest/reference/catalogs-visible#bdrstat_subscription) _deprecated_
+-   [`bdr.state_journal_details`](/pgd/latest/reference/catalogs-visible#)
 -   [`bdr.subscription`](/pgd/latest/reference/catalogs-visible#bdrsubscription)
 -   [`bdr.subscription_summary`](/pgd/latest/reference/catalogs-visible#bdrsubscription_summary)
 -   [`bdr.tables`](/pgd/latest/reference/catalogs-visible#bdrtables)
+-   [`bdr.taskmgr_local_work_queue`](/pgd/latest/reference/catalogs-visible#bdrtaskmgr_local_work_queue)
+-   [`bdr.taskmgr_work_queue`](/pgd/latest/reference/catalogs-visible#bdrtaskmgr_work_queue)
+-   [`bdr.worker_errors`](/pgd/latest/reference/catalogs-visible#) _deprecated_
+-   [`bdr.workers`](/pgd/latest/reference/catalogs-visible#bdrworkers)
+-   [`bdr.writers`](/pgd/latest/reference/catalogs-visible#bdrwriters)
+-    `bdr.xid_peer_progress`
 
 EXECUTE privilege on:
 
+-    `bdr.bdr_edition` _deprecated_
 -   [`bdr.bdr_version`](/pgd/latest/reference/functions#bdrbdr_version)
 -   [`bdr.bdr_version_num`](/pgd/latest/reference/functions#bdrbdr_version_num)
 -   [`bdr.decode_message_payload`](/pgd/latest/reference/functions-internal#bdrdecode_message_payload)
+-   [`bdr.get_consensus_status`](/pgd/latest/reference/functions#bdrget_consensus_status)
+-   [`bdr.get_decoding_worker_stat`](/pgd/latest/reference/functions#bdrget_decoding_worker_stat)
 -   [`bdr.get_global_locks`](/pgd/latest/reference/functions-internal#bdrget_global_locks)
+-    `bdr.get_min_required_replication_slots`
+-    `bdr.get_min_required_worker_processes`
 -   [`bdr.get_raft_status`](/pgd/latest/reference/functions#bdrget_raft_status)
 -   [`bdr.get_relation_stats`](/pgd/latest/reference/functions#bdrget_relation_stats)
 -   [`bdr.get_slot_flush_timestamp`](/pgd/latest/reference/functions-internal#bdrget_slot_flush_timestamp)
--   `bdr.get_sub_progress_timestamp`
+-    `bdr.get_sub_progress_timestamp`
 -   [`bdr.get_subscription_stats`](/pgd/latest/reference/functions#bdrget_subscription_stats)
+-   [`bdr.lag_control`](/pgd/latest/reference/functions#bdrlag_control)
+-    `bdr.lag_history`
+-   [`bdr.node_catchup_state_name`](/pgd/latest/reference/functions-internal#bdrnode_catchup_state_name)
+-   [`bdr.node_kind_name`](/pgd/latest/reference/functions-internal#bdrnode_kind_name)
 -   [`bdr.peer_state_name`](/pgd/latest/reference/functions-internal#bdrpeer_state_name)
+-    `bdr.pglogical_proto_version_ranges`
 -   [`bdr.show_subscription_status`](/pgd/latest/reference/functions-internal#bdrshow_subscription_status)
+-   [`bdr.show_workers`](/pgd/latest/reference/functions-internal#bdrshow_workers)
+-   [`bdr.show_writers`](/pgd/latest/reference/functions-internal#bdrshow_writers)
+-    `bdr.stat_get_activity`
+-   [`bdr.wal_sender_stats`](/pgd/latest/reference/functions#bdrwal_sender_stats)
+-    `bdr.worker_role_id_name`
 
 ### bdr_monitor
 
 All privileges from `bdr_read_all_stats`.
 
+Also, SELECT privilege on:
+
+-   [`bdr.group_raft_details`](/pgd/latest/reference/catalogs-visible#bdrgroup_raft_details)
+-   [`bdr.group_replslots_details`](/pgd/latest/reference/catalogs-visible#bdrgroup_replslots_details)
+-   [`bdr.group_subscription_summary`](/pgd/latest/reference/catalogs-visible#bdrgroup_subscription_summary)
+-   [`bdr.group_versions_details`](/pgd/latest/reference/catalogs-visible#bdrgroup_versions_details)
+-    `bdr.raft_instances`
+
 Also, EXECUTE privilege on:
 
--   [`bdr.monitor_group_versions`](/pgd/latest/reference/functions#bdrmonitor_group_versions)
+-    `bdr.get_raft_instance_by_nodegroup`
+-    `bdr.monitor_camo_on_all_nodes`
 -   [`bdr.monitor_group_raft`](/pgd/latest/reference/functions#bdrmonitor_group_raft)
+-   [`bdr.monitor_group_versions`](/pgd/latest/reference/functions#bdrmonitor_group_versions)
 -   [`bdr.monitor_local_replslots`](/pgd/latest/reference/functions#bdrmonitor_local_replslots)
+-    `bdr.monitor_raft_details_on_all_nodes`
+-    `bdr.monitor_replslots_details_on_all_nodes`
+-    `bdr.monitor_subscription_details_on_all_nodes`
+-    `bdr.monitor_version_details_on_all_nodes`
+-    `bdr.node_group_member_info`
 
 ### bdr_application
 


### PR DESCRIPTION
## What Changed?

The lists of objects for which each of these predefined roles has privileges on, are somewhat outdated.

Update the lists based on a query of the actual database privileges installed for each role.

BDR-4899 (incorporating the additional permissions added via BDR-4842 and BDR-4885).