### PR TITLE
Windows-specific issue for archive logs in EPAS

### DIFF
--- a/product_docs/docs/epas/17/epas_security_guide/05_edb_audit_logging/08_audit_log_archiving.mdx
+++ b/product_docs/docs/epas/17/epas_security_guide/05_edb_audit_logging/08_audit_log_archiving.mdx
@@ -29,6 +29,13 @@ To configure EDB Postgres Advanced Server to enable compression and expiration o
 1.  To enable compression of log files, set the parameter `edb_audit_archiver_compress_size_limit` and `edb_audit_archiver_compress_time_limit` to the values you want.
 1.  To enable expiration of log files, set the parameter `edb_audit_archiver_expire_size_limit` and `edb_audit_archiver_expire_time_limit` to the values you want. 
 1.  To enable both compression and expiration, set the parameters `edb_audit_archiver_compress_size_limit`, `edb_audit_archiver_compress_time_limit`, `edb_audit_archiver_expire_size_limit`, `edb_audit_archiver_expire_time_limit`, and `edb_audit_archiver_expire_command` to the values you want.
+  !!! Note
+      On Windows, the value you provide for `edb_audit_archiver_expire_command` must include the command prompt used to run the `copy` command. For example, you could enter the following command:
+
+      ```
+      edb_audit_archiver_expire_command = 'cmd.exe copy "%p" "C:\Program Files\edb\as14\data"'
+      ```
+      In this example, you could replace `cmd.exe` with  any other command prompt, such as `powershell.exe` for the Windows PowerShell.
 
 The following is an example of the configuration parameter settings in the `postgresql.conf` file.
 


### PR DESCRIPTION
Added a note about edb_audit_archiver_expire_command

