### PR TITLE
Replication Server: Removed Windows 19 versions due to end-of-support

### DIFF
--- a/product_docs/docs/eprs/7/installing/index.mdx
+++ b/product_docs/docs/eprs/7/installing/index.mdx
@@ -60,7 +60,7 @@ Select a link to access the applicable installation instructions:
 
 ## Windows
 
-- [Windows Server 2022](windows), [Windows Server 2019](windows)
+- [Windows Server 2022](windows)
 
 !!!Note
 We recommend that you follow all installation steps strictly. Any modification in the steps may lead to an unstable installation. If your installation environment can't directly access the EDB repos, consult with EDB to identify the proper installation instructions for your environment.

--- a/product_docs/docs/eprs/7/supported_platforms.mdx
+++ b/product_docs/docs/eprs/7/supported_platforms.mdx
@@ -7,8 +7,8 @@ redirects:
 
 Replication Server is certified to work with the following Java platforms:
 
-|     Operating systems      |                            JDK versions                             |
-| -------------------------- | ------------------------------------------------------------------- |
+| Operating systems          | JDK versions                                                        |
+|----------------------------|---------------------------------------------------------------------|
 | CentOS 7                   | Red Hat OpenJDK 8                                                   |
 | SLES 12                    | Red Hat OpenJDK 8                                                   |
 | SLES 15                    | OpenJDK 11                                                          |
@@ -18,9 +18,8 @@ Replication Server is certified to work with the following Java platforms:
 | Rocky Linux 9 /AlmaLinux 9 | Red Hat OpenJDK 11                                                  |
 | PPCLE RHEL 8               | Red Hat OpenJDK 8                                                   |
 | PPCLE RHEL 9               | Red Hat OpenJDK 11                                                  |
-| Windows Server 2019        | Red Hat OpenJDK 8                                                   |
 | Windows Server 2022        | Oracle JDK 8                                                        |
 | Debian 10 and 11           | Red Hat OpenJDK 11                                                  |
-| Ubuntu 20, 22          | OpenJDK 11                                                          |
+| Ubuntu 20, 22              | OpenJDK 11                                                          |
 
 See [Product Compatibility](https://www.enterprisedb.com/platform-compatibility#eprs) for more information on operating system support.


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/DOCS-784

I deleted all mentions of Windows 19 in */eprs/7/* documentation. 