### PR TITLE
fix autocluster example

### DIFF
--- a/advocacy_docs/pg_extensions/advanced_storage_pack/using.mdx
+++ b/advocacy_docs/pg_extensions/advanced_storage_pack/using.mdx
@@ -156,7 +156,7 @@ This example is for an IoT thermostat that reports house temperatures and temper
 ```sql
 CREATE TABLE iot (
     thermostat_id         BIGINT NOT NULL,
-    recordtime            TIMESTAMPTZ NOT NULL,
+    recordtime            TIME NOT NULL,
     measured_temperature  FLOAT4,
     temperature_setting   FLOAT4
 ) USING autocluster;
@@ -180,12 +180,12 @@ The `cols` parameter specifies the table that's clustered. In this case, `{1}` c
 Populate the table with the `thermostat_id` and `recordtime` data:
 
 ```sql
-INSERT INTO iot (thermostat_id, recordtime) VALUES (456, 12:01);
-INSERT INTO iot (thermostat_id, recordtime) VALUES (8945, 04:55);
-INSERT INTO iot (thermostat_id, recordtime) VALUES (456, 15:32);
-INSERT INTO iot (thermostat_id, recordtime) VALUES (6785, 01:36);
-INSERT INTO iot (thermostat_id, recordtime) VALUES (456, 19:25);
-INSERT INTO iot (thermostat_id, recordtime) VALUES (5678, 03:44);
+INSERT INTO iot (thermostat_id, recordtime) VALUES (456, '12:01');
+INSERT INTO iot (thermostat_id, recordtime) VALUES (8945, '04:55');
+INSERT INTO iot (thermostat_id, recordtime) VALUES (456, '15:32');
+INSERT INTO iot (thermostat_id, recordtime) VALUES (6785, '01:36');
+INSERT INTO iot (thermostat_id, recordtime) VALUES (456, '19:25');
+INSERT INTO iot (thermostat_id, recordtime) VALUES (5678, '03:44');
 ```
 
 When you select the data from the IoT table, you can see from the ctid location that the data with the same `thermostat_id` was clustered together:


### PR DESCRIPTION
The example had timestamptz as datatype and inserted only hour:minute unquoted.

Besides the obvious quoting, we should either change the data to match the datatype, or the datatype to match the hour:minute data. Using full timestamptz probably wouldn't improve the example, which is well served by simple data. So using `time` as column datatype is adequate.

This intends to cover issue #5486 .