### PR TITLE
Migration Toolkit: schema-qualified command-line options

### DIFF
--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -115,19 +115,19 @@ By default, Migration Toolkit assumes the source database is Oracle and the targ
 
 By default, Migration Toolkit imports both the data and the object definition when migrating a schema. Alternatively, you can choose to import either the data or the object definitions.
 
-`-sourcedbtype <source_type>`
+### `-sourcedbtype <source_type>`
 
 The `-sourcedbtype` option specifies the source database type. For `source_type`, use one of the following values: `mysql`, `oracle`, `sqlserver`, `sybase`, `postgresql` or `enterprisedb`. `source_type` isn't case sensitive. By default, `source_type` is `oracle`.
 
-`-targetdbtype <target_type>`
+### `-targetdbtype <target_type>`
 
 The `-targetdbtype` option specifies the target database type. For `target_type`, use one of the following values: `enterprisedb`, `postgres`, or `postgresql`. `target_type` isn't case sensitive. By default, `target_type` is `enterprisedb`.
 
-`-schemaOnly`
+### `-schemaOnly`
 
 This option imports the schema definition and creates all selected schema objects in the target database. You can't use this option with the `‑dataOnly` option.
 
-`-dataOnly`
+### `-dataOnly`
 
 This option copies only the data. When used with the `-tables` option, Migration Toolkit imports data only for the selected tables. You can't use this option with the `-schemaOnly` option.
 
@@ -137,11 +137,11 @@ This option copies only the data. When used with the `-tables` option, Migration
 
 By default, Migration Toolkit imports the source schema objects or data into a schema of the same name. If the target schema doesn't exist, Migration Toolkit creates a schema. Alternatively, you can specify a custom schema name by using the `‑targetSchema` option. You can choose to drop the existing schema and create a new schema using the following option:
 
-`-dropSchema [true|false]`
+### `-dropSchema [true|false]`
 
 With this option set to `true`, Migration Toolkit drops the existing schema and any objects in that schema and creates a new schema. By default, `-dropSchema` is `false`.
 
-`-targetSchema <schema_name>`
+### `-targetSchema <schema_name>`
 
 Use the `-targetSchema` option to specify the name of the migrated schema. If you're migrating multiple schemas, specify a name for each schema in a comma-separated list with no intervening space characters. Without the `-targetSchema` option, the name of the new schema is the same as the name of the source schema.
 
@@ -153,11 +153,11 @@ You can't specify `information-schema`, `dbo`, `sys`, or `pg_catalog` as target 
 
 Use the following options to select specific schema objects to migrate:
 
-`-allTables`
+### `-allTables`
 
 Import all tables from the source schema.
 
-`-tables <table_list>`
+### `-tables <table_list>`
 
 Import the selected tables from the source schema. `table_list` is a comma-separated list of table names with no intervening space characters. 
 
@@ -167,7 +167,7 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -tables comp_schema.emp,comp_schema.dept,finance_schema.acctg`
 
-`-excludeTables <table_list>`
+### `-excludeTables <table_list>`
 
 Exclude the selected tables from migration. The `table_list` is a comma-separated list of table names with no intervening space characters. This option applies when all tables from a schema are selected for migration using the `-allTables` option.
 
@@ -177,41 +177,41 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -allTables -excludeTables comp_schema.emp,finance_schema.jobhist`
 
-`-constraints`
+### `-constraints`
 
 Import the table constraints. This option is valid only when importing an entire schema or when you specify the `-allTables` or `-tables <table_list>` options.
 
-`-ignoreCheckConstFilter`
+### `-ignoreCheckConstFilter`
 
 By default, Migration Toolkit doesn't implement migration of check constraints and default clauses from a Sybase database. To migrate constraints and default clauses from a Sybase database, include the `‑ignoreCheckConstFilter` parameter when specifying the `-constraints` parameter.
 
-`-skipCKConst`
+### `-skipCKConst`
 
 Omit the migration of check constraints. This option is useful when migrating check constraints that are based on built-in functions in the source database that aren't supported in the target database.
 
 This option is valid only when importing an entire schema or when the `-allTables` or `-tables <table_list>` options are specified.
 
-`-skipFKConst`
+### `-skipFKConst`
 
 Omit migrating foreign-key constraints. This option is valid only when importing an entire schema or when the `-allTables` or `-tables <table_list>` options are specified.
 
-`-skipColDefaultClause`
+### `-skipColDefaultClause`
 
 Omit migrating the column `DEFAULT` clause.
 
-`-indexes`
+### `-indexes`
 
 Import the table indexes. This option is valid when importing an entire schema or when the `-allTables` or `-tables <table_list>` option is specified.
 
-`-triggers`
+### `-triggers`
 
 Import the table triggers. This option is valid when importing an entire schema or when the `allTables` or `-tables <table_list>` option is specified.
 
-`-allViews`
+### `-allViews`
 
 Import the views from the source schema. This option migrates dynamic and materialized views from the source. Oracle and Postgres materialized views are supported.
 
-`-views <view_list>`
+### `-views <view_list>`
 
 Import the specified materialized or dynamic views from the source schema. Oracle and Postgres materialized views are supported. `view_list` is a comma-separated list of view names with no intervening space characters.
 
@@ -221,7 +221,7 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -views comp_schema.all_emp,comp_schema.mgmt_list,finance_schema.acct_list`
 
-`-excludeViews <view_list>`
+### `-excludeViews <view_list>`
 
 Exclude the selected views from migration. The `view_list` is a comma-separated list of view names with no intervening space characters. This option applies when all views from a schema are selected for migration using the `-allViews` option.
 
@@ -231,11 +231,11 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -allViews -excludeViews comp_schema.all_emp,finance_schema.acct_list`
 
