### PR TITLE
Generated files to reinstate SLES 12 for all products

### DIFF
--- a/product_docs/docs/edb_plus/41/installing/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/index.mdx
@@ -33,7 +33,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/edbplus_sles_15)
+- [SLES 15](linux_x86_64/edbplus_sles_15), [SLES 12](linux_x86_64/edbplus_sles_12)
 
 ### Debian and derivatives
 
@@ -49,7 +49,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/edbplus_sles_15)
+- [SLES 15](linux_ppc64le/edbplus_sles_15), [SLES 12](linux_ppc64le/edbplus_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/edb_plus/41/installing/linux_ppc64le/edbplus_sles_12.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_ppc64le/edbplus_sles_12.mdx
@@ -1,0 +1,59 @@
+---
+navTitle: SLES 12
+title: Installing EDB*Plus on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /edb_plus/41/03_installing_edb_plus/install_on_linux/ibm_power_ppc64le/edbplus_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-edbplus
+```
+
+## Initial configuration
+
+After performing a Linux installation of EDB\*Plus, you must set the values of environment variables that allow EDB\*Plus to locate your Java installation:
+
+```shell
+export JAVA_HOME=<path_to_java>
+export PATH=<path_to_java>/bin:$PATH
+```

--- a/product_docs/docs/edb_plus/41/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - edbplus_rhel_9
   - edbplus_rhel_8
   - edbplus_sles_15
+  - edbplus_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](edbplus_sles_15)
+
+- [SLES 12](edbplus_sles_12)

--- a/product_docs/docs/edb_plus/41/installing/linux_x86_64/edbplus_sles_12.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_x86_64/edbplus_sles_12.mdx
@@ -1,0 +1,59 @@
+---
+navTitle: SLES 12
+title: Installing EDB*Plus on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /edb_plus/41/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-edbplus
+```
+
+## Initial configuration
+
+After performing a Linux installation of EDB\*Plus, you must set the values of environment variables that allow EDB\*Plus to locate your Java installation:
+
+```shell
+export JAVA_HOME=<path_to_java>
+export PATH=<path_to_java>/bin:$PATH
+```

--- a/product_docs/docs/edb_plus/41/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - edbplus_other_linux_9
   - edbplus_other_linux_8
   - edbplus_sles_15
+  - edbplus_sles_12
   - edbplus_ubuntu_22
   - edbplus_ubuntu_20
   - edbplus_debian_11
@@ -43,6 +44,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](edbplus_sles_15)
+
+- [SLES 12](edbplus_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/efm/4/installing/index.mdx
+++ b/product_docs/docs/efm/4/installing/index.mdx
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/efm_sles_15)
+- [SLES 15](linux_x86_64/efm_sles_15), [SLES 12](linux_x86_64/efm_sles_12)
 
 ### Debian and derivatives
 
