### PR TITLE
JDBC connector - 42.2.19.1 release notes

### DIFF
--- a/product_docs/docs/jdbc_connector/42.5.4.2/01_jdbc_rel_notes/12_jdbc_42.2.19.1_rel_notes.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/01_jdbc_rel_notes/12_jdbc_42.2.19.1_rel_notes.mdx
@@ -15,4 +15,4 @@ New features, enhancements, bug fixes, and other changes in the EDB JDBC Connect
 | Enhancement    | EDB JDBC Connector now supports GSSAPI encrypted connection. See [Support for GSSAPI Encrypted Connection](../09_security_and_encryption/03_support_for_gssapi_encrypted_connection).                                                                                                              |
 
 !!! Note
-    EDB JDBC Connector v42.2.19.1 does not support Java 1.6 and 1.7. Previous versions of EDB JDBC Connector continue to support Java 1.6 and 1.7.
+    EDB JDBC Connector v42.2.19.1 does not support Java 1.6 and 1.7. Previous versions of EDB JDBC Connector support Java 1.6 and 1.7 but will not get any future updates, enhancements or bug fixes. 


### PR DESCRIPTION
## What Changed?

Fixed a note in the release notes of version 42.2.19.1 as per [EC-3089](https://enterprisedb.atlassian.net/browse/EC-3089)





[EC-3089]: https://enterprisedb.atlassian.net/browse/EC-3089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