-`-allSequences`
+### `-allSequences`
 
 Import all sequences from the source schema.
 
-`-sequences <sequence_list>`
+### `-sequences <sequence_list>`
 
 Import the selected sequences from the source schema. `<sequence_list>` is a comma-separated list of sequence names with no intervening space characters.
 
@@ -245,7 +245,7 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -sequences comp_schema.my_sequence,finance_schema.my_sequence_with_increment`
 
-`-excludeSequences <sequence_list>` 
+### `-excludeSequences <sequence_list>` 
 
 Exclude selected sequences from the migration. 
 The `sequence_list` is a comma-separated list of sequence names with no intervening space characters.
@@ -257,11 +257,11 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -allSequences -excludeSequences comp_schema.my_sequence,finance_schema.my_sequence_with_increment`
 
-`-allProcs`
+### `-allProcs`
 
 Import all stored procedures from the source schema.
 
-`-procs <procedures_list>`
+### `-procs <procedures_list>`
 
 Import the selected stored procedures from the source schema. `procedures_list` is a comma-separated list of procedure names with no intervening space characters.
 
@@ -271,7 +271,7 @@ When migrating multiple schemas, or all schemas (with the `-allSchema` option), 
 
 For example: `-allSchema -procs comp_schema.show_notice,finance_schema.show_custom_notice`
 
-`-excludeProcs <procedures_list>` 
+### `-excludeProcs <procedures_list>` 
 
 Exclude selected procedures from migration. 
 The `procedures_list` is a comma-separated list of procedure names with no intervening space characters.
@@ -283,11 +283,11 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -allProcs -excludeProcs comp_schema.show_notice,finance_schema.show_custom_notice`
 
-`-allFuncs`
+### `-allFuncs`
 
 Import all functions from the source schema.
 
-`-funcs <function_list>`
+### `-funcs <function_list>`
 
 Import the selected functions from the source schema. `function_list` is a comma-separated list of function names with no intervening space characters.
 
@@ -297,7 +297,7 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -funcs comp_schema.calculate_average_salary,finance_schema.add_two_numbers`
 
-`-excludeFuncs <function_list>` 
+### `-excludeFuncs <function_list>` 
 
 Exclude selected functions from migration. 
 The `function_list` is a comma-separated list of function names with no intervening space characters.
@@ -309,15 +309,15 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -allFuncs -excludeFuncs comp_schema.calculate_average_salary,finance_schema.add_two_numbers`
 
-`-checkFunctionBodies [true/false]`
+### `-checkFunctionBodies [true/false]`
 
 When `false`, disables validation of the function body during function creation. Disabling this validation avoids errors if the function contains forward references. The default value is `true`.
 
-`-allPackages`
+### `-allPackages`
 
 Import all packages from the source schema.
 
-`-packages <package_list>`
+### `-packages <package_list>`
 
 Import the selected packages from the source schema. `package_list` is a comma-separated list of package names with no intervening space characters.
 
@@ -327,7 +327,7 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -packages comp_schema.my_package1,finance_schema.mypackage2`
 
-`-excludePackages <package_list>` 
+### `-excludePackages <package_list>` 
 
 Exclude selected packages from migration. 
 The `package_list` is a comma-separated list of package names with no intervening space characters.
@@ -339,19 +339,19 @@ When migrating multiple schemas, or all schemas (with the `-allSchemas` option),
 
 For example: `-allSchemas -allPackages -excludePackages comp_schema.my_package1,finance_schema.mypackage2`
 
-`-allDomains`
+### `-allDomains`
 
 Import all domain, enumeration, and composite types from the source database. This option is valid only when both the source and target are stored on a Postgres host.
 
-`-allQueues`
+### `-allQueues`
 
 Import all queues from the source schema. These are queues created and managed by the DBMS_AQ and DBMS_AQADM built-in packages. When Oracle is the source database, you must also specify the `-objectTypes` option. When EDB Postgres Advanced Server is the source database, you must also specify the `-allDomains` and `-allTables` options. Oracle and EDB Postgres Advanced Server queues are supported.
 
-`-queues <queue_list>`
+### `-queues <queue_list>`
 
 Import the selected queues from the source schema. `queue_list` is a comma-separated list of queue names with no intervening space characters. These are queues created and managed by the DBMS_AQ and DBMS_AQADM built-in packages. When Oracle is the source database, you must also specify the `-objectTypes`. When EDB Postgres Advanced Server is the source database, you must also specify `-allDomains` and `-allTables`. Oracle and EDB Postgres Advanced Server queues are supported.
 
-`-excludeQueues <queue_list>` 
+### `-excludeQueues <queue_list>` 
 
 Exclude selected queues from migration. 
 The `queue_list` is a comma-separated list of queue names with no intervening space characters.
@@ -359,15 +359,15 @@ This option applies when all queues from a schema are selected for migration usi
 
 Example: `-allQueues -excludeQueues EMP_QUEUE1,EMP_QUEUE2`
 
-`-allRules`
+### `-allRules`
 
 Import all rules from the source database. This option is valid only when both the source and target are stored on a Postgres host.
 
-`-allGroups`
+### `-allGroups`
 
 Import all groups from the source database.
 
-`-groups <group_list>`
+### `-groups <group_list>`
 
 The selected groups from the source database. The `<group_list>` is a comma-separated list of group names e.g. `-groups acct_emp,mkt_emp`.
 
@@ -377,63 +377,63 @@ The selected groups from the source database. The `<group_list>` is a comma-sepa
 
 Use the migration options to control the details of the migration process.
 