@@ -68,7 +68,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/efm_sles_15)
+- [SLES 15](linux_ppc64le/efm_sles_15), [SLES 12](linux_ppc64le/efm_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/efm/4/installing/linux_ppc64le/efm_sles_12.mdx
+++ b/product_docs/docs/efm/4/installing/linux_ppc64le/efm_sles_12.mdx
@@ -1,0 +1,71 @@
+---
+navTitle: SLES 12
+title: Installing Failover Manager on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /efm/4/03_installing_efm/ibm_power_ppc64le/efm_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host (not needed for witness nodes).
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-efm<4x>
+```
+
+Where `<4x>` is the version of Failover Manager that you're installing. For example, if you're installing version 4.9, the package name is `edb-efm49`.
+
+The installation process creates a user named efm that has privileges to invoke scripts that control the Failover Manager service for clusters owned by enterprisedb or postgres.
+
+## Initial configuration
+
+If you're using Failover Manager to monitor a cluster owned by a user other than enterprisedb or postgres, see [Extending Failover Manager permissions](../../04_configuring_efm/04_extending_efm_permissions/#extending_efm_permissions).
+
+After installing on each node of the cluster:
+
+1.  Modify the [cluster properties file](../../04_configuring_efm/01_cluster_properties/#cluster_properties) on each node.
+2.  Modify the [cluster members file](../../04_configuring_efm/03_cluster_members/#cluster_members) on each node.
+3.  If applicable, configure and test virtual IP address settings and any scripts that are identified in the cluster properties file.
+4.  Start the agent on each node of the cluster. For more information, see [Controlling the Failover Manager service](../../08_controlling_efm_service/).

--- a/product_docs/docs/efm/4/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/efm/4/installing/linux_ppc64le/index.mdx
@@ -14,6 +14,7 @@ navigation:
   - efm_rhel_9
   - efm_rhel_8
   - efm_sles_15
+  - efm_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -27,3 +28,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](efm_sles_15)
+
+- [SLES 12](efm_sles_12)

--- a/product_docs/docs/efm/4/installing/linux_x86_64/efm_sles_12.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/efm_sles_12.mdx
@@ -1,0 +1,71 @@
+---
+navTitle: SLES 12
+title: Installing Failover Manager on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /efm/4/03_installing_efm/x86_amd64/efm_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host (not needed for witness nodes).
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-efm<4x>
+```
+
+Where `<4x>` is the version of Failover Manager that you're installing. For example, if you're installing version 4.9, the package name is `edb-efm49`.
+
+The installation process creates a user named efm that has privileges to invoke scripts that control the Failover Manager service for clusters owned by enterprisedb or postgres.
+
+## Initial configuration
+
+If you're using Failover Manager to monitor a cluster owned by a user other than enterprisedb or postgres, see [Extending Failover Manager permissions](../../04_configuring_efm/04_extending_efm_permissions/#extending_efm_permissions).
+
+After installing on each node of the cluster:
+
+1.  Modify the [cluster properties file](../../04_configuring_efm/01_cluster_properties/#cluster_properties) on each node.
+2.  Modify the [cluster members file](../../04_configuring_efm/03_cluster_members/#cluster_members) on each node.
+3.  If applicable, configure and test virtual IP address settings and any scripts that are identified in the cluster properties file.
+4.  Start the agent on each node of the cluster. For more information, see [Controlling the Failover Manager service](../../08_controlling_efm_service/).

--- a/product_docs/docs/efm/4/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/efm/4/installing/linux_x86_64/index.mdx
@@ -16,6 +16,7 @@ navigation:
   - efm_other_linux_9
   - efm_other_linux_8
   - efm_sles_15
+  - efm_sles_12
   - efm_ubuntu_22
   - efm_ubuntu_20
   - efm_debian_12
@@ -45,6 +46,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](efm_sles_15)
+
+- [SLES 12](efm_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/11/installing/index.mdx
+++ b/product_docs/docs/epas/11/installing/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/epas_sles_15)
+- [SLES 15](linux_x86_64/epas_sles_15), [SLES 12](linux_x86_64/epas_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/epas_sles_15)
+- [SLES 15](linux_ppc64le/epas_sles_15), [SLES 12](linux_ppc64le/epas_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/11/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle
+  - /epas/11/epas_inst_linux/installing_epas_using_edb_repository/ppcle/epas_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 11, the package name would be `edb-as11-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/11/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb
+
+sudo systemctl start edb-as-11
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (11.0.0, server 11.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/11/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/epas/11/installing/linux_ppc64le/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - epas_rhel_9
   - epas_rhel_8
   - epas_sles_15
+  - epas_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -28,3 +29,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)

--- a/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86
+  - /epas/11/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 11, the package name would be `edb-as11-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/11/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-11-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as11/bin/edb-as-11-setup initdb
+
+sudo systemctl start edb-as-11
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (11.0.0, server 11.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/11/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/epas/11/installing/linux_x86_64/index.mdx
@@ -17,6 +17,7 @@ navigation:
   - epas_other_linux_9
   - epas_other_linux_8
   - epas_sles_15
+  - epas_sles_12
   - epas_ubuntu_22
   - epas_ubuntu_20
   - epas_debian_11
@@ -45,6 +46,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/12/installing/index.mdx
+++ b/product_docs/docs/epas/12/installing/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/epas_sles_15)
+- [SLES 15](linux_x86_64/epas_sles_15), [SLES 12](linux_x86_64/epas_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/epas_sles_15)
+- [SLES 15](linux_ppc64le/epas_sles_15), [SLES 12](linux_ppc64le/epas_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/12/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle
+  - /epas/12/epas_inst_linux/installing_epas_using_edb_repository/ppcle/epas_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 12, the package name would be `edb-as12-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/12/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb
+
+sudo systemctl start edb-as-12
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (12.0.0, server 12.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/12/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/epas/12/installing/linux_ppc64le/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - epas_rhel_9
   - epas_rhel_8
   - epas_sles_15
+  - epas_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -28,3 +29,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)

--- a/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86
+  - /epas/12/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 12, the package name would be `edb-as12-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/12/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-12-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as12/bin/edb-as-12-setup initdb
+
+sudo systemctl start edb-as-12
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (12.0.0, server 12.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/12/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/epas/12/installing/linux_x86_64/index.mdx
@@ -17,6 +17,7 @@ navigation:
   - epas_other_linux_9
   - epas_other_linux_8
   - epas_sles_15
+  - epas_sles_12
   - epas_ubuntu_22
   - epas_ubuntu_20
   - epas_debian_11
@@ -45,6 +46,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/13/installing/index.mdx
+++ b/product_docs/docs/epas/13/installing/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/epas_sles_15)
+- [SLES 15](linux_x86_64/epas_sles_15), [SLES 12](linux_x86_64/epas_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/epas_sles_15)
+- [SLES 15](linux_ppc64le/epas_sles_15), [SLES 12](linux_ppc64le/epas_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/13/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle
+  - /epas/13/epas_inst_linux/installing_epas_using_edb_repository/ppcle/epas_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 13, the package name would be `edb-as13-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/13/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb
+
+sudo systemctl start edb-as-13
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (13.0.0, server 13.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/13/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/epas/13/installing/linux_ppc64le/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - epas_rhel_9
   - epas_rhel_8
   - epas_sles_15
+  - epas_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -28,3 +29,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)

--- a/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86
+  - /epas/13/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 13, the package name would be `edb-as13-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/13/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb
+
+sudo systemctl start edb-as-13
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (13.0.0, server 13.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/13/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/epas/13/installing/linux_x86_64/index.mdx
@@ -17,6 +17,7 @@ navigation:
   - epas_other_linux_9
   - epas_other_linux_8
   - epas_sles_15
+  - epas_sles_12
   - epas_ubuntu_22
   - epas_ubuntu_20
   - epas_debian_11
@@ -45,6 +46,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/14/installing/index.mdx
+++ b/product_docs/docs/epas/14/installing/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/epas_sles_15)
+- [SLES 15](linux_x86_64/epas_sles_15), [SLES 12](linux_x86_64/epas_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/epas_sles_15)
+- [SLES 15](linux_ppc64le/epas_sles_15), [SLES 12](linux_ppc64le/epas_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/14/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle
+  - /epas/14/epas_inst_linux/installing_epas_using_edb_repository/ppcle/epas_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 14, the package name would be `edb-as14-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/14/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb
+
+sudo systemctl start edb-as-14
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (14.0.0, server 14.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/14/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/epas/14/installing/linux_ppc64le/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - epas_rhel_9
   - epas_rhel_8
   - epas_sles_15
+  - epas_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -28,3 +29,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)

--- a/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86
+  - /epas/14/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 14, the package name would be `edb-as14-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/14/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb
+
+sudo systemctl start edb-as-14
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (14.0.0, server 14.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/14/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/epas/14/installing/linux_x86_64/index.mdx
@@ -17,6 +17,7 @@ navigation:
   - epas_other_linux_9
   - epas_other_linux_8
   - epas_sles_15
+  - epas_sles_12
   - epas_ubuntu_22
   - epas_ubuntu_20
   - epas_debian_11
@@ -45,6 +46,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/15/installing/index.mdx
+++ b/product_docs/docs/epas/15/installing/index.mdx
@@ -40,7 +40,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/epas_sles_15)
+- [SLES 15](linux_x86_64/epas_sles_15), [SLES 12](linux_x86_64/epas_sles_12)
 
 ### Debian and derivatives
 
@@ -56,7 +56,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/epas_sles_15)
+- [SLES 15](linux_ppc64le/epas_sles_15), [SLES 12](linux_ppc64le/epas_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/15/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle
+  - /epas/15/epas_inst_linux/installing_epas_using_edb_repository/ppcle/epas_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 15, the package name would be `edb-as15-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/15/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/specifying_cluster_options/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb
+
+sudo systemctl start edb-as-15
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (15.0.0, server 15.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/15/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/epas/15/installing/linux_ppc64le/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - epas_rhel_9
   - epas_rhel_8
   - epas_sles_15
+  - epas_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -28,3 +29,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)

--- a/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/15/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86
+  - /epas/15/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 15, the package name would be `edb-as15-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/15/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/specifying_cluster_options/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb
+
+sudo systemctl start edb-as-15
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (15.0.0, server 15.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/15/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/epas/15/installing/linux_x86_64/index.mdx
@@ -17,6 +17,7 @@ navigation:
   - epas_other_linux_9
   - epas_other_linux_8
   - epas_sles_15
+  - epas_sles_12
   - epas_ubuntu_22
   - epas_ubuntu_20
   - epas_debian_11
@@ -45,6 +46,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/16/installing/index.mdx
+++ b/product_docs/docs/epas/16/installing/index.mdx
@@ -37,7 +37,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/epas_sles_15)
+- [SLES 15](linux_x86_64/epas_sles_15), [SLES 12](linux_x86_64/epas_sles_12)
 
 ### Debian and derivatives
 
@@ -53,7 +53,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/epas_sles_15)
+- [SLES 15](linux_ppc64le/epas_sles_15), [SLES 12](linux_ppc64le/epas_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/epas/16/installing/linux_ppc64le/epas_sles_12.mdx
+++ b/product_docs/docs/epas/16/installing/linux_ppc64le/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/16/epas_inst_linux/installing_epas_using_edb_repository/ibm_power_ppc64le/epas_sles12_ppcle
+  - /epas/16/epas_inst_linux/installing_epas_using_edb_repository/ppcle/epas_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 16, the package name would be `edb-as16-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/16/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-16-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/specifying_cluster_options/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as16/bin/edb-as-16-setup initdb
+
+sudo systemctl start edb-as-16
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (16.0.0, server 16.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/16/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/epas/16/installing/linux_ppc64le/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - epas_rhel_9
   - epas_rhel_8
   - epas_sles_15
+  - epas_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -28,3 +29,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)

--- a/product_docs/docs/epas/16/installing/linux_x86_64/epas_sles_12.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/epas_sles_12.mdx
@@ -1,0 +1,147 @@
+---
+navTitle: SLES 12
+title: Installing EDB Postgres Advanced Server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/16/epas_inst_linux/installing_epas_using_edb_repository/x86_amd64/epas_sles12_x86
+  - /epas/16/epas_inst_linux/installing_epas_using_edb_repository/x86/epas_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced server you are installing. For example, if you are installing version 16, the package name would be `edb-as16-server`.
+
+To install an individual component:
+
+```shell
+sudo zypper -n install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/16/installing/linux_install_details/rpm_packages/).
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-16-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/specifying_cluster_options/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as16/bin/edb-as-16-setup initdb
+
+sudo systemctl start edb-as-16
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (16.0.0, server 16.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/16/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/epas/16/installing/linux_x86_64/index.mdx
@@ -17,6 +17,7 @@ navigation:
   - epas_other_linux_9
   - epas_other_linux_8
   - epas_sles_15
+  - epas_sles_12
   - epas_ubuntu_22
   - epas_ubuntu_20
   - epas_debian_12
@@ -46,6 +47,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](epas_sles_15)
+
+- [SLES 12](epas_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/eprs/7/installing/index.mdx
+++ b/product_docs/docs/eprs/7/installing/index.mdx
@@ -38,7 +38,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/eprs_sles_15)
+- [SLES 15](linux_x86_64/eprs_sles_15), [SLES 12](linux_x86_64/eprs_sles_12)
 
 ### Debian and derivatives
 
@@ -54,7 +54,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/eprs_sles_15)
+- [SLES 15](linux_ppc64le/eprs_sles_15), [SLES 12](linux_ppc64le/eprs_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_sles_12.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_ppc64le/eprs_sles_12.mdx
@@ -1,0 +1,72 @@
+---
+navTitle: SLES 12
+title: Installing Replication Server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /eprs/7/03_installation/03_installing_rpm_package/ibm_power_ppc64le/eprs_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+You can install all Replication Server components with a single install command, or you may choose to install selected, individual components by installing only those particular packages.
+
+To install all Replication Server components:
+
+```shell
+sudo zypper  -y install edb-xdb
+```
+
+To install an individual component:
+
+```shell
+sudo zypper  -y install <package_name>
+```
+
+Where `<package_name>` is:
+
+| Package name         | Component                                                             |
+| -------------------- | --------------------------------------------------------------------- |
+| `edb-xdb-console`    | Replication console and the Replication Server command line interface |
+| `edb-xdb-publisher`  | Publication server                                                    |
+| `edb-xdb-subscriber` | Subscription server                                                   |
+
+## Initial configuration
+
+Before using Replication Server, you must download and install JDBC drivers. See [Installing a JDBC driver](/eprs/7/installing/installing_jdbc_driver) for details.

--- a/product_docs/docs/eprs/7/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_ppc64le/index.mdx
@@ -14,6 +14,7 @@ navigation:
   - eprs_rhel_9
   - eprs_rhel_8
   - eprs_sles_15
+  - eprs_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -27,3 +28,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](eprs_sles_15)
+
+- [SLES 12](eprs_sles_12)

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_sles_12.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_sles_12.mdx
@@ -1,0 +1,72 @@
+---
+navTitle: SLES 12
+title: Installing Replication Server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+You can install all Replication Server components with a single install command, or you may choose to install selected, individual components by installing only those particular packages.
+
+To install all Replication Server components:
+
+```shell
+sudo zypper  -n install edb-xdb
+```
+
+To install an individual component:
+
+```shell
+sudo zypper  -n install <package_name>
+```
+
+Where `<package_name>` is:
+
+| Package name         | Component                                                             |
+| -------------------- | --------------------------------------------------------------------- |
+| `edb-xdb-console`    | Replication console and the Replication Server command line interface |
+| `edb-xdb-publisher`  | Publication server                                                    |
+| `edb-xdb-subscriber` | Subscription server                                                   |
+
+## Initial configuration
+
+Before using Replication Server, you must download and install JDBC drivers. See [Installing a JDBC driver](/eprs/7/installing/installing_jdbc_driver) for details.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/index.mdx
@@ -16,6 +16,7 @@ navigation:
   - eprs_other_linux_9
   - eprs_other_linux_8
   - eprs_sles_15
+  - eprs_sles_12
   - eprs_ubuntu_22
   - eprs_ubuntu_20
   - eprs_debian_11
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](eprs_sles_15)
+
+- [SLES 12](eprs_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/hadoop_data_adapter/2/installing/index.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/index.mdx
@@ -35,7 +35,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/hadoop_sles_15)
+- [SLES 15](linux_x86_64/hadoop_sles_15), [SLES 12](linux_x86_64/hadoop_sles_12)
 
 ### Debian and derivatives
 
@@ -51,7 +51,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/hadoop_sles_15)
+- [SLES 15](linux_ppc64le/hadoop_sles_15), [SLES 12](linux_ppc64le/hadoop_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_12.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/hadoop_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing Hadoop Foreign Data Wrapper on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/ibm_power_ppc64le/hadoop_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as15-hdfs_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced Server. Replace `15` with the version of EDB Postgres Advanced Server you are using.

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - hadoop_rhel_9
   - hadoop_rhel_8
   - hadoop_sles_15
+  - hadoop_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,5 +27,7 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](hadoop_sles_15)
+
+- [SLES 12](hadoop_sles_12)
 
 After you complete the installation, see [Initial configuration](../../configuring).

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_sles_12.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/hadoop_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing Hadoop Foreign Data Wrapper on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/x86_amd64/hadoop_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as15-hdfs_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced Server. Replace `15` with the version of EDB Postgres Advanced Server you are using.

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - hadoop_other_linux_9
   - hadoop_other_linux_8
   - hadoop_sles_15
+  - hadoop_sles_12
   - hadoop_ubuntu_22
   - hadoop_ubuntu_20
   - hadoop_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](hadoop_sles_15)
+
+- [SLES 12](hadoop_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/index.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/index.mdx
@@ -47,7 +47,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/jdbc_sles_15)
+- [SLES 15](linux_x86_64/jdbc_sles_15), [SLES 12](linux_x86_64/jdbc_sles_12)
 
 ### Debian and derivatives
 
@@ -63,7 +63,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/jdbc_sles_15)
+- [SLES 15](linux_ppc64le/jdbc_sles_15), [SLES 12](linux_ppc64le/jdbc_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - jdbc_rhel_9
   - jdbc_rhel_8
   - jdbc_sles_15
+  - jdbc_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](jdbc_sles_15)
+
+- [SLES 12](jdbc_sles_12)

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_sles_12.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_ppc64le/jdbc_sles_12.mdx
@@ -1,0 +1,60 @@
+---
+navTitle: SLES 12
+title: Installing EDB JDBC Connector on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/ibm_power_ppc64le/jdbc42_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Ensure that Java is installed on your system. You can download a Java installer that matches your environment from the Oracle Java Downloads [website](http://www.oracle.com/technetwork/java/javase/downloads/index.html). Documentation that contains detailed installation instructions is available through the associated `Installation Instruction` links on the same page.
+
+- Review [Supported JDBC distributions](/jdbc_connector/latest/02_requirements_overview/#supported-jdk-distribution).
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-jdbc
+```

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - jdbc_other_linux_9
   - jdbc_other_linux_8
   - jdbc_sles_15
+  - jdbc_sles_12
   - jdbc_ubuntu_22
   - jdbc_ubuntu_20
   - jdbc_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](jdbc_sles_15)
+
+- [SLES 12](jdbc_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_sles_12.mdx
+++ b/product_docs/docs/jdbc_connector/42.5.4.2/installing/linux_x86_64/jdbc_sles_12.mdx
@@ -1,0 +1,60 @@
+---
+navTitle: SLES 12
+title: Installing EDB JDBC Connector on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/x86_amd64/jdbc42_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Ensure that Java is installed on your system. You can download a Java installer that matches your environment from the Oracle Java Downloads [website](http://www.oracle.com/technetwork/java/javase/downloads/index.html). Documentation that contains detailed installation instructions is available through the associated `Installation Instruction` links on the same page.
+
+- Review [Supported JDBC distributions](/jdbc_connector/latest/02_requirements_overview/#supported-jdk-distribution).
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-jdbc
+```

--- a/product_docs/docs/migration_toolkit/55/installing/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/index.mdx
@@ -50,7 +50,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/mtk_sles_15)
+- [SLES 15](linux_x86_64/mtk_sles_15), [SLES 12](linux_x86_64/mtk_sles_12)
 
 ### Debian and derivatives
 
@@ -66,7 +66,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/mtk_sles_15)
+- [SLES 15](linux_ppc64le/mtk_sles_15), [SLES 12](linux_ppc64le/mtk_sles_12)
 
 ## Macintosh
 

