### PR TITLE
Added note on non-ascii characters not being supported

### DIFF
--- a/advocacy_docs/supported-open-source/postgresql/installing/windows.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/windows.mdx
@@ -30,7 +30,7 @@ Rather than use the EDB installer, you can also obtain a prebuilt installation p
 To perform an installation using the graphical installation wizard, you need superuser or administrator privileges.
 
 !!!note Notes
-   - Multi-byte, non-ascii characters are not supported in user or machine names.
+   - EDB doesn't support all non-ASCII, multi-byte characters in user or machine names. Use ASCII characters only to avoid installation errors related to unsupported path names.
    - If you're using the graphical installation wizard to perform a system ***upgrade***, the installer preserves the configuration options specified during the previous installation.
 !!!
 


### PR DESCRIPTION
## What Changed?

We found a Jira (https://enterprisedb.atlassian.net/browse/DOCS-1007) for an old GitHub issue https://github.com/EnterpriseDB/docs/issues/3490. 

The conclusion of the discussion was that we need a note with a disclaimer that non-ascii characters are not supported for user or machine names for PostgreSQL installations/upgrades to work on Windows with the wizard. 