-`-truncLoad`
+### `-truncLoad`
 
 Truncate the data from the table before importing new data. Use this option with the `-dataOnly` option.
 
-`-enableConstBeforeDataLoad`
+### `-enableConstBeforeDataLoad`
 
 Include the `-enableConstBeforeDataLoad` option if a nonpartitioned source table is mapped to a partitioned table. This option enables all triggers on the target table, including any triggers that redirect data to individual partitions, before the data migration. `-enableConstBeforeDataLoad` is valid only if you also specify the `-truncLoad` parameter.
 
-`-retryCount [<value>]`
+### `-retryCount [<value>]`
 
 If you're performing a multiple-schema migration, objects that fail to migrate during the first migration attempt due to cross-schema dependencies might successfully migrate during a later migration. Use the `-retryCount` option to specify the number of attempts for Migration Toolkit to make to migrate an object that failed during an initial migration attempt. Specify a value greater than 0. The default value is 2.
 
-`-safeMode`
+### `-safeMode`
 
 If you include the `-safeMode` option, Migration Toolkit commits each row as migrated. If the migration fails to transfer all records, rows inserted prior to the point of failure remain in the target database.
 
-`-fastCopy`
+### `-fastCopy`
 
 Including the `-fastCopy` option specifies for Migration Toolkit to bypass WAL logging to perform the COPY operation in an optimized way. It is disabled by default. If you choose to use the `-fastCopy` option, you might not be able to recover the migrated data in the target database if the migration is interrupted.
 
-`-replaceNullChar <value>`
+### `-replaceNullChar <value>`
 
 The Migration Toolkit supports importing a column with a value of NULL. However, the Migration Toolkit doesn't support importing NULL character values (embedded binary zeros 0x00) with the JDBC connection protocol. If you're importing data that includes the NULL character, use the `-replaceNullChar` option to replace the NULL character with a single, non-NULL replacement character. Don't enclose the replacement character in quotes or apostrophes.
 
 Once the data is migrated, use a SQL statement to replace the character specified by `-replaceNullChar` with binary zeros.
 
-`-analyze`
+### `-analyze`
 
 Include the `-analyze` option to invoke the Postgres `ANALYZE` operation against a target database. The optimizer consults the statistics collected by the `ANALYZE` operation, using the information to construct efficient query plans.
 
-`-vacuumAnalyze`
+### `-vacuumAnalyze`
 
 Include the `-vacuumAnalyze` option to invoke both the `VACUUM` and `ANALYZE` operations against a target database. The optimizer consults the statistics collected by the `ANALYZE` operation, using the information to construct efficient query plans. The `VACUUM` operation reclaims any storage space occupied by dead tuples in the target database.
 
-`-copyDelimiter`
+### `-copyDelimiter`
 
 Specify a single character to use as a delimiter in the COPY command when loading table data. The default value is `'\t'` (tab).
 
-`-batchSize`
+### `-batchSize`
 
 Specify the batch size of bulk inserts. Valid values are 1 to 1000. The default batch size is 1000. Reduce the value of `-batchSize` if Out of Memory exceptions occur.
 
-`-cpBatchSize`
+### `-cpBatchSize`
 
 Specify the batch size in MB to use in the COPY command. Any value greater than 0 is valid. The default batch size is 8MB.
 
-`-lobBatchSize`
+### `-lobBatchSize`
 
 Specify the number of rows to load in a batch for LOB data types. The data migration for a table containing a large object type (LOB) column, such as `BYTEA`, `BLOB`, or `CLOB`, is performed one row at a time by default. This is to avoid an out-of-heap-space error in case an individual LOB column holds hundreds of megabytes of data. In case the LOB column average data size is at a lower end, you can customize the LOB batch size by specifying the number of rows in each batch with any value greater than 0.
 
-`-fetchSize`
+### `-fetchSize`
 
 Use the `-fetchSize` option to specify the number of rows fetched in a result set. If the designated `-fetchSize` is too large, you might encounter Out of Memory exceptions. Include the `-fetchSize` option to avoid this pitfall when migrating large tables. The default fetch size is specific to the JDBC driver implementation and varies by database.
 
 MySQL users note: By default, the MySQL JDBC driver fetches all of the rows in a table into the Migration Toolkit in a single network round trip. This behavior can easily exceed available memory for large tables. If you encounter an out-of-heap-space error, specify `-fetchSize 1` as a command line argument to force Migration Toolkit to load the table data one row at a time.
 
-`-filterProp <file_name>`
+### `-filterProp <file_name>`
 
 `<file_name>` specifies the name of a file that contains constraints in key=value pairs. Each record read from the database is evaluated against the constraints. Those that satisfy the constraints are migrated. 
  
@@ -445,7 +445,7 @@ The right side specifies a condition that must be true for each row migrated.
 
 For example, this code migrates only those countries with a `COUNTRY_ID` value that isn't equal to `AR`: 
 
-`COUNTRIES=COUNTRY_ID<>'AR'`
+### `COUNTRIES=COUNTRY_ID<>'AR'`
 
 This constraint applies to the COUNTRIES table. 
 
@@ -510,7 +510,7 @@ Migration Toolkit resumes the migration based on the mode that it was using to m
 
 You can specify several connection retry options:
 
-`-connRetryCount [<connection_attempts>]`
+### `-connRetryCount [<connection_attempts>]`
 
 Use the `-connRetryCount` option to specify the number of retry attempts to perform if the target database connection fails. 
 The `[<connection_attempts>]` value must be a number between 0 and 50. The default is 3 retry attempts. 
