### PR TITLE
Added trademark in titles

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-ml/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-ml/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI - AI/ML
+title: EDB Postgres® AI - AI/ML
 navTitle: AI/ML
 indexCards: simple
 iconName: BrainCircuit

--- a/advocacy_docs/edb-postgres-ai/ai-ml/install-tech-preview.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-ml/install-tech-preview.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI AI/ML - Installing the pgai tech preview
+title: EDB Postgres® AI AI/ML - Installing the pgai tech preview
 navTitle: Installing
 description: How to install the EDB Postgres AI AI/ML pgai tech preview and run the container image.
 prevNext: true

--- a/advocacy_docs/edb-postgres-ai/ai-ml/overview.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-ml/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI AI/ML - Overview
+title: EDB Postgres® AI AI/ML - Overview
 navTitle: Overview
 description: Where to start with EDB Postgres AI AI/ML and the pgai tech preview.
 prevNext: True

--- a/advocacy_docs/edb-postgres-ai/ai-ml/using-tech-preview/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-ml/using-tech-preview/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI AI/ML - Using the pgai tech preview
+title: EDB Postgres® AI AI/ML - Using the pgai tech preview
 navTitle: Using
 description: Using the EDB Postgres AI AI/ML tech preview to build a simple retrieval augmented generation (RAG) application in Postgres.
 navigation:

--- a/advocacy_docs/edb-postgres-ai/analytics/concepts.mdx
+++ b/advocacy_docs/edb-postgres-ai/analytics/concepts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Concepts - EDB Postgres Lakehouse
+title: Concepts - EDB Postgres® Lakehouse
 navTitle: Concepts
 description: Learn about the ideas and terminology behind EDB Postgres Lakehouse for Analytics workloads.
 ---

--- a/advocacy_docs/edb-postgres-ai/analytics/quick_start.mdx
+++ b/advocacy_docs/edb-postgres-ai/analytics/quick_start.mdx
@@ -1,5 +1,5 @@
 ---
-title: Quick Start - EDB Postgres Lakehouse
+title: Quick Start - EDB Postgres® Lakehouse
 navTitle: Quick Start
 description: Launch a Lakehouse Node and query sample data.
 ---

--- a/advocacy_docs/edb-postgres-ai/analytics/reference.mdx
+++ b/advocacy_docs/edb-postgres-ai/analytics/reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reference - EDB Postgres Lakehouse
+title: Reference - EDB Postgres® Lakehouse
 navTitle: Reference
 description: Things to know about EDB Postgres Lakehouse
 ---

--- a/advocacy_docs/edb-postgres-ai/console/agent/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/agent/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Console - Agent
+title: EDB Postgres® AI Console - Agent
 navTitle: Agent
 description: Installing, configuring, testing, and running Beacon Agent
 indexCards: simple

--- a/advocacy_docs/edb-postgres-ai/console/estate.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/estate.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Console - Estate
+title: EDB Postgres® AI Console - Estate
 navTitle: Estate
 description: How to manage and integrate EDB Postgres AI Databases and more with EDB Postgres AI Console's single pane of glass.
 ---

--- a/advocacy_docs/edb-postgres-ai/console/getstarted.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/getstarted.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Console - Get Started
+title: EDB Postgres® AI Console - Get Started
 navTitle: Get Started
 description: Get started with the EDB Postgres AI Console.
 ---

--- a/advocacy_docs/edb-postgres-ai/console/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Console
+title: EDB Postgres® AI Console
 navTitle: Console
 indexCards: simple
 iconName: Control

--- a/advocacy_docs/edb-postgres-ai/databases/cloudservice.mdx
+++ b/advocacy_docs/edb-postgres-ai/databases/cloudservice.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Cloud Service
+title: EDB Postgres® AI Cloud Service
 navTitle: Cloud Service
 description: An introduction to the EDB Postgres AI Cloud Service and its features.
 ---

--- a/advocacy_docs/edb-postgres-ai/databases/databases.mdx
+++ b/advocacy_docs/edb-postgres-ai/databases/databases.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Databases
+title: EDB Postgres® AI Databases
 navTitle: Databases
 description: Deploy EDB Postgres AI Databases on-premises with the EDB Postgres AI Estate and Agent components.
 ---

