### PR TITLE
Fixed references to bdr.raft_local_election_timeout in the docs.

### DIFF
--- a/product_docs/docs/pgd/5/reference/index.json
+++ b/product_docs/docs/pgd/5/reference/index.json
@@ -160,7 +160,7 @@
   "bdrglobal_keepalives_count": "/pgd/latest/reference/pgd-settings#bdrglobal_keepalives_count",
   "bdrglobal_tcp_user_timeout": "/pgd/latest/reference/pgd-settings#bdrglobal_tcp_user_timeout",
   "bdrraft_global_election_timeout": "/pgd/latest/reference/pgd-settings#bdrraft_global_election_timeout",
-  "bdrraft_local_election_timeout": "/pgd/latest/reference/pgd-settings#bdrraft_local_election_timeout",
+  "bdrraft_group_election_timeout": "/pgd/latest/reference/pgd-settings#bdrraft_group_election_timeout",
   "bdrraft_response_timeout": "/pgd/latest/reference/pgd-settings#bdrraft_response_timeout",
   "bdrraft_keep_min_entries": "/pgd/latest/reference/pgd-settings#bdrraft_keep_min_entries",
   "bdrraft_log_min_apply_duration": "/pgd/latest/reference/pgd-settings#bdrraft_log_min_apply_duration",

--- a/product_docs/docs/pgd/5/reference/index.mdx
+++ b/product_docs/docs/pgd/5/reference/index.mdx
@@ -228,7 +228,7 @@ The reference section is a definitive listing of all functions, views, and comma
  * [`bdr.global_tcp_user_timeout`](pgd-settings#bdrglobal_tcp_user_timeout)
 ### [Internal settings - Raft timeouts](pgd-settings#internal-settings---raft-timeouts)
  * [`bdr.raft_global_election_timeout`](pgd-settings#bdrraft_global_election_timeout)
- * [`bdr.raft_local_election_timeout`](pgd-settings#bdrraft_local_election_timeout)
+ * [`bdr.raft_group_election_timeout`](pgd-settings#bdrraft_group_election_timeout)
  * [`bdr.raft_response_timeout`](pgd-settings#bdrraft_response_timeout)
 ### [Internal settings - Other Raft values](pgd-settings#internal-settings---other-raft-values)
  * [`bdr.raft_keep_min_entries`](pgd-settings#bdrraft_keep_min_entries)

--- a/product_docs/docs/pgd/5/reference/pgd-settings.mdx
+++ b/product_docs/docs/pgd/5/reference/pgd-settings.mdx
@@ -579,7 +579,7 @@ To account for network failures, the Raft consensus protocol implements timeouts
 for elections and requests. This value is used when a request is
 being sent to the global (top-level) group. The default is 6 seconds (6s).
 
-### `bdr.raft_local_election_timeout`
+### `bdr.raft_group_election_timeout`
 
 To account for network failures, the Raft consensus protocol implements timeouts
 for elections and requests. This value is used when a request is
@@ -589,7 +589,7 @@ being sent to the sub-group. The default is 3 seconds (3s).
 
 For responses, the settings of
 [`bdr.raft_global_election_timeout`](#bdrraft_global_election_timeout) and
-[`bdr.raft_local_election_timeout`](#bdrraft_local_election_timeout) are used
+[`bdr.raft_group_election_timeout`](#bdrraft_group_election_timeout) are used
 as appropriate. You can override this behavior by setting
 this variable. The setting of `bdr.raft_response_timeout` must be less than
 either of the election timeout values. Set this variable to -1 to disable the override.


### PR DESCRIPTION
## What Changed?

Fixed references.