### PR TITLE
Style guide: full stop in frontmatter descriptions

### DIFF
--- a/advocacy_docs/community/contributing/styleguide.mdx
+++ b/advocacy_docs/community/contributing/styleguide.mdx
@@ -661,16 +661,16 @@ because the symbol can affect how search engines index and find pages.
 
 ## Frontmatter 
 
-The frontmatter is located at the top of every markdown page, and allows you to specify metadata and options in YAML language. Frontmatter lets you control how a page will render.
+The frontmatter is located at the top of every Markdown page and allows you to specify metadata and options in YAML language. Frontmatter lets you control how a page renders.
 
-Ensure your page, at minimum, includes a `title` and `description` as metadata. It can include other metadata such as `navTitle`, `deepToC`, etc. 
+Ensure your page, at minimum, includes a `title` and `description` as metadata. It can include other metadata such as `navTitle`, `deepToC`, and so on. 
 
 ```yaml
 ---
-title: Working with the Repo
-description: Step by step instructions to install and use the docs repo.
+title: Working with the repo
+description: Step-by-step instructions to install and use the docs repo.
 ---
 ```
 
 !!!note
-   Ensure the `description` has a final stop, even if it isn't a full grammatical sentence. Descriptions are used to dynamically build a summary for each section in `index` pages. Since all descriptions are then displayed next to each other, add a full stop to ensure visual consistency.
+   Ensure the `description` has a final stop (period), even if it isn't a full grammatical sentence. Descriptions are used to dynamically build a summary for each section in `index` pages. Since all descriptions are then displayed next to each other, add a full stop to ensure visual consistency.

--- a/advocacy_docs/community/contributing/styleguide.mdx
+++ b/advocacy_docs/community/contributing/styleguide.mdx
@@ -74,6 +74,7 @@ Included in this guide:
 * 13 [Dates](#dates)
 * 14 [Terminology considerations](#terminology-considerations)
 * 15 [Trademark symbols](#trademark-symbols)
+* 16 [Frontmatter](#frontmatter)
 
 ## Language and tone
 
@@ -657,3 +658,19 @@ Examples: EDB Postgres® AI, EDB Postgres® Analytics, EDB Postgres® Machine Le
 For other trademarks, the documentation site already includes a general disclaimer at the footer of every page called "Trademark" which links to https://www.enterprisedb.com/trademarks.
 Contrary to the specifications on [Trademarks](https://www.enterprisedb.com/trademarks), don't include the symbol in page titles, 
 because the symbol can affect how search engines index and find pages.
+
+## Frontmatter 
+
+The frontmatter is located at the top of every markdown page, and allows you to specify metadata and options in YAML language. Frontmatter lets you control how a page will render.
+
+Ensure your page, at minimum, includes a `title` and `description` as metadata. It can include other metadata such as `navTitle`, `deepToC`, etc. 
+
+```yaml
+---
+title: Working with the Repo
+description: Step by step instructions to install and use the docs repo.
+---
+```
+
+!!!note
+   Ensure the `description` has a final stop, even if it isn't a full grammatical sentence. Descriptions are used to dynamically build a summary for each section in `index` pages. Since all descriptions are then displayed next to each other, add a full stop to ensure visual consistency.


### PR DESCRIPTION
## What Changed?

Since page descriptions are being used to dynamically add summary tiles to index pages, we should probably make frontmatter descriptions obligatory. I think we should then also make full stops for descriptions a style guide requirement, so that tiles look consistent when displayed next to other pages' descriptions. 

See screenshot for example:

E.g. 
![Screenshot 2024-09-09 at 14 37 10](https://github.com/user-attachments/assets/75b96844-9606-4772-8c1f-1174f144fa7b)

WDYT?