@@ -523,7 +523,7 @@ Example:
 $ ./runMTK.sh -connRetryCount 2 -dataOnly -tables dept,emp,jobhist public
 ```
 
-`-connRetryInterval [<seconds>]`
+### `-connRetryInterval [<seconds>]`
 
 Use the `-connRetryInterval` option to specify the seconds to wait before each subsequent reconnection attempt 
 if the target database connection fails. 
@@ -537,7 +537,7 @@ Example:
 $ ./runMTK.sh -connRetryCount 2 -connRetryInterval 50 -dataOnly -tables dept,emp,jobhist public
 ```
 
-`-abortConnOnFailure` [true/false]`
+### `-abortConnOnFailure` [true/false]`
 
 Specify whether to abort the migration if all the reconnection attempts failed. 
 
@@ -552,7 +552,7 @@ Example:
 $ ./runMTK.sh -connRetryCount 2 -connRetryInterval 50 -abortConnOnFailure false -dataOnly -tables dept,emp,jobhist public
 ```
 
-`-pgIdleTxSessionTimeOut [<seconds>]`
+### `-pgIdleTxSessionTimeOut [<seconds>]`
 
 Specify the PostgreSQL or EDB Postgres Advanced Server `idle_in_transaction_session_timeout`, which defines the time after which
 the database terminates the session when a migration transaction is in idle state. 
@@ -582,7 +582,7 @@ Parallel data migration at the schema level uses multiple threads to migrate sev
 
 The following options control the way MTK migrates data in parallel.
 
-`-loaderCount [<value>]`
+### `-loaderCount [<value>]`
 
 Use the `-loaderCount` option to specify the number of parallel threads available in the pool to perform data load in parallel. This option is particularly useful if the host system that's running Migration Toolkit has high-end CPU and RAM resources. While `value` can be any nonzero, positive number, we recommend that value not exceed the number of CPU cores. For example, a dual-core CPU has an optimal value of `2`. The default is `1`.
 
@@ -592,13 +592,13 @@ The number of table-level threads can introduce overhead on the source database 
     When multiple threads are used, depending on the actual number of threads and table data size, you might need to adjust the memory heap size for the Migration Toolkit.
 
 
-`-parallelLoadRowLimit [<value>]`
+### `-parallelLoadRowLimit [<value>]`
 
 Use the `-parallelLoadRowLimit` option to specify the minimum number of rows required in a table to perform data load in parallel at the table level. The `<value>` parameter must be greater than 0. The default is 100,000. 
 
 For example, if the value of `-parallelLoadRowLimit` is 10,000, only tables with the number of rows 10,000 and greater are loaded in parallel at the table level. The other tables migrate in sequential mode or at the schema level.
 
-`-tableLoaderLimit [<value>]`
+### `-tableLoaderLimit [<value>]`
 
 Use the `-tableLoaderLimit` option to specify the maximum number of threads to assign from the thread pool to load a single table data in parallel chunks at the table level. The `<value>` parameter must not be greater than the value of `-loaderCount`. The default value is equal to the value of the `-loaderCount` option. This option is implicitly changed based on the nondefault custom value of `-loaderCount`. 
 
@@ -698,19 +698,19 @@ Choose the number of threads depending on the CPU and RAM resources available on
 
 The following options apply only when the source database is Oracle.
 
-`-objectTypes`
+### `-objectTypes`
 
 Import the user-defined object types from the schema list specified at the end of the `runMTK.sh` command.
 
-`-allUsers`
+### `-allUsers`
 
 Import all users and roles from the source database. The `‑allUsers` option is supported only when migrating from an Oracle database to an EDB Postgres Advanced Server database.
 
-`-users <user_list>`
+### `-users <user_list>`
 
 Import the selected users or roles from the source Oracle database. `<user_list>` is a comma-separated list of user/role names with no intervening space characters (e.g., `-users MTK, SAMPLE, acctg`). The `-users` option is supported only when migrating from an Oracle database to an EDB Postgres Advanced Server database.
 
-`-allProfiles`
+### `-allProfiles`
 
 Import all custom (that is, user-created) profiles from the source database. Other Oracle noncustom profiles such as `DEFAULT` and `MONITORING_PROFILE` aren't imported.
 
@@ -735,7 +735,7 @@ For the imported profiles, only the following password parameters associated wit
 !!! Note
     The `‑allProfiles` option is supported only when migrating from an Oracle database to an EDB Postgres Advanced Server database.
 
-`-profiles <profile_list>`
+### `-profiles <profile_list>`
 
 Import the selected, custom (that is, user-created) profiles from the source Oracle database. `profile_list` is a comma-separated list of profile names with no intervening space characters (e.g., `-profiles ADMIN_PROFILE,USER_PROFILE`). Oracle noncustom profiles such as `DEFAULT` and `MONITORING_PROFILE` aren't imported.
 
@@ -744,11 +744,11 @@ As with the `-allProfiles` option, only the password parameters are imported. Th
 !!! Note
     The `-profiles` option is supported only when migrating from an Oracle database to an EDB Postgres Advanced Server database.
 
-`-importPartitionAsTable <table_list>`
+### `-importPartitionAsTable <table_list>`
 
 Include the `-importPartitionAsTable` parameter to import the contents of a partitioned table that resides on an Oracle host into a single nonpartitioned table. `table_list` is a comma-separated list of table names with no intervening space characters (for example, `-importPartitionAsTable emp,dept,acctg`).
 
-`-copyViaDBLinkOra`
+### `-copyViaDBLinkOra`
 
 The `dblink_ora` module provides EDB Postgres Advanced Server-to-Oracle connectivity at the SQL level. `dblink_ora` is bundled and installed as part of the EDB Postgres Advanced Server database installation. `dblink_ora` uses the `COPY API` method to transfer data between databases. This method is considerably faster than the `JDBC COPY` method.
 
@@ -760,7 +760,7 @@ $./runMTK.sh -copyViaDBLinkOra -allTables HR
 
 The target EDB Postgres Advanced Server database must have `dblink_ora` installed and configured. See [dblink_ora](/epas/latest/working_with_oracle_data/06_dblink_ora/).
 
-`-allDBLinks [link_Name_1=password_1,link_Name_2=password_2,...]`
+### `-allDBLinks [link_Name_1=password_1,link_Name_2=password_2,...]`
 
 Choose this option to migrate Oracle database links. The password information for each link connection in the source database is encrypted so, unless specified, the dummy password edb is substituted.
 
@@ -780,15 +780,15 @@ $./runMTK.sh -allDBLinks LINK_NAME1=abc,LINK_NAME2=xyz HR
 
 Migration Toolkit migrates only the database link types that are currently supported by EnterpriseDB. These types include fixed user links of public and private type.
 
-`-allSynonyms`
+### `-allSynonyms`
 
 Include the `-allSynonyms` option to migrate all public and private synonyms from an Oracle database to an EDB Postgres Advanced Server database. If a synonym with the same name already exists in the target database, the existing synonym is replaced with the migrated version.
 
-`-allPublicSynonyms`
+### `-allPublicSynonyms`
 
 Include the `-allPublicSynonyms` option to migrate all public synonyms from an Oracle database to an EDB Postgres Advanced Server database. If a synonym with the same name already exists in the target database, the existing synonym is replaced with the migrated version.
 
-`-excludeSynonyms <synonym_list>` 
+### `-excludeSynonyms <synonym_list>` 
 
 Exclude selected synonyms from migration. 
 The `synonym_list` is a comma-separated list of synonym names with no intervening space characters.
@@ -796,11 +796,11 @@ This option applies when all synonyms from a schema are selected for migration u
 
 Example: `-allSynonyms -excludeSynonyms SYNEMP1,SYNEMP2`
 
-`-allPrivateSynonyms`
+### `-allPrivateSynonyms`
 
 Include the `-allPrivateSynonyms` option to migrate all private synonyms from an Oracle database to an EDB Postgres Advanced Server database. If a synonym with the same name already exists in the target database, the existing synonym is replaced with the migrated version.
 
-`-useOraCase`
+### `-useOraCase`
 
 Include the `-useOraCase` option to preserve the Oracle default, uppercase naming convention for all database objects when migrating from an Oracle database to an EDB Postgres Advanced Server database.
 
@@ -889,7 +889,7 @@ DEPTNO  | DNAME      | LOC
 (4 rows)
 ```
 
