### PR TITLE
Remove version-specific releases from Replication Manager documentation

### DIFF
--- a/product_docs/docs/efm/4/efm_deploy_arch/03_efm_vip.mdx
+++ b/product_docs/docs/efm/4/efm_deploy_arch/03_efm_vip.mdx
@@ -19,7 +19,7 @@ on three servers as following:
   
   Systems                                   |Components
   ------------------------------------------|-----------------------------------------------------------------------------
-  PG Primary, PG Standby1, and PG Standby2  | Primary / standby nodes running Advanced Server 13 and Failover Manager 4.2
+  PG Primary, PG Standby1, and PG Standby2  | Primary / standby nodes running Advanced Server and Failover Manager
   
 
 ### Specifying VIP

--- a/product_docs/docs/efm/4/efm_deploy_arch/04_efm_client_connect_failover.mdx
+++ b/product_docs/docs/efm/4/efm_deploy_arch/04_efm_client_connect_failover.mdx
@@ -24,7 +24,7 @@ Install and configure Advanced Server and Failover Manager on three servers as f
 
   Systems                                    | Components
   -------------------------------------------|----------------------------------------------------------------------------- 
-  PG Primary, PG Standby1, and PG Standby2   | Primary or standby nodes running Advanced Server 13 and Failover Manager 4.2
+  PG Primary, PG Standby1, and PG Standby2   | Primary or standby nodes running Advanced Server and Failover Manager
   
 
 You don't need to configure the virtual IP configuration in `efm.properties` (`virtual.ip`,

--- a/product_docs/docs/efm/4/efm_deploy_arch/05_efm_pgbouncer.mdx
+++ b/product_docs/docs/efm/4/efm_deploy_arch/05_efm_pgbouncer.mdx
@@ -54,7 +54,7 @@ Install and configure Advanced Server database, Failover Manager, and EDB PgBoun
    Systems            | Components
   --------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   PgDB srv 1, 2, 3    | Primary / standby node running Advanced Server and Failover Manager
-  PgBouncer srv 1, 2  | PgBouncer node running EDB PgBouncer. Register these two nodes as targets in the target group. Two is the minimum and is sufficient for most cases.
+  PgBouncer srv 1, 2  | PgBouncer node running EDB PgBouncer 1.15. Register these two nodes as targets in the target group. Two is the minimum and is sufficient for most cases.
   
 
 ### Configuring Failover Manager

--- a/product_docs/docs/efm/4/efm_deploy_arch/05_efm_pgbouncer.mdx
+++ b/product_docs/docs/efm/4/efm_deploy_arch/05_efm_pgbouncer.mdx
@@ -53,8 +53,8 @@ Install and configure Advanced Server database, Failover Manager, and EDB PgBoun
  
    Systems            | Components
   --------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  PgDB srv 1, 2, 3    | Primary / standby node running Advanced Server 13 and Failover Manager 4.2
-  PgBouncer srv 1, 2  | PgBouncer node running EDB PgBouncer 1.15. Register these two nodes as targets in the target group. Two is the minimum and is sufficient for most cases.
+  PgDB srv 1, 2, 3    | Primary / standby node running Advanced Server and Failover Manager
+  PgBouncer srv 1, 2  | PgBouncer node running EDB PgBouncer. Register these two nodes as targets in the target group. Two is the minimum and is sufficient for most cases.
   
 
 ### Configuring Failover Manager

--- a/product_docs/docs/efm/4/efm_deploy_arch/06_efm_pgpool.mdx
+++ b/product_docs/docs/efm/4/efm_deploy_arch/06_efm_pgpool.mdx
@@ -39,8 +39,8 @@ EDB Pgpool-II as follows:
   
   **Systems**                           |  **Components**
   --------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  PgDB server 1, server2, and server 3  | Primary / standby node running Advanced Server 13 and Failover Manager 4.2
-  EDB Pgpool-II                                |Pgpool node running EDB Pgpool-II 4.2 in a watchdog configuration. Register these three nodes as targets in the target group. Three is the minimum and is sufficient for most cases.
+  PgDB server 1, server2, and server 3  | Primary / standby node running Advanced Server and Failover Manager
+  EDB Pgpool-II                                |Pgpool node running EDB Pgpool-II in a watchdog configuration. Register these three nodes as targets in the target group. Three is the minimum and is sufficient for most cases.
   
   
 

--- a/product_docs/docs/efm/4/efm_deploy_arch/06_efm_pgpool.mdx
+++ b/product_docs/docs/efm/4/efm_deploy_arch/06_efm_pgpool.mdx
@@ -37,10 +37,10 @@ Install and configure Advanced Server database, Failover Manager, and
 EDB Pgpool-II as follows:
 
   
-  **Systems**                           |  **Components**
-  --------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  PgDB server 1, server2, and server 3  | Primary / standby node running Advanced Server and Failover Manager
-  EDB Pgpool-II                                |Pgpool node running EDB Pgpool-II in a watchdog configuration. Register these three nodes as targets in the target group. Three is the minimum and is sufficient for most cases.
+  | **Systems**                          | **Components**                                                                                                                                                                       |
+  |--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | PgDB server 1, server2, and server 3 | Primary / standby node running Advanced Server and Failover Manager                                                                                                                  |
+  | EDB Pgpool-II                        | Pgpool node running EDB Pgpool-II 4.2 in a watchdog configuration. Register these three nodes as targets in the target group. Three is the minimum and is sufficient for most cases. |
   
   
 


### PR DESCRIPTION
## What Changed?

From slack conversation:

https://edb.slack.com/archives/CU5QEU5L7/p1721927285903279

I suggest we add a compatibility matrix so customers can know how to "mix and match" EPAS versions with EFM versions (what is supported and has been tested?). 