### PR TITLE
Update installation instructions for Patroni to use `edb-patroni`

### DIFF
--- a/advocacy_docs/supported-open-source/patroni/index.mdx
+++ b/advocacy_docs/supported-open-source/patroni/index.mdx
@@ -15,6 +15,7 @@ navigation:
 - "#Installing"
 - installing_patroni
 - installing_etcd
+- installing_with_TPA
 - "#Using"
 - cluster_management
 - tips

--- a/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
+++ b/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
@@ -30,7 +30,7 @@ Packages are available for all subscribed customers with a valid EDB account und
 !!! Note
     The `edb-patroni` does not provide packages for the etcd server needed for the DCS cluster
 
-Once you have the EDB repository configured on all the nodesof the cluster, run the following commands depending on the Linux distribution you are using
+Once you have the EDB repository configured on all the nodes of the cluster, run the following commands depending on the Linux distribution you are using.
 
 ### Debian/Ubuntu
 

--- a/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
+++ b/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
@@ -9,21 +9,7 @@ tags:
 
 EDB provides Patroni to customers via the `edb-patroni` package. This package provides Patroni itself and all its dependencies, so there is no need to install additional packages on the Postgres nodes.
 
-Extra packages which no longer have to be installed separately are the following:
-
-- python3-cdiff
-- python3-psutil
-- python3-psycopg2
-- python3-ydiff
-- python3-click
-- python3-six
-- python3-dateutil
-- python3-prettytable
-- python3-pyyaml
-- python3-urllib3
-- python3-etcd
-- python3-dns
-- python3-certifi
+As the dependencies no longer have to be installed separately, there is no need to install the python3-cdiff, python3-psutil, python3-psycopg2, python3-ydiff, python3-click, python3-click, python3-six, python3-dateutil, python3-prettytable, python3-pyyaml, python3-urllib3, python3-etcd, python3-dns or python3-certifi packages.
 
 Packages are available for all subscribed customers with a valid EDB account under any entitlement (Community360, Standard, and Enterprise).
 

