### PR TITLE
Debian 12 install topics - EDB*Plus, MTK, Replication Server

### DIFF
--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -69,6 +69,12 @@ products:
       - name: Debian 11
         arch: x86_64
         supported versions: [55]
+      - name: Debian 12
+        arch: x86_64
+        supported versions: [55]
+      - name: Debian 12
+        arch: arm64
+        supported versions: [55]
       - name: RHEL 8
         arch: ppc64le
         supported versions: [55]
@@ -420,6 +426,12 @@ products:
         supported versions: [41]
       - name: Debian 11
         arch: x86_64
+        supported versions: [41]
+      - name: Debian 12
+        arch: x86_64
+        supported versions: [41]
+      - name: Debian 12
+        arch: arm64
         supported versions: [41]
       - name: Ubuntu 20.04
         arch: x86_64
@@ -831,6 +843,12 @@ products:
         supported versions: [7]
       - name: Debian 11
         arch: x86_64
+        supported versions: [7]
+      - name: Debian 12
+        arch: x86_64
+        supported versions: [7]
+      - name: Debian 12
+        arch: arm64
         supported versions: [7]
       - name: Ubuntu 22.04
         arch: x86_64

--- a/product_docs/docs/edb_plus/41/installing/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/index.mdx
@@ -13,6 +13,7 @@ redirects:
 navigation:
   - linux_x86_64
   - linux_ppc64le
+  - linux_arm64
   - windows
   - configuring_linux_installation
 ---
@@ -39,7 +40,7 @@ Select a link to access the applicable installation instructions:
 
 - [Ubuntu 22.04](linux_x86_64/edbplus_ubuntu_22), [Ubuntu 20.04](linux_x86_64/edbplus_ubuntu_20)
 
-- [Debian 11](linux_x86_64/edbplus_debian_11)
+- [Debian 12](linux_x86_64/edbplus_debian_12), [Debian 11](linux_x86_64/edbplus_debian_11)
 
 ## Linux [IBM Power (ppc64le)](linux_ppc64le)
 
@@ -50,6 +51,12 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/edbplus_sles_15), [SLES 12](linux_ppc64le/edbplus_sles_12)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Debian and derivatives
+
+- [Debian 12](linux_arm64/edbplus_debian_12)
 
 ## Windows
 

--- a/product_docs/docs/edb_plus/41/installing/linux_arm64/edbplus_debian_12.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_arm64/edbplus_debian_12.mdx
@@ -1,0 +1,48 @@
+---
+navTitle: Debian 12
+title: Installing EDB*Plus on Debian 12 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /edb_plus/41/03_installing_edb_plus/install_on_linux/arm64/edbplus_deb12_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo apt-get -y install edb-edbplus
+```
+
+## Initial configuration
+
+After performing a Linux installation of EDB\*Plus, you must set the values of environment variables that allow EDB\*Plus to locate your Java installation:
+
+```shell
+export JAVA_HOME=<path_to_java>
+export PATH=<path_to_java>/bin:$PATH
+```

--- a/product_docs/docs/edb_plus/41/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_arm64/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Installing EDB*Plus on Linux AArch64 (ARM64)"
+navTitle: "On Linux ARM64"
+
+navigation:
+  - edbplus_debian_12
+---
+
+Operating system-specific install instructions are described in the corresponding documentation:
+
+### Debian and derivatives
+
+- [Debian 12](edbplus_debian_12)

--- a/product_docs/docs/edb_plus/41/installing/linux_x86_64/edbplus_debian_12.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_x86_64/edbplus_debian_12.mdx
@@ -1,0 +1,48 @@
+---
+navTitle: Debian 12
+title: Installing EDB*Plus on Debian 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /edb_plus/41/03_installing_edb_plus/install_on_linux/x86_amd64/edbplus_deb12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo apt-get -y install edb-edbplus
+```
+
+## Initial configuration
+
+After performing a Linux installation of EDB\*Plus, you must set the values of environment variables that allow EDB\*Plus to locate your Java installation:
+
+```shell
+export JAVA_HOME=<path_to_java>
+export PATH=<path_to_java>/bin:$PATH
+```

--- a/product_docs/docs/edb_plus/41/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_x86_64/index.mdx
@@ -18,6 +18,7 @@ navigation:
   - edbplus_sles_12
   - edbplus_ubuntu_22
   - edbplus_ubuntu_20
+  - edbplus_debian_12
   - edbplus_debian_11
 ---
 
