### PR TITLE
improve needed permissions spec for fault injection

### DIFF
--- a/product_docs/docs/biganimal/release/using_cluster/fault_injection_testing/index.mdx
+++ b/product_docs/docs/biganimal/release/using_cluster/fault_injection_testing/index.mdx
@@ -13,7 +13,7 @@ the availability and recovery of the cluster.
 Ensure you meet the following requirements before using fault injection testing:
 
 + You have connected your BigAnimal cloud account with your Azure subscription.  See [Setting up your Azure Marketplace account](/biganimal/latest/getting_started/02_azure_market_setup/) for more information.
-+ You should have permissions in your Azure subscription to view and delete VMs.
++ You have permissions in your Azure subscription to view and delete VMs and also the ability to view Kubernetes pods via Azure Kubernetes Service RBAC Reader.
 + You have PGD CLI installed.  See [Installing PGD CLI](/pgd/latest/cli/installing_cli/#) for more information. 
 + You have created a `pgd-cli-config.yml` file in your home directory.  See [Configuring PGD CLI](/pgd/latest/cli/configuring_cli/) for more information.
 


### PR DESCRIPTION
Customer needs Azure Kubernetes Service RBAC Reader as well, added.

## What Changed?

Added Azure Kubernetes Service RBAC Reader to Azure permissions bullet.