--- a/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - mtk_rhel_9
   - mtk_rhel_8
   - mtk_sles_15
+  - mtk_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](mtk_sles_15)
+
+- [SLES 12](mtk_sles_12)

--- a/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_sles_12.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_ppc64le/mtk_sles_12.mdx
@@ -1,0 +1,54 @@
+---
+navTitle: SLES 12
+title: Installing Migration Toolkit on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /migration_toolkit/55/05_installing_mtk/install_on_linux/ibm_power_ppc64le/mtk55_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-migrationtoolkit
+```
+
+## Initial configuration
+
+Before invoking Migration Toolkit, you must download and install JDBC drivers for connecting to the source and target databases. See [Installing a JDBC driver](/migration_toolkit/latest/installing/installing_jdbc_driver/) for details.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - mtk_other_linux_9
   - mtk_other_linux_8
   - mtk_sles_15
+  - mtk_sles_12
   - mtk_ubuntu_22
   - mtk_ubuntu_20
   - mtk_debian_11
@@ -43,6 +44,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](mtk_sles_15)
+
+- [SLES 12](mtk_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_sles_12.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_sles_12.mdx
@@ -1,0 +1,54 @@
+---
+navTitle: SLES 12
+title: Installing Migration Toolkit on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-migrationtoolkit
+```
+
+## Initial configuration
+
+Before invoking Migration Toolkit, you must download and install JDBC drivers for connecting to the source and target databases. See [Installing a JDBC driver](/migration_toolkit/latest/installing/installing_jdbc_driver/) for details.

