### PR TITLE
Migration Toolkit: SRC_DB_USER role

### DIFF
--- a/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
+++ b/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
@@ -195,7 +195,7 @@ An Oracle URL contains the following information:
 
 -   `<service_name>` &mdash; The name of the Oracle service.
 
--   `SRC_DB_USER` &mdash; Specifies the name of a privileged Oracle user. The Oracle user needs read access to the source database objects you want to migrate. If you want to migrate users/roles and related profiles/privileges, grant the Oracle user SELECT privileges on the following Oracle catalogs:
+-   `SRC_DB_USER` &mdash; Specifies the name of a privileged Oracle user. The Oracle user needs read access to the source database objects you want to migrate. If you want to migrate users/roles and related profiles/privileges, grant the Oracle user SELECT privileges on the following Oracle catalog objects:
     
     - `DBA_ROLES`
     - `DBA_USERS`
@@ -204,6 +204,7 @@ An Oracle URL contains the following information:
     - `DBA_ROLE_PRIVS`
     - `ROLE_ROLE_PRIVS`
     - `DBA_SYS_PRIVS`
+
 
 -   `SRC_DB_PASSWORD` &mdash; Contains the password of the specified user.
 

--- a/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
+++ b/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
@@ -195,7 +195,15 @@ An Oracle URL contains the following information:
 
 -   `<service_name>` &mdash; The name of the Oracle service.
 
--   `SRC_DB_USER` &mdash; Specifies the name of a privileged Oracle user. The Oracle user needs DBA privilege to migrate objects from Oracle to Advanced Server. The DBA privilege can be granted to the Oracle user with the Oracle `GRANT DBA TO user` command to ensure all of the desired database objects are migrated.
+-   `SRC_DB_USER` &mdash; Specifies the name of a privileged Oracle user. The Oracle user needs read access to the source database objects you want to migrate. If you want to migrate users/roles and related profiles/privileges, grant the Oracle user SELECT privileges on the following Oracle catalogs:
+    
+    - `DBA_ROLES`
+    - `DBA_USERS`
+    - `DBA_TAB_PRIVS`
+    - `DBA_PROFILES`
+    - `DBA_ROLE_PRIVS`
+    - `ROLE_ROLE_PRIVS`
+    - `DBA_SYS_PRIVS`
 
 -   `SRC_DB_PASSWORD` &mdash; Contains the password of the specified user.
 


### PR DESCRIPTION
## What Changed?

The user does not require DBA privileges for the SRC_DB_USER parameter. This PR updates the documentation to reflect the actual privileges it requires.

https://enterprisedb.atlassian.net/browse/DOCS-783