### PR TITLE
Remove references of Stack Builder from EPRS docs

### DIFF
--- a/product_docs/docs/eprs/7/installing/uninstalling.mdx
+++ b/product_docs/docs/eprs/7/installing/uninstalling.mdx
@@ -21,7 +21,7 @@ Uninstalling Replication Server doesn't remove any databases used as primary nod
 
 Use the Replication Server console or the Replication Server command line interface to delete any existing single-master or multi-master replication systems before you uninstall Replication Server. Otherwise the control-schema objects created in the publication databases or primary nodes remain in those databases. You must then delete these control-schema objects manually, such as by using a SQL command line utility.
 
-If you installed Replication Server using the Replication Server installer program invoked from Stack Builder or StackBuilder Plus, uninstall Replication Server by invoking the `uninstall-xdbreplicationserver` script.
+If you installed Replication Server using the Replication Server installer program invoked from StackBuilder Plus, uninstall Replication Server by invoking the `uninstall-xdbreplicationserver` script.
 
 <div id="uninstalling_xdb_rpm_package" class="registered_link"></div>
 

--- a/product_docs/docs/eprs/7/installing/upgrading_replication_server/upgrading_with_gui_installer.mdx
+++ b/product_docs/docs/eprs/7/installing/upgrading_replication_server/upgrading_with_gui_installer.mdx
@@ -23,7 +23,7 @@ You can upgrade to Replication Server 7 using the graphical installer.
 
 1.  On the Ready to Install screen, select **Next**.
 
-    The remaining screens that appear confirm completion of the installation process and allow you to exit from Stack Builder or StackBuilder Plus.
+    The remaining screens that appear confirm completion of the installation process and allow you to exit from StackBuilder Plus.
 
 1.  After installation completes, the publication server of the new Replication Server product is running, connected to the controller database used by Replication Server 6.2. The subscription server might be running at this point, which is an expected outcome of this process.
 

--- a/product_docs/docs/eprs/7/installing/windows.mdx
+++ b/product_docs/docs/eprs/7/installing/windows.mdx
@@ -27,13 +27,19 @@ EDB provides a graphical interactive installer for Windows. You can access it tw
 
 ## Installing directly
 
-After downloading the graphical installer, to start the installation wizard, assume sufficient privileges (superuser or administrator) and double-click the installer icon. If prompted, provide a password.
+Download the graphical installer from the [downloads portal](https://www.enterprisedb.com/software-downloads-postgres#replication-server). 
+
+Then, assume sufficient privileges (superuser or administrator), and start the installation wizard by double-clicking the installer icon. 
+If prompted, provide a password.
 
 In some versions of Windows, to invoke the installer with administrator privileges, you need to right-click the installer icon and select **Run as Administrator** from the context menu.
 
 Proceed to [Using the graphical installer](#using-the-graphical-installer).
 
 ## Using StackBuilder Plus
+
+!!! Note
+    This method is available to EDB Postgres Advanced Server users only. PostgreSQL users must resort to the [direct installation](#installing-directly) method.
 
 You can invoke the graphical installer with StackBuilder Plus. See [Using StackBuilder Plus](/epas/latest/installing/windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus/). 
 

--- a/product_docs/docs/eprs/7/installing/windows.mdx
+++ b/product_docs/docs/eprs/7/installing/windows.mdx
@@ -12,7 +12,7 @@ EDB provides a graphical interactive installer for Windows. You can access it tw
 
 - Download the graphical installer from the [Downloads page](https://www.enterprisedb.com/software-downloads-postgres#replication-server) and invoke the installer directly. See [Installing directly](/eprs/latest/installing/windows/#installing-directly).
 
-- Use Stack Builder (with PostgreSQL) or StackBuilder Plus (with EDB Postgres Advanced Server) to download the EDB installer package and invoke the graphical installer. See [Using Stack Builder or StackBuilder Plus](/eprs/latest/installing/windows/#using-stack-builder-or-stackbuilder-plus).
+- Use StackBuilder Plus (with EDB Postgres Advanced Server) to download the EDB installer package and invoke the graphical installer. See [Using StackBuilder Plus](/eprs/latest/installing/windows/#using-stack-builder-or-stackbuilder-plus).
 
 
 ## Prerequisites
@@ -33,19 +33,9 @@ In some versions of Windows, to invoke the installer with administrator privileg
 
 Proceed to [Using the graphical installer](#using-the-graphical-installer).
 
-## Using Stack Builder or StackBuilder Plus
+## Using StackBuilder Plus
 
-If you're using PostgreSQL, you can invoke the graphical installer with Stack Builder. See [Using Stack Builder](https://www.enterprisedb.com/docs/supported-open-source/postgresql/installing/03_using_stackbuilder/). 
-
-1. In Stack Builder, follow the prompts until you get to the module selection page.
-
-1. Expand the **Registration-required and trial products** node. 
-
-1. Expand the **EnterpriseDB Tools** node and select **Replication Server**. 
-
-1. Proceed to [Using the graphical installer](#using-the-graphical-installer).
-
-If you're using EDB Postgres Advanced Server, you can invoke the graphical installer with StackBuilder Plus. See [Using StackBuilder Plus](/epas/latest/installing/windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus/). 
+You can invoke the graphical installer with StackBuilder Plus. See [Using StackBuilder Plus](/epas/latest/installing/windows/installing_advanced_server_with_the_interactive_installer/using_stackbuilder_plus/). 
 
 1. In StackBuilder Plus, follow the prompts until you get to the module selection page. 
 
@@ -74,7 +64,7 @@ If you're using EDB Postgres Advanced Server, you can invoke the graphical insta
 
     -   **Admin User** &mdash; The Replication Server administrator user name needed to authenticate some Replication Server actions, such as registering a publication server or subscription server running on this host. You can enter any alphanumeric string for the admin user name. The default admin user name is admin.
 
-   -   **Admin Password** &mdash; Password of your choice for the Replication Server administrator.
+    -   **Admin Password** &mdash; Password of your choice for the Replication Server administrator.
 
    The admin user and the admin password (in encrypted form) are saved to the `XDB_HOME\etc\edb-repl.conf` configuration file. Select **Next**.
 


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/DOCS-669 

References for Stack Builder Plus can remain. 