### PR TITLE
PEM - Probes target type fix

### DIFF
--- a/product_docs/docs/pem/9/monitoring_performance/probes.mdx
+++ b/product_docs/docs/pem/9/monitoring_performance/probes.mdx
@@ -178,18 +178,18 @@ Use the **General** tab to modify the definition of an existing probe or to spec
     - The **Mandatory columns** column indicates the coloumns you must configure in the probe query to ensure the required data is collected.
     - The **Probe examples** column provides some existing probes you can explore to better understand how probes are used in practice.
 
-    | Target type | Execution level | Mandatory columns                                    | Probe examples |
-    |-------------|-----------------|------------------------------------------------------|----------------|
-    | Agent       | Agent           | None                                                 | cpu_usage      |
-    | Server      | Server          | None                                                 |                |
-    | Database    | Database        | None                                                 |                |
-    | Schema      | Database        | schema_name                                          |                |
-    | Table       | Database        | schema_name, table_name                              |                |
-    | Index       | Database        | schema_name, index_name                              | index_size     |
-    | Sequence    | Database        | schema_name, sequence_name                           |                |
-    | View        | Database        | schema_name, view_name                               |                |
-    | Function    | Database        | schema_name, arg_types, function_type, function_name |                |
-    | Extension   | Extension       | None                                                 | Extension      |
+    | Target type | Execution level | Mandatory columns                                    | Probe examples      |
+    |-------------|-----------------|------------------------------------------------------|---------------------|
+    | Agent       | Agent           | None                                                 | cpu_usage           |
+    | Server      | Server          | None                                                 | server_info         |
+    | Database    | Database        | None                                                 | database_size       |
+    | Schema      | Database        | schema_name                                          | oc_extension        |
+    | Table       | Database        | schema_name, table_name                              | table_size          |
+    | Index       | Database        | schema_name, index_name                              | index_size          |
+    | Sequence    | Database        | schema_name, sequence_name                           | oc_sequence         |
+    | View        | Database        | schema_name, view_name                               | mview_size          |
+    | Function    | Database        | schema_name, arg_types, function_type, function_name | function_statistics |
+    | Extension   | Extension       | None                                                 | bdr_node_summary    |
 
     !!!note
     - The custom probes set to a database or larger target type (including schema, table, index, view, sequence, and functions) collect the information at the database level. 


### PR DESCRIPTION
## What Changed?

Added remaining probe examples to the Target type table as per [PEM-5115](https://enterprisedb.atlassian.net/browse/PEM-5115)





[PEM-5115]: https://enterprisedb.atlassian.net/browse/PEM-5115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