### PR TITLE
Bake in copy edit changes into the templates

### DIFF
--- a/product_docs/docs/pgd/5/reference/index.mdx
+++ b/product_docs/docs/pgd/5/reference/index.mdx
@@ -345,7 +345,7 @@ The reference section is a definitive listing of all functions, views, and comma
  * [Internal functions](autopartition#internal-functions)
  * [`bdr.autopartition_create_partition`](autopartition#bdrautopartition_create_partition)
  * [`bdr.autopartition_drop_partition`](autopartition#bdrautopartition_drop_partition)
-## Stream Triggers Reference
+## Stream triggers reference
 
 
 ## [Stream triggers manipulation interfaces](streamtriggers/interfaces)

--- a/product_docs/docs/pgd/5/reference/index.mdx.src
+++ b/product_docs/docs/pgd/5/reference/index.mdx.src
@@ -1,8 +1,8 @@
 ---
-title: "PGD Reference"
-navTitle: "PGD Reference"
+title: "PGD reference"
+navTitle: "PGD reference"
 description: >
-  The complete reference to all functions, views and commands available in EDB Postgres Distributed.
+  The complete reference to all functions, views, and commands available in EDB Postgres Distributed.
 indexCards: none
 navigation:
 - catalogs-visible
@@ -23,5 +23,5 @@ navigation:
 - functions-internal
 ---
 
-The reference section is a definitive listing of all functions, views and commands available in EDB Postgres Distributed.
+The reference section is a definitive listing of all functions, views, and commands available in EDB Postgres Distributed.
 


### PR DESCRIPTION
## What Changed?

Copy edits were done to content generated from templates. This puts the changes into the templates.