-`-skipUserSchemaCreation`
+### `-skipUserSchemaCreation`
 
 When an Oracle user is migrated, a role (that is, a user name) is created in the target database server for the Oracle user if the role doesn't already exist. The role name is created in lowercase letters. When a new role is created, a schema with the same name is also created in lowercase letters.
 
@@ -903,11 +903,11 @@ Thus, if the `-useOraCase` option is specified without the `-skipUserSchemaCreat
 
 Use these migration options to view Migration Toolkit help and version information. You can also use these options to control Migration Toolkit feedback and logging options.
 
-`-help`
+### `-help`
 
 Display the application command-line usage information.
 
-`-logDir <log_path>`
+### `-logDir <log_path>`
 
 Include this option to specify where to write the log files. `<log_path>` is the location for saving log files. By default, on Linux log files are written to:
 
@@ -917,15 +917,15 @@ On Windows, the log files are saved to:
 
 `%HOMEDRIVE%%HOMEPATH%\.enterprisedb\migration-toolkit\logs`
 
-`-logFileCount <file_count>`
+### `-logFileCount <file_count>`
 
 Include this option to specify the number of files used in log file rotation. Specify a value of `0` to disable log file rotation and create a single log file. This file is truncated when it reaches the value specified using the `logFileSize` option. `<file_count>` must be greater than or equal to 0. The default is 20.
 
-`-logFileSize <file_size>`
+### `-logFileSize <file_size>`
 
 Include this option to specify the maximum file size limit in MB before rotating to a new log file. `file_size` must be greater than 0. The default is 50.
 
-`-logBadSQL`
+### `-logBadSQL`
 
 Include this option to save the schema definition (DDL script) of any failed objects to a file. The file is saved under the same path used for the error logs and is named in the format:
 
@@ -933,11 +933,11 @@ Include this option to save the schema definition (DDL script) of any failed obj
 
 Where `schema_name` is the name of the schema and `timestamp` is the timestamp of the Migration Toolkit run.
 
-`-verbose [on|off]`
+### `-verbose [on|off]`
 
 Display application log messages on standard output. By default, verbose is on.
 
-`-version`
+### `-version`
 
 Display the Migration Toolkit version.
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Migration Toolkit command options"
 navTitle: "Command options"
-
 redirects:
   - /migration_toolkit/latest/08_mtk_command_options/
 ---
@@ -160,13 +159,23 @@ Import all tables from the source schema.
 
 `-tables <table_list>`
 
-Import the selected tables from the source schema. `table_list` is a comma-separated list of table names with no intervening space characters (for example, `-tables emp,dept,acctg`). 
+Import the selected tables from the source schema. `table_list` is a comma-separated list of table names with no intervening space characters. 
 
-When migrating multiple schemas, or all schemas (with the `-allSchema` option), the table name must be schema-qualified (for example, `-tables comp_schema.emp,comp_schema.dept,finance_schema.acctg`).
+For example: `-tables emp,dept,acctg`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the table name must be schema-qualified, for example: 
+
+For example: `-allSchemas -tables comp_schema.emp,comp_schema.dept,finance_schema.acctg`
 
 `-excludeTables <table_list>`
 
-Exclude the selected tables from migration. The `table_list` is a comma-separated list of table names with no intervening space characters (for example, `-excludeTables emp,jobhist`). This option applies when all tables from a schema are selected for migration using the `-allTables` option.
+Exclude the selected tables from migration. The `table_list` is a comma-separated list of table names with no intervening space characters. This option applies when all tables from a schema are selected for migration using the `-allTables` option.
+
+For example: `-allTables -excludeTables emp,jobhist` 
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the excluded table name must be schema-qualified. 
+
+For example: `-allSchemas -allTables -excludeTables comp_schema.emp,finance_schema.jobhist`
 
 `-constraints`
 
@@ -204,11 +213,23 @@ Import the views from the source schema. This option migrates dynamic and materi
 
 `-views <view_list>`
 
-Import the specified materialized or dynamic views from the source schema. Oracle and Postgres materialized views are supported. `view_list` is a comma-separated list of view names with no intervening space characters (for example, `-views all_emp,mgmt_list,acct_list`).
+Import the specified materialized or dynamic views from the source schema. Oracle and Postgres materialized views are supported. `view_list` is a comma-separated list of view names with no intervening space characters.
+
+For example: `-views all_emp,mgmt_list,acct_list`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the view name must be schema-qualified.
+
+For example: `-allSchemas -views comp_schema.all_emp,comp_schema.mgmt_list,finance_schema.acct_list`).
 
 `-excludeViews <view_list>`
 
-Exclude the selected views from migration. The `view_list` is a comma-separated list of view names with no intervening space characters (for example, `-excludeViews all_emp,acct_list`). This option applies when all views from a schema are selected for migration using the `-allViews` option.
+Exclude the selected views from migration. The `view_list` is a comma-separated list of view names with no intervening space characters. This option applies when all views from a schema are selected for migration using the `-allViews` option.
+
+For example: `-allViews -excludeViews all_emp,acct_list`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the excluded view name must be schema-qualified:
+
+For example: `-allSchemas -allViews -excludeViews comp_schema.all_emp,finance_schema.acct_list`
 
 `-allSequences`
 
@@ -218,13 +239,23 @@ Import all sequences from the source schema.
 
 Import the selected sequences from the source schema. `<sequence_list>` is a comma-separated list of sequence names with no intervening space characters.
 
+For example: `-sequences my_sequence,my_sequence_with_increment`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the sequence name must be schema-qualified.
+
+For example: `-sequences comp_schema.my_sequence,finance_schema.my_sequence_with_increment`
+
 `-excludeSequences <sequence_list>` 
 
 Exclude selected sequences from the migration. 
 The `sequence_list` is a comma-separated list of sequence names with no intervening space characters.
 This option applies when all sequences from a schema are selected for migration using the `-allSequences` option.  
 
-Example: `-allSequences -excludeSequences my_sequence,my_sequence_with_increment`
+For example: `-allSequences -excludeSequences my_sequence,my_sequence_with_increment`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the excluded sequence name must be schema-qualified.
+
+For example: `-allSchemas -allSequences -excludeSequences comp_schema.my_sequence,finance_schema.my_sequence_with_increment`
 
 `-allProcs`
 
@@ -234,13 +265,23 @@ Import all stored procedures from the source schema.
 
 Import the selected stored procedures from the source schema. `procedures_list` is a comma-separated list of procedure names with no intervening space characters.
 
+For example: `-procs show_notice,show_custom_notice`
+
+When migrating multiple schemas, or all schemas (with the `-allSchema` option), the procedure name must be schema-qualified.
+
+For example: `-allSchema -procs comp_schema.show_notice,finance_schema.show_custom_notice`
+
 `-excludeProcs <procedures_list>` 
 
 Exclude selected procedures from migration. 
 The `procedures_list` is a comma-separated list of procedure names with no intervening space characters.
 This option applies when all procedures from a schema are selected for migration using the `-allProcs` option.
 
-Example: `-allProcs -excludeProcs show_notice,show_custom_notice`
+For example: `-allProcs -excludeProcs show_notice,show_custom_notice`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the excluded procedure name must be schema-qualified. 
+
+For example: `-allSchemas -allProcs -excludeProcs comp_schema.show_notice,finance_schema.show_custom_notice`
 
 `-allFuncs`
 
@@ -250,13 +291,23 @@ Import all functions from the source schema.
 
 Import the selected functions from the source schema. `function_list` is a comma-separated list of function names with no intervening space characters.
 
+For example: `-funcs calculate_average_salary,add_two_numbers`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the function name must be schema-qualified.
+
+For example: `-allSchemas -funcs comp_schema.calculate_average_salary,finance_schema.add_two_numbers`
+
 `-excludeFuncs <function_list>` 
 
 Exclude selected functions from migration. 
 The `function_list` is a comma-separated list of function names with no intervening space characters.
 This option applies when all functions from a schema are selected for migration using the `-allFuncs` option. 
 
-Example: `-allFuncs -excludeFuncs calculate_average_salary,add_two_numbers`
+For example: `-allFuncs -excludeFuncs calculate_average_salary,add_two_numbers`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the excluded function name must be schema-qualified.
+
+For example: `-allSchemas -allFuncs -excludeFuncs comp_schema.calculate_average_salary,finance_schema.add_two_numbers`
 
 `-checkFunctionBodies [true/false]`
 
@@ -270,6 +321,12 @@ Import all packages from the source schema.
 
 Import the selected packages from the source schema. `package_list` is a comma-separated list of package names with no intervening space characters.
 
+For example: `-packages my_package1, mypackage2`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the package name must be schema-qualified.
+
+For example: `-allSchemas -packages comp_schema.my_package1,finance_schema.mypackage2`
+
 `-excludePackages <package_list>` 
 
 Exclude selected packages from migration. 
@@ -277,6 +334,10 @@ The `package_list` is a comma-separated list of package names with no intervenin
 This option applies when all packages from a schema are selected for migration using the `-allPackages` option.
 
 Example: `-allPackages -excludePackages my_package1, mypackage2`
+
+When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the excluded package name must be schema-qualified.
+
+For example: `-allSchemas -allPackages -excludePackages comp_schema.my_package1,finance_schema.mypackage2`
 
 `-allDomains`
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -219,7 +219,7 @@ For example: `-views all_emp,mgmt_list,acct_list`
 
 When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the view name must be schema-qualified.
 
-For example: `-allSchemas -views comp_schema.all_emp,comp_schema.mgmt_list,finance_schema.acct_list`).
+For example: `-allSchemas -views comp_schema.all_emp,comp_schema.mgmt_list,finance_schema.acct_list`
 
 `-excludeViews <view_list>`
 
@@ -243,7 +243,7 @@ For example: `-sequences my_sequence,my_sequence_with_increment`
 
 When migrating multiple schemas, or all schemas (with the `-allSchemas` option), the sequence name must be schema-qualified.
 
-For example: `-sequences comp_schema.my_sequence,finance_schema.my_sequence_with_increment`
+For example: `-allSchemas -sequences comp_schema.my_sequence,finance_schema.my_sequence_with_increment`
 
 `-excludeSequences <sequence_list>` 
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -9,7 +9,7 @@ redirects:
 
 To control details of the migration, append migration options when you run Migration Toolkit. For example, to migrate all schemas in a database, append the `-allSchemas` option to the command:
 
-`$ ./runMTK.sh -allSchemas`
+`./runMTK.sh -allSchemas`
 
 !!! Note
     - The `-allSchemas` parameter is supported only for the Oracle, EDB Postgres Advanced Server, and PostgreSQL source database. It isn't supported for Sybase, MS SQL Server, and MySQL source databases.
@@ -41,37 +41,37 @@ If you specify the `-offlineMigration` option in the command line, Migration Too
 To perform an offline migration of both schema and data, specify the `‑offlineMigration` keyword, followed by the schema name:
 
 ```shell
