### PR TITLE
Correct the formatting of admonitions in pem installation docs

### DIFF
--- a/install_template/templates/products/postgres-enterprise-manager-server/debian-11.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/debian-11.njk
@@ -7,10 +7,13 @@ To determine if your repository exists, enter this command:
 `apt-cache search enterprisedb`
 {% endblock repocheck %}  
 {% block debianUbuntuNote %}!!! Note               
+
       Debian 10 changed the requirements for accepting certificates.
 
       - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
-      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak"{% endblock debianUbuntuNote %}
+      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak"
+
+      !!!{% endblock debianUbuntuNote %}
 {% block firewallDebianCommand %}```shell
    iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
    ```{% endblock firewallDebianCommand %}

--- a/install_template/templates/products/postgres-enterprise-manager-server/ubuntu-20.04.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/ubuntu-20.04.njk
@@ -7,10 +7,13 @@ To determine if your repository exists, enter this command:
 `apt-cache search enterprisedb`
 {% endblock repocheck %}
 {% block debianUbuntuNote %}!!! Note               
+
       Ubuntu 20 changed the requirements for accepting certificates.
 
       - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
-      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."{% endblock debianUbuntuNote %}
+      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
+
+      !!!{% endblock debianUbuntuNote %}
 {% block firewallDebianCommand %}```shell
    iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
    ```{% endblock firewallDebianCommand %}

--- a/install_template/templates/products/postgres-enterprise-manager-server/ubuntu-22.04.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/ubuntu-22.04.njk
@@ -6,11 +6,14 @@ To determine if your repository exists, enter this command:
   
 `apt-cache search enterprisedb`
 {% endblock repocheck %}
-{% block debianUbuntuNote %}!!! Note               
+{% block debianUbuntuNote %}!!! Note
+
       Ubuntu 20 changed the requirements for accepting certificates.
 
       - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
-      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."{% endblock debianUbuntuNote %}
+      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
+
+      !!!{% endblock debianUbuntuNote %}
 {% block firewallDebianCommand %}```shell
    iptables -t filter -A INPUT -p TCP --dport 8443 -j ACCEPT
    ```{% endblock firewallDebianCommand %}

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_10.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_10.mdx
@@ -65,6 +65,8 @@ Before you begin the installation process:
      - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak"
 
+     !!!
+
 4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 
    ```shell

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_11.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_debian_11.mdx
@@ -59,11 +59,14 @@ Before you begin the installation process:
      sudo apt-get install edb-postgresextended-sslutils-<x>
      ```
 
-     !!! Note  
+     !!! Note
+
      Debian 10 changed the requirements for accepting certificates.
 
      - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak"
+
+     !!!
 
 4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_20.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_20.mdx
@@ -59,11 +59,14 @@ Before you begin the installation process:
      sudo apt-get install edb-postgresextended-sslutils-<x>
      ```
 
-     !!! Note  
+     !!! Note
+
      Ubuntu 20 changed the requirements for accepting certificates.
 
      - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
+
+     !!!
 
 4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 

--- a/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_22.mdx
+++ b/product_docs/docs/pem/8/installing/linux_x86_64/pem_ubuntu_22.mdx
@@ -59,11 +59,14 @@ Before you begin the installation process:
      sudo apt-get install edb-postgresextended-sslutils-<x>
      ```
 
-     !!! Note  
+     !!! Note
+
      Ubuntu 20 changed the requirements for accepting certificates.
 
      - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
+
+     !!!
 
 4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_11.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_11.mdx
@@ -59,11 +59,14 @@ Before you begin the installation process:
      sudo apt-get install edb-postgresextended-sslutils-<x>
      ```
 
-     !!! Note  
+     !!! Note
+
      Debian 10 changed the requirements for accepting certificates.
 
      - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak"
+
+     !!!
 
 4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_20.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_20.mdx
@@ -59,11 +59,14 @@ Before you begin the installation process:
      sudo apt-get install edb-postgresextended-sslutils-<x>
      ```
 
-     !!! Note  
+     !!! Note
+
      Ubuntu 20 changed the requirements for accepting certificates.
 
      - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
+
+     !!!
 
 4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_22.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_22.mdx
@@ -59,11 +59,14 @@ Before you begin the installation process:
      sudo apt-get install edb-postgresextended-sslutils-<x>
      ```
 
-     !!! Note  
+     !!! Note
+
      Ubuntu 20 changed the requirements for accepting certificates.
 
      - If you want to install the PEM agent on a machine with an old version of sslutils, then you must upgrade sslutils to 1.3. Version 1.3 has a 4096-bit RSA key and sha256 signature algorithm support added to it.
      - If you don't upgrade sslutils to 1.3, then PEM agent might fail to connect to the PEM backend database server, and it might log the error "ca md too weak."
+
+     !!!
 
 4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
 


### PR DESCRIPTION
## What Changed?

Fix a few un-indented un-closed admonitions. These weren't causing rendering issues due to their location in list items, but they were causing distracting warnings and could trip us up in the future.