### PR TITLE
EPRS: fix to offline snapshot steps

### DIFF
--- a/product_docs/docs/eprs/7/05_smr_operation/03_creating_subscription/02_adding_subscription_database.mdx
+++ b/product_docs/docs/eprs/7/05_smr_operation/03_creating_subscription/02_adding_subscription_database.mdx
@@ -4,7 +4,7 @@ title: "Adding a subscription database"
 
 <div id="adding_subscription_database" class="registered_link"></div>
 
-You must identify to Replication Server the database for subscriptions. You do this buy creating a subscription database definition.
+To allow Replication Server to identify an instance as a database for subscription, you must create a subscription database definition.
 
 After you create the subscription database definition, a Subscription Database node representing that subscription database definition appears in the replication tree of the Replication Server console. Subscriptions created subordinate to this subscription database definition have their publications replicated to the database identified by the subscription database definition.
 

--- a/product_docs/docs/eprs/7/07_common_operations/09_offline_snapshot.mdx
+++ b/product_docs/docs/eprs/7/07_common_operations/09_offline_snapshot.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Loading tables from an external data source (offline snapshot)"
+deepToC: true
 ---
 
 <div id="offline_snapshot" class="registered_link"></div>
@@ -87,14 +88,13 @@ The default value is `true`.
 
 You can use an offline snapshot to first load the subscription tables of a single-master replication system. For a publication that's intended to have multiple subscriptions, you can create some of the subscriptions using the default Replication Server snapshot replication process as described in [Performing snapshot replication](../05_smr_operation/04_on_demand_replication/01_perform_replication/#perform_replication). You can create other subscriptions from an offline snapshot.
 
