### PR TITLE
DOCS-524 - Feature request - use attach/detach concurrently

### DIFF
--- a/product_docs/docs/pgd/4/bdr/scaling.mdx
+++ b/product_docs/docs/pgd/4/bdr/scaling.mdx
@@ -22,10 +22,10 @@ Otherwise, later executions will alter the definition.
 `bdr.autopartition()` doesn't lock the actual table. It changes the
 definition of when and how new partition maintenance actions take place.
 
-PGD AutoPartition leverages underlying Postgres features that allow a partition
-to be attached or detached/dropped without locking the rest of the table
-(Autopartion currently only supports this when used with 2nd Quadrant Postgres
-11).
+PGD Autopartition in PGD 4.3.5 and later leverages underlying Postgres features
+that allow a partition to be attached or detached/dropped without locking the
+rest of the table. Versions of PGD prior to 4.3.5 don't support this feature and
+will lock the tables.
 
 An ERROR is raised if the table isn't RANGE partitioned or a multi-column
 partition key is used.

--- a/product_docs/docs/pgd/5/scaling.mdx
+++ b/product_docs/docs/pgd/5/scaling.mdx
@@ -24,8 +24,9 @@ function to create or alter the definition of automatic range partitioning for a
 no definition exists, it's created. Otherwise, later executions will alter the
 definition.
 
-PGD Autopartition in PGD 5 currently locks the actual table while performing 
-new partition maintenance operations.
+PGD Autopartition in PGD 5.5 and later leverages underlying Postgres features that allow a
+partition to be attached or detached/dropped without locking the rest of the
+table. Versions of PGD prior to 5.5 don't support this feature and will lock the tables.
 
 An ERROR is raised if the table isn't RANGE partitioned or a multi-column
 partition key is used.


### PR DESCRIPTION
## What Changed?

Updated autopartition to note concurrency now enabled generally.

Applied to 4.x and 5.x doc sets.