--- a/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
+++ b/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
@@ -53,4 +53,5 @@ See [Quick start on RHEL8](rhel8_quick_start/#4-patroni) for a more detailed con
 
 ### Installing community packages
 
-We also support community packages provided via the PGDG repositories. Follow the [PGDG deb download instructions](https://www.postgresql.org/download/linux/debian/) to set up the `apt` repository, or the [PGDG rpm download instructions](https://yum.postgresql.org/) for the `yum` repository. Keep in mind that for PGDG rpm repositories you will need to configure Extra Packages for Enterprise Linux ([EPEL](https://fedoraproject.org/wiki/EPEL)) and enable the `pgdg-extras` repository.
+We also support community packages provided through PGDG repositories. Follow the [PGDG deb download instructions](https://www.postgresql.org/download/linux/debian/) to set up the `apt` repository, or the [PGDG rpm download instructions](https://yum.postgresql.org/) for the `yum` repository. Keep in mind that for PGDG rpm repositories you will need to configure Extra Packages for Enterprise Linux ([EPEL](https://fedoraproject.org/wiki/EPEL)).
+

--- a/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
+++ b/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
@@ -51,5 +51,6 @@ sudo dnf install -y edb-patroni
 
 See [Quick start on RHEL8](rhel8_quick_start/#4-patroni) for a more detailed configuration example.
 
+### Installing community packages
 
 We also support community packages provided via the PGDG repositories. Follow the [PGDG deb download instructions](https://www.postgresql.org/download/linux/debian/) to set up the `apt` repository, or the [PGDG rpm download instructions](https://yum.postgresql.org/) for the `yum` repository. Keep in mind that for PGDG rpm repositories you will need to configure Extra Packages for Enterprise Linux ([EPEL](https://fedoraproject.org/wiki/EPEL)) and enable the `pgdg-extras` repository.

--- a/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
+++ b/advocacy_docs/supported-open-source/patroni/installing_patroni.mdx
@@ -7,28 +7,49 @@ tags:
   - Patroni
 ---
 
-Patroni packages are provided through the PGDG `apt` and `yum` repositories.
+EDB provides Patroni to customers via the `edb-patroni` package. This package provides Patroni itself and all its dependencies, so there is no need to install additional packages on the Postgres nodes.
 
-See [Platform Compatibility](https://www.enterprisedb.com/resources/platform-compatibility#epas) for the supported OS list (only `Linux x86-64 (amd64)` currently).
+Extra packages which no longer have to be installed separately are the following:
+
+- python3-cdiff
+- python3-psutil
+- python3-psycopg2
+- python3-ydiff
+- python3-click
+- python3-six
+- python3-dateutil
+- python3-prettytable
+- python3-pyyaml
+- python3-urllib3
+- python3-etcd
+- python3-dns
+- python3-certifi
+
+Packages are available for all subscribed customers with a valid EDB account under any entitlement (Community360, Standard, and Enterprise).
+
+!!! Note
+    The `edb-patroni` does not provide packages for the etcd server needed for the DCS cluster
+
+Once you have the EDB repository configured on all the nodesof the cluster, run the following commands depending on the Linux distribution you are using
 
 ### Debian/Ubuntu
 
-To install Patroni, configure the [PostgreSQL](https://www.postgresql.org/download/linux/debian/) `apt` repository. Then run:
-
 ```bash
-sudo apt-get install -y patroni
+sudo apt-get install -y edb-patroni
 ```
+
+!!! Note
+    On Debian and Ubuntu installations, if you've previously installed the Patroni package named `patroni` using the EDB repositories, `apt upgrade` will not replace this package with the `edb-patroni` package. Executing `apt install edb-patroni` will install `edb-patroni` as a replacement of `patroni`.
 
 See [Quick start on Debian 11](debian11_quick_start/#4-patroni) for a more detailed configuration example.
 
 ### RHEL/CentOS
 
-You can install Patroni from the [PostgreSQL](https://yum.postgresql.org/) `yum` repository. It requires Extra Packages for Enterprise Linux ([EPEL](https://fedoraproject.org/wiki/EPEL)).
-
-After you configured the repositories, run the following command to install Patroni and its dependencies for etcd:
-
 ```bash
-sudo dnf install -y patroni patroni-etcd
+sudo dnf install -y edb-patroni
 ```
 
 See [Quick start on RHEL8](rhel8_quick_start/#4-patroni) for a more detailed configuration example.
+
+
+We also support community packages provided via the PGDG repositories. Follow the [PGDG deb download instructions](https://www.postgresql.org/download/linux/debian/) to set up the `apt` repository, or the [PGDG rpm download instructions](https://yum.postgresql.org/) for the `yum` repository. Keep in mind that for PGDG rpm repositories you will need to configure Extra Packages for Enterprise Linux ([EPEL](https://fedoraproject.org/wiki/EPEL)) and enable the `pgdg-extras` repository.

--- a/advocacy_docs/supported-open-source/patroni/installing_with_TPA.mdx
+++ b/advocacy_docs/supported-open-source/patroni/installing_with_TPA.mdx
@@ -1,0 +1,1 @@
+### Deploying a Patroni cluster with TPA

--- a/advocacy_docs/supported-open-source/patroni/installing_with_TPA.mdx
+++ b/advocacy_docs/supported-open-source/patroni/installing_with_TPA.mdx
@@ -1,1 +1,13 @@
+---
+title: 'Deploying Patroni with TPA'
+navTitle: 'Deploying with TPA'
+description: 'Short description on deploying Patroni with TPA'
+tags:
+  - Installation
+  - Patroni
+  - TPA
+---
+
 ### Deploying a Patroni cluster with TPA
+
+The recommended way for deploying Patroni clusters is by doing so with TPA. We recommend going over the [TPA documentation](https://www.enterprisedb.com/docs/tpa/latest/) for further information on deploying M1 architectures with Patroni as the failover manager.


### PR DESCRIPTION
With release 3.3.0 of Patroni we've introduced a new `edb-patroni` package which provides all the dependencies in a single package.

These dependencies will be installed in a virtual environment where Patroni will run.

This removes the need to install `python3-ydiff`, `python3-cdiff`, and others.

## What Changed?

