### PR TITLE
Full nav cards in versioned docs + bugfixes

### DIFF
--- a/src/components/card-decks.js
+++ b/src/components/card-decks.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "../components/";
 import { Col } from "react-bootstrap";
-import Icon, { iconNames } from "../components/icon/";
+import Icon from "../components/icon/";
 import GithubSlugger from "github-slugger";
 
 const KatacodaBadge = () => <span className="new-thing">Demo</span>;

--- a/src/components/card-decks.js
+++ b/src/components/card-decks.js
@@ -6,44 +6,35 @@ import GithubSlugger from "github-slugger";
 
 const KatacodaBadge = () => <span className="new-thing">Demo</span>;
 
-const showInteractiveBadge = (frontmatter) =>
-  frontmatter.showInteractiveBadge != null
-    ? frontmatter.showInteractiveBadge
-    : !!frontmatter.katacodaPanel;
-
 const FullCard = ({ card }) => {
-  const iconName = card.frontmatter.iconName || iconNames.DOTTED_BOX;
-
   return (
     <div className="card rounded shadow-sm p-2 mt-4 w-100">
-      <Link to={card.fields.path}>
-        <Icon
-          iconName={iconName}
-          className={`${
-            iconName === iconNames.DOTTED_BOX && "opacity-1"
-          } mt-3 ms-3 fill-orange`}
-          width="100"
-          height="100"
-        />
-      </Link>
+      {card.iconName && (
+        <Link to={card.path}>
+          <Icon
+            iconName={card.iconName}
+            className="mt-3 ms-3 fill-orange"
+            width="100"
+            height="100"
+          />
+        </Link>
+      )}
       <div className="card-body">
         <h3 className="card-title balance-text">
-          <Link to={card.fields.path}>
-            {card.frontmatter.navTitle || card.frontmatter.title}
-          </Link>
+          <Link to={card.path}>{card.navTitle || card.title}</Link>
         </h3>
 
-        <p className="card-text">{card.frontmatter.description}</p>
+        <p className="card-text">{card.description}</p>
 
         <div className="d-grid gap-2">
-          {card.children.map((child) => (
+          {card.items.map((child) => (
             <Link
-              key={child.fields.path}
-              to={child.fields.path}
+              key={child.path}
+              to={child.path}
               className="btn btn-link text-start p-0"
             >
-              {child.frontmatter.navTitle || child.frontmatter.title}
-              {showInteractiveBadge(child.frontmatter) && <KatacodaBadge />}
+              {child.navTitle || child.title}
+              {child.interactive && <KatacodaBadge />}
             </Link>
           ))}
         </div>
@@ -56,13 +47,13 @@ const SimpleCard = ({ card }) => (
   <div className="card rounded shadow-sm p-1 mb-4 w-100">
     <div className="card-body">
       <h3 className="card-title balance-text">
-        <Link className="stretched-link" to={card.fields.path}>
-          {card.frontmatter.navTitle || card.frontmatter.title}
-          {showInteractiveBadge(card.frontmatter) && <KatacodaBadge />}
+        <Link className="stretched-link" to={card.path}>
+          {card.navTitle || card.title}
+          {card.interactive && <KatacodaBadge />}
         </Link>
       </h3>
 
-      <p className="card-text">{card.frontmatter.description}</p>
+      <p className="card-text">{card.description}</p>
     </div>
   </div>
 );
@@ -81,7 +72,7 @@ const CardDecks = ({ cards, cardType = "simple", deckTitle = "" }) => {
           {cards.map((card) => {
             return (
               <Col
-                key={card.fields.path}
+                key={card.path}
                 md={12}
                 lg={6}
                 xl={cardType === "simple" && 4}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ import SideNavigation from "./side-navigation";
 import StubCards from "./stub-cards";
 import TableOfContents from "./table-of-contents";
 import TextBalancer from "./text-balancer";
+import Tiles, { TileModes } from "./tiles.js";
 import TimedBanner from "./timed-banner";
 import TopBar from "./top-bar";
 import TreeNode from "./tree-node";
@@ -61,6 +62,8 @@ export {
   StubCards,
   TableOfContents,
   TextBalancer,
+  Tiles,
+  TileModes,
   TimedBanner,
   TopBar,
   TreeNode,

--- a/src/components/prev-next.js
+++ b/src/components/prev-next.js
@@ -1,11 +1,10 @@
 import React from "react";
 import { Link } from "./";
 
-const PrevNext = ({ prevNext, depth, depthLimit = 3 }) => {
+const PrevNext = ({ prevNext }) => {
   let prevLink = prevNext.prev;
   let nextLink = prevNext.next;
-  if (depth <= depthLimit) prevLink = null;
-  if ((nextLink?.depth || 0) <= depthLimit) nextLink = null;
+  let upLink = prevNext.up;
 
   return (
     <div className="d-flex justify-content-between mt-5">
@@ -17,6 +16,17 @@ const PrevNext = ({ prevNext, depth, depthLimit = 3 }) => {
           >
             <h5 className="m-0">&larr; Prev</h5>
             <p className="m-0 small balance-text">{prevLink.title}</p>
+          </Link>
+        )}
+      </div>
+      <div className="max-w-40">
+        {upLink && (
+          <Link
+            to={upLink.path}
+            className="p-3 d-inline-block btn btn-outline-primary text-start"
+          >
+            <h5 className="m-0">&uarr; Up</h5>
+            <p className="m-0 small balance-text">{upLink.title}</p>
           </Link>
         )}
       </div>

--- a/src/components/tiles.js
+++ b/src/components/tiles.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { CardDecks } from "../components";
+
+export const TileModes = {
+  None: "none",
+  Simple: "simple",
+  Full: "full",
+};
+
+const Tiles = ({ mode, node }) => {
+  if (!node || !node.items) return null;
+  if (mode === TileModes.None) return null;
+
+  if (Object.values(TileModes).includes(mode)) {
+    const decks = {};
+    let currentDeckName = "";
+    for (let item of node.items) {
+      if (!item.path) {
+        currentDeckName = item.title;
+      } else {
+        decks[currentDeckName] = decks[currentDeckName] || [];
+        decks[currentDeckName].push(item);
+      }
+    }
+
+    return Object.keys(decks).map((deckName) => {
+      return (
+        <CardDecks
+          cards={decks[deckName]}
+          cardType={mode}
+          deckTitle={deckName}
+        />
+      );
+    });
+  }
+  return null;
+};
+
+export default Tiles;

--- a/src/constants/gatsby-utils.js
+++ b/src/constants/gatsby-utils.js
@@ -288,17 +288,8 @@ const findPrevNextNavNodes = (navRoot, currNode) => {
   // Find previous page
   if (currNode !== navRoot) {
     if (currIndex > 0) {
-      prevNext.prev = currNode.parent.children[currIndex - 1];
-      // this preserves an existing bug (for testing purposes)
-      // it will only descend into the previous node's children
-      // if its path sorts after the current node alphabetically
-      // I believe this originally worked because nodes were
-      // created in filesystem order. When navigation changes were
-      // introduced, this became increasingly unreliable.
-      if (prevNext.prev?.path?.localeCompare(currNode.path) > 0) {
-        for (const node of currNode.parent.children[currIndex - 1]) {
-          if (node.depth === currNode.depth + 1) prevNext.prev = node;
-        }
+      for (const node of currNode.parent.children[currIndex - 1]) {
+        if (node.depth <= currNode.depth + 1) prevNext.prev = node;
       }
     } else if (currIndex === 0 && currNode.parent !== navRoot)
       prevNext.prev = currNode.parent;

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -14,6 +14,8 @@ import {
   PrevNext,
   SideNavigation,
   TableOfContents,
+  Tiles,
+  TileModes,
 } from "../components";
 import { products } from "../constants/products";
 import { FeedbackDropdown } from "../components/feedback-dropdown";
@@ -92,60 +94,6 @@ const findDescendent = (root, predicate) => {
   for (let node of root.items) {
     const result = findDescendent(node, predicate);
     if (result) return result;
-  }
-  return null;
-};
-
-const getCards = (node, searchDepth) => {
-  const card = {
-    fields: {
-      path: node.path,
-      depth: node.depth,
-    },
-    frontmatter: {
-      navTitle: node.navTitle,
-      title: node.title,
-      description: node.description,
-      iconName: node.iconName,
-      interactive: node.interactive,
-    },
-    children:
-      searchDepth && node.items
-        ? node.items.map((n) => getCards(n, searchDepth - 1))
-        : [],
-  };
-  return card;
-};
-
-const TileModes = {
-  None: "none",
-  Simple: "simple",
-  Full: "full",
-};
-const Tiles = ({ mode, node }) => {
-  if (!node || !node.items) return null;
-
-  if (Object.values(TileModes).includes(mode) && mode !== TileModes.None) {
-    const decks = {};
-    let currentDeckName = "";
-    for (let item of node.items) {
-      if (!item.path) {
-        currentDeckName = item.title;
-      } else {
-        decks[currentDeckName] = decks[currentDeckName] || [];
-        decks[currentDeckName].push(getCards(item, mode === "simple" ? 0 : 1));
-      }
-    }
-
-    return Object.keys(decks).map((deckName) => {
-      return (
-        <CardDecks
-          cards={decks[deckName]}
-          cardType={mode}
-          deckTitle={deckName}
-        />
-      );
-    });
   }
   return null;
 };

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -4,7 +4,6 @@ import { graphql, Link } from "gatsby";
 import { isPathAnIndexPage } from "../constants/utils";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import {
-  CardDecks,
   DevOnly,
   DevFrontmatter,
   Footer,
@@ -292,7 +291,7 @@ const DocTemplate = ({ data, pageContext }) => {
               </Col>
             )}
           </ContentRow>
-          {depth > 2 && <PrevNext prevNext={prevNext} depth={depth} />}
+          {depth > 2 && <PrevNext prevNext={prevNext} />}
           <DevFrontmatter frontmatter={frontmatter} />
 
           <Footer timestamp={mtime} githubFileLink={githubFileHistoryLink} />

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -171,14 +171,7 @@ const LearnDocTemplate = ({ data, pageContext }) => {
               </Col>
             )}
           </ContentRow>
-          {showPrevNext && depth > 1 && (
-            <PrevNext
-              prevNext={prevNext}
-              path={path}
-              depth={depth}
-              depthLimit={2}
-            />
-          )}
+          {showPrevNext && <PrevNext prevNext={prevNext} />}
 
           <DevFrontmatter frontmatter={frontmatter} />
 


### PR DESCRIPTION
## What Changed?

- Section headings now render for card navigation section in unversioned docs
- Full card navigation no longer renders icons, when there are no icons defined for child pages
- Navigation order no longer ignored for grandchildren in "full" card navigation cards
- Sidebar navigation now expands normally even when page title is "NULL".
- As discussed on IA call, there's a new "Up" button that takes you to the parent, and the Prev button now behaves in a consistent fashion everywhere: to the last descendant of the previous sibling (IOW, the page for which the "next" button will take you to the current page). Existing behavior took you to the last child of the previous sibling, unless filename of previous sibling sorts alphabetically before the filename of current node in which case prev button takes you to previous sibling.
