### PR TITLE
Add table of metric names for 3PM integrations

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/third_party_integrations/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/third_party_integrations/index.mdx
@@ -14,3 +14,103 @@ The third-party integrations available in BigAnimal are:
 
 - [Datadog](./datadog)
 - [New Relic](./newrelic)
+
+## Metric naming
+
+When metrics from BigAnimal are exported to third-party monitoring services, they are renamed in accordance with the naming conventions of the target platform.
+
+The name below provides a mapping between [BigAnimal metric names](/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx) 
+and the name that metric will be assigned when exported to a third-party services.
+
+!!! Note Kubernetes metrics
+In addition to the metrics listed below, which pertain to the Postgres instances, BigAnimal also exports metrics from the underlying Kubernetes infrastructure. These are prefixed with `k8s.`.
+!!!
+
+| BigAnimal metric name                            | Metric name for third-party integrations                  |
+| ------------------------------------------------ | --------------------------------------------------------- |
+| cnp_pg_backends_waiting_total                    | postgres.raw.backends_waiting_total                       |
+| cnp_pg_database_size_bytes                       | postgres.raw.pg_database_size_bytes                       |
+| cnp_pg_database_xid_age                          | postgres.raw.pg_database_xid_age                          |
+| cnp_pg_database_mxid_age                         | postgres.raw.pg_database_mxid_age                         |
+| cnp_pg_postmaster_start_time                     | postgres.raw.pg_postmaster_start_time                     |
+| cnp_pg_replication_lag                           | postgres.raw.pg_replication_lag                           |
+| cnp_pg_replication_in_recovery                   | postgres.raw.pg_replication_in_recovery                   |
+| cnp_pg_replication_slots_active                  | postgres.raw.pg_replication_slots_active                  |
+| cnp_pg_replication_slots_pg_wal_lsn_diff         | postgres.raw.pg_replication_slots_pg_wal_lsn_diff         |
+| cnp_pg_stat_archiver_archived_count              | postgres.raw.pg_stat_archiver_archived_count              |
+| cnp_pg_stat_archiver_failed_count                | postgres.raw.pg_stat_archiver_failed_count                |
+| cnp_pg_stat_archiver_seconds_since_last_archival | postgres.raw.pg_stat_archiver_seconds_since_last_archival |
+| cnp_pg_stat_archiver_seconds_since_last_failure  | postgres.raw.pg_stat_archiver_seconds_since_last_failure  |
+| cnp_pg_stat_archiver_last_archived_time          | postgres.raw.pg_stat_archiver_last_archived_time          |
+| cnp_pg_stat_archiver_last_failed_time            | postgres.raw.pg_stat_archiver_last_failed_time            |
+| cnp_pg_stat_archiver_last_archived_wal_start_lsn | postgres.raw.pg_stat_archiver_last_archived_wal_start_lsn |
+| cnp_pg_stat_archiver_last_failed_wal_start_lsn   | postgres.raw.pg_stat_archiver_last_failed_wal_start_lsn   |
+| cnp_pg_stat_archiver_stats_reset_time            | postgres.raw.pg_stat_archiver_stats_reset_time            |
+| cnp_pg_stat_bgwriter_checkpoints_timed           | postgres.raw.pg_stat_bgwriter_checkpoints_timed           |
+| cnp_pg_stat_bgwriter_checkpoints_req             | postgres.raw.pg_stat_bgwriter_checkpoints_req             |
+| cnp_pg_stat_bgwriter_checkpoint_write_time       | postgres.raw.pg_stat_bgwriter_checkpoint_write_time       |
+| cnp_pg_stat_bgwriter_checkpoint_sync_time        | postgres.raw.pg_stat_bgwriter_checkpoint_sync_time        |
+| cnp_pg_stat_bgwriter_buffers_checkpoint          | postgres.raw.pg_stat_bgwriter_buffers_checkpoint          |
+| cnp_pg_stat_bgwriter_buffers_clean               | postgres.raw.pg_stat_bgwriter_buffers_clean               |
+| cnp_pg_stat_bgwriter_maxwritten_clean            | postgres.raw.pg_stat_bgwriter_maxwritten_clean            |
+| cnp_pg_stat_bgwriter_buffers_backend             | postgres.raw.pg_stat_bgwriter_buffers_backend             |
+| cnp_pg_stat_bgwriter_buffers_backend_fsync       | postgres.raw.pg_stat_bgwriter_buffers_backend_fsync       |
+| cnp_pg_stat_bgwriter_buffers_alloc               | postgres.raw.pg_stat_bgwriter_buffers_alloc               |
+| cnp_pg_stat_database_xact_commit                 | postgres.raw.pg_stat_database_xact_commit                 |
+| cnp_pg_stat_database_xact_rollback               | postgres.raw.pg_stat_database_xact_rollback               |
+| cnp_pg_stat_database_blks_read                   | postgres.raw.pg_stat_database_blks_read                   |
+| cnp_pg_stat_database_blks_hit                    | postgres.raw.pg_stat_database_blks_hit                    |
+| cnp_pg_stat_database_tup_returned                | postgres.raw.pg_stat_database_tup_returned                |
+| cnp_pg_stat_database_tup_fetched                 | postgres.raw.pg_stat_database_tup_fetched                 |
+| cnp_pg_stat_database_tup_inserted                | postgres.raw.pg_stat_database_tup_inserted                |
+| cnp_pg_stat_database_tup_updated                 | postgres.raw.pg_stat_database_tup_updated                 |
+| cnp_pg_stat_database_tup_deleted                 | postgres.raw.pg_stat_database_tup_deleted                 |
+| cnp_pg_stat_database_conflicts                   | postgres.raw.pg_stat_database_conflicts                   |
+| cnp_pg_stat_database_temp_files                  | postgres.raw.pg_stat_database_temp_files                  |
+| cnp_pg_stat_database_temp_bytes                  | postgres.raw.pg_stat_database_temp_bytes                  |
+| cnp_pg_stat_database_deadlocks                   | postgres.raw.pg_stat_database_deadlocks                   |
+| cnp_pg_stat_database_blk_read_time               | postgres.raw.pg_stat_database_blk_read_time               |
+| cnp_pg_stat_database_blk_write_time              | postgres.raw.pg_stat_database_blk_write_time              |
+| cnp_pg_stat_database_conflicts_confl_tablespace  | postgres.raw.pg_stat_database_conflicts_confl_tablespace  |
+| cnp_pg_stat_database_conflicts_confl_lock        | postgres.raw.pg_stat_database_conflicts_confl_lock        |
+| cnp_pg_stat_database_conflicts_confl_snapshot    | postgres.raw.pg_stat_database_conflicts_confl_snapshot    |
+| cnp_pg_stat_database_conflicts_confl_bufferpin   | postgres.raw.pg_stat_database_conflicts_confl_bufferpin   |
+| cnp_pg_stat_database_conflicts_confl_deadlock    | postgres.raw.pg_stat_database_conflicts_confl_deadlock    |
+| cnp_pg_stat_user_tables_seq_scan                 | postgres.raw.pg_stat_user_tables_seq_scan                 |
+| cnp_pg_stat_user_tables_seq_tup_read             | postgres.raw.pg_stat_user_tables_seq_tup_read             |
+| cnp_pg_stat_user_tables_idx_scan                 | postgres.raw.pg_stat_user_tables_idx_scan                 |
+| cnp_pg_stat_user_tables_idx_tup_fetch            | postgres.raw.pg_stat_user_tables_idx_tup_fetch            |
+| cnp_pg_stat_user_tables_n_tup_ins                | postgres.raw.pg_stat_user_tables_n_tup_ins                |
+| cnp_pg_stat_user_tables_n_tup_upd                | postgres.raw.pg_stat_user_tables_n_tup_upd                |
+| cnp_pg_stat_user_tables_n_tup_del                | postgres.raw.pg_stat_user_tables_n_tup_del                |
+| cnp_pg_stat_user_tables_n_tup_hot_upd            | postgres.raw.pg_stat_user_tables_n_tup_hot_upd            |
+| cnp_pg_stat_user_tables_n_live_tup               | postgres.raw.pg_stat_user_tables_n_live_tup               |
+| cnp_pg_stat_user_tables_n_dead_tup               | postgres.raw.pg_stat_user_tables_n_dead_tup               |
+| cnp_pg_stat_user_tables_n_mod_since_analyze      | postgres.raw.pg_stat_user_tables_n_mod_since_analyze      |
+| cnp_pg_stat_user_tables_last_vacuum              | postgres.raw.pg_stat_user_tables_last_vacuum              |
+| cnp_pg_stat_user_tables_last_autovacuum          | postgres.raw.pg_stat_user_tables_last_autovacuum          |
+| cnp_pg_stat_user_tables_last_analyze             | postgres.raw.pg_stat_user_tables_last_analyze             |
+| cnp_pg_stat_user_tables_last_autoanalyze         | postgres.raw.pg_stat_user_tables_last_autoanalyze         |
+| cnp_pg_stat_user_tables_vacuum_count             | postgres.raw.pg_stat_user_tables_vacuum_count             |
+| cnp_pg_stat_user_tables_autovacuum_count         | postgres.raw.pg_stat_user_tables_autovacuum_count         |
+| cnp_pg_stat_user_tables_analyze_count            | postgres.raw.pg_stat_user_tables_analyze_count            |
+| cnp_pg_stat_user_tables_autoanalyze_count        | postgres.raw.pg_stat_user_tables_autoanalyze_count        |
+| cnp_pg_stat_replication_backend_start_age        | postgres.raw.pg_stat_replication_backend_start_age        |
+| cnp_pg_stat_replication_backend_xmin_age         | postgres.raw.pg_stat_replication_backend_xmin_age         |
+| cnp_pg_stat_replication_sent_diff_bytes          | postgres.raw.pg_stat_replication_sent_diff_bytes          |
+| cnp_pg_stat_replication_write_diff_bytes         | postgres.raw.pg_stat_replication_write_diff_bytes         |
+| cnp_pg_stat_replication_flush_diff_bytes         | postgres.raw.pg_stat_replication_flush_diff_bytes         |
+| cnp_pg_stat_replication_replay_diff_bytes        | postgres.raw.pg_stat_replication_replay_diff_bytes        |
+| cnp_pg_stat_replication_write_lag_seconds        | postgres.raw.pg_stat_replication_write_lag_seconds        |
+| cnp_pg_stat_replication_flush_lag_seconds        | postgres.raw.pg_stat_replication_flush_lag_seconds        |
+| cnp_pg_stat_replication_replay_lag_seconds       | postgres.raw.pg_stat_replication_replay_lag_seconds       |
+| cnp_pg_statio_user_tables_heap_blks_read         | postgres.raw.pg_statio_user_tables_heap_blks_read         |
+| cnp_pg_statio_user_tables_heap_blks_hit          | postgres.raw.pg_statio_user_tables_heap_blks_hit          |
+| cnp_pg_statio_user_tables_idx_blks_read          | postgres.raw.pg_statio_user_tables_idx_blks_read          |
+| cnp_pg_statio_user_tables_idx_blks_hit           | postgres.raw.pg_statio_user_tables_idx_blks_hit           |
+| cnp_pg_statio_user_tables_toast_blks_read        | postgres.raw.pg_statio_user_tables_toast_blks_read        |
+| cnp_pg_statio_user_tables_toast_blks_hit         | postgres.raw.pg_statio_user_tables_toast_blks_hit         |
+| cnp_pg_statio_user_tables_tidx_blks_read         | postgres.raw.pg_statio_user_tables_tidx_blks_read         |
+| cnp_pg_statio_user_tables_tidx_blks_hit          | postgres.raw.pg_statio_user_tables_tidx_blks_hit          |
+| cnp_pg_settings_setting                          | postgres.raw.pg_settings_setting                          |
+| cnp_xlog_insert_lsn                              | postgres.raw.xlog_insert_lsn                              |

--- a/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/third_party_integrations/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/05_monitoring_and_logging/third_party_integrations/index.mdx
@@ -19,7 +19,7 @@ The third-party integrations available in BigAnimal are:
 
 When metrics from BigAnimal are exported to third-party monitoring services, they are renamed in accordance with the naming conventions of the target platform.
 
-The name below provides a mapping between [BigAnimal metric names](/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/index.mdx) 
+The name below provides a mapping between [BigAnimal metric names](/biganimal/release/using_cluster/05_monitoring_and_logging/metrics/) 
 and the name that metric will be assigned when exported to a third-party services.
 
 !!! Note Kubernetes metrics


### PR DESCRIPTION
This is a quick edit to get this information published for a customer. We should consider embedding these names in the list of metrics rather than a separate table as a future improvement.
