### PR TITLE
Remove minimum db version info in 4.8 release notes

### DIFF
--- a/product_docs/docs/efm/4/efm_rel_notes/02_efm_48_rel_notes.mdx
+++ b/product_docs/docs/efm/4/efm_rel_notes/02_efm_48_rel_notes.mdx
@@ -7,7 +7,6 @@ Enhancements, bug fixes, and other changes in EFM 4.8 include:
 | Type | Description |
 | ---- |------------ |
 | Enhancement | The minimum Java version required to run Failover Manager is now version 11 instead of 8. |
-| Enhancement | The minimum database server version now supported is 11.  |
 | Enhancement | New CLI command 'efm reset-members added' to remove cached node addreses after a node is removed from a cluster. [Support ticket: #1047118]|
 | Enhancement | Encryption/decryption of database password will now work in a FIPS environment. [Support ticket: #90803, #90805] |
 | Enhancement | Changed the order to retrieve WAL replay/receive queries from a standby during a cluster status call. This can help avoid confusing output when the database cluster is under load. |


### PR DESCRIPTION
We don't put supported database version information into the release notes -- users should check the platform compatibility page instead.

Adding it here was my mistake last time around, and the information is wrong now that v11 has gone out of support.


