### PR TITLE
PGD: clarify table access method extension usage

### DIFF
--- a/product_docs/docs/pgd/5/appusage/table-access-methods.mdx
+++ b/product_docs/docs/pgd/5/appusage/table-access-methods.mdx
@@ -14,7 +14,7 @@ The following TAMs were certified for use with PGD 5.0:
 Usage of any other TAM is restricted until certified by EDB.
 
 To use one of these TAMs on a PGD cluster, the appropriate extension library
-(`autocluster` and/or `refdata`) *must* be added to the
+(`autocluster` and/or `refdata`) must be added to the
 `shared_preload_libraries` parameter on each node, and the PostgreSQL server
 restarted.
 

--- a/product_docs/docs/pgd/5/appusage/table-access-methods.mdx
+++ b/product_docs/docs/pgd/5/appusage/table-access-methods.mdx
@@ -3,23 +3,32 @@ title: Use of table access methods (TAMs) in PGD
 navTitle: Table access methods
 ---
 
-PGD 5.0 supports two table access methods (TAMs) released with EDB Postgres 15.0. These
-two TAMs were certified and are allowed in PGD 5.0:
+The [EDB Advanced Storage Pack](/pg_extensions/advanced_storage_pack/) provides a selection
+of table access methods (TAMs), available from EDB Postgres 15.0.
 
- * Auto cluster
- * Ref data
+The following TAMs were certified for use with PGD 5.0:
 
-Any other TAM is restricted until certified by EDB. If you're planning to use
-any of the TAMs on a table, you need to configure that TAM on
-each participating node in the PGD cluster. To configure auto cluster or ref
-data TAM, on each node:
+ * [Autocluster](/pg_extensions/advanced_storage_pack/#autocluster)
+ * [Refdata](/pg_extensions/advanced_storage_pack/#refdata)
 
-1.   Update `postgresql.conf` to specify TAMs `autocluster` or `refdata` for the
-    `shared_preload_libraries` parameter.
-1.   Restart the server and execute `CREATE EXTENSION autocluster;` or
-    `CREATE EXTENSION refdata;`.
+Usage of any other TAM is restricted until certified by EDB.
 
-After you create the extension, you can use TAM to create a table using `CREATE
-TABLE test USING autocluster;` or `CREATE TABLE test USING refdata;`. These commands
-replicate to all the PGD nodes. For more information on these table access
-methods, see [`CREATE TABLE`](/epas/latest/reference/oracle_compatibility_reference/epas_compat_sql/36_create_table/).
+To use one of these TAMs on a PGD cluster, the appropriate extension library
+(`autocluster` and/or `refdata`) *must* be added to the
+`shared_preload_libraries` parameter on each node, and the PostgreSQL server
+restarted.
+
+Once the extension library is present in `shared_preload_libraries` on all nodes
+in the cluster, the extension itself can be created with `CREATE EXTENSION
+autocluster;` or `CREATE EXTENSION refdata;`. The `CREATE EXTENSION` command
+only needs to be executed on one node; it will be replicated to the other
+nodes in the cluster.
+
+After you create the extension, use `CREATE TABLE test USING autocluster;` or
+`CREATE TABLE test USING refdata;` to create a table with the specified TAM. These commands
+replicate to all PGD nodes in the cluster.
+
+For more information on these table access methods, see:
+
+- [Autocluster example](/pg_extensions/advanced_storage_pack/using/#autocluster-example)
+- [Refdata example](pg_extensions/advanced_storage_pack/using/#refdata-example)


### PR DESCRIPTION
## What Changed?

This commit adds some cross-references to the "EDB Advanced Storage Pack" documentation, which contains further information about the respective table access methods.

It also clarifies the procedure for installing the extensions on a PGD cluster, in particular emphasising that "shared_preload_libraries" needs to be configured on each node, whereas the "CREATE EXTENSION" command only needs to be executed on one node.

BDR-5140.


