### PR TITLE
Update working-with-ai-data-in-postgres.mdx

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-ml/using-tech-preview/working-with-ai-data-in-postgres.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-ml/using-tech-preview/working-with-ai-data-in-postgres.mdx
@@ -118,7 +118,7 @@ __OUTPUT__
 (5 rows)
 ```
 
-### Working without auto embedding
+## Working without auto embedding
 
 You can now create a retriever without auto embedding. This means that the application has control over when the embeddings computation occurs. It also means that the computation is a bulk operation. For demonstration you can simply create a second retriever for the same products table that you just previously created the first retriever for, but setting `auto_embedding` to false.
 


### PR DESCRIPTION
I believe that `Working without auto embedding` should be on the same level with `Working with auto embedding`. 

And there is a missing quick link of `Working without auto embedding` on the right side.

## What Changed?

