### PR TITLE
Sync CODEOWNERS with the Team Allocation spreadsheet

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,40 @@
 # First pass basic codeowners file
 
-product_docs/docs/pgd/ @djw-m
-product_docs/docs/epas/ @nidhibhammar
+product_docs/docs/pgd/ @djw-m @jpe442 @piano35-edb
+product_docs/docs/epas/ @nidhibhammar @gvasquezvargas 
+product_docs/docs/edb_plus/ @gvasquezvargas @nidhibhammar
+product_docs/docs/pem/ @nidhibhammar @gvasquezvargas 
+product_docs/docs/net_connector/ @jpe442 @nidhibhammar
+product_docs/docs/jdbc_connector/ @jpe442 @nidhibhammar
+product_docs/docs/odbc_connector/ @jpe442 @nidhibhammar
+product_docs/docs/ocl_connector/ @jpe442 @nidhibhammar
+product_docs/docs/mongo_data_adapter/ @jpe442 @nidhibhammar
+product_docs/docs/mysql_data_adapter/ @jpe442 @nidhibhammar
+product_docs/docs/hadoop_data_adapter/ @jpe442 @nidhibhammar
+product_docs/docs/tde/ @gvasquezvargas @nidhibhammar
+product_docs/docs/postgis/ @piano35-edb @nidhibhammar
+product_docs/docs/pgbouncer/ @piano35-edb @nidhibhammar
+product_docs/docs/pgpool/ @piano35-edb @nidhibhammar
+product_docs/docs/efm/ @nidhibhammar
+product_docs/docs/language_pack/ @piano35-edb @nidhibhammar
+product_docs/docs/tpa/ @djw-m
+product_docs/docs/postgres_distributed_for_kubernetes/ @jpe442 @djw-m @gvasquezvargas 
+product_docs/docs/postgres_for_kubernetes/ @jpe442 @djw-m @gvasquezvargas 
+advocacy_docs/supported-open-source/cloud_native_pg/ @djw-m @piano35-edb @gvasquezvargas
+advocacy_docs/tools/edb_sqlpatch/ @djw-m
+security/ @djw-m
+product_docs/docs/biganimal/ @jpe442 @nidhibhammar @piano35-edb
+product_docs/docs/migration_portal/ @gvasquezvargas @nidhibhammar
+product_docs/docs/migration_toolkit/ @gvasquezvargas @nidhibhammar
+advocacy_docs/migrating/oracle/ @gvasquezvargas @nidhibhammar
+advocacy_docs/pg_extensions/ldap_sync/ @piano35-edb @gvasquezvargas @nidhibhammar
+advocacy_docs/pg_extensions/advanced_storage_pack/ @piano35-edb @gvasquezvargas @nidhibhammar
+advocacy_docs/pg_extensions/pg_tuner/ @piano35-edb @gvasquezvargas @nidhibhammar
+advocacy_docs/pg_extensions/query_advisor/ @piano35-edb @gvasquezvargas @nidhibhammar
+advocacy_docs/pg_extensions/wait_states/ @piano35-edb @gvasquezvargas @nidhibhammar
+advocacy_docs/pg_extensions/pg_failover_slots/ @nidhibhammar
+**/installing @dwicinas 
+advocacy_docs/supported-open-source/barman/ @piano35-edb @jpe442
+product_docs/docs/pge/  @gvasquezvargas 
+advocacy_docs/supported-open-source/postgresql/ @piano35-edb 
+


### PR DESCRIPTION
## What Changed?

Per team meeting, let's sync this up with the Team Allocation spreadsheet.