### PR TITLE
DOCS-372-problem-on-https-www-enterprisedb-com-docs-pgd-3

### DIFF
--- a/product_docs/docs/pgd/3.6/index.mdx
+++ b/product_docs/docs/pgd/3.6/index.mdx
@@ -3,6 +3,7 @@ title: "EDB Postgres Distributed"
 navigation:
 - release-notes
 - rel_notes-pglogical
+hidePDF: true
 ---
 
 EDB Postgres Distributed provides loosely-coupled multi-master logical replication
@@ -47,13 +48,7 @@ To provide very high availability, avoid data conflicts, and to cope with more a
 
 BDR Enterprise requires EDB Postgres Extended v11 (formerly known as 2ndQuadrant Postgres) which is SQL and on-disk compatible with PostgreSQL.
 
-!!!note
-  The documentation for the latest stable 3.6 release is available here:
-
-  [BDR 3.6 Enterprise Edition](https://documentation.enterprisedb.com/bdr3-enterprise/release/latest-3.6/)
-
-  **This is a protected area of our website, if you need access please [contact us](https://www.enterprisedb.com/contact)**
-!!!
+* [BDR 3.6.33 Enterprise Edition (PDF)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/pglogical3.6.33.pdf)
 
 ### BDR Standard
 
@@ -70,13 +65,7 @@ The following are included to support very high availability and geographically 
 
 BDR Standard requires PostgreSQL v10 or v11.
 
-!!!note
-  The documentation for the latest stable 3.6 release is available here:
-
-  [BDR 3.6 Standard Edition](https://documentation.enterprisedb.com/bdr3/release/latest-3.6/)
-
-   **This is a protected area of our website, if you need access please [contact us](https://www.enterprisedb.com/contact)**
-!!!
+* [BDR 3.6.33 Standard Edition (pdf)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/3.6/bdr3.6.33-se.pdf)
 
 ## pglogical 3.6
 
@@ -84,10 +73,4 @@ BDR depends on the pglogical 3 extension to provide the replication
 channel upon which BDR builds.
 
 
-!!!note
-  The documentation for the latest stable 3.6 release is available here:
-
-  [pglogical 3.6](https://documentation.enterprisedb.com/pglogical3/release/latest-3.6/)
-
-   **This is a protected area of our website, if you need access please [contact us](https://www.enterprisedb.com/contact)**
-!!!
+*  [pglogical 3.6.33 (pdf)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/pglogical3.6.33.pdf)

--- a/product_docs/docs/pgd/3.6/index.mdx
+++ b/product_docs/docs/pgd/3.6/index.mdx
@@ -48,7 +48,7 @@ To provide very high availability, avoid data conflicts, and to cope with more a
 
 BDR Enterprise requires EDB Postgres Extended v11 (formerly known as 2ndQuadrant Postgres) which is SQL and on-disk compatible with PostgreSQL.
 
-* [BDR 3.6.33 Enterprise Edition (PDF)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/pglogical3.6.33.pdf)
+* [BDR 3.6.33 Enterprise Edition (PDF)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/bdr3.6.33-ee.pdf)
 
 ### BDR Standard
 

--- a/product_docs/docs/pgd/3.6/index.mdx
+++ b/product_docs/docs/pgd/3.6/index.mdx
@@ -48,7 +48,7 @@ To provide very high availability, avoid data conflicts, and to cope with more a
 
 BDR Enterprise requires EDB Postgres Extended v11 (formerly known as 2ndQuadrant Postgres) which is SQL and on-disk compatible with PostgreSQL.
 
-* [BDR 3.6.33 Enterprise Edition (PDF)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/bdr3.6.33-ee.pdf)
+* [BDR 3.6.33 Enterprise Edition (PDF)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/3.6/bdr3.6.33-ee.pdf)
 
 ### BDR Standard
 
@@ -73,4 +73,4 @@ BDR depends on the pglogical 3 extension to provide the replication
 channel upon which BDR builds.
 
 
-*  [pglogical 3.6.33 (pdf)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/pglogical3.6.33.pdf)
+*  [pglogical 3.6.33 (pdf)](https://media.githubusercontent.com/media/EnterpriseDB/docs-archive/main/docs/bdr/3.6/pglogical3.6.33.pdf)


### PR DESCRIPTION
## What Changed?

Switched BDR 3.6 page to point at docs-archive PDF archives of the 3.6 documentation.
