### PR TITLE
Outdated link in TPA harp documentation.

### DIFF
--- a/product_docs/docs/tpa/23/reference/harp.mdx
+++ b/product_docs/docs/tpa/23/reference/harp.mdx
@@ -14,7 +14,7 @@ Contact EDB to obtain access to these packages.
 
 ## Configuring HARP
 
-See the [HARP documentation](https://documentation.enterprisedb.com/harp/release/latest/configuration/)
+See the [HARP documentation](https://www.enterprisedb.com/docs/pgd/4/harp/)
 for more details on HARP configuration.
 
 | Variable                          | Default value | Description                                                                                                                                                                                     |


### PR DESCRIPTION
Target link does not exist. DJ suggested this could be the correct link https://www.enterprisedb.com/docs/pgd/4/harp/. However, I am wondering if we should be linking to older docs at all? Maybe the recommended path now is to have PGD instead of installing BDR or HARP components?

## What Changed?

