### PR TITLE
PGD: updates for bdr.replicate_ddl_command() reference entry

### DIFF
--- a/product_docs/docs/pgd/5/reference/functions.mdx
+++ b/product_docs/docs/pgd/5/reference/functions.mdx
@@ -380,7 +380,7 @@ Function to replicate a DDL command to a group of nodes.
 #### Synopsis
 
 ```sql
-bdr.replicate_ddl_command(ddlcommand text, 
+bdr.replicate_ddl_command(ddl_cmd text,
                           replication_sets text[],
                           ddl_locking text,
                           execute_locally bool)
@@ -388,15 +388,16 @@ bdr.replicate_ddl_command(ddlcommand text,
 
 #### Parameters
 
-- `ddlcommand` &mdash; DDL command to execute.
-- `replication_sets` &mdash; An array of replication set names to apply the `ddlcommand` to. If NULL (or the fuction is only passed the `ddlcommand`), this is set to the active PGD groups's default replication set.
-- `ddl_locking` &mdash; A string that sets the [`bdr.ddl_locking`](/pgd/latest/reference/pgd-settings#bdrddl_locking) value while replicating. Defaults to the GUC value for `bdr.ddl_locking` on the local system that is running the replicate_ddl_command. 
-- `execute_locally` &mdash; A boolean which determines wether the DDL command will be executed locally. Defaults to true.
+- `ddl_cmd` &mdash; DDL command to execute.
+- `replication_sets` &mdash; An array of replication set names to apply the `ddlcommand` to. If NULL (or the function is only passed the `ddlcommand`), this is set to the active PGD groups's default replication set.
+- `ddl_locking` &mdash; A string that sets the [`bdr.ddl_locking`](/pgd/latest/reference/pgd-settings#bdrddl_locking) value while replicating. Defaults to the GUC value for `bdr.ddl_locking` on the local system that is running the replicate_ddl_command.
+- `execute_locally` &mdash; A boolean which determines whether the DDL command will be executed locally. Defaults to true.
 
 #### Notes
 
-The only required parameter of this function is the `ddlcommand`.
+The only required parameter of this function is `ddl_cmd`.
 
+`bdr.replicate_ddl_command()` ignores [`bdr.ddl_replication`](./pgd-settings#bdrddl_replication).
 
 ### `bdr.run_on_all_nodes`
 


### PR DESCRIPTION
## What Changed?

Following changes made:
- parameter name "ddl_cmd" corrected
- added note that "bdr.ddl_replication" will be overridden
- fixed a couple of typos.

BDR-5153.

