### PR TITLE
Streamline PGD4K as official abbreviation and other minor fixes

### DIFF
--- a/product_docs/docs/postgres_distributed_for_kubernetes/1/group_cleanup.mdx
+++ b/product_docs/docs/postgres_distributed_for_kubernetes/1/group_cleanup.mdx
@@ -40,7 +40,7 @@ the PGDGroup is being deleted, and the nodes will not be parted from the PGD clu
 ### Cleanup parted node
 
 Once the PGDGroup is deleted, its metadata will remain in the catalog in `PARTED`
-state in the `bdr.node_summary` table. The PG4k-PGD operator
+state in the `bdr.node_summary` table. The PGD4K operator
 defines a CRD named `PGDGroupCleanup` to help clean up the `PARTED` PGDGroup.
 
 In the example below, the `PGDGroupCleanup` executes locally from `region-a`,

--- a/product_docs/docs/postgres_distributed_for_kubernetes/1/index.mdx
+++ b/product_docs/docs/postgres_distributed_for_kubernetes/1/index.mdx
@@ -34,7 +34,7 @@ directoryDefaults:
 
 ---
 
-EDB Postgres Distributed for Kubernetes (`pg4k-pgd`) is an
+EDB Postgres Distributed for Kubernetes (`PGD4K`) is an
 operator designed to manage EDB Postgres Distributed (PGD) workloads on
 Kubernetes, with traffic routed by PGD Proxy.
 

--- a/product_docs/docs/postgres_distributed_for_kubernetes/1/known_issues.mdx
+++ b/product_docs/docs/postgres_distributed_for_kubernetes/1/known_issues.mdx
@@ -59,4 +59,4 @@ All issues and limitations known for the EDB Postgres Distributed version that y
 your EDB Postgres Distributed for Kubernetes instance.
 
 For example, if the EDB Postgres Distributed version you are using is 5.x, your EDB Postgres Distributed for Kubernetes 
-instance will be affected by these [5.x known issues](/pgd/latest/known_issues/) and [5.x limitations](/pgd/latest/limitations/).
+instance will be affected by these [5.x known issues](/pgd/5/known_issues/) and [5.x limitations](/pgd/5/limitations/).

--- a/product_docs/docs/postgres_distributed_for_kubernetes/1/supported_versions.mdx
+++ b/product_docs/docs/postgres_distributed_for_kubernetes/1/supported_versions.mdx
@@ -17,6 +17,6 @@ The Postgres (operand) versions are limited to those supported by
 
 !!! Important
     Please be aware that this page is informative only.
-    The ["Platform Compatibility"](https://www.enterprisedb.com/product-compatibility#cnp) page
+    The ["Platform Compatibility"](https://www.enterprisedb.com/product-compatibility#bdrk8s) page
     from the EDB website contains the official list of supported software and
     Kubernetes distributions.


### PR DESCRIPTION
## What Changed?

Streamline PGD4K as official abbreviation
Correct /latest/ links to /5/ links for PGD references
Corrected link that referenced PG4K instead of PGD4K