--- a/advocacy_docs/edb-postgres-ai/databases/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/databases/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Databases
+title: EDB Postgres® AI Databases
 navTitle: Databases
 indexCards: simple
 iconName: Database

--- a/advocacy_docs/edb-postgres-ai/databases/options.mdx
+++ b/advocacy_docs/edb-postgres-ai/databases/options.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Databases - Deployment Options
+title: EDB Postgres® AI Databases - Deployment Options
 navTitle: Deployment Options
 description: High Availability and other options available for EDB Postgres AI Databases and on EDB Postgres AI Cloud Service.
 deepToC: true

--- a/advocacy_docs/edb-postgres-ai/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Home
+title: EDB Postgres® AI Home
 navTitle: Home
 directoryDefaults:
   product: "EDB Postgres AI"

--- a/advocacy_docs/edb-postgres-ai/overview/concepts.mdx
+++ b/advocacy_docs/edb-postgres-ai/overview/concepts.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Overview - Concepts
+title: EDB Postgres® AI Overview - Concepts
 navTitle: Concepts
 description: A look at the concepts that underpin EDB Postgres AI.
 ---

--- a/advocacy_docs/edb-postgres-ai/overview/guide.mdx
+++ b/advocacy_docs/edb-postgres-ai/overview/guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Overview - Guide
+title: EDB Postgres® AI Overview - Guide
 navTitle: Guide
 description: What do you want to use EDB Postgres AI for? Start navigating the documentation here.
 ---

--- a/advocacy_docs/edb-postgres-ai/overview/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/overview/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Overview
+title: EDB Postgres® AI Overview
 navTitle: Overview
 indexCards: simple
 iconName: Earth

--- a/advocacy_docs/edb-postgres-ai/overview/releasenotes.mdx
+++ b/advocacy_docs/edb-postgres-ai/overview/releasenotes.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Overview - Release Notes
+title: EDB Postgres® AI Overview - Release Notes
 navTitle: Release Notes
 description: The current features released and updated in EDB Postgres AI.
 ---

--- a/advocacy_docs/edb-postgres-ai/tools/backup.mdx
+++ b/advocacy_docs/edb-postgres-ai/tools/backup.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Tools - Backup and Recovery
+title: EDB Postgres® AI Tools - Backup and Recovery
 navTitle: Backup and Recovery
 description: The backup and recovery tools available in EDB Postgres AI Tools
 ---

--- a/advocacy_docs/edb-postgres-ai/tools/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/tools/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI - Tools
+title: EDB Postgres® AI - Tools
 navTitle: Tools
 indexCards: simple
 iconName: Toolbox

--- a/advocacy_docs/edb-postgres-ai/tools/management.mdx
+++ b/advocacy_docs/edb-postgres-ai/tools/management.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Tools - Management
+title: EDB Postgres® AI Tools - Management
 navTitle: Management
 description: An introduction to the management tools of EDB Postgres AI such as Postgres Enterprise Manager.
 ---

--- a/advocacy_docs/edb-postgres-ai/tools/migration-and-ai.mdx
+++ b/advocacy_docs/edb-postgres-ai/tools/migration-and-ai.mdx
@@ -1,5 +1,5 @@
 ---
-title: EDB Postgres AI Tools - Migration and AI
+title: EDB Postgres® AI Tools - Migration and AI
 navTitle: Migration and AI
 description: The Migration offering of EDB Postgres AI Tools includes an innovative migration copilot.
 ---


### PR DESCRIPTION
## What Changed?

According to https://www.enterprisedb.com/trademarks, the trademark sign ® must go in: 
- first occurrence of trademark in titles
- first occurrence of trademark in the text 

I fixed the first occurrence in text in https://github.com/EnterpriseDB/docs/pull/5680 for the new EDB Postgres AI section, and now fixing titles for the same section of our documentation. 

I need a quick sanity check that this is the direction we want to take. 