--- a/product_docs/docs/mongo_data_adapter/5/installing/index.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/index.mdx
@@ -35,7 +35,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/mongo_sles_15)
+- [SLES 15](linux_x86_64/mongo_sles_15), [SLES 12](linux_x86_64/mongo_sles_12)
 
 ### Debian and derivatives
 
@@ -51,7 +51,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/mongo_sles_15)
+- [SLES 15](linux_ppc64le/mongo_sles_15), [SLES 12](linux_ppc64le/mongo_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - mongo_rhel_9
   - mongo_rhel_8
   - mongo_sles_15
+  - mongo_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,5 +27,7 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](mongo_sles_15)
+
+- [SLES 12](mongo_sles_12)
 
 After you complete the installation, see [Initial configuration](../../configuring).

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_12.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_ppc64le/mongo_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing MongoDB Foreign Data Wrapper on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/ibm_power_ppc64le/mongo_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as15-mongo_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced Server. Replace `15` with the version of EDB Postgres Advanced Server you are using.

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - mongo_other_linux_9
   - mongo_other_linux_8
   - mongo_sles_15
+  - mongo_sles_12
   - mongo_ubuntu_22
   - mongo_ubuntu_20
   - mongo_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](mongo_sles_15)
+
+- [SLES 12](mongo_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_sles_12.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_x86_64/mongo_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing MongoDB Foreign Data Wrapper on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/x86_amd64/mongo_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as15-mongo_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced Server. Replace `15` with the version of EDB Postgres Advanced Server you are using.

--- a/product_docs/docs/mysql_data_adapter/2/installing/index.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/index.mdx
@@ -34,7 +34,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/mysql_sles_15)
+- [SLES 15](linux_x86_64/mysql_sles_15), [SLES 12](linux_x86_64/mysql_sles_12)
 
 ### Debian and derivatives
 
@@ -50,7 +50,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/mysql_sles_15)
+- [SLES 15](linux_ppc64le/mysql_sles_15), [SLES 12](linux_ppc64le/mysql_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - mysql_rhel_9
   - mysql_rhel_8
   - mysql_sles_15
+  - mysql_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](mysql_sles_15)
+
+- [SLES 12](mysql_sles_12)

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_12.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_ppc64le/mysql_sles_12.mdx
@@ -1,0 +1,70 @@
+---
+navTitle: SLES 12
+title: Installing MySQL Foreign Data Wrapper on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/ibm_power_ppc64le/mysql_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the MySQL community repository:
+  ```shell
+  sudo wget https://dev.mysql.com/get/mysql80-community-release-sles12-5.noarch.rpm
+  rpm --import /etc/RPM-GPG-KEY-mysql-2022
+  ```
+- Enable the MySQL8 repository and disable the MySQL 5 repository:
+
+  ```shell
+  sudo zypper modifyrepo -e mysql80-community
+  sudo zypper modifyrepo -d mysql57-community
+  ```
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as15-mysql8_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced server and `8` is the version of MySQL to be installed.

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - mysql_other_linux_9
   - mysql_other_linux_8
   - mysql_sles_15
+  - mysql_sles_12
   - mysql_ubuntu_22
   - mysql_ubuntu_20
   - mysql_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](mysql_sles_15)