-$ ./runMTK.sh -offlineMigration <schema_name>
+./runMTK.sh -offlineMigration <schema_name>
 ```
 
 Each database object definition is saved in a separate file with a name derived from the schema name and object type in your home folder. To specify an alternative file destination, include a directory name after the `‑offlineMigration` option:
 
 ```shell
-$ ./runMTK.sh -offlineMigration <file_dest> <schema_name>
+./runMTK.sh -offlineMigration <file_dest> <schema_name>
 ```
 
 To perform an offline migration of only schema objects (creating empty tables), specify the `‑schemaOnly` keyword in addition to the `‑offlineMigration` keyword when invoking Migration Toolkit:
 
 ```shell
-$ ./runMTK.sh -offlineMigration -schemaOnly <schema_name>
+./runMTK.sh -offlineMigration -schemaOnly <schema_name>
 ```
 
 To perform an offline migration of only data, omitting any schema object definitions, specify the `‑dataOnly` keyword and the `‑offlineMigration` keyword when invoking Migration Toolkit:
 
 ```shell
-$ ./runMTK.sh -offlineMigration -dataOnly <schema_name>
+./runMTK.sh -offlineMigration -dataOnly <schema_name>
 ```
 
 By default, data is written in COPY format. To write the data in a plain SQL format, include the `‑safeMode` keyword:
 
 ```shell
