### PR TITLE
fix efm auto.allow.hosts property description

### DIFF
--- a/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/4/04_configuring_efm/01_cluster_properties.mdx
@@ -614,12 +614,12 @@ ping.server.command=/bin/ping -q -c3 -w5
 
 <div id="auto_allow_hosts" class="registered_link"></div>
 
-Use the `auto.allow.hosts` property to instruct the server to use the addresses specified in the `.nodes` file of the first nostarts to update the allowed host list. Enabling this property by setting `auto.allow.hosts` to `true` can simplify cluster startup.
+Use the `auto.allow.hosts` property to instruct the server to use the addresses specified in the `.nodes` file of the first node to start to set the allowed host list. Enabling this property by setting `auto.allow.hosts` to `true` can simplify cluster startup.
 
 ```ini
-# Have the first nostarts automatically add the addresses
-# from its .nodes file to the allowed host list. This will make
-# it faster to start the cluster when the initial set of hosts
+# Have the first node started automatically add the addresses from
+# its .nodes file to the allowed host list. This will make it
+# faster to start the cluster when the initial set of hosts
 # is already known.
 auto.allow.hosts=false
 ```


### PR DESCRIPTION
I think something automated clobbered this, because the descriptive text and the property comment description both were garbled. The descriptive text now makes sense again, though it's a long sentence and I'm open to suggestions.

I changed "update" to "set" because there isn't actually a list to update since the cluster doesn't exist before starting this node. Am ok with going back though.

## What Changed?

