### PR TITLE
Changed wording to remove references to Eager All-Node Replication from Known Issue

### DIFF
--- a/product_docs/docs/pgd/5/known_issues.mdx
+++ b/product_docs/docs/pgd/5/known_issues.mdx
@@ -41,9 +41,7 @@ release.
     Adding or removing a pair doesn't require a restart of Postgres or even a
     reload of the configuration.
 
--   Group Commit can't be combined with [CAMO](durability/camo/) or [Eager
-    All-Node Replication](consistency/eager/). Eager Replication currently works
-    only by using the global PGD commit scope.
+-   Group Commit can't be combined with [CAMO](durability/camo/). 
 
 -   Transactions using Eager Replication can't yet execute DDL. The TRUNCATE
     command is allowed.


### PR DESCRIPTION
It looks like there was a Known Issue left over from PGD version 4 that made it into 5, even though things had changed for 5. Namely, it was the case in version 4 that Group Commit was incompatible with Eager Replication, but now it is actually a conflict resolution option of Group Commit, replacing the global scope: "The global scope no longer exists. To create scope with the same behavior, use [Group Commit](https://www.enterprisedb.com/docs/pgd/latest/durability/group-commit/)."


