### PR TITLE
Included schema scope options for `-allSchemas` and multiple schemas on Invoking MTK page

### DIFF
--- a/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
+++ b/product_docs/docs/migration_toolkit/55/06_building_toolkit.properties_file.mdx
@@ -28,7 +28,7 @@ Before executing Migration Toolkit commands, modify the `toolkit.properties` fil
 
 !!! Note
 
-    Unless specified in the command line, Migration Toolkit expects the source database to be Oracle and the target database to be EDB Postgres Advanced Server. For any other source or target database, specify the `-sourcedbtype` or `-targetdbtype` options as described in [Migrating from a non-Oracle source database](/migration_toolkit/latest/07_invoking_mtk/#migrating-from-a-non-oracle-source-database).
+    Unless specified in the command line, Migration Toolkit expects the source database to be Oracle and the target database to be EDB Postgres Advanced Server. For any other source or target database, specify the `-sourcedbtype` or `-targetdbtype` options as described in [Migrating from a non-Oracle source database](/migration_toolkit/latest/07_invoking_mtk/#migrating-schemas-from-a-non-oracle-source-database).
 
 For specifying a target database on BigAnimal, see [Defining a BigAnimal URL](#defining-a-biganimal-url).
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -43,40 +43,40 @@ If you specify the `-offlineMigration` option in the command line, Migration Too
 !!! Note 
     The following examples invoke Migration Toolkit in Linux. To invoke Migration Toolkit in Windows, use the `runMTK.bat` command instead of the `runMTK.sh` command.
 
-To perform an offline migration of both schema and data, specify the `‑offlineMigration` keyword, followed by the schema name:
+To perform an offline migration of both schema and data, specify the `‑offlineMigration` keyword, followed by the [schema scope](../07_invoking_mtk/#migrating-schemas):
 
 ```shell
-./runMTK.sh -offlineMigration <schema_name>
+./runMTK.sh -offlineMigration <schema_scope>
 ```
 
-Each database object definition is saved in a separate file with a name derived from the schema name and object type in your home folder. To specify an alternative file destination, include a directory name after the `‑offlineMigration` option:
+Each database object definition is saved in a separate file with a name derived from each schema name and object type in your home folder. To specify an alternative file destination, include a directory name after the `‑offlineMigration` option:
 
 ```shell
-./runMTK.sh -offlineMigration <file_dest> <schema_name>
+./runMTK.sh -offlineMigration <file_dest> <schema_scope>
 ```
 
 To perform an offline migration of only schema objects (creating empty tables), specify the `‑schemaOnly` keyword in addition to the `‑offlineMigration` keyword when invoking Migration Toolkit:
 
 ```shell
-./runMTK.sh -offlineMigration -schemaOnly <schema_name>
+./runMTK.sh -offlineMigration -schemaOnly <schema_scope>
 ```
 
 To perform an offline migration of only data, omitting any schema object definitions, specify the `‑dataOnly` keyword and the `‑offlineMigration` keyword when invoking Migration Toolkit:
 
 ```shell
-./runMTK.sh -offlineMigration -dataOnly <schema_name>
+./runMTK.sh -offlineMigration -dataOnly <schema_scope>
 ```
 
 By default, data is written in COPY format. To write the data in a plain SQL format, include the `‑safeMode` keyword:
 
 ```shell
-./runMTK.sh -offlineMigration -dataOnly -safeMode <schema_name>
+./runMTK.sh -offlineMigration -dataOnly -safeMode <schema_scope>
 ```
 
 By default, when you perform an offline migration that contains table data, a separate file is created for each table. To create a single file that contains the data from multiple tables, specify the `‑singleDataFile` keyword:
 
 ```shell
-./runMTK.sh -offlineMigration -dataOnly -singleDataFile -safeMode <schema_name>
+./runMTK.sh -offlineMigration -dataOnly -singleDataFile -safeMode <schema_scope>
 ```
 
 !!! Note

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Invoking Migration Toolkit"
-
+description: "Learn how to perform a migration with the Migration Toolkit."
+deepToC: true
 ---
 
 <div id="invoking_mtk" class="registered_link"></div>
@@ -42,41 +43,48 @@ Migration Toolkit supports importing a column with a value of NULL. However, Mig
 
 Once the data is migrated, use a SQL statement to replace the character specified by `-replaceNullChar` with binary zeros.
 
-## Migrating a schema from Oracle
+## Migrating schemas
 
-Unless specified in the command line, Migration Toolkit expects the source database to be Oracle and the target database to be EDB Postgres Advanced Server. To migrate a complete schema on Linux, navigate to the executable and invoke the following command:
+When migrating schemas from the source database specified in the `toolkit.properties` file, you have the following options:
 
-`$ ./runMTK.sh <schema_name>`
+- To migrate a single schema, specify the schema name.
+- To migrate multiple schemas, provide a comma-delimited list of schema names.
+- To migrate all the schemas, use `-allSchemas` from the source database.
 
-To migrate a complete schema on Windows, navigate to the executable and invoke the following command:
+|                  | On Linux                                                     | On Windows                                                    |
+|------------------|--------------------------------------------------------------|---------------------------------------------------------------|
+| Single schema    | `$ ./runMTK.sh <schema_name>`                                | `> .\runMTK.bat <schema_name>`                                |
+| Multiple schemas | `$ ./runMTK.sh <schema_name1>,<schema_name2>,<schema_name3>` | `> .\runMTK.bat <schema_name1>,<schema_name2>,<schema_name3>` |
+| All schemas      | `$ ./runMTK.sh -allSchemas`                                  | `> .\runMTK.bat -allSchemas`                                  |
 
-`> .\runMTK.bat <schema_name>`
+### Migrating schemas from Oracle
 
-Where:
+Unless specified in the command line, Migration Toolkit expects the source database to be Oracle and the target database to be EDB Postgres Advanced Server. To migrate schemas, navigate to the executable and invoke the following command.
 
-`<schema_name>` is the schema you want to migrate from the source database specified in the `toolkit.properties` file. You can include a single `schema_name` value, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
+On Linux:
 
-!!! Note
-    - When the default database user of a migrated schema is automatically migrated, the custom profile of the default database user is also migrated if a custom profile exists. A custom profile is a user-created profile. For example, custom profiles exclude Oracle profiles `DEFAULT` and `MONITORING_PROFILE`.
-    - PostgreSQL default rows are limited to 8 KB in size. This means that each table row must fit into a single 8 KB block, Otherwise, an error occurs indicating, for example, that we can create a table with 1600 columns of INT and insert data for all the columns. However, we can't do the same with BIGINT columns because INT is stored as 4 bytes, but each BIGINT requires more space (8 bytes). For more information, see [PostgreSQL Limits](https://www.postgresql.org/docs/14/limits.html) in the PostgreSQL documentation.
+`$ ./runMTK.sh <schema_scope>`
 
-On Linux, execute the following command:
+On Windows:
 
-`$ ./runMTK.sh <schema_name1>,<schema_name2>,<schema_name3>`
+`> .\runMTK.bat <schema_scope>`
 
-On Windows, execute the following command:
+Where `<schema_scope>` is the scope of schemas to migrate from the source database specified in the `toolkit.properties` file. You can include a single value to migrate one schema, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
 
-`> .\runMTK.bat <schema_name1>,<schema_name2>,<schema_name3>`
+!!!note Notes
+   - When the default database user of a migrated schema is automatically migrated, the custom profile of the default database user is also migrated if a custom profile exists. A custom profile is a user-created profile. For example, custom profiles exclude Oracle profiles `DEFAULT` and `MONITORING_PROFILE`.
+   - PostgreSQL default rows are limited to 8 KB in size. This means that each table row must fit into a single 8 KB block, Otherwise, an error occurs indicating, for example, that we can create a table with 1600 columns of INT and insert data for all the columns. However, we can't do the same with BIGINT columns because INT is stored as 4 bytes, but each BIGINT requires more space (8 bytes). For more information, see [PostgreSQL Limits](https://www.postgresql.org/docs/14/limits.html) in the PostgreSQL documentation.
+!!!
 
 <div id="migrate_non_oracle" class="registered_link"></div>
 
-## Migrating from a non-Oracle source database
+### Migrating schemas from a non-Oracle source database
 
 If you don't specify a source database type and a target database type, Postgres assumes the source database is Oracle and the target database is EDB Postgres Advanced Server.
 
 To invoke Migration Toolkit, open a command window, navigate to the executable, and invoke the following command:
 
-`$ ./runMTK.sh -sourcedbtype <source_type> -targetdbtype <target_type> [options, …] <schema_name>;`
+`$ ./runMTK.sh -sourcedbtype <source_type> -targetdbtype <target_type> [options, …] <schema_scope>;`
 
 `-sourcedbtype <source_type>`
 
@@ -100,9 +108,9 @@ To invoke Migration Toolkit, open a command window, navigate to the executable, 
 | EDB Postgres Advanced Server | enterprisedb           |
 | PostgreSQL                   | postgres or postgresql |
 
-`<schema_name>`
+`<schema_scope>`
 
-`<schema_name>` is the schema you want to migrate from the source database specified in the `toolkit.properties` file. You can include a single `schema_name` value, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
+`<schema_scope>` represents the schemas to migrate from the source database specified in the `toolkit.properties` file. You can include a single value to migrate one schema, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
 
 The following example migrates a schema (table definitions and table content) named `HR` from a MySQL database on a Linux system to an EDB Postgres Advanced Server host. The command includes the `‑sourcedbtype` and `-targetdbtype` options.
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
@@ -8,6 +8,10 @@ deepToC: true
 
 After installing Migration Toolkit and specifying connection properties for the source and target databases in the [toolkit.properties file](../06_building_toolkit.properties_file), Migration Toolkit is ready to perform migrations.
 
+!!!note
+   Ensure the operating system user account running the Migration Toolkit is the owner of the `toolkit.properties` file with a minimum of read permission on the file. See [Invalid file permissions](../09_mtk_errors/#invalid-file-permissions) for more information.
+!!!
+
 The Migration Toolkit executable is named `runMTK.sh` on Linux systems and `runMTK.bat` on Windows systems. On a Linux system, the executable is located in:
 
 `/usr/edb/migrationtoolkit/bin`
@@ -17,21 +21,6 @@ On Windows, the executable is located in:
 `C:\Program Files\edb\mtk\bin`
 
 See [Migration Toolkit command options](08_mtk_command_options) for information on controlling details of the migration.
-
-
-!!! Note
-    If the following error appears upon invoking the Migration Toolkit, check the file permissions of the `toolkit.properties` file.
-
-```text
-MTK-11015: The connection credentials file ../etc/toolkit.properties is
-not secure and accessible to group/others users. This file contains
-plain passwords and should be restricted to Migration Toolkit owner user
-only.
-```
-
-The operating system user account running the Migration Toolkit must be the owner of the `toolkit.properties` file with a minimum of read permission on the file. In addition, there must be no permissions of any kind for group and other users. The following is an example of the recommended file permissions, where user enterprisedb is running the Migration Toolkit.
-
-`-rw------- 1 enterprisedb enterprisedb 191 Aug 1 09:59 toolkit.properties`
 
 ## Importing character data with embedded binary zeros (NULL characters)
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
@@ -54,13 +54,11 @@ To migrate a complete schema on Windows, navigate to the executable and invoke t
 
 Where:
 
-`<schema_name>` is the name of the schema in the source database specified in the `toolkit.properties` file that you want to migrate. You must include at least one `schema_name` value.
+`<schema_name>` is the schema you want to migrate from the source database specified in the `toolkit.properties` file. You can include a single `schema_name` value, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
 
 !!! Note
     - When the default database user of a migrated schema is automatically migrated, the custom profile of the default database user is also migrated if a custom profile exists. A custom profile is a user-created profile. For example, custom profiles exclude Oracle profiles `DEFAULT` and `MONITORING_PROFILE`.
     - PostgreSQL default rows are limited to 8 KB in size. This means that each table row must fit into a single 8 KB block, Otherwise, an error occurs indicating, for example, that we can create a table with 1600 columns of INT and insert data for all the columns. However, we can't do the same with BIGINT columns because INT is stored as 4 bytes, but each BIGINT requires more space (8 bytes). For more information, see [PostgreSQL Limits](https://www.postgresql.org/docs/14/limits.html) in the PostgreSQL documentation.
-
-You can migrate multiple schemas by following the command name with a comma-delimited list of schema names.
 
 On Linux, execute the following command:
 
@@ -104,7 +102,7 @@ To invoke Migration Toolkit, open a command window, navigate to the executable, 
 
 `<schema_name>`
 
-`<schema_name>` is the name of the schema in the source database specified in the `toolkit.properties` file that you want to migrate. You must include at least one `<schema_name>` value.
+`<schema_name>` is the schema you want to migrate from the source database specified in the `toolkit.properties` file. You can include a single `schema_name` value, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
 
 The following example migrates a schema (table definitions and table content) named `HR` from a MySQL database on a Linux system to an EDB Postgres Advanced Server host. The command includes the `‑sourcedbtype` and `-targetdbtype` options.
 
@@ -116,7 +114,7 @@ On Windows, use the following command:
 
 `> .\runMTK.bat -sourcedbtype mysql -targetdbtype enterprisedb HR`
 
-You can migrate multiple schemas from a source database by including a comma-delimited list of schemas at the end of the Migration Toolkit command. The following example migrates multiple schemas (named HR and ACCTG) from a MySQL database to a PostgreSQL database.
+The following example migrates multiple schemas (named HR and ACCTG) from a MySQL database to a PostgreSQL database.
 
 On Linux, use the following command:
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
@@ -34,7 +34,7 @@ Once the data is migrated, use a SQL statement to replace the character specifie
 
 ## Migrating schemas
 
-When migrating schemas from the source database specified in the [toolkit.properties file](../06_building_toolkit.properties_file), you have the following options:
+When migrating schemas from the source database specified in the [toolkit.properties file](../06_building_toolkit.properties_file), you have to provide the `<schema_scope>` for the migration. You have these options:
 
 - To migrate a single schema, specify the schema name.
 - To migrate multiple schemas, provide a comma-delimited list of schema names.

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
@@ -38,7 +38,7 @@ When migrating schemas from the source database specified in the [toolkit.proper
 
 - To migrate a single schema, specify the schema name.
 - To migrate multiple schemas, provide a comma-delimited list of schema names.
-- To migrate all the schemas, use `-allSchemas` from the source database.
+- To migrate all the schemas, use the `-allSchemas` option.
 
 These examples display how to execute the command depending on your operating system and schema scope.
 
@@ -68,7 +68,7 @@ Where `<schema_scope>` is the [scope of schemas](#migrating-schemas) to migrate 
 
 <details><summary>Single schema example</summary>
 
-The following example migrates a schema (table definitions and table content) named `HR` from an Oracle database to an EDB Postgres Advanced Server host.
+The following example migrates a schema (table definitions and table content) named `HR` from an Oracle database to an EDB Postgres Advanced Server database.
 
 On Linux:
 

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/index.mdx
@@ -45,11 +45,13 @@ Once the data is migrated, use a SQL statement to replace the character specifie
 
 ## Migrating schemas
 
-When migrating schemas from the source database specified in the `toolkit.properties` file, you have the following options:
+When migrating schemas from the source database specified in the [toolkit.properties file](../06_building_toolkit.properties_file), you have the following options:
 
 - To migrate a single schema, specify the schema name.
 - To migrate multiple schemas, provide a comma-delimited list of schema names.
 - To migrate all the schemas, use `-allSchemas` from the source database.
+
+These examples display how to execute the command depending on your operating system and schema scope.
 
 |                  | On Linux                                                     | On Windows                                                    |
 |------------------|--------------------------------------------------------------|---------------------------------------------------------------|
@@ -63,13 +65,74 @@ Unless specified in the command line, Migration Toolkit expects the source datab
 
 On Linux:
 
-`$ ./runMTK.sh <schema_scope>`
+```shell
+$ ./runMTK.sh <schema_scope>
+```
 
 On Windows:
 
-`> .\runMTK.bat <schema_scope>`
+```shell
+> .\runMTK.bat <schema_scope>
+```
 
-Where `<schema_scope>` is the scope of schemas to migrate from the source database specified in the `toolkit.properties` file. You can include a single value to migrate one schema, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
+Where `<schema_scope>` is the [scope of schemas](#migrating-schemas) to migrate which can be a single schema, multiple schemas, or all schemas from the specified database.
+
+<details><summary>Single schema example</summary>
+
+The following example migrates a schema (table definitions and table content) named `HR` from an Oracle database to an EDB Postgres Advanced Server host.
+
+On Linux:
+
+```shell
+$ ./runMTK.sh HR
+```
+
+On Windows:
+
+```shell
+> .\runMTK.bat HR
+```
+
+</details> 
+<br/>
+
+<details><summary>Multiple schemas example</summary> 
+
+The following example migrates multiple schemas (named HR and ACCTG) from an Oracle database to a PostgreSQL database.
+
+On Linux:
+
+```shell
+$ ./runMTK.sh -targetdbtype postgres HR,ACCTG
+```
+
+On Windows:
+
+```shell
+> .\runMTK.bat -targetdbtype postgres HR,ACCTG
+```
+
+</details>
+<br/>
+
+<details><summary>All schemas example</summary> 
+
+The following example migrates all schemas from the Oracle database specified in the [toolkit.properties file](../06_building_toolkit.properties_file) to an EDB Postgres Advanced Server database. 
+
+On Linux:
+
+```shell
+$ ./runMTK.sh -allSchemas
+```
+
+On Windows:
+
+```shell
+> .\runMTK.bat -allSchemas
+```
+
+</details>
+<br/>
 
 !!!note Notes
    - When the default database user of a migrated schema is automatically migrated, the custom profile of the default database user is also migrated if a custom profile exists. A custom profile is a user-created profile. For example, custom profiles exclude Oracle profiles `DEFAULT` and `MONITORING_PROFILE`.
@@ -84,7 +147,9 @@ If you don't specify a source database type and a target database type, Postgres
 
 To invoke Migration Toolkit, open a command window, navigate to the executable, and invoke the following command:
 
-`$ ./runMTK.sh -sourcedbtype <source_type> -targetdbtype <target_type> [options, …] <schema_scope>;`
+```shell
+$ ./runMTK.sh -sourcedbtype <source_type> -targetdbtype <target_type> [options, …] <schema_scope>;
+```
 
 `-sourcedbtype <source_type>`
 
@@ -110,24 +175,64 @@ To invoke Migration Toolkit, open a command window, navigate to the executable, 
 
 `<schema_scope>`
 
-`<schema_scope>` represents the schemas to migrate from the source database specified in the `toolkit.properties` file. You can include a single value to migrate one schema, a comma-delimited list of schema names, or you can use `-allSchemas` to migrate all the schemas from the source database.
+Where `<schema_scope>` is the [scope of schemas](#migrating-schemas) to migrate which can be a single schema, multiple schemas, or all schemas from the specified database.
+
+<details><summary>Single schema example</summary>
 
 The following example migrates a schema (table definitions and table content) named `HR` from a MySQL database on a Linux system to an EDB Postgres Advanced Server host. The command includes the `‑sourcedbtype` and `-targetdbtype` options.
 
-On Linux, use the following command:
+On Linux:
 
-`$ ./runMTK.sh -sourcedbtype mysql -targetdbtype enterprisedb HR`
+```shell
+$ ./runMTK.sh -sourcedbtype mysql -targetdbtype enterprisedb HR
+```
 
-On Windows, use the following command:
+On Windows:
 
-`> .\runMTK.bat -sourcedbtype mysql -targetdbtype enterprisedb HR`
+```shell
+> .\runMTK.bat -sourcedbtype mysql -targetdbtype enterprisedb HR
+```
+
+</details> 
+<br/>
+
+<details><summary>Multiple schemas example</summary> 
 
 The following example migrates multiple schemas (named HR and ACCTG) from a MySQL database to a PostgreSQL database.
 
-On Linux, use the following command:
+On Linux:
 
-`$ ./runMTK.sh -sourcedbtype mysql -targetdbtype postgres HR,ACCTG`
+```shell
+$ ./runMTK.sh -sourcedbtype mysql -targetdbtype postgres HR,ACCTG
+```
 
-On Windows, use the following command:
+On Windows:
 
-`> .\runMTK.bat -sourcedbtype mysql -targetdbtype postgres HR,ACCTG`
+```shell
+> .\runMTK.bat -sourcedbtype mysql -targetdbtype postgres HR,ACCTG
+```
+
+</details>
+<br/>
+
+<details><summary>All schemas example</summary> 
+
+The following example migrates all schemas from a PostgreSQL database specified in the [toolkit.properties file](../06_building_toolkit.properties_file) to an EDB Postgres Advanced Server database.
+
+!!! Note
+    The `-allSchemas` parameter is supported only for Oracle, EDB Postgres Advanced Server, and PostgreSQL source databases.
+
+On Linux:
+
+```shell
+$ ./runMTK.sh -sourcedbtype postgres -allSchemas
+```
+
+On Windows:
+
+```shell
+> .\runMTK.bat -sourcedbtype postgres -allSchemas
+```
+
+</details>
+<br/>

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/mtk_command_options_in_file/creating_txt_file.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/mtk_command_options_in_file/creating_txt_file.mdx
@@ -66,12 +66,12 @@ Specifying an option both at the command line and in the text file causes the mi
 
 ## Order of processing
 
-Migration Toolkit reads command line options and option files in the order you provide them when running the command. Ensure you add the [schema scope](executing_migration_with_txt/#provide-the-scope-for-the-schema-migration) (`schema_name` or `-allSchemas`) as the last parameter at the command line.
+Migration Toolkit reads command line options and option files in the order you provide them when running the command. Ensure you add the [schema scope](../../07_invoking_mtk/#migrating-schemas) as the last parameter at the command line.
 
-For example, if you run the following command, Migration Toolkit first recognizes the `-sourcedbtype oracle` option, and then reads the contents of `options_textfile` in order from top to bottom. The last parameter is the schema scope (`<schema_name>` or `-allSchemas`).
+For example, if you run the following command, Migration Toolkit first recognizes the `-sourcedbtype oracle` option, and then reads the contents of `options_textfile` in order from top to bottom. The last parameter is the `<schema_scope>`.
 
 ```shell
-runMTK.sh -sourcedbtype oracle -optionsFile options_textfile schema_name
+runMTK.sh -sourcedbtype oracle -optionsFile options_textfile <schema_scope>
 ```
 
 Using an options file means that you can employ different syntaxes to perform a migration where parameters are executed in the same way. The following alternatives perform the same migration.
@@ -79,7 +79,7 @@ Using an options file means that you can employ different syntaxes to perform a 
 **Alternative 1**
 
 ```shell
-runMTK.sh -sourcedbtype oracle -optionsFile <options_textfile> <schema_name>
+runMTK.sh -sourcedbtype oracle -optionsFile <options_textfile> <schema_scope>
 ```
 
 Where the content of the `<options_textfile>` file is:
@@ -92,7 +92,7 @@ dataOnly
 **Alternative 2**
 
 ```shell
-runMTK.sh -sourcedbtype oracle -optionsFile <options_textfile> -dataOnly <schema_name>
+runMTK.sh -sourcedbtype oracle -optionsFile <options_textfile> -dataOnly <schema_scope>
 ```
 
 Where the content of the `<options_textfile>` file is:

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/mtk_command_options_in_file/executing_migration_with_txt.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/mtk_command_options_in_file/executing_migration_with_txt.mdx
@@ -45,7 +45,7 @@ Syntax of the migration command:
 Command line equivalent:
 
 ```shell
-./runMTK.sh -tables comp_schema.emp,comp_schema.dept,finance_schema.acctg schema1
+./runMTK.sh -tables comp_schema.emp,comp_schema.dept,finance_schema.acctg comp_schema,finance_schema
 ```
 
 ## Use options file to exclude tables and include functions

--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/mtk_command_options_in_file/executing_migration_with_txt.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/mtk_command_options_in_file/executing_migration_with_txt.mdx
@@ -7,7 +7,7 @@ deepToC: true
 After you create the options file, reference it when executing the migration command:
 
 ```shell
-./runMTK.sh -optionsFile <options_textfile> <schema_name>
+./runMTK.sh -optionsFile <options_textfile> <schema_scope>
 ```
 
 !!!note
@@ -24,6 +24,8 @@ Specify the scope of the schemas to migrate:
 
 -   If you want to specify a subset of schemas, specify the schemas you want to migrate at the command line with no preceding option and as a comma-separated list. Schema specifications must be the last parameter at the command line.
 
+See [Migrating schemas](../../07_invoking_mtk/#migrating-schemas) for more information on `<schema_scope>`.
+
 Here are some examples for specifying all options in the file.
 
 ## Migrate a schema with specific tables
@@ -37,13 +39,13 @@ tables comp_schema.emp,comp_schema.dept,finance_schema.acctg
 Syntax of the migration command:
 
 ```shell
-./runMTK.sh -optionsFile options_textfile schema_name
+./runMTK.sh -optionsFile options_textfile schema1
 ```
 
 Command line equivalent:
 
 ```shell
-./runMTK.sh -tables comp_schema.emp,comp_schema.dept,finance_schema.acctg schema_name
+./runMTK.sh -tables comp_schema.emp,comp_schema.dept,finance_schema.acctg schema1
 ```
 
 ## Use options file to exclude tables and include functions
@@ -71,13 +73,13 @@ funcs finance_schema.add_two_numbers
 Syntax of the migration command:
 
 ```shell
-./runMTK.sh -allTables -optionsFile excludeInclude.options -safeMode -connRetryCount 7  schema_name
+./runMTK.sh -allTables -optionsFile excludeInclude.options -safeMode -connRetryCount 7  schema1
 ```
 
 Command line equivalent:
 
 ```shell
-./runMTK.sh  -allTables -excludeTables comp_schema.emp,finance_schema.jobhist,temp_schema.temp_table,more_schema.more_tables  -funcs finance_schema.add_two_numbers -safeMode -connRetryCount 7  schema_name
+./runMTK.sh  -allTables -excludeTables comp_schema.emp,finance_schema.jobhist,temp_schema.temp_table,more_schema.more_tables -funcs finance_schema.add_two_numbers -safeMode -connRetryCount 7  schema1
 ```
 
 ## Offline migration

--- a/product_docs/docs/migration_toolkit/55/09_mtk_errors.mdx
+++ b/product_docs/docs/migration_toolkit/55/09_mtk_errors.mdx
@@ -37,6 +37,23 @@ not valid to use to connect to the Oracle source database.
 
 To resolve this error, edit the `toolkit.properties` file, specifying the name and password of a valid user with privileges to perform the migration in the `SRC_DB_USER` and `SRC_DB_PASSWORD` properties.
 
+### Invalid file permissions
+
+*When I try to perform a migration with Migration Toolkit, I get the following error:*
+
+```text
+MTK-11015: The connection credentials file ../etc/toolkit.properties is
+not secure and accessible to group/others users. This file contains
+plain passwords and should be restricted to Migration Toolkit owner user
+only.
+```
+
+To resolve this error, ensure the operating system user account running the Migration Toolkit is the owner of the `toolkit.properties` file with a minimum of read permission on the file. In addition, there must be no permissions of any kind for group and other users. 
+
+The following is an example of the recommended file permissions, where user enterprisedb is running the Migration Toolkit.
+
+`-rw------- 1 enterprisedb enterprisedb 191 Aug 1 09:59 toolkit.properties`
+
 ### Connection rejected: FATAL: password
 
 *When I try to perform a migration with Migration Toolkit, I get the following error:*


### PR DESCRIPTION
## What Changed?

- I created a new section dedicated to schema_scope [here](https://deploy-preview-6032--edb-docs-staging.netlify.app/docs/migration_toolkit/latest/07_invoking_mtk/#migrating-schemas), where I added an overview table with the three possibilities per OS (single schema, multiple schemas, all schemas). 

- I added examples for each of the three schema scope variations in expandable sections for [migrations from Oracle](https://deploy-preview-6032--edb-docs-staging.netlify.app/docs/migration_toolkit/latest/07_invoking_mtk/#migrating-schemas) and also for migrations from [non-Oracle](https://deploy-preview-6032--edb-docs-staging.netlify.app/docs/migration_toolkit/latest/07_invoking_mtk/#migrating-schemas-from-a-non-oracle-source-database). I did this using expandable snippets. 

- The original "invoking MTK" page included an [MTK error message](https://www.enterprisedb.com/docs/migration_toolkit/latest/07_invoking_mtk/#:~:text=Copy-,MTK%2D11015,-%3A%20The%20connection%20credentials), which felt noisy and out of place. I moved that to the [error messages page](https://www.enterprisedb.com/docs/migration_toolkit/latest/07_invoking_mtk/#:~:text=Copy-,MTK%2D11015,-%3A%20The%20connection%20credentials). But also made sure to drop a note telling customers about the minimal toolkit.properties permissions required to run the command.

- I altered mentions of <schema_name> to <schema_scope> in most places. In some spots where  <schema_name> refers to the actual name of the schema, I left it untouched.

https://enterprisedb.atlassian.net/browse/DOCS-1022