### PR TITLE
edb_wait_states - Added 1.3 release notes and new function

### DIFF
--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/index.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/index.mdx
@@ -8,5 +8,5 @@ The EDB Wait States documentation describes the latest version of EDB Wait State
 
 |             Version              | Release Date |
 | -------------------------------- | ------------ |
-| [1.3](wait_states_1.3_rel_notes) | 23 Apr 2024  |
+| [1.3](wait_states_1.3_rel_notes) | 09 May 2024  |
 | [1.2](wait_states_1.2_rel_notes) | 15 Feb 2024  |

--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/index.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/index.mdx
@@ -8,4 +8,5 @@ The EDB Wait States documentation describes the latest version of EDB Wait State
 
 |             Version              | Release Date |
 | -------------------------------- | ------------ |
+| [1.3](wait_states_1.3_rel_notes) | 23 Apr 2024  |
 | [1.2](wait_states_1.2_rel_notes) | 15 Feb 2024  |

--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.3_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.3_rel_notes.mdx
@@ -1,0 +1,10 @@
+---
+title: Release notes for Wait States version 1.3
+navTitle: "Version 1.3"
+---
+
+This release of Wait States includes:
+
+| Type        | Description                                             |
+|-------------|---------------------------------------------------------|
+| Enhancement | Added new function `edb_wait_states_directory_size()`.  |        

--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.3_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.3_rel_notes.mdx
@@ -2,6 +2,7 @@
 title: Release notes for Wait States version 1.3
 navTitle: "Version 1.3"
 ---
+Release date: 09 May 2024
 
 This release of Wait States includes:
 

--- a/advocacy_docs/pg_extensions/wait_states/using.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/using.mdx
@@ -137,6 +137,36 @@ wait_event       | PgSleep
                     .
 ```
 
+## `edb_wait_states_directory_size`
+
+This function gives the size of the `$PGDATA/edb_wait_states` directory.
+
+```sql
+edb_wait_states_directory_size(
+  IN start_ts timestampz default '-inifinity'::timestampz,
+  IN end_ts timestampz default 'infinity'::timestampz
+);
+```
+
+The function returns the total size of all the files in the `edb_wait_states` directory in bytes. Optionally specify the `start_ts` and `end_ts` timestamps to get the file size of all the files in the specified interval.
+
+!!!note
+This function calculates and gives the size of all the files with prefix `ews_*` only. It ignores any other file added to the `edb_wait_states` directory manually.
+!!!
+
+### Example
+
+This example shows the sample output from the `edb_wait_states_directory_size()` function:
+
+```sql
+edb=# select edb_wait_states_directory_size();
+__OUTPUT__
+ edb_wait_states_directory_size
+ ------------------------------
+                        1712256
+ (1 row)
+```
+
 ## `edb_wait_states_queries`
 
 This function gives information about the queries sampled by the BGW. For example:


### PR DESCRIPTION
## What Changed?

Added 1.3 release notes and edb_wait_states_directory_size function as per [EXT-648](https://enterprisedb.atlassian.net/browse/EXT-648)/ [DOCS-438](https://enterprisedb.atlassian.net/browse/DOCS-438)





[EXT-648]: https://enterprisedb.atlassian.net/browse/EXT-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-438]: https://enterprisedb.atlassian.net/browse/DOCS-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