### PR TITLE
Edits to BigAnimal PR5577

### DIFF
--- a/product_docs/docs/biganimal/release/release_notes/2024_01_jan_rel_notes.mdx
+++ b/product_docs/docs/biganimal/release/release_notes/2024_01_jan_rel_notes.mdx
@@ -3,7 +3,7 @@ title: BigAnimal January 2024 release notes
 navTitle: January 2024
 ---
 
-BigAnimal's January 2024 includes the following enhancements and bugfixes:
+BigAnimal's January 2024 release includes the following enhancements and bug fixes:
 
 | Type | Description |
 |------|-------------|

--- a/product_docs/docs/biganimal/release/release_notes/2024_02_feb_rel_notes.mdx
+++ b/product_docs/docs/biganimal/release/release_notes/2024_02_feb_rel_notes.mdx
@@ -3,7 +3,7 @@ title: BigAnimal February 2024 release notes
 navTitle: February 2024
 ---
 
-BigAnimal's February 2024 includes the following enhancements and bugfixes:
+BigAnimal's February 2024 release includes the following enhancements and bug fixes:
 
 | Type        | Description                                                                                                                                                                                     |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/product_docs/docs/biganimal/release/release_notes/2024_03_mar_rel_notes.mdx
+++ b/product_docs/docs/biganimal/release/release_notes/2024_03_mar_rel_notes.mdx
@@ -3,7 +3,7 @@ title: BigAnimal March 2024 release notes
 navTitle: March 2024
 ---
 
-BigAnimal's March 2024 includes the following enhancements and bugfixes:
+BigAnimal's March 2024 release includes the following enhancements and bug fixes:
 
 | Type | Description |
 |------|-------------|

--- a/product_docs/docs/biganimal/release/release_notes/2024_04_apr_rel_notes.mdx
+++ b/product_docs/docs/biganimal/release/release_notes/2024_04_apr_rel_notes.mdx
@@ -3,7 +3,7 @@ title: BigAnimal April 2024 release notes
 navTitle: April 2024
 ---
 
-In April 2024 BigAnimal saw the following enhancements and bugfixes:
+BigAnimal's April 2024 release includes the following enhancements and bug fixes:
 
 | Type | Description |
 |------|-------------|


### PR DESCRIPTION
Added missing word and fixed typo in 2024 release notes intros; made April 2024 release note intro wording consistent with others.

