### PR TITLE
Fix backtick line formatting

### DIFF
--- a/product_docs/docs/pgd/5/scaling.mdx
+++ b/product_docs/docs/pgd/5/scaling.mdx
@@ -127,8 +127,8 @@ The expression is evaluated each time the system checks for new partitions.
 For a partitioned table on column type `integer`, you can specify the
 `partition_autocreate_expression` as `SELECT max(partcol) FROM
 schema.partitioned_table`. The system then regularly checks if the maximum value
-of the partitioned column is within the distance of `minimum_advance_partitions
-* partition_increment` of the last partition's upper bound. Create an index on
+of the partitioned column is within the distance of `minimum_advance_partitions * partition_increment`
+of the last partition's upper bound. Create an index on
 the `partcol` so that the query runs efficiently. If you don't specify the
 `partition_autocreate_expression` for a partition table on column type
 `integer`, `smallint`, or `bigint`, then the system sets it to `max(partcol)`.


### PR DESCRIPTION
## What Changed?

In https://www.enterprisedb.com/docs/pgd/latest/scaling/.

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/2d4e2b05-6ba6-4347-95a9-85a33b6a299f">
