### PR TITLE
PGD: fix references to deprecated GUC "bdr.raft_election_timeout"

### DIFF
--- a/product_docs/docs/pgd/5/monitoring/sql.mdx
+++ b/product_docs/docs/pgd/5/monitoring/sql.mdx
@@ -573,10 +573,10 @@ From time to time, Raft consensus starts a new election to define a
 new `RAFT_LEADER`. During an election, there might be an intermediary
 situation where there's no `RAFT_LEADER`, and some of the nodes consider
 themselves as `RAFT_CANDIDATE`. The whole election can't take longer
-than `bdr.raft_election_timeout` (by default it's set to 6 seconds). If
+than `bdr.raft_global_election_timeout` (by default it's set to 6 seconds). If
 the query above returns an in-election situation, then wait for
-`bdr.raft_election_timeout`, and run the query again. If after
-`bdr.raft_election_timeout` has passed and some the listed conditions are
+`bdr.raft_global_election_timeout`, and run the query again. If after
+`bdr.raft_global_election_timeout` has passed and some the listed conditions are
 still not met, then Raft consensus isn't working.
 
 Raft consensus might not be working correctly on only a single node.
@@ -587,15 +587,15 @@ make sure that:
 -   All PGD nodes are accessible to each other through both regular and
     replication connections (check file `pg_hba.conf`).
 -   PGD versions are the same on all nodes.
--   `bdr.raft_election_timeout` is the same on all nodes.
+-   `bdr.raft_global_election_timeout` is the same on all nodes.
 
 In some cases, especially if nodes are geographically distant from each
 other or network latency is high, the default value of
-`bdr.raft_election_timeout` (6 seconds) might not be enough. If Raft
+`bdr.raft_global_election_timeout` (6 seconds) might not be enough. If Raft
 consensus is still not working even after making sure everything is
-correct, consider increasing `bdr.raft_election_timeout` to 30
+correct, consider increasing `bdr.raft_global_election_timeout` to 30
 seconds on all nodes. For PGD 3.6.11 and later, setting
-`bdr.raft_election_timeout` requires only a server reload.
+`bdr.raft_global_election_timeout` requires only a server reload.
 
 Given how Raft consensus affects cluster operational tasks, and also as
 Raft consensus is directly responsible for advancing the group slot,

--- a/product_docs/docs/pgd/5/reference/functions.mdx
+++ b/product_docs/docs/pgd/5/reference/functions.mdx
@@ -245,7 +245,7 @@ with full voting rights.
 
 If `wait_for_completion` is false, the request is served on
 a best-effort basis. If the node can't become a leader in the
-`bdr.raft_election_timeout` period, then some other capable node
+`bdr.raft_global_lection_timeout` period, then some other capable node
 becomes the leader again. Also, the leadership can change over the
 period of time per Raft protocol. A `true` return result indicates
 only that the request was submitted successfully.


### PR DESCRIPTION
## What Changed?

From 5.0, BDR GUC "bdr.raft_election_timeout" is obsolete and has been replaced by "bdr.raft_global_election_timeout", so update the remaining references in the PGD 5 docs.

DOCS-1024.