### PR TITLE
DMS: added purl for UI link

### DIFF
--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Configuring and running the EDB DMS Reader"
 deepToC: true
+redirects: 
+  - /purl/dms/configure_source
 ---
 
 ## Getting credentials


### PR DESCRIPTION
## What Changed?

At the moment, the staging environment string links to a page in our _preview_ documentation. 
After we go live, the string should link to the _live_ documentation. 

I have set up a permanent URL that we can embed in the UI, so the link does not become outdated, and we can change the content/location of the page without worrying about breaking links. 

![Screenshot 2024-09-04 at 14 09 00](https://github.com/user-attachments/assets/ab4532d1-af73-40fe-a037-25219be20763)

The link the UI team can embed to the string will be: 
https://www.enterprisedb.com/docs/purl/dms/configure_source