-$ ./runMTK.sh -offlineMigration -dataOnly -safeMode <schema_name>
+./runMTK.sh -offlineMigration -dataOnly -safeMode <schema_name>
 ```
 
 By default, when you perform an offline migration that contains table data, a separate file is created for each table. To create a single file that contains the data from multiple tables, specify the `‑singleDataFile` keyword:
 
 ```shell
-$ ./runMTK.sh -offlineMigration -dataOnly -singleDataFile -safeMode <schema_name>
+./runMTK.sh -offlineMigration -dataOnly -singleDataFile -safeMode <schema_name>
 ```
 
 !!! Note
@@ -86,25 +86,25 @@ You can use the edb-psql or psql command line to execute the scripts generated d
 1.  Use the `createdb` command to create the acctg database, into which you'll restore the migrated database objects:
 
     ```shell
-    $ createdb -U enterprisedb acctg
+    createdb -U enterprisedb acctg
     ```
 
 2.  Connect to the new database with edb-psql:
 
     ```shell
-    $ edb-psql -U enterprisedb acctg
+    edb-psql -U enterprisedb acctg
     ```
 
 3.  Use the `\i` meta-command to invoke the migration script that creates the object definitions:
 
     ```shell
-    $ acctg=# \i ./mtk_hr_ddl.sql
+    acctg=# \i ./mtk_hr_ddl.sql
     ```
 
 4.  If the `-offlineMigration` command included the `‑singleDataFile` keyword, the `mtk_hr_data.sql` script will contain the commands required to re-create all of the objects in the new target database. Populate the database with the command:
 
     ```shell
-    $ acctg=# \i ./mtk_hr_data.sql
+    acctg=# \i ./mtk_hr_data.sql
     ```
 
 <div id="import_options" class="registered_link"></div>
@@ -520,7 +520,7 @@ Since the retry applies to the migration of data, it isn't compatible with the `
 Example: 
 
 ```
-$ ./runMTK.sh -connRetryCount 2 -dataOnly -tables dept,emp,jobhist public
+./runMTK.sh -connRetryCount 2 -dataOnly -tables dept,emp,jobhist public
 ```
 
 ### `-connRetryInterval [<seconds>]`