+
+- [SLES 12](mysql_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_sles_12.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_x86_64/mysql_sles_12.mdx
@@ -1,0 +1,70 @@
+---
+navTitle: SLES 12
+title: Installing MySQL Foreign Data Wrapper on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/x86_amd64/mysql_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the MySQL community repository:
+  ```shell
+  sudo wget https://dev.mysql.com/get/mysql80-community-release-sles12-5.noarch.rpm
+  rpm --import /etc/RPM-GPG-KEY-mysql-2022
+  ```
+- Enable the MySQL8 repository and disable the MySQL 5 repository:
+
+  ```shell
+  sudo zypper modifyrepo -e mysql80-community
+  sudo zypper modifyrepo -d mysql57-community
+  ```
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as15-mysql8_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced server and `8` is the version of MySQL to be installed.

--- a/product_docs/docs/ocl_connector/14/installing/index.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/ocl_sles_15)
+- [SLES 15](linux_x86_64/ocl_sles_15), [SLES 12](linux_x86_64/ocl_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/ocl_sles_15)
+- [SLES 15](linux_ppc64le/ocl_sles_15), [SLES 12](linux_ppc64le/ocl_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/ocl_connector/14/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - ocl_rhel_9
   - ocl_rhel_8
   - ocl_sles_15
+  - ocl_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](ocl_sles_15)
+
+- [SLES 12](ocl_sles_12)

--- a/product_docs/docs/ocl_connector/14/installing/linux_ppc64le/ocl_sles_12.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_ppc64le/ocl_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB OCL Connector on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/14/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-oci
+sudo zypper -n install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/14/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - ocl_other_linux_9
   - ocl_other_linux_8
   - ocl_sles_15
+  - ocl_sles_12
   - ocl_ubuntu_20
   - ocl_debian_11
 ---
@@ -42,6 +43,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](ocl_sles_15)
+
+- [SLES 12](ocl_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/ocl_connector/14/installing/linux_x86_64/ocl_sles_12.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_x86_64/ocl_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB OCL Connector on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/14/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-oci
+sudo zypper -n install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/15/installing/index.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/ocl_sles_15)
+- [SLES 15](linux_x86_64/ocl_sles_15), [SLES 12](linux_x86_64/ocl_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/ocl_sles_15)
+- [SLES 15](linux_ppc64le/ocl_sles_15), [SLES 12](linux_ppc64le/ocl_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/ocl_connector/15/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - ocl_rhel_9
   - ocl_rhel_8
   - ocl_sles_15
+  - ocl_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](ocl_sles_15)
+
+- [SLES 12](ocl_sles_12)

--- a/product_docs/docs/ocl_connector/15/installing/linux_ppc64le/ocl_sles_12.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_ppc64le/ocl_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB OCL Connector on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/15/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-oci
+sudo zypper -n install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/15/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - ocl_other_linux_9
   - ocl_other_linux_8
   - ocl_sles_15
+  - ocl_sles_12
   - ocl_ubuntu_22
   - ocl_ubuntu_20
   - ocl_debian_11
@@ -43,6 +44,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](ocl_sles_15)
+
+- [SLES 12](ocl_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/ocl_connector/15/installing/linux_x86_64/ocl_sles_12.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_x86_64/ocl_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB OCL Connector on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/15/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-oci
+sudo zypper -n install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/16/installing/index.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/index.mdx
@@ -37,7 +37,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/ocl_sles_15)
+- [SLES 15](linux_x86_64/ocl_sles_15), [SLES 12](linux_x86_64/ocl_sles_12)
 
 ### Debian and derivatives
 
@@ -53,7 +53,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/ocl_sles_15)
+- [SLES 15](linux_ppc64le/ocl_sles_15), [SLES 12](linux_ppc64le/ocl_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/ocl_connector/16/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - ocl_rhel_9
   - ocl_rhel_8
   - ocl_sles_15
+  - ocl_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](ocl_sles_15)
+
+- [SLES 12](ocl_sles_12)

--- a/product_docs/docs/ocl_connector/16/installing/linux_ppc64le/ocl_sles_12.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/linux_ppc64le/ocl_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB OCL Connector on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/16/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/ibm_power_ppc64le/ocl_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-oci
+sudo zypper -n install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/16/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - ocl_other_linux_9
   - ocl_other_linux_8
   - ocl_sles_15
+  - ocl_sles_12
   - ocl_ubuntu_22
   - ocl_ubuntu_20
   - ocl_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](ocl_sles_15)
