### PR TITLE
Fix 05_specify_custom_url_for_oracle_jdbc.mdx - DOCS-588

### DIFF
--- a/product_docs/docs/eprs/7/10_appendix/03_miscellaneous_xdb_processing_topics/01_publications_and_subscriptions_server_conf_options/05_specify_custom_url_for_oracle_jdbc.mdx
+++ b/product_docs/docs/eprs/7/10_appendix/03_miscellaneous_xdb_processing_topics/01_publications_and_subscriptions_server_conf_options/05_specify_custom_url_for_oracle_jdbc.mdx
@@ -16,7 +16,7 @@ By default, Replication Server supports the basic thin-client URL pattern for an
 The following is an example of custom connectivity to an Oracle database.
 
 ```text
-oraJDBCCustomURL=jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=$HOST)(PORT=$PORT))(CONNECT_DATA=(SERVICE_NAME =$SERVICE_NAME)(SERVER=DEDICATED)))
+oraJDBCCustomURL=jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=$HOST)(PORT=$PORT))(CONNECT_DATA=(SERVICE_NAME=$SERVICE_NAME)(SERVER=DEDICATED)))
 ```
 
 The parameters prefixed with a dollar sign ``($)`` are dynamically replaced based on the actual connection values specified when adding the Oracle publication database (see [Adding a publication database](../../../05_smr_operation/02_creating_publication/02_adding_pub_database/#adding_pub_database)). Alternatively, you can replace the parameters prefixed with a dollar sign with hardcoded values in the URL string, in which case these hardcoded values override what is specified when adding the publication database.


### PR DESCRIPTION
Removes space from customURL

## What Changed?