@@ -534,7 +534,7 @@ Since the retry applies to the migration of data, it isn't compatible with the `
 Example: 
 
 ```
-$ ./runMTK.sh -connRetryCount 2 -connRetryInterval 50 -dataOnly -tables dept,emp,jobhist public
+./runMTK.sh -connRetryCount 2 -connRetryInterval 50 -dataOnly -tables dept,emp,jobhist public
 ```
 
 ### `-abortConnOnFailure` [true/false]`
@@ -549,7 +549,7 @@ Since the retry applies to the migration of data, it isn't compatible with the `
 Example: 
 
 ```
-$ ./runMTK.sh -connRetryCount 2 -connRetryInterval 50 -abortConnOnFailure false -dataOnly -tables dept,emp,jobhist public
+./runMTK.sh -connRetryCount 2 -connRetryInterval 50 -abortConnOnFailure false -dataOnly -tables dept,emp,jobhist public
 ```
 
 ### `-pgIdleTxSessionTimeOut [<seconds>]`
@@ -620,7 +620,7 @@ The algorithm works in three steps:
 In this scenario, migrate four tables&mdash;`tab1, tab2, tab3, tab4`&mdash;with parallel data loading:
 
 ```text
-# ./runMTK.sh -sourcedbtype enterprisedb -targetdbtype enterprisedb -loaderCount 4 -parallelLoadRowLimit 10000 -tableLoaderLimit 2 -tables tab1,tab2,tab3,tab4 public
+./runMTK.sh -sourcedbtype enterprisedb -targetdbtype enterprisedb -loaderCount 4 -parallelLoadRowLimit 10000 -tableLoaderLimit 2 -tables tab1,tab2,tab3,tab4 public
 ```
 
 Table `tab1` has 50,000 rows, table `tab2` has 9,500 rows, table `tab3` has 50,001 rows and table `tab4` has 9,999 rows. The list of tables for step 1 is `tab1, tab2, tab3`, and `tab4`.
@@ -676,7 +676,7 @@ This way, four threads are used to migrate four tables in parallel at the mixed-
 If you change command options to set `-tableLoaderLimit` to `1`, you can have pure schema-level parallelism:
 
 ```text
-# ./runMTK.sh -sourcedbtype enterprisedb -targetdbtype enterprisedb -loaderCount 4 -parallelLoadRowLimit 10000 -tableLoaderLimit 1 -tables tab1,tab2,tab3,tab4 public
+./runMTK.sh -sourcedbtype enterprisedb -targetdbtype enterprisedb -loaderCount 4 -parallelLoadRowLimit 10000 -tableLoaderLimit 1 -tables tab1,tab2,tab3,tab4 public
 ```
 
 Each table is processed simultaneously in one thread:
@@ -755,7 +755,7 @@ The `dblink_ora` module provides EDB Postgres Advanced Server-to-Oracle connecti
 This example uses the `dblink_ora` `COPY API` to migrate all tables from the `HR` schema:
 
 ```shell
-$./runMTK.sh -copyViaDBLinkOra -allTables HR
+./runMTK.sh -copyViaDBLinkOra -allTables HR
 ```
 
 The target EDB Postgres Advanced Server database must have `dblink_ora` installed and configured. See [dblink_ora](/epas/latest/working_with_oracle_data/06_dblink_ora/).
@@ -767,7 +767,7 @@ Choose this option to migrate Oracle database links. The password information fo
 To migrate all database links using edb as the dummy password for the connected user:
 
 ```shell
-$./runMTK.sh -allDBLinks HR
+./runMTK.sh -allDBLinks HR
 ```
 
 You can alternatively specify the password for each of the database links through a comma-separated list of name=value pairs with no intervening space characters. Specify the link name on the left side of the pair and the password value on the right side.
@@ -775,7 +775,7 @@ You can alternatively specify the password for each of the database links throug
 To migrate all database links with the actual passwords specified on the command line:
 
 ```shell
-$./runMTK.sh -allDBLinks LINK_NAME1=abc,LINK_NAME2=xyz HR
+./runMTK.sh -allDBLinks LINK_NAME1=abc,LINK_NAME2=xyz HR
 ```
 
 Migration Toolkit migrates only the database link types that are currently supported by EnterpriseDB. These types include fixed user links of public and private type.
@@ -962,7 +962,7 @@ TARGET_DB_PASSWORD=password
 The following command invokes Migration Toolkit:
 
 ```shell
-$ ./runMTK.sh EDB
+./runMTK.sh EDB
 __OUTPUT__
 Running EnterpriseDB Migration Toolkit (Build 48.0.0) ...
 Source database connectivity info...

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -160,7 +160,9 @@ Import all tables from the source schema.
 
 `-tables <table_list>`
 
-Import the selected tables from the source schema. `table_list` is a comma-separated list of table names with no intervening space characters (for example, `-tables emp,dept,acctg`).
+Import the selected tables from the source schema. `table_list` is a comma-separated list of table names with no intervening space characters (for example, `-tables emp,dept,acctg`). 
+
+When migrating multiple schemas, or all schemas (with the `-allSchema` option), the table name must be schema-qualified (for example, `-tables comp_schema.emp,comp_schema.dept,finance_schema.acctg`).
 
 `-excludeTables <table_list>`
 


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/DOCS-795
When `-allSchemas` is enabled, the referenced objects (tables, views, procs, etc.) must be schema-qualified. I added examples and clarifying phrasing around this to each section the `-allSchemas` applies to. 