+
+- [SLES 12](ocl_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/ocl_connector/16/installing/linux_x86_64/ocl_sles_12.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/linux_x86_64/ocl_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB OCL Connector on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/16/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/x86_amd64/ocl_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-oci
+sudo zypper -n install edb-oci-devel
+```

--- a/product_docs/docs/odbc_connector/13/installing/index.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/odbc_sles_15)
+- [SLES 15](linux_x86_64/odbc_sles_15), [SLES 12](linux_x86_64/odbc_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/odbc_sles_15)
+- [SLES 15](linux_ppc64le/odbc_sles_15), [SLES 12](linux_ppc64le/odbc_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/odbc_connector/13/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - odbc_rhel_9
   - odbc_rhel_8
   - odbc_sles_15
+  - odbc_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](odbc_sles_15)
+
+- [SLES 12](odbc_sles_12)

--- a/product_docs/docs/odbc_connector/13/installing/linux_ppc64le/odbc_sles_12.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_ppc64le/odbc_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB ODBC Connector on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/ibm_power_ppc64le/odbc13_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-odbc
+sudo zypper -n install edb-odbc-devel
+```

--- a/product_docs/docs/odbc_connector/13/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - odbc_other_linux_9
   - odbc_other_linux_8
   - odbc_sles_15
+  - odbc_sles_12
   - odbc_ubuntu_22
   - odbc_ubuntu_20
   - odbc_debian_11
@@ -43,6 +44,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](odbc_sles_15)
+
+- [SLES 12](odbc_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/odbc_connector/13/installing/linux_x86_64/odbc_sles_12.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_x86_64/odbc_sles_12.mdx
@@ -1,0 +1,57 @@
+---
+navTitle: SLES 12
+title: Installing EDB ODBC Connector on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/x86_amd64/odbc13_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-odbc
+sudo zypper -n install edb-odbc-devel
+```

--- a/product_docs/docs/odbc_connector/16/installing/index.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/index.mdx
@@ -37,7 +37,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/odbc_sles_15)
+- [SLES 15](linux_x86_64/odbc_sles_15), [SLES 12](linux_x86_64/odbc_sles_12)
 
 ### Debian and derivatives
 
@@ -53,7 +53,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/odbc_sles_15)
+- [SLES 15](linux_ppc64le/odbc_sles_15), [SLES 12](linux_ppc64le/odbc_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - odbc_rhel_9
   - odbc_rhel_8
   - odbc_sles_15
+  - odbc_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](odbc_sles_15)
+
+- [SLES 12](odbc_sles_12)

--- a/product_docs/docs/odbc_connector/16/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - odbc_other_linux_9
   - odbc_other_linux_8
   - odbc_sles_15
+  - odbc_sles_12
   - odbc_ubuntu_22
   - odbc_ubuntu_20
   - odbc_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](odbc_sles_15)
+
+- [SLES 12](odbc_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/8/installing/index.mdx
+++ b/product_docs/docs/pem/8/installing/index.mdx
@@ -40,7 +40,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/pem_sles_15)
+- [SLES 15](linux_x86_64/pem_sles_15), [SLES 12](linux_x86_64/pem_sles_12)
 
 ### Debian and derivatives
 
@@ -56,7 +56,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/pem_sles_15)
+- [SLES 15](linux_ppc64le/pem_sles_15), [SLES 12](linux_ppc64le/pem_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/pem/8/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/pem/8/installing/linux_ppc64le/index.mdx
@@ -14,6 +14,7 @@ navigation:
   - pem_rhel_9
   - pem_rhel_8
   - pem_sles_15
+  - pem_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -27,3 +28,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_sles_15)
+
+- [SLES 12](pem_sles_12)

--- a/product_docs/docs/pem/8/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/index.mdx
@@ -16,6 +16,7 @@ navigation:
   - pem_other_linux_9
   - pem_other_linux_8
   - pem_sles_15
+  - pem_sles_12
   - pem_ubuntu_22
   - pem_ubuntu_20
   - pem_debian_11
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_sles_15)
+
+- [SLES 12](pem_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/8/installing_pem_agent/index.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/index.mdx
@@ -35,7 +35,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/pem_agent_sles_15)
+- [SLES 15](linux_x86_64/pem_agent_sles_15), [SLES 12](linux_x86_64/pem_agent_sles_12)
 
 ### Debian and derivatives
 
@@ -51,7 +51,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/pem_agent_sles_15)
+- [SLES 15](linux_ppc64le/pem_agent_sles_15), [SLES 12](linux_ppc64le/pem_agent_sles_12)
 
 ## Windows
 

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/index.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - pem_agent_rhel_9
   - pem_agent_rhel_8
   - pem_agent_sles_15
+  - pem_agent_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_agent_sles_15)
+
+- [SLES 12](pem_agent_sles_12)

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
@@ -1,0 +1,56 @@
+---
+navTitle: SLES 12
+title: Installing Postgres Enterprise Manager agent on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/8/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles12_ppcle
+---
+
+!!! Note
+
+    Postgres Enterprise Manager 8.3 and later is supported on SLES.
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pem-agent
+```
+
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/index.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - pem_agent_other_linux_9
   - pem_agent_other_linux_8
   - pem_agent_sles_15
+  - pem_agent_sles_12
   - pem_agent_ubuntu_22
   - pem_agent_ubuntu_20
   - pem_agent_debian_11
@@ -43,6 +44,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_agent_sles_15)
+
+- [SLES 12](pem_agent_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/8/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
@@ -1,0 +1,56 @@
+---
+navTitle: SLES 12
+title: Installing Postgres Enterprise Manager agent on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/8/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles12_x86
+---
+
+!!! Note
+
+    Postgres Enterprise Manager 8.3 and later is supported on SLES.
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pem-agent
+```
+
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing/index.mdx
+++ b/product_docs/docs/pem/9/installing/index.mdx
@@ -41,7 +41,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/pem_sles_15)
+- [SLES 15](linux_x86_64/pem_sles_15), [SLES 12](linux_x86_64/pem_sles_12)
 
 ### Debian and derivatives
 
@@ -57,7 +57,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/pem_sles_15)
+- [SLES 15](linux_ppc64le/pem_sles_15), [SLES 12](linux_ppc64le/pem_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/index.mdx
@@ -14,6 +14,7 @@ navigation:
   - pem_rhel_9
   - pem_rhel_8
   - pem_sles_15
+  - pem_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -27,3 +28,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_sles_15)
+
+- [SLES 12](pem_sles_12)

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_12.mdx
@@ -1,0 +1,97 @@
+---
+navTitle: SLES 12
+title: Installing Postgres Enterprise Manager server on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/9/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/ibm_power_ppc64le/pem_server_sles12_ppcle/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/ppc64le/pem_server_sles12_ppcle/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/x86_amd64/pem_server_sles12_ppcle/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/x86/pem_server_sles12_ppcle/
+---
+
+!!! Note
+
+    Postgres Enterprise Manager 8.3 and later is supported on SLES.
+
+## Prerequisites
+
+Before you begin the installation process:
+
+1. Install a [supported Postgres instance](/pem/latest/#postgres-compatibility) for PEM to use as a backend database.
+
+   You can install this instance on the same server to be used for the PEM web application or on a separate server. You can also use an existing Postgres instance if it is configured as detailed in the next steps.
+
+2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
+
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+
+   - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
+
+   - To allow the chosen superuser to connect using password authentication, add a line to `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, such as `host all superusername 127.0.0.1/32 scram-sha-256`.
+
+   !!! Note
+   If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/latest/managing_database_server/#modifying-the-pg_hbaconf-file).
+
+   If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
+   !!!
+
+3. Verify that the `sslutils` extension is installed on your Postgres server.
+
+   If you're using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you also need to install the `hstore contrib` module.
+
+   - If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
+
+     ```shell
+     sudo zypper install edb-as<x>-server-sslutils
+     ```
+
+   - If you're using PostgreSQL, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the PostgreSQL version.
+     ```shell
+     sudo zypper install sslutils_<x> postgresql<x>-contrib
+     ```
+   - If you're using EDB Postgres Extended Server, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version.
+     ```shell
+     sudo zypper install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
+     ```
+
+4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
+
+   ```shell
+   firewall-cmd --permanent --zone=public --add-port=8443/tcp
+
+   firewall-cmd --reload
+   ```
+
+5. Make sure the components Postgres Enterprise Manager depends on are up to date on all servers. You can do this by updating the whole system using your package manager as shown below.
+   If you prefer to update individual packages, a full list of dependencies is provided in [Dependencies of the PEM Server and Agent on Linux](../dependencies.md).
+
+   ```shell
+   sudo zypper update
+   ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pem
+```
+
+## Initial configuration
+
+```shell
+# You can configure the PEM server using the following command:
+sudo /usr/edb/pem/bin/configure-pem-server.sh
+```
+
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
+
+!!! Note
+
+    - The operating system user pem is created while installing the PEM server. The PEM server web application is a WSGI application, which runs under Apache HTTPD. The pem application data and the session is saved to this user's home directory.
+
+## Supported locales
+
+Currently, the Postgres Enterprise Manager server and web interface support a locale of `English(US) en_US` and use of a period (.) as a language separator character. Using an alternate locale or a separator character other than a period might cause errors.

--- a/product_docs/docs/pem/9/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/index.mdx
@@ -16,6 +16,7 @@ navigation:
   - pem_other_linux_9
   - pem_other_linux_8
   - pem_sles_15
+  - pem_sles_12
   - pem_ubuntu_22
   - pem_ubuntu_20
   - pem_debian_12
@@ -45,6 +46,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_sles_15)
+
+- [SLES 12](pem_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_12.mdx
@@ -1,0 +1,97 @@
+---
+navTitle: SLES 12
+title: Installing Postgres Enterprise Manager server on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/9/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/x86_amd64/pem_server_sles12_x86
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/ibm_power_ppc64le/pem_server_sles12_x86/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/ppc64le/pem_server_sles12_x86/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/x86_amd64/pem_server_sles12_x86/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/x86/pem_server_sles12_x86/
+---
+
+!!! Note
+
+    Postgres Enterprise Manager 8.3 and later is supported on SLES.
+
+## Prerequisites
+
+Before you begin the installation process:
+
+1. Install a [supported Postgres instance](/pem/latest/#postgres-compatibility) for PEM to use as a backend database.
+
+   You can install this instance on the same server to be used for the PEM web application or on a separate server. You can also use an existing Postgres instance if it is configured as detailed in the next steps.
+
+2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
+
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+
+   - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
+
+   - To allow the chosen superuser to connect using password authentication, add a line to `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, such as `host all superusername 127.0.0.1/32 scram-sha-256`.
+
+   !!! Note
+   If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/latest/managing_database_server/#modifying-the-pg_hbaconf-file).
+
+   If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
+   !!!
+
+3. Verify that the `sslutils` extension is installed on your Postgres server.
+
+   If you're using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you also need to install the `hstore contrib` module.
+
+   - If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
+
+     ```shell
+     sudo zypper install edb-as<x>-server-sslutils
+     ```
+
+   - If you're using PostgreSQL, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the PostgreSQL version.
+     ```shell
+     sudo zypper install sslutils_<x> postgresql<x>-contrib
+     ```
+   - If you're using EDB Postgres Extended Server, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version.
+     ```shell
+     sudo zypper install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
+     ```
+
+4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
+
+   ```shell
+   firewall-cmd --permanent --zone=public --add-port=8443/tcp
+
+   firewall-cmd --reload
+   ```
+
+5. Make sure the components Postgres Enterprise Manager depends on are up to date on all servers. You can do this by updating the whole system using your package manager as shown below.
+   If you prefer to update individual packages, a full list of dependencies is provided in [Dependencies of the PEM Server and Agent on Linux](../dependencies.md).
+
+   ```shell
+   sudo zypper update
+   ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pem
+```
+
+## Initial configuration
+
+```shell
+# You can configure the PEM server using the following command:
+sudo /usr/edb/pem/bin/configure-pem-server.sh
+```
+
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
+
+!!! Note
+
+    - The operating system user pem is created while installing the PEM server. The PEM server web application is a WSGI application, which runs under Apache HTTPD. The pem application data and the session is saved to this user's home directory.
+
+## Supported locales
+
+Currently, the Postgres Enterprise Manager server and web interface support a locale of `English(US) en_US` and use of a period (.) as a language separator character. Using an alternate locale or a separator character other than a period might cause errors.

--- a/product_docs/docs/pem/9/installing_pem_agent/index.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/index.mdx
@@ -36,7 +36,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/pem_agent_sles_15)
+- [SLES 15](linux_x86_64/pem_agent_sles_15), [SLES 12](linux_x86_64/pem_agent_sles_12)
 
 ### Debian and derivatives
 
@@ -52,7 +52,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/pem_agent_sles_15)
+- [SLES 15](linux_ppc64le/pem_agent_sles_15), [SLES 12](linux_ppc64le/pem_agent_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/index.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - pem_agent_rhel_9
   - pem_agent_rhel_8
   - pem_agent_sles_15
+  - pem_agent_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_agent_sles_15)
+
+- [SLES 12](pem_agent_sles_12)

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_ppc64le/pem_agent_sles_12.mdx
@@ -1,0 +1,56 @@
+---
+navTitle: SLES 12
+title: Installing Postgres Enterprise Manager agent on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/9/installing_pem_agent/installing_on_linux/ibm_power_ppc64le/pem_agent_sles12_ppcle
+---
+
+!!! Note
+
+    Postgres Enterprise Manager 8.3 and later is supported on SLES.
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pem-agent
+```
+
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/index.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - pem_agent_other_linux_9
   - pem_agent_other_linux_8
   - pem_agent_sles_15
+  - pem_agent_sles_12
   - pem_agent_ubuntu_22
   - pem_agent_ubuntu_20
   - pem_agent_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pem_agent_sles_15)
+
+- [SLES 12](pem_agent_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_x86_64/pem_agent_sles_12.mdx
@@ -1,0 +1,56 @@
+---
+navTitle: SLES 12
+title: Installing Postgres Enterprise Manager agent on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/9/installing_pem_agent/installing_on_linux/x86_amd64/pem_agent_sles12_x86
+---
+
+!!! Note
+
+    Postgres Enterprise Manager 8.3 and later is supported on SLES.
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pem-agent
+```
+
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pgbouncer/1/installing/index.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/index.mdx
@@ -37,7 +37,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/pgbouncer_sles_15)
+- [SLES 15](linux_x86_64/pgbouncer_sles_15), [SLES 12](linux_x86_64/pgbouncer_sles_12)
 
 ### Debian and derivatives
 
@@ -53,7 +53,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/pgbouncer_sles_15)
+- [SLES 15](linux_ppc64le/pgbouncer_sles_15), [SLES 12](linux_ppc64le/pgbouncer_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - pgbouncer_rhel_9
   - pgbouncer_rhel_8
   - pgbouncer_sles_15
+  - pgbouncer_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -28,3 +29,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pgbouncer_sles_15)
+
+- [SLES 12](pgbouncer_sles_12)

--- a/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_sles_12.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_ppc64le/pgbouncer_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing EDB pgBouncer on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgbouncer/1/01_installation/install_on_linux/ibm_power_ppc64le/pgbouncer_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pgbouncer<xx>
+```
+
+Where `<xx>` is the version of EDB PgBouncer you are installing. For example, if you are installing version 1.22, the package name would be `edb-pgbouncer122`.

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/index.mdx
@@ -17,6 +17,7 @@ navigation:
   - pgbouncer_other_linux_9
   - pgbouncer_other_linux_8
   - pgbouncer_sles_15
+  - pgbouncer_sles_12
   - pgbouncer_ubuntu_22
   - pgbouncer_ubuntu_20
   - pgbouncer_debian_12
@@ -46,6 +47,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pgbouncer_sles_15)
+
+- [SLES 12](pgbouncer_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_sles_12.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_x86_64/pgbouncer_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing EDB pgBouncer on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgbouncer/1/01_installation/install_on_linux/x86_amd64/pgbouncer_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pgbouncer<xx>
+```
+
+Where `<xx>` is the version of EDB PgBouncer you are installing. For example, if you are installing version 1.22, the package name would be `edb-pgbouncer122`.

--- a/product_docs/docs/pgpool/4/installing/index.mdx
+++ b/product_docs/docs/pgpool/4/installing/index.mdx
@@ -41,7 +41,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/pgpool_sles_15)
+- [SLES 15](linux_x86_64/pgpool_sles_15), [SLES 12](linux_x86_64/pgpool_sles_12)
 
 ### Debian and derivatives
 
@@ -57,7 +57,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/pgpool_sles_15)
+- [SLES 15](linux_ppc64le/pgpool_sles_15), [SLES 12](linux_ppc64le/pgpool_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/pgpool/4/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_ppc64le/index.mdx
@@ -14,6 +14,7 @@ navigation:
   - pgpool_rhel_9
   - pgpool_rhel_8
   - pgpool_sles_15
+  - pgpool_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -27,3 +28,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pgpool_sles_15)
+
+- [SLES 12](pgpool_sles_12)

--- a/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_ppc64le/pgpool_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing EDB Pgpool-II on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/ibm_power_ppc64le/pgpool_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pgpool<xx>
+```
+
+Where `<xx>` is the version of EDB PgPool-II you are installing. For example, if you are installing version 4.3, the package name would be `edb-pgpool43`.

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/index.mdx
@@ -20,6 +20,7 @@ navigation:
   - pgpool_other_linux_9
   - pgpool_other_linux_8
   - pgpool_sles_15
+  - pgpool_sles_12
   - pgpool_ubuntu_22
   - pgpool_ubuntu_20
   - pgpool_debian_12
@@ -49,6 +50,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pgpool_sles_15)
+
+- [SLES 12](pgpool_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_x86_64/pgpool_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing EDB Pgpool-II on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/x86_amd64/pgpool_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-pgpool<xx>
+```
+
+Where `<xx>` is the version of EDB PgPool-II you are installing. For example, if you are installing version 4.3, the package name would be `edb-pgpool43`.

--- a/product_docs/docs/pgpool/4/installing_extensions/index.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/index.mdx
@@ -38,7 +38,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/pgpoolext_sles_15)
+- [SLES 15](linux_x86_64/pgpoolext_sles_15), [SLES 12](linux_x86_64/pgpoolext_sles_12)
 
 ### Debian and derivatives
 
@@ -54,7 +54,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/pgpoolext_sles_15)
+- [SLES 15](linux_ppc64le/pgpoolext_sles_15), [SLES 12](linux_ppc64le/pgpoolext_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/index.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - pgpoolext_rhel_9
   - pgpoolext_rhel_8
   - pgpoolext_sles_15
+  - pgpoolext_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pgpoolext_sles_15)
+
+- [SLES 12](pgpoolext_sles_12)

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_ppc64le/pgpoolext_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing EDB Pgpool-II Extensions on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgpool/4/02_extensions/ibm_power_ppc64le/pgpoolext_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-pgpool<yy>-extensions
+```
+
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.4 and EDB Postgres Advanced Server version 15, the package name would be `edb-as15-pgpool44-extensions`.

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/index.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/index.mdx
@@ -19,6 +19,7 @@ navigation:
   - pgpoolext_other_linux_9
   - pgpoolext_other_linux_8
   - pgpoolext_sles_15
+  - pgpoolext_sles_12
   - pgpoolext_ubuntu_22
   - pgpoolext_ubuntu_20
   - pgpoolext_debian_12
@@ -48,6 +49,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](pgpoolext_sles_15)
+
+- [SLES 12](pgpoolext_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_sles_12.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_x86_64/pgpoolext_sles_12.mdx
@@ -1,0 +1,58 @@
+---
+navTitle: SLES 12
+title: Installing EDB Pgpool-II Extensions on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgpool/4/02_extensions/x86_amd64/pgpoolext_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+sudo zypper -n install edb-as<xx>-pgpool<yy>-extensions
+```
+
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.4 and EDB Postgres Advanced Server version 15, the package name would be `edb-as15-pgpool44-extensions`.

--- a/product_docs/docs/postgis/3/installing/index.mdx
+++ b/product_docs/docs/postgis/3/installing/index.mdx
@@ -37,7 +37,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_x86_64/postgis_sles_15)
+- [SLES 15](linux_x86_64/postgis_sles_15), [SLES 12](linux_x86_64/postgis_sles_12)
 
 ### Debian and derivatives
 
@@ -53,7 +53,7 @@ Select a link to access the applicable installation instructions:
 
 ### SUSE Linux Enterprise (SLES)
 
-- [SLES 15](linux_ppc64le/postgis_sles_15)
+- [SLES 15](linux_ppc64le/postgis_sles_15), [SLES 12](linux_ppc64le/postgis_sles_12)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 

--- a/product_docs/docs/postgis/3/installing/linux_ppc64le/index.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_ppc64le/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - postgis_rhel_9
   - postgis_rhel_8
   - postgis_sles_15
+  - postgis_sles_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -26,3 +27,5 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](postgis_sles_15)
+
+- [SLES 12](postgis_sles_12)

--- a/product_docs/docs/postgis/3/installing/linux_ppc64le/postgis_sles_12.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_ppc64le/postgis_sles_12.mdx
@@ -1,0 +1,65 @@
+---
+navTitle: SLES 12
+title: Installing PostGIS on SLES 12 ppc64le
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /postgis/latest/01a_installing_postgis/installing_on_linux/ibm_power_ppc64le/postgis_sles12_ppcle
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/ppc64le
+  sudo SUSEConnect -p sle-sdk/12.5/ppc64le
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+# To install PostGIS 3.4:
+zypper -n install edb-as<xx>-postgis34
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 13-15:
+zypper -n install edb-as<xx>-postgis3
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 12:
+zypper -n install edb-as12-postgis
+```
+
+Where `<xx>` is the version of EDB Postgres Advanced Server. Replace `<xx>` with the version of EDB Postgres Advanced Server you are using. For example, `edb-as15-postgis34`.

--- a/product_docs/docs/postgis/3/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_x86_64/index.mdx
@@ -15,6 +15,7 @@ navigation:
   - postgis_other_linux_9
   - postgis_other_linux_8
   - postgis_sles_15
+  - postgis_sles_12
   - postgis_ubuntu_22
   - postgis_ubuntu_20
   - postgis_debian_12
@@ -44,6 +45,8 @@ Operating system-specific install instructions are described in the correspondin
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](postgis_sles_15)
+
+- [SLES 12](postgis_sles_12)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/postgis/3/installing/linux_x86_64/postgis_sles_12.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_x86_64/postgis_sles_12.mdx
@@ -1,0 +1,65 @@
+---
+navTitle: SLES 12
+title: Installing PostGIS on SLES 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /postgis/latest/01a_installing_postgis/installing_on_linux/x86_amd64/postgis_sles12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `zypper lr -E | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Activate the required SUSE module:
+  ```shell
+  sudo SUSEConnect -p PackageHub/12.5/x86_64
+  sudo SUSEConnect -p sle-sdk/12.5/x86_64
+
+  ```
+- Refresh the metadata:
+  ```shell
+  sudo zypper refresh
+  ```
+
+## Install the package
+
+```shell
+# To install PostGIS 3.4:
+sudo zypper -n install edb-as<xx>-postgis34
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 13-15:
+sudo zypper -n install edb-as<xx>-postgis3
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 12:
+sudo zypper -n install edb-as12-postgis
+```
+
+Where `<xx>` is the version of EDB Postgres Advanced Server. Replace `<xx>` with the version of EDB Postgres Advanced Server you are using. For example, `edb-as15-postgis34`.


### PR DESCRIPTION
Generated new install topics for SLES 12 and generated new index pages to reflect addition. This work simply restores the install topics that were mistakenly removed as part of the RHEL 7/ Debian 10 removals. 

