### PR TITLE
Fix release years that were changed for 4.0/4.1

### DIFF
--- a/product_docs/docs/efm/4/efm_rel_notes/index.mdx
+++ b/product_docs/docs/efm/4/efm_rel_notes/index.mdx
@@ -16,8 +16,8 @@ about the release that introduced the feature.
 | [4.4](06_efm_44_rel_notes) | 05 Jan 2022|
 | [4.3](07_efm_43_rel_notes) | 18 Dec 2021|
 | [4.2](08_efm_42_rel_notes) | 19 Apr 2021 |
-| [4.1](09_efm_41_rel_notes) | 11 Dec 2021|
-| [4.0](10_efm_40_rel_notes) | 02 Sep 2021 |
+| [4.1](09_efm_41_rel_notes) | 11 Dec 2020|
+| [4.0](10_efm_40_rel_notes) | 02 Sep 2020 |
 
 
 


### PR DESCRIPTION
Back in commit 0fcdb9f1c37e24e8ca7e2e80c228e368dd5c7237, the release years for efm versions 4.0 and 4.1 got bumped up by a year (so that 4.0 and 4.1 were actually released AFTER 4.2). Fixing this based on the diff of the commit above and the dates of the changes in efm code itself.

## What Changed?

