### PR TITLE
Use github-slugger for section header links

### DIFF
--- a/src/components/card-decks.js
+++ b/src/components/card-decks.js
@@ -72,7 +72,7 @@ const CardDecks = ({ cards, cardType = "simple", deckTitle = "" }) => {
   return (
     <>
       {deckTitle && (
-        <h2 className="mt-3" id={slugger.slug(deckTitle)}>
+        <h2 className="mt-3" id={"section-" + slugger.slug(deckTitle)}>
           {deckTitle}
         </h2>
       )}

--- a/src/components/card-decks.js
+++ b/src/components/card-decks.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "../components/";
 import { Col } from "react-bootstrap";
 import Icon, { iconNames } from "../components/icon/";
+import GithubSlugger from "github-slugger";
 
 const KatacodaBadge = () => <span className="new-thing">Demo</span>;
 
@@ -9,10 +10,6 @@ const showInteractiveBadge = (frontmatter) =>
   frontmatter.showInteractiveBadge != null
     ? frontmatter.showInteractiveBadge
     : !!frontmatter.katacodaPanel;
-
-const makeAnchor = (text) => {
-  return text.split(" ").join("-").toLowerCase().replace("/", "");
-};
 
 const FullCard = ({ card }) => {
   const iconName = card.frontmatter.iconName || iconNames.DOTTED_BOX;
@@ -71,13 +68,11 @@ const SimpleCard = ({ card }) => (
 );
 
 const CardDecks = ({ cards, cardType = "simple", deckTitle = "" }) => {
+  let slugger = new GithubSlugger();
   return (
     <>
       {deckTitle && (
-        <h2
-          className="mt-3"
-          id={deckTitle.split(" ").join("-").toLowerCase().replace("/", "")}
-        >
+        <h2 className="mt-3" id={slugger.slug(deckTitle)}>
           {deckTitle}
         </h2>
       )}

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -242,7 +242,7 @@ const DocTemplate = ({ data, pageContext }) => {
     if (sections) {
       sections.forEach((section) =>
         newtoc.items.push({
-          url: "#" + slugger.slug(section.title),
+          url: "#section-" + slugger.slug(section.title),
           title: section.title,
         }),
       );

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -17,6 +17,7 @@ import {
 } from "../components";
 import { products } from "../constants/products";
 import { FeedbackDropdown } from "../components/feedback-dropdown";
+import GithubSlugger from "github-slugger";
 
 export const query = graphql`
   query ($nodeId: String!) {
@@ -55,11 +56,6 @@ const makeVersionArray = (versions, pathVersions, path) => {
       pathVersions[i] ||
       `${getProductUrlBase(path)}/${i === 0 ? "latest" : version}`,
   }));
-};
-
-// This should be reusable but for now....
-const makeAnchor = (text) => {
-  return "#" + text.split(" ").join("-").toLowerCase().replace("/", "");
 };
 
 const buildSections = (navTree) => {
@@ -193,6 +189,7 @@ const Section = ({ section }) => (
 );
 
 const DocTemplate = ({ data, pageContext }) => {
+  const slugger = new GithubSlugger();
   const { fields, body, tableOfContents, fileAbsolutePath } = data.mdx;
   const gitData = data.edbGit;
   const { path, mtime, depth } = fields;
@@ -245,7 +242,7 @@ const DocTemplate = ({ data, pageContext }) => {
     if (sections) {
       sections.forEach((section) =>
         newtoc.items.push({
-          url: makeAnchor(section.title),
+          url: "#" + slugger.slug(section.title),
           title: section.title,
         }),
       );


### PR DESCRIPTION
## What Changed?

Switch to [GithubSlugger](https://github.com/Flet/github-slugger) for generating card section links. This is the same library used for the rest of the ToC and should therefore avoid most issues with punctuation, etc.

One thing to note: I've made no effort to avoid collisions here between section headers and other headers already used in the same topic. While normally this is handled by incrementing a suffix, that won't happen here - so if you use a header in markdown and the same header text for a section title, the section title link will take you to the section in the markdown. This is rare, and easy enough to avoid by just using unique section titles. Note that using the same title for multiple navigation sections *will* generate a unique suffix and work just fine, but is still a terrible idea and you shouldn't do it.