-To create a subscription from an offline snapshot:
+### Preparing the publication and subscription server configuration:
+
+Perform these steps before creating any subscriptions:
 
 1.  Register the publication server, add the publication database definition, and create the publication as described in [Creating a publication](../05_smr_operation/02_creating_publication/#creating_publication).
 
 1.  Register the subscription server and add the subscription database definition as described in [Registering a subscription server](../05_smr_operation/03_creating_subscription/01_registering_subscription_server/#registering_subscription_server) and [Adding a subscription database](../05_smr_operation/03_creating_subscription/02_adding_subscription_database/#adding_subscription_database).
-
-    !!! Note
-        You must perform steps 3 and 4 before creating the subscription. You can repeat steps 5 through 9 each time you want to create another subscription from an offline snapshot.
 
 1.  Modify the publication server configuration file if these options aren't already set as described by the following:
 
@@ -103,9 +103,17 @@ To create a subscription from an offline snapshot:
 
 1.  If you modified the publication server configuration file in Step 3, reload configuration of the publication server. See ["Reloading the Publication or Subscription Server Configuration File (reloadconf)"](../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions on reloading the publication server's configuration.
 
-1.  In the subscription database, create the schema and the subscription table definitions, and load the subscription tables from your offline data source. The subscription database user name used in [Adding a subscription database](../05_smr_operation/03_creating_subscription/02_adding_subscription_database/#adding_subscription_database) must have full privileges over the database objects created in this step. Also review the beginning of [Adding a subscription database](../05_smr_operation/03_creating_subscription/02_adding_subscription_database/#adding_subscription_database) regarding the rules as to how Replication Server creates the subscription definitions from the publication for each database type. You must follow these same conventions when you create the target definitions manually.
+### Creating subscription servers 
+
+Execute these steps to create a subscription from an offline snapshot. Repeat them for each additional subscription. 
 
 1.  Add the subscription as described in [Adding a subscription](../05_smr_operation/03_creating_subscription/03_adding_subscription/#adding_subscription).
+
+1.  In the subscription database, create the schema and the subscription table definitions, and load the subscription tables from your offline data source. The subscription database user name used in [Adding a subscription database](../05_smr_operation/03_creating_subscription/02_adding_subscription_database/#adding_subscription_database) must have full privileges over the database objects created in this step. Also review the beginning of [Adding a subscription database](../05_smr_operation/03_creating_subscription/02_adding_subscription_database/#adding_subscription_database) regarding the rules as to how Replication Server creates the subscription definitions from the publication for each database type. You must follow these same conventions when you create the target definitions manually.
+
+    !!!note 
+    Ensure you synchronize the offline data source from the source Publication database after you have completed the creation of a subscription. Otherwise, certain changes from the source database won't be replicated.
+    !!!
 
 1.  Perform an on-demand synchronization replication. See [Performing synchronization replication](../05_smr_operation/04_on_demand_replication/02_perform_sync_replication/#perform_sync_replication) to learn how to perform an on-demand synchronization replication.
 
@@ -120,12 +128,11 @@ You can use an offline snapshot to first load the primary nodes of a multi-maste
 !!! Note
     Offline snapshots aren't supported for a multi-master replication system that's actively in use. Any changes on an active primary node are lost during the offline snapshot process of dumping or restoring the data of another node.
 
-To create a primary node from an offline snapshot:
+### Preparing the publication and subscription server configurations:
+
+Perform these steps before adding primary nodes:
 
 1.  Register the publication server, add the primary definition node, and create the publication as described in [Creating a publication](../06_mmr_operation/02_creating_publication_mmr/#creating_publication_mmr).
-
-    !!! Note
-        You must perform the steps 3 and 4 before adding a primary node to be loaded by an offline snapshot. You can repeat Steps 5 through 10 each time you want to create another primary node from an offline snapshot.
 
 1.  Be sure there's no schedule defined on the replication system. If there is, remove the schedule until you complete this process. See [Removing a schedule](03_managing_schedule/#remove_schedule) for details.
 
@@ -136,9 +143,17 @@ To create a primary node from an offline snapshot:
 
 1.  If you modified the publication server configuration file in step 3, reload configuration of the publication server. See ["Reloading the Publication or Subscription Server Configuration File (reloadconf)" ](../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions to reload the publication server's configuration.
 
-1.  In the database to use as the new primary node, create the schema and the table definitions, and load the tables from your offline data source.
+### Adding primary nodes 
+
+Execute these steps to add a primary node from an offline snapshot. Repeat them for each additional primary node.
 
 1.  Add the primary node as described in [Creating more primary nodes](../06_mmr_operation/03_creating_primary_nodes/#creating_primary_nodes) with the options **Replicate Publication Schema** and **Perform Initial Snapshot** cleared.
+
+1.  In the database to use as the new primary node, create the schema and the table definitions, and load the tables from your offline data source.
+
+    !!!note
+    Ensure you synchronize the offline data source from the source Publication database after you have added the target node in the MMR cluster. Otherwise, certain changes from the source database won't be replicated.
+    !!!
 
 1.  Perform an initial on-demand synchronization. See [Performing synchronization replication](../06_mmr_operation/05_on_demand_replication_mmr/#perform_synchronization_replication_mmr) to learn how to perform an on demand-synchronization.
 

--- a/product_docs/docs/eprs/7/07_common_operations/09_offline_snapshot.mdx
+++ b/product_docs/docs/eprs/7/07_common_operations/09_offline_snapshot.mdx
@@ -101,7 +101,7 @@ Perform these steps before creating any subscriptions:
     -   Change the `offlineSnapshot` option to `true`. When you restart the publication server or reload the publication server's configuration via reloadconf, `offlineSnapshot` set to `true` has two effects. One is that creating a subscription doesn't create the schema and subscription table definitions in the subscription database as is done with the default setting. The other is that creating a subscription sets a column in the control schema indicating an offline snapshot is used to load this subscription.
     -   Set the `batchInitialSync` option to the appropriate setting for your situation as discussed at the end of [Non-batch mode synchronization](#non_batch_mode_sync).
 
-1.  If you modified the publication server configuration file in Step 3, reload configuration of the publication server. See ["Reloading the Publication or Subscription Server Configuration File (reloadconf)"](../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions on reloading the publication server's configuration.
+1.  If you modified the publication server configuration, reload the configuration. See [Reloading the Publication or Subscription Server Configuration File (reloadconf)](../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions on reloading the publication server's configuration.
 
 ### Creating subscription servers 
 
@@ -112,14 +112,14 @@ Execute these steps to create a subscription from an offline snapshot. Repeat th
 1.  In the subscription database, create the schema and the subscription table definitions, and load the subscription tables from your offline data source. The subscription database user name used in [Adding a subscription database](../05_smr_operation/03_creating_subscription/02_adding_subscription_database/#adding_subscription_database) must have full privileges over the database objects created in this step. Also review the beginning of [Adding a subscription database](../05_smr_operation/03_creating_subscription/02_adding_subscription_database/#adding_subscription_database) regarding the rules as to how Replication Server creates the subscription definitions from the publication for each database type. You must follow these same conventions when you create the target definitions manually.
 
     !!!note 
-    Ensure you synchronize the offline data source from the source Publication database after you have completed the creation of a subscription. Otherwise, certain changes from the source database won't be replicated.
+    Ensure you don't load the offline data source from the source Publication database until after you complete the creation of a subscription. Otherwise, certain changes from the source database won't be replicated.
     !!!
 
 1.  Perform an on-demand synchronization replication. See [Performing synchronization replication](../05_smr_operation/04_on_demand_replication/02_perform_sync_replication/#perform_sync_replication) to learn how to perform an on-demand synchronization replication.
 
 1.  If you aren't planning to load any other subscriptions using an offline snapshot at this time, change the `offlineSnapshot` option back to `false` and the `batchInitialSync` option to `true` in the publication server configuration file.
 
-1.  If you modified the publication server configuration file in step 8, reload configuration of the publication server.
+1.  If you modified the publication server configuration, reload the configuration file.
 
 ## Multi-master replication offline snapshot
 
@@ -141,7 +141,7 @@ Perform these steps before adding primary nodes:
     -   Set the `offlineSnapshot` option to `true`. When you restart the publication server or reload the publication server's configuration via reloadconf, this setting has the effect that adding a primary node sets a column in the control schema indicating an offline snapshot is used to load this primary node.
     -   Set the `batchInitialSync` option to the appropriate setting for your situation as discussed at the end of [Non-batch mode synchronization](#non_batch_mode_sync).
 
-1.  If you modified the publication server configuration file in step 3, reload configuration of the publication server. See ["Reloading the Publication or Subscription Server Configuration File (reloadconf)" ](../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions to reload the publication server's configuration.
+1.  If you modified the publication server configuration file, reload the configuration. See [Reloading the Publication or Subscription Server Configuration File (reloadconf)](../05_smr_operation/02_creating_publication/01_registering_publication_server/#registering_publication_server) for directions to reload the publication server's configuration.
 
 ### Adding primary nodes 
 
@@ -152,13 +152,13 @@ Execute these steps to add a primary node from an offline snapshot. Repeat them 
 1.  In the database to use as the new primary node, create the schema and the table definitions, and load the tables from your offline data source.
 
     !!!note
-    Ensure you synchronize the offline data source from the source Publication database after you have added the target node in the MMR cluster. Otherwise, certain changes from the source database won't be replicated.
+    Ensure you don't load the offline data source from the source Publication database until after you add the target node in the MMR cluster. Otherwise, certain changes from the source database won't be replicated.
     !!!
 
 1.  Perform an initial on-demand synchronization. See [Performing synchronization replication](../06_mmr_operation/05_on_demand_replication_mmr/#perform_synchronization_replication_mmr) to learn how to perform an on demand-synchronization.
 
 1.  If you aren't planning to load any other primary nodes using an offline snapshot at this time, change the `offlineSnapshot` option back to `false` and the `batchInitialSync` option to `true` in the publication server configuration file.
 
-1.  If you modified the publication server configuration file in step 8, reload configuration of the publication server.
+1.  If you modified the publication server configuration, reload the configuration file.
 
 1.  Add the schedule again if you removed it. See [Creating a schedule](02_creating_schedule/#creating_schedule) to learn how to create a schedule.


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/DOCS-950
https://enterprisedb.atlassian.net/browse/XDB-2225

- Subscription creation must happen before any other subscription objects are added. ➡️  steps have been swapped in the order. 
- Subscription creation must happen before any synchronization attempts. ➡️ added note
- As a standard in documentation, we should refrain from referring to specific numbered steps (e.g. repeat steps 5-10 for each new node). This increases the risk of steps moving, being added or deleted and the docs becoming outdated ➡️  Added level 3 headings (h3) to separate what must happen once vs. what mus happen several times for each subscription, so we don't have to refer to the step numbers. 
- Fixed a typo and improved introductory phrase on the 02_adding_subscription_database.mdx page.