### PR TITLE
fix(ET-1265): Updates migration service documentation

### DIFF
--- a/product_docs/docs/transporter/ba_preview/getting_started/create_database.mdx
+++ b/product_docs/docs/transporter/ba_preview/getting_started/create_database.mdx
@@ -2,8 +2,8 @@
 title: "Creating a database cluster"
 ---
 
-Before you migrate your database to EDB Postgres® AI, create an empty database in a database cluster. 
-You will configure this database to be the target of your migration when using EDB Transporter. 
+If you have not created a destination cluster you can do so in the EDB Postgres® AI portal.
+An existing cluster can be used as a migration destination -- take care to ensure the tables being migrated and the load generated on destination will not interfere with existing workloads.
 
 1.  Access the [EDB Postgres AI Console](https://portal.biganimal.com) and log in with your EDB Postgres AI Database Cloud Service credentials.
 

--- a/product_docs/docs/transporter/ba_preview/getting_started/prepare_schema.mdx
+++ b/product_docs/docs/transporter/ba_preview/getting_started/prepare_schema.mdx
@@ -2,4 +2,52 @@
 title: "Preparing schema"
 ---
 
-Use [EDB Migration Portal](https://www.enterprisedb.com/docs/migration_portal/latest/) to assess Oracle database sources for schema compatibility before starting the data migration process. Address incompatible schemas or exclude them from the migration and migrate the schema to the new database **without applying constraints**.
+# Oracle to EPAS Migrations
+
+Use [EDB Migration Portal](https://www.enterprisedb.com/docs/migration_portal/latest/) to assess Oracle database sources for schema compatibility before starting the data migration process. 
+
+EDB's Migration Portal offers the ability to [migrate database schema](https://www.enterprisedb.com/docs/migration_portal/latest/04_mp_migrating_database/03_mp_schema_migration/) through either an offline file export or a live application to the destination cluster.
+
+# Other Migrations
+
+For migrations to and from Postgres we recommend using [EDBs Migration Toolkit](https://deploy-preview-5759--edb-docs-staging.netlify.app/docs/migration_toolkit/latest/) to manage schema. MTK's [offline migration](https://www.enterprisedb.com/docs/migration_toolkit/latest/07_invoking_mtk/08_mtk_command_options/#offline-migration-options) capability provides an easy way to extract database schema.
+
+Tools such as `pg_dump` and `pg_restore` are another valid route for migrating DDL.
+
+# Destination Database Schema Integrity and Performance Considerations
+
+The presence of destination database constraints, triggers, and WAL logging can impact migration performance. If the target database has limited resources or resource contention is detected during migration consider delayed application of database constraints.
+
+The impact of various constraints and settings are described below.
+
+## Identity and Deduplication constraints
+
+`PRIMARY KEY`
+`UNIQUE`
+
+These types of constraints are implicitly leveraged by EDB Transporter to provide an exactly-once-delivery guarantee when syncing data to the destination database. `PRIMARY KEY` and `UNIQUE` constraints should be applied before the data migration begins, while other types of constraints can be withheld until after data migration completes. `PRIMARY KEY` or `UNIQUE` is sufficient to achieve exactly-once-delivery.
+
+For rows in tables that do not have `PRIMARY KEY` or `UNIQUE` constraints it is only possible to achieve at-least-once delivery. Deduplication can be performed during integrity validation such as with [EDB LiveCompare](https://www.enterprisedb.com/docs/livecompare/latest/).
+
+## Performance Impacting Constraints
+
+The EDB Transporter Writer is able to apply change events in parallel against destination clusters. For data migrations, we can delay application of the following constraints until after data movement is complete:
+
+`FOREIGN KEY` / `REFERENCES`
+`CHECK`
+`CASCADE`
+`EXCLUDE`
+
+These constraints should be applied after a snapshot is done or the user signals the end of a streaming CDC migration.
+
+In particular, data migration can only proceed in serial if `FOREIGN KEY` constraints are present in the destination tables.
+
+Other types of constraints lead to unnecessary CPU and memory utilization given the context of an in-flight data migration from a consistent and referentially integral source database.
+
+For Oracle sources we recommend Migration Portal be used to separate constraints from other destination DDL. This is supported in the [offline migration experience](https://www.enterprisedb.com/docs/migration_portal/latest/04_mp_migrating_database/03_mp_schema_migration/#offline-migration).
+
+For other sources Migration Toolkit can be used with `-offlineMigration` can be used to [extract source schema](https://www.enterprisedb.com/docs/migration_toolkit/latest/07_invoking_mtk/08_mtk_command_options/#offline-migration-options). MTK automatically separates constraints from other DDL objects in the exported DDL.
+
+## Less Impactful Constraints
+
+`NOT NULL` does not impose a significant performance impact for destination clusters.

--- a/product_docs/docs/transporter/ba_preview/index.mdx
+++ b/product_docs/docs/transporter/ba_preview/index.mdx
@@ -3,7 +3,7 @@ title: EDB Transporter
 indexCards: simple
 deepToC: true
 directoryDefaults:
-  description: "EDB Transporter is a cloud-first migration solution based on Debezium and Kafka. Change-event data streaming enables secure, fault-tolerant, and performant migrations to BigAnimal, on-premise EPAS/Postgres, or other cloud-hosted databases."
+  description: "EDB Transporter is our PG AI integrated migration solution based on Debezium and Kafka. Change-event data streaming enables secure, fault-tolerant, and performant migrations to BigAnimal, on-premise EPAS/Postgres, or other cloud-hosted databases."
 navigation:
   - "#Concepts"
   - terminology
@@ -20,12 +20,10 @@ navigation:
 
 ---
 
-## Why to use EDB Transporter?
+## PG AI Migrations Powered By EDB Transporter
 
-EDB Transporter offers you an effective way to migrate database data from one database to another. It does this by using the technique known as change data capture (CDC). This process catches changes in a source database’s rows being made by applications and streams them to a destination database. It reshapes the data to the schema of the destination database.
+EDB Transporter offers a secure and fault-tolerant way to migrate database data to the PG AI platform. Using change data capture (CDC) and event streaming, source database row changes are replicated to the migration destination. Users are able to select a subset of their schemas' tables to migrate including support for schema, table, and column name remapping.
 
-By streaming the changes from one database to another, the process avoids the traditional “big bang” of exporting, converting, and importing that came with traditional migration.
+EDB Transporter is built on Apache Kafka and the open-source Debezium CDC platform.
 
-EDB Transporter is built on Kafka, a data-streaming technology, and Debezium, which uses that technology to move captured data between databases.
-
-When the source database is on premises or in a private cloud, then you need to install EDB Transporter’s Reader.
+Self-managed database sources required download and configuration of the EDB Transporter Reader.

--- a/product_docs/docs/transporter/ba_preview/limitations.mdx
+++ b/product_docs/docs/transporter/ba_preview/limitations.mdx
@@ -19,6 +19,6 @@ Unsupported Oracle data types include:
 - XML
 - Spatial
 
-Don't use EDB Transporter for replicating Oracle tables that contain blob, clob, or nclob columns and are expected to get UPDATE changes. Streaming UPDATE changes currently aren't handled correctly.
+Don't use EDB Transporter for replicating Oracle tables that contain BLOB, CLOB, or NCLOB columns that are expected to change. These types are supported for snapshots but are not captured in the streaming CDC replication.
 
-Also, `BINARY_FLOAT` and `BINARY_DOUBLE` types in Oracle might contain `Nan`, `+INF`, and `-INF` values. EDB Transporter doesn't support these values.
+`BINARY_FLOAT` and `BINARY_DOUBLE` types in Oracle that might contain `Nan`, `+INF`, and `-INF` values are not supported by EDB Transporter.

--- a/product_docs/docs/transporter/ba_preview/terminology.mdx
+++ b/product_docs/docs/transporter/ba_preview/terminology.mdx
@@ -5,15 +5,21 @@ description: Learn some basic concepts associated with EDB Transporter.
 
 This terminology is important to understand EDB Transporter functionality.
 
-## Kafka
+## Analytics Sync
+PG AI Analytics Sync is a type of replication/migration supported by EDB Transporter. EPAS and Postgres source database snapshots are transformed into Delta Lake format in CSP Object Storage -- exposed as PG AI Managed Storage Locations.
+
+## Apache Kafka
 Apache Kafka is an open-source, distributed-event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
 
-## Change data capture (CDC)
+## Change Data Capture (CDC)
 CDC is a set of software design patterns used to determine and track the data that changed (the *deltas*) so that you can take action using the changed data.
 
 ## Debezium
-Debezium is an open-source distributed platform for CDC.
+Debezium is a Java-based open-source platform for CDC. Debezium is supported by the Red Hat community.
 
-## Reader
-The reader uses Debezium to perform CDC operations on the source database and produce Kafka messages containing the change events.
+## Transporter Reader
+The Reader uses Debezium to perform CDC operations on the source database and produce Kafka messages containing the change events.
+
+## Transporter Writer
+The Writer consumes CDC events from Kafka and applies them to the destination database. For migrations to the PG AI platform the Writer is run and managed by EDB.
 


### PR DESCRIPTION
## What Changed?

I've updated some documentation content based on testing and review.

## Not In Scope

Anything unrelated to MP/MTK schema management. I made some small updates but am stopping to avoid scope creep.