### PR TITLE
DOCS-804 Broken architecture image in rep sets docs

### DIFF
--- a/product_docs/docs/pgd/5/repsets.mdx
+++ b/product_docs/docs/pgd/5/repsets.mdx
@@ -261,7 +261,7 @@ There's also, as we recommend, a witness node, named `witness` in `region-c`, bu
 
 This configuration looks like this:
 
-![Multi-Region 3 Nodes Configuration](./images/always-on-2x3-aa-updated.png)
+![Multi-Region 3 Nodes Configuration](./planning/images/always-on-2x3-aa-updated.png)
 
 This is the standard Always-on multiregion configuration as discussed in the [Choosing your architecture](planning/architectures) section.
 


### PR DESCRIPTION
## What Changed?

Fix image path (was now in planning section images)