### PR TITLE
Remove mentions of multihost support from agent to server

### DIFF
--- a/product_docs/docs/pem/9/pem_rel_notes/970_rel_notes.mdx
+++ b/product_docs/docs/pem/9/pem_rel_notes/970_rel_notes.mdx
@@ -12,7 +12,6 @@ New features, enhancements, bug fixes, and other changes in PEM 9.7.0 include:
 | Enhancement  | Added PGD extension details in the Core usage report.                                                                                                                                       |
 | Enhancement  | If max_connections is set to 1 in the `agent.cfg` file, PEM agent startup process makes it to 2 in the backend code to avoid PEM's probe data collection failure. [Support ticket: #101924] |
 | Enhancement  | Probes are now re-run on restart of agent and monitored server.                                                                                                                             |
-| Enhancement  | Added support for multi-host connection strings for the connections from agent to PEM Server.                                                                                               |
 | Enhancement  | Introduced v12 REST API to fix the API schema for alerts (GET) and alert templates (GET/PUT/POST).                                                                                          |
 | Bug&nbsp;fix | Fixed an issue where the version information was missing in the `pemworker` utility usage.                                                                                                  |
 | Bug&nbsp;fix | Fixed an issue with `reminder_notification_interval` setting. Now you can configure this parameter to a value less than 1 hour.                                                             |

--- a/product_docs/docs/pem/9/registering_agent.mdx
+++ b/product_docs/docs/pem/9/registering_agent.mdx
@@ -108,24 +108,6 @@ When invoking the pemworker utility, append command line options to the command 
 ## Advanced usage
 The following are some advanced options for PEM agent registration.
 
-### Registering multiple hosts for high availability
-
-If you are using PEM to manage multiple database servers for high availability, register your PEM agent with the primary, as well as any standby hosts. In a switchover scenario, registering all hosts allows the PEM agent to automatically recognize the new primary instance (that used to be a standby) without any manual intervention.
-
-If you don't register all hosts, the PEM agent won't be able to perform write queries on the new primary host until it is manually registered. 
-
-Use the `--pem-server` and `--pem-port` options to specify all hosts when registering the PEM agent: 
-
-```
-/usr/edb/pem/agent/bin/pemworker --register-agent \ --pem-server host1,host2 \ --pem-port 5444,5432
-``` 
-
-!!!note 
-   After configuring all hosts, the PEM agent tries to connect to a host in the specified order. However, it will only be able to connect to the host currently accepting connections, the primary host.
-!!! 
-
-See [Specifying Multiple Hosts](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS) for more information. 
-
 ### Setting the agent ID
 Each registered PEM agent must have a unique agent ID. The value `max(id)+1` is assigned to each agent ID unless a value is provided using the `-o` options as shown [below](#overriding-default-configurations---examples).
 


### PR DESCRIPTION
Due to an issue with the implementation,
we do not wish to document this as an official feature of PEM 9.7.0 at this time

