### PR TITLE
Added PG/PGE/EPAS 16 to list of supported versions

### DIFF
--- a/product_docs/docs/livecompare/2/supported_technologies.mdx
+++ b/product_docs/docs/livecompare/2/supported_technologies.mdx
@@ -31,14 +31,14 @@ LiveCompare has three kinds of connections:
 
 The table shows versions and details about supported technologies and the context in which you can use them in LiveCompare.
 
-| Technology                     | Versions                        | Possible connections                 |
-| ------------------------------ | ------------------------------- | --------------------------- |
-| PostgreSQL                     | 10, 11, 12, 13, 14, and 15 | Data and output          |
-| EDB PostgreSQL Extended        | 10, 11, 12, 13, 14, and 15      | Data and output          |
-| EDB PostgreSQL Advanced (EPAS) | 11, 12, 13, 14, and 15               | Data and output          |
-| pglogical                      | 2 and 3                         | Initial, data, and output |
-| EDB Postgres Distributed (PGD) | 1, 2, 3, 4, and 5                   | Initial, data, and output |
-| Oracle                         | 11g, 12c, 18c, 19c, and 21c      | A single data connection    |
+| Technology                            | Versions                        | Possible connections      |
+| ------------------------------------- | ------------------------------- | ------------------------- |
+| PostgreSQL                            | 10, 11, 12, 13, 14, 15, and 16  | Data and output           |
+| EDB PostgreSQL Extended (PGE)         | 10, 11, 12, 13, 14, 15, and 16  | Data and output           |
+| EDB PostgreSQL Advanced Server (EPAS) | 11, 12, 13, 14, 15, and 16      | Data and output           |
+| pglogical                             | 2 and 3                         | Initial, data, and output |
+| EDB Postgres Distributed (PGD)        | 1, 2, 3, 4, and 5               | Initial, data, and output |
+| Oracle                                | 11g, 12c, 18c, 19c, and 21c     | A single data connection  |
 
 ## PgBouncer support
 


### PR DESCRIPTION
Updated the supported technologies table by adding version 16 to the list of PostgreSQL, EDB PostgreSQL Extended (PGE), and EDB Postgres Advanced Server (EPAS). 

LIV-239 [https://enterprisedb.atlassian.net/browse/LIV-239] indicates that support for version 16 has been tested and supported.

Also, updated the Technology names for PGE and EPAS.

## What Changed?