@@ -52,5 +53,7 @@ Operating system-specific install instructions are described in the correspondin
 - [Ubuntu 22.04](edbplus_ubuntu_22)
 
 - [Ubuntu 20.04](edbplus_ubuntu_20)
+
+- [Debian 12](edbplus_debian_12)
 
 - [Debian 11](edbplus_debian_11)

--- a/product_docs/docs/eprs/7/installing/index.mdx
+++ b/product_docs/docs/eprs/7/installing/index.mdx
@@ -14,6 +14,7 @@ redirects:
 
 navigation:
   - linux_x86_64
+  - linux_arm64
   - linux_ppc64le
   - windows
   - installing_jdbc_driver
@@ -44,7 +45,7 @@ Select a link to access the applicable installation instructions:
 
 - [Ubuntu 22.04](linux_x86_64/eprs_ubuntu_22), [Ubuntu 20.04](linux_x86_64/eprs_ubuntu_20)
 
-- [Debian 11](linux_x86_64/eprs_debian_11)
+- [Debian 12](linux_x86_64/eprs_debian_12), [Debian 11](linux_x86_64/eprs_debian_11)
 
 ## Linux [IBM Power (ppc64le)](linux_ppc64le)
 
@@ -55,6 +56,12 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/eprs_sles_15), [SLES 12](linux_ppc64le/eprs_sles_12)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Debian and derivatives
+
+- [Debian 12](linux_arm64/eprs_debian_12)
 
 ## Windows
 

--- a/product_docs/docs/eprs/7/installing/linux_arm64/eprs_debian_12.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_arm64/eprs_debian_12.mdx
@@ -1,0 +1,61 @@
+---
+navTitle: Debian 12
+title: Installing Replication Server on Debian 12 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /eprs/7/03_installation/03_installing_rpm_package/arm64/eprs_deb12_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+You can install all Replication Server components with a single install command, or you may choose to install selected, individual components by installing only those particular packages.
+
+To install all Replication Server components:
+
+```shell
+sudo apt-get  -y install edb-xdb
+```
+
+To install an individual component:
+
+```shell
+sudo apt-get  -y install <package_name>
+```
+
+Where `<package_name>` is:
+
+| Package name         | Component                                                             |
+| -------------------- | --------------------------------------------------------------------- |
+| `edb-xdb-console`    | Replication console and the Replication Server command line interface |
+| `edb-xdb-publisher`  | Publication server                                                    |
+| `edb-xdb-subscriber` | Subscription server                                                   |
+
+## Initial configuration
+
+Before using Replication Server, you must download and install JDBC drivers. See [Installing a JDBC driver](/eprs/7/installing/installing_jdbc_driver) for details.

--- a/product_docs/docs/eprs/7/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_arm64/index.mdx
@@ -1,0 +1,21 @@
+---
+title: "Installing Replication Server on Linux AArch64 (ARM64)"
+navTitle: "On Linux ARM64"
+
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+# Leaf template: products/replication-server/arm64_index.njk
+
+redirects:
+  - /eprs/latest/03_installation/03_installing_rpm_package/x86_amd64/
+
+navigation:
+  - eprs_debian_12
+---
+
+Operating system-specific install instructions are described in the corresponding documentation:
+
+### Debian and derivatives
+
+- [Debian 12](eprs_debian_12)

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_debian_12.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/eprs_debian_12.mdx
@@ -1,0 +1,61 @@
+---
+navTitle: Debian 12
+title: Installing Replication Server on Debian 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /eprs/7/03_installation/03_installing_rpm_package/x86_amd64/eprs_deb12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+You can install all Replication Server components with a single install command, or you may choose to install selected, individual components by installing only those particular packages.
+
+To install all Replication Server components:
+
+```shell
+sudo apt-get  -y install edb-xdb
+```
+
+To install an individual component:
+
+```shell
+sudo apt-get  -y install <package_name>
+```
+
+Where `<package_name>` is:
+
+| Package name         | Component                                                             |
+| -------------------- | --------------------------------------------------------------------- |
+| `edb-xdb-console`    | Replication console and the Replication Server command line interface |
+| `edb-xdb-publisher`  | Publication server                                                    |
+| `edb-xdb-subscriber` | Subscription server                                                   |
+
+## Initial configuration
+
+Before using Replication Server, you must download and install JDBC drivers. See [Installing a JDBC driver](/eprs/7/installing/installing_jdbc_driver) for details.

