### PR TITLE
PGD: improve description of "transaction_id" pseudo-GUC

### DIFF
--- a/product_docs/docs/pgd/5/reference/functions.mdx
+++ b/product_docs/docs/pgd/5/reference/functions.mdx
@@ -46,9 +46,9 @@ Returns the current subscription statistics.
 
 ## System and progress information parameters
 
-PGD exposes some parameters that you can query using `SHOW` in psql
-or using `PQparameterStatus` (or equivalent) from a client
-application.
+PGD exposes some parameters that you can query directly in SQL using e.g.
+`SHOW` or the `current_setting()` function, and/or using `PQparameterStatus`
+(or equivalent) from a client application.
 
 ### `bdr.local_node_id`
 
@@ -68,8 +68,10 @@ becomes remotely visible.
 
 ### `transaction_id`
 
-As soon as Postgres assigns a transaction id, if CAMO is enabled, this parameter is
-updated to show the transaction id just assigned.
+If a CAMO transaction is in progress, `transaction_id` will be updated to show
+the assigned transaction id. Note that this parameter can only be queried
+using `PQparameterStatus` or equivalent. See section [Application use](../durability/camo#application-use)
+for a usage example.
 
 ### `bdr.is_node_connected`
 


### PR DESCRIPTION
Current doc: https://www.enterprisedb.com/docs/pgd/latest/reference/functions/#transaction_id

## What Changed?

This is only queryable as a reported GUC via libpq's PQparameterStatus() function, and is never accessible at SQL level. Rewrite the description to clarify this, linking to a helpful code example while we're at it.

Also rework the introductory section to make it clearer that one of the GUC-like objects about to be described is not query-able via SQL.

DOCS-1028.


