### PR TITLE
EDB PgBouncer 1.23 release

### DIFF
--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/09_11610_rel_notes.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/09_11610_rel_notes.mdx
@@ -1,6 +1,6 @@
 ---
-title: "EDB PgBouncer 1.16.0.0 release notes"
-navTitle: Version 1.16.0.0
+title: "EDB PgBouncer 1.16.1.0 release notes"
+navTitle: Version 1.16.1.0
 ---
 
 Released: 11 Dec 2021

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/12300_rel_notes.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/12300_rel_notes.mdx
@@ -1,0 +1,12 @@
+---
+title: "EDB PgBouncer 1.23.0.0 release notes"
+navTitle: Version 1.23.0.0
+---
+
+Released: 16 Jul 2024
+
+EDB PgBouncer 1.23.0.0 includes the following upstream merge and security fix:
+
+|      Type      |                                                                    Description                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Upstream merge | Merged with community PgBouncer 1.23.0.0. See the community [Release Notes](https://www.pgbouncer.org/changelog.html#pgbouncer-123x) for details. |

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/12300_rel_notes.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/12300_rel_notes.mdx
@@ -3,7 +3,7 @@ title: "EDB PgBouncer 1.23.0.0 release notes"
 navTitle: Version 1.23.0.0
 ---
 
-Released: 16 Jul 2024
+Released: 17 Jul 2024
 
 EDB PgBouncer 1.23.0.0 includes the following upstream merge and security fix:
 

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/index.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/index.mdx
@@ -2,12 +2,24 @@
 title: "Release notes"
 redirects:
   - ../01_whats_new/
+navigation:
+  - 12300_rel_notes
+  - 02_12210_rel_notes
+  - 03_12200_rel_notes
+  - 04_12100_rel_notes
+  - 05_12000_rel_notes
+  - 06_11900_rel_notes
+  - 07_11800_rel_notes
+  - 08_11700_rel_notes
+  - 09_11610_rel_notes
+  - 10_11601_rel_notes
 ---
 
 The EDB PgBouncer documentation describes the latest version of EDB PgBouncer 1, including minor releases and patches. The release notes provide information on what was new in each release. For new functionality introduced in a minor or patch release, the content also indicates the release that introduced the feature.
 
 |            Version             | Release date |                               Upstream merges                                |
 | ------------------------------ | ------------ | ---------------------------------------------------------------------------- |
+| [1.23.0.0](12300_rel_notes)    | 16 Jul 2024  | Upstream [1.23.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-123x) |
 | [1.22.1.0](02_12210_rel_notes) | 16 Apr 2024  | Upstream [1.22.1.0](https://www.pgbouncer.org/changelog.html#pgbouncer-122x) |
 | [1.22.0.0](03_12200_rel_notes) | 29 Feb 2024  | Upstream [1.22.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-122x) |
 | [1.21.0.0](04_12100_rel_notes) | 16 Oct 2023  | Upstream [1.21.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-121x) |

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/index.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/index.mdx
@@ -19,7 +19,7 @@ The EDB PgBouncer documentation describes the latest version of EDB PgBouncer 1,
 
 |            Version             | Release date |                               Upstream merges                                |
 | ------------------------------ | ------------ | ---------------------------------------------------------------------------- |
-| [1.23.0.0](12300_rel_notes)    | 16 Jul 2024  | Upstream [1.23.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-123x) |
+| [1.23.0.0](12300_rel_notes)    | 17 Jul 2024  | Upstream [1.23.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-123x) |
 | [1.22.1.0](02_12210_rel_notes) | 16 Apr 2024  | Upstream [1.22.1.0](https://www.pgbouncer.org/changelog.html#pgbouncer-122x) |
 | [1.22.0.0](03_12200_rel_notes) | 29 Feb 2024  | Upstream [1.22.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-122x) |
 | [1.21.0.0](04_12100_rel_notes) | 16 Oct 2023  | Upstream [1.21.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-121x) |

--- a/product_docs/docs/pgbouncer/1/supported_platforms.mdx
+++ b/product_docs/docs/pgbouncer/1/supported_platforms.mdx
@@ -8,21 +8,22 @@ The EDB PgBouncer is supported on the same platforms as EDB Postgres Advanced Se
 
 This table lists the latest EDB PgBouncer versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions.
 
-| EDB PgBouncer | EPAS 16 | EPAS 15  | EPAS 14 | EPAS 13 | EPAS 12 |   
-| ------------- | ------- | -------  | ------- | ------- | ------- |   
-| 1.22          | Y       | Y        | Y       | Y       | Y       |
-| 1.21          | Y       | Y        | Y       | Y       | Y       |
-| 1.20          | Y       | Y        | Y       | Y       | Y       |
-| 1.19          | Y       | Y        | Y       | Y       | Y       |  
-| 1.18          | Y       | Y        | Y       | Y       | Y       | 
-| 1.17          | N       | N        | Y       | Y       | Y       | 
-| 1.16          | N       | N        | Y       | Y       | Y       |   
-| 1.15          | N       | N        | N       | Y       | Y       |   
-| 1.14          | N       | N        | N       | Y       | Y       |   
-| 1.13          | N       | N        | N       | N       | Y       |   
-| 1.12          | N       | N        | N       | N       | Y       |  
-| 1.9           | N       | N        | N       | N       | N       |  
-| 1.7           | N       | N        | N       | N       | N       |    
+| EDB PgBouncer | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 | EPAS 12 |
+|---------------|---------|---------|---------|---------|---------|
+| 1.23          | Y       | Y       | Y       | Y       | Y       |
+| 1.22          | Y       | Y       | Y       | Y       | Y       |
+| 1.21          | Y       | Y       | Y       | Y       | Y       |
+| 1.20          | Y       | Y       | Y       | Y       | Y       |
+| 1.19          | Y       | Y       | Y       | Y       | Y       |
+| 1.18          | Y       | Y       | Y       | Y       | Y       |
+| 1.17          | N       | N       | Y       | Y       | Y       |
+| 1.16          | N       | N       | Y       | Y       | Y       |
+| 1.15          | N       | N       | N       | Y       | Y       |
+| 1.14          | N       | N       | N       | Y       | Y       |
+| 1.13          | N       | N       | N       | N       | Y       |
+| 1.12          | N       | N       | N       | N       | Y       |
+| 1.9           | N       | N       | N       | N       | N       |
+| 1.7           | N       | N       | N       | N       | N       |
 
 
 The documented and supported functionality of each version of EDB PgBouncer is the same. The information in this documentation applies to all supported versions of EDB PgBouncer.


### PR DESCRIPTION
## What Changed?

New upstream merge of PgBouncer https://enterprisedb.atlassian.net/browse/RL-177 
Also edited the 1.16.1.0 topic title, as it said 1.16.0.0 when referring to a 1.16.1.0 release. 