### PR TITLE
DMS: migration stop

### DIFF
--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/mark_completed.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/mark_completed.mdx
@@ -2,7 +2,11 @@
 title: "Mark migration as completed"
 ---
 
-The EDB DMS Reader will continue to stream any data updates performed on the source database to the target database until you mark the migration as completed. Check that your data is present in the target database before you mark it as completed. 
+The EDB DMS Reader will continue to stream any data updates performed on the source database to the target database until you mark the migration as completed.
+
+It is important that you carefully select the best time to stop the data migration stream. Ensure no new inserts are executed in the source and verify that the last known inserts have been synchronized in the target.
+
+After checking that your data is present in the target database you can stop the stream by marking the migration as completed.
 
 1.  In the [EDB Postgres AI Console](https://portal.biganimal.com), in your project, select **Migrate** > **Migrations**.
 


### PR DESCRIPTION
## What Changed?

Adding some information regarding the point in time when a customer should stop the migration. 
In the future, the team will add statuses in the UI for this. For now, we are just adding some information for clarity.