### PR TITLE
PGD: improve documentation of bdr.stat_[relation|subscription] catalogue relations

### DIFF
--- a/product_docs/docs/pgd/4/bdr/catalogs.mdx
+++ b/product_docs/docs/pgd/4/bdr/catalogs.mdx
@@ -786,8 +786,15 @@ is set correctly when the wait relates to BDR.
 
 ### `bdr.stat_relation`
 
-Apply statistics for each relation. Contains data only if the tracking
-is enabled and something was replicated for a given relation.
+Shows apply statistics for each relation. Contains data only if tracking is enabled via
+[`bdr.track_relation_apply`](/pgd/4/bdr/configuration.mdx#bdrtrack_relation_apply),
+and if data was replicated for a given relation.
+
+`lock_acquire_time` is only updated if [`bdr.track_apply_lock_timing`](/pgd/4/bdr/configuration.mdx#bdrtrack_apply_lock_timing)
+is set to `on` (default: `off`).
+
+The stored relation statistics can be reset by calling
+[`bdr.reset_relation_stats()`](/pgd/4/bdr/functions.mdx#bdrreset_relation_stats).
 
 #### `bdr.stat_relation` columns
 
@@ -811,8 +818,11 @@ is enabled and something was replicated for a given relation.
 
 ### `bdr.stat_subscription`
 
-Apply statistics for each subscription. Contains data only if the tracking
-is enabled.
+Shows apply statistics for each subscription. Contains data only if tracking is enabled via
+[`bdr.track_subscription_apply`](/pgd/4/bdr/configuration.mdx#bdrtrack_subscription_apply).
+
+The stored subscription statistics can be reset by calling
+[`bdr.reset_subscription_stats()`](/pgd/4/bdr/functions.mdx#bdrreset_subscripion_stats).
 
 #### `bdr.stat_subscription` columns
 

--- a/product_docs/docs/pgd/4/bdr/configuration.mdx
+++ b/product_docs/docs/pgd/4/bdr/configuration.mdx
@@ -488,11 +488,14 @@ and receivers don't have a writer ID.
     archival, and rotation to prevent disk space exhaustion.
 
 -   `bdr.track_subscription_apply` &mdash; Track apply statistics for
-    each subscription.
+    each subscription via [`bdr.stat_subscription`](/pgd/4/bdr/catalogs.mdx#bdrstat_subscription).
+    The default value is `on`.
 -   `bdr.track_relation_apply` &mdash; Track apply statistics for each
-    relation.
+    relation via [`bdr.stat_relation`](/pgd/4/bdr/catalogs.mdx#bdrstat_relation).
+    The default value is `off`.
 -   `bdr.track_apply_lock_timing` &mdash; Track lock timing when tracking
-    statistics for relations.
+    statistics for relations via [`bdr.stat_relation`](/pgd/4/bdr/catalogs.mdx#bdrstat_relation).
+    The default value is `off`.
 
 ### Internals
 

--- a/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
+++ b/product_docs/docs/pgd/5/reference/catalogs-visible.mdx
@@ -857,33 +857,45 @@ is set correctly when the wait relates to PGD.
 
 ### `bdr.stat_relation`
 
-Apply statistics for each relation. Contains data only if the tracking
-is enabled and something was replicated for a given relation.
+Shows apply statistics for each relation. Contains data only if tracking is enabled via
+[`bdr.track_relation_apply`](/pgd/5/reference/pgd-settings.mdx#bdrtrack_relation_apply)
+and if data was replicated for a given relation.
+
+`lock_acquire_time` is only updated if [`bdr.track_apply_lock_timing`](/pgd/5/reference/pgd-settings.mdx#bdrtrack_apply_lock_timing)
+is set to `on` (default: `off`).
+
+The stored relation statistics can be reset by calling
+[`bdr.reset_relation_stats()`](/pgd/5/reference/functions-internal.mdx#bdrreset_relation_stats).
 
 #### `bdr.stat_relation` columns
 
-| Column              | Type             | Description                                                                                                                     |
-| ------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| nspname             | name             | Name of the relation's schema                                                                                                   |
-| relname             | name             | Name of the relation                                                                                                            |
-| relid               | oid              | OID of the relation                                                                                                             |
-| total_time          | double precision | Total time spent processing replication for the relation                                                                        |
-| ninsert             | bigint           | Number of inserts replicated for the relation                                                                                   |
-| nupdate             | bigint           | Number of updates replicated for the relation                                                                                   |
-| ndelete             | bigint           | Number of deletes replicated for the relation                                                                                   |
-| ntruncate           | bigint           | Number of truncates replicated for the relation                                                                                 |
-| shared_blks_hit     | bigint           | Total number of shared block cache hits for the relation                                                                        |
-| shared_blks_read    | bigint           | Total number of shared blocks read for the relation                                                                             |
-| shared_blks_dirtied | bigint           | Total number of shared blocks dirtied for the relation                                                                          |
-| shared_blks_written | bigint           | Total number of shared blocks written for the relation                                                                          |
-| blk_read_time       | double precision | Total time spent reading blocks for the relation, in milliseconds (if `track_io_timing` is enabled, otherwise zero)             |
-| blk_write_time      | double precision | Total time spent writing blocks for the relation, in milliseconds (if `track_io_timing` is enabled, otherwise zero)             |
-| lock_acquire_time   | double precision | Total time spent acquiring locks on the relation, in milliseconds (if `bdr.track_apply_lock_timing` is enabled, otherwise zero) |
+| Column              | Type                     | Description                                                                                                                     |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| nspname             | name                     | Name of the relation's schema                                                                                                   |
+| relname             | name                     | Name of the relation                                                                                                            |
+| relid               | oid                      | OID of the relation                                                                                                             |
+| total_time          | double precision         | Total time spent processing replication for the relation                                                                        |
+| ninsert             | bigint                   | Number of inserts replicated for the relation                                                                                   |
+| nupdate             | bigint                   | Number of updates replicated for the relation                                                                                   |
+| ndelete             | bigint                   | Number of deletes replicated for the relation                                                                                   |
+| ntruncate           | bigint                   | Number of truncates replicated for the relation                                                                                 |
+| shared_blks_hit     | bigint                   | Total number of shared block cache hits for the relation                                                                        |
+| shared_blks_read    | bigint                   | Total number of shared blocks read for the relation                                                                             |
+| shared_blks_dirtied | bigint                   | Total number of shared blocks dirtied for the relation                                                                          |
+| shared_blks_written | bigint                   | Total number of shared blocks written for the relation                                                                          |
+| blk_read_time       | double precision         | Total time spent reading blocks for the relation, in milliseconds (if `track_io_timing` is enabled, otherwise zero)             |
+| blk_write_time      | double precision         | Total time spent writing blocks for the relation, in milliseconds (if `track_io_timing` is enabled, otherwise zero)             |
+| lock_acquire_time   | double precision         | Total time spent acquiring locks on the relation, in milliseconds (if `bdr.track_apply_lock_timing` is enabled, otherwise zero) |
+| stats_reset         | timestamp with time zone | Time of the last statistics reset (performed by `bdr.reset_relation_stats()`)                                                   |
+
 
 ### `bdr.stat_subscription`
 
-Apply statistics for each subscription. Contains data only if the tracking
-is enabled.
+Shows apply statistics for each subscription. Contains data only if tracking is enabled via
+[`bdr.track_subscription_apply`](/pgd/5/reference/pgd-settings.mdx#bdrtrack_subscription_apply).
+
+The stored subscription statistics can be reset by calling
+[`bdr.reset_subscription_stats()`](/pgd/5/reference/functions-internal.mdx#bdrreset_subscription_stats).
 
 #### `bdr.stat_subscription` columns
 
@@ -935,7 +947,7 @@ is enabled.
 | nprovisional_waits   | bigint                   | Number of update/delete operations on same tuples by concurrent apply transactions. These are provisional waits. See [Parallel Apply](../parallelapply) |
 | ntuple_waits         | bigint                   | Number of update/delete operations that waited to be safely applied. See [Parallel Apply](../parallelapply) |
 | ncommit_waits        | bigint                   | Number of fully applied transactions that had to wait before being committed. See [Parallel Apply](../parallelapply) |
-| stats_reset          | timestamp with time zone | Time when these subscription statistics were reset                                                                  |
+| stats_reset          | timestamp with time zone | Time of the last statistics reset (performed by `bdr.reset_subscription_stats()`)                                   |
 
 ### `bdr.subscription`
 

--- a/product_docs/docs/pgd/5/reference/pgd-settings.mdx
+++ b/product_docs/docs/pgd/5/reference/pgd-settings.mdx
@@ -472,15 +472,21 @@ archival, and rotation to prevent disk space exhaustion.
 
 ### `bdr.track_subscription_apply`
 
-Track apply statistics for each subscription.
+Track apply statistics for each subscription via [`bdr.stat_subscription`](/pgd/5/reference/catalogs-visible.mdx#bdrstat_subscription).
+
+The default value is `on`.
 
 ### `bdr.track_relation_apply`
 
-Track apply statistics for each relation.
+Track apply statistics for each relation via [`bdr.stat_relation`](/pgd/5/reference/catalogs-visible.mdx#bdrstat_relation).
+
+The default value is `off`.
 
 ### `bdr.track_apply_lock_timing`
 
-Track lock timing when tracking statistics for relations.
+Track lock timing when tracking statistics for relations via [`bdr.stat_relation`](/pgd/5/reference/catalogs-visible.mdx#bdrstat_relation).
+
+The default value is `off`.
 
 ## Decoding Worker
 


### PR DESCRIPTION
## What Changed?

For the catalogue relations "bdr.stat_relation" and "bdr.stat_subscription", make it clear which GUCs enable/disable tracking, and also note the respective statistics reset functions.

Also add missing "stats_reset" column on "bdr.stat_relation" for PGD 5.
