### PR TITLE
Fix PEM installer links

### DIFF
--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -678,22 +678,22 @@ products:
     platforms:
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 9
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: Debian 12
         arch: x86_64
         supported versions: [9]
@@ -702,45 +702,45 @@ products:
         supported versions: [9]
       - name: Debian 11
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 15
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 12
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 12
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
   - name: Postgres Enterprise Manager agent
     platforms:
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 9
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: Debian 12
         arch: x86_64
         supported versions: [9]
@@ -749,25 +749,25 @@ products:
         supported versions: [9]
       - name: Debian 11
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 15
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 12
         arch: x86_64
-        supported versions: [8, 9]
+        supported versions: [9]
       - name: SLES 12
         arch: ppc64le
-        supported versions: [8, 9]
+        supported versions: [9]
   - name: PostgreSQL
     platforms:
       - name: RHEL 8

--- a/install_template/templates/products/edb-postgres-extended-server/index.njk
+++ b/install_template/templates/products/edb-postgres-extended-server/index.njk
@@ -3,6 +3,7 @@
 
 {% block frontmatter %}
 {{super()}}
+description: Installation instructions for EDB Postgres Extended Server on Linux.
 {% endblock frontmatter %}
 {% block navigation %}
 {{- super() -}}

--- a/install_template/templates/products/postgres-enterprise-manager-server/base.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/base.njk
@@ -33,7 +33,7 @@ After fulfilling the prerequisites and completing the installation procedure des
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file. 
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
    
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_arm64/pem_debian_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_arm64/pem_debian_12.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_rhel_8.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_rhel_8.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_rhel_9.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_rhel_9.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_12.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_15.mdx
+++ b/product_docs/docs/pem/9/installing/linux_ppc64le/pem_sles_15.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_11.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_11.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_debian_12.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_other_linux_8.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_other_linux_8.mdx
@@ -28,7 +28,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_other_linux_9.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_other_linux_9.mdx
@@ -28,7 +28,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_8.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_8.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_9.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_rhel_9.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_12.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_12.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_15.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_sles_15.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_20.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_20.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_22.mdx
+++ b/product_docs/docs/pem/9/installing/linux_x86_64/pem_ubuntu_22.mdx
@@ -27,7 +27,7 @@ Before you begin the installation process:
 
 2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
 
-   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](/pem/8/installing/configuring_the_pem_server_on_linux.mdx).)
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
 
    - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
 

--- a/product_docs/docs/pge/15/installing/index.mdx
+++ b/product_docs/docs/pge/15/installing/index.mdx
@@ -2,6 +2,8 @@
 navTitle: Installing
 title: Installing EDB Postgres Extended Server on Linux
 
+description: Installation instructions for EDB Postgres Extended Server on Linux.
+
 navigation:
   - linux_x86_64
 ---

--- a/product_docs/docs/pge/16/installing/index.mdx
+++ b/product_docs/docs/pge/16/installing/index.mdx
@@ -1,7 +1,9 @@
 ---
 navTitle: Installing
 title: Installing EDB Postgres Extended Server on Linux
+
 description: Installation instructions for EDB Postgres Extended Server on Linux.
+
 navigation:
   - linux_x86_64
   - linux_arm64


### PR DESCRIPTION
## What Changed?

One link (per installation target) was pointing to PEM 8. This was always incorrect; now it also does not work.