--- a/product_docs/docs/eprs/7/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_x86_64/index.mdx
@@ -19,6 +19,7 @@ navigation:
   - eprs_sles_12
   - eprs_ubuntu_22
   - eprs_ubuntu_20
+  - eprs_debian_12
   - eprs_debian_11
 ---
 
@@ -53,5 +54,7 @@ Operating system-specific install instructions are described in the correspondin
 - [Ubuntu 22.04](eprs_ubuntu_22)
 
 - [Ubuntu 20.04](eprs_ubuntu_20)
+
+- [Debian 12](eprs_debian_12)
 
 - [Debian 11](eprs_debian_11)

--- a/product_docs/docs/migration_toolkit/55/installing/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/index.mdx
@@ -28,6 +28,7 @@ legacyRedirects:
 
 navigation:
   - linux_x86_64
+  - linux_arm64
   - linux_ppc64le
   - install_on_mac
   - install_on_windows
@@ -56,7 +57,7 @@ Select a link to access the applicable installation instructions:
 
 - [Ubuntu 22.04](linux_x86_64/mtk_ubuntu_22), [Ubuntu 20.04](linux_x86_64/mtk_ubuntu_20)
 
-- [Debian 11](linux_x86_64/mtk_debian_11)
+- [Debian 12](linux_x86_64/mtk_debian_12), [Debian 11](linux_x86_64/mtk_debian_11)
 
 ## Linux [IBM Power (ppc64le)](linux_ppc64le)
 
@@ -67,6 +68,12 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/mtk_sles_15), [SLES 12](linux_ppc64le/mtk_sles_12)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Debian and derivatives
+
+- [Debian 12](linux_arm64/mtk_debian_12)
 
 ## Macintosh
 

--- a/product_docs/docs/migration_toolkit/55/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_arm64/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Installing Migration Toolkit on Linux AArch64 (ARM64)"
+navTitle: "On Linux ARM64"
+
+navigation:
+  - mtk_debian_12
+---
+
+Operating system-specific install instructions are described in the corresponding documentation:
+
+### Debian and derivatives
+
+- [Debian 12](mtk_debian_12)

--- a/product_docs/docs/migration_toolkit/55/installing/linux_arm64/mtk_debian_12.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_arm64/mtk_debian_12.mdx
@@ -1,0 +1,43 @@
+---
+navTitle: Debian 12
+title: Installing Migration Toolkit on Debian 12 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /migration_toolkit/55/05_installing_mtk/install_on_linux/arm64/mtk55_deb12_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo apt-get -y install edb-migrationtoolkit
+```
+
+## Initial configuration
+
+Before invoking Migration Toolkit, you must download and install JDBC drivers for connecting to the source and target databases. See [Installing a JDBC driver](/migration_toolkit/latest/installing/installing_jdbc_driver/) for details.

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/index.mdx
@@ -18,6 +18,7 @@ navigation:
   - mtk_sles_12
   - mtk_ubuntu_22
   - mtk_ubuntu_20
+  - mtk_debian_12
   - mtk_debian_11
 ---
 
@@ -52,5 +53,7 @@ Operating system-specific install instructions are described in the correspondin
 - [Ubuntu 22.04](mtk_ubuntu_22)
 
 - [Ubuntu 20.04](mtk_ubuntu_20)
+
+- [Debian 12](mtk_debian_12)
 
 - [Debian 11](mtk_debian_11)

--- a/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_debian_12.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_x86_64/mtk_debian_12.mdx
@@ -1,0 +1,43 @@
+---
+navTitle: Debian 12
+title: Installing Migration Toolkit on Debian 12 x86_64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /migration_toolkit/55/05_installing_mtk/install_on_linux/x86_amd64/mtk55_deb12_x86
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo apt-get -y install edb-migrationtoolkit
+```
+
+## Initial configuration
+
+Before invoking Migration Toolkit, you must download and install JDBC drivers for connecting to the source and target databases. See [Installing a JDBC driver](/migration_toolkit/latest/installing/installing_jdbc_driver/) for details.


### PR DESCRIPTION
## What Changed?

Added Debian 12 install topics for EDB*Plus, MTK and replication server as per [Docs-750](https://enterprisedb.atlassian.net/browse/DOCS-750), [Docs-766](https://enterprisedb.atlassian.net/browse/DOCS-766), and [Docs-767](https://enterprisedb.atlassian.net/browse/DOCS-767).
