### PR TITLE
EPAS - Added oracle 19c support to Database link

### DIFF
--- a/product_docs/docs/epas/11/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/11/epas_compat_sql/21_create_public_database_link.mdx
@@ -38,7 +38,7 @@ For information about high availability, load balancing, and replication for Pos
 <https://www.postgresql.org/docs/11/static/high-availability.html>
 
 !!! Note
-    -  For Advanced Server 11, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
+    -  For Advanced Server 11, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), Oracle version 18c Release 1 (18.2) and  Oracle version 19c (all minor versions).
     -  The `edb_dblink_oci.rescans` GUC can be set to `SCROLL` or `SERIALIZABLE` at the server level in `postgresql.conf` file. It can also be set at session level using the `SET` command, but the setting will not be applied to existing dblink connections due to dblink connection caching.
     -  When executing `SELECT` on LOB data of more than 4000 characters, it is advisable to use `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding the `PGA_AGGREGATE_LIMIT`.
 

--- a/product_docs/docs/epas/12/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/12/epas_compat_sql/21_create_public_database_link.mdx
@@ -40,7 +40,7 @@ For information about high availability, load balancing, and replication for Pos
 <https://www.postgresql.org/docs/12/static/high-availability.html>
 
 !!! Note
-    -  For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
+    -  For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), Oracle version 18c Release 1 (18.2) and  Oracle version 19c (all minor versions).
     -  The `edb_dblink_oci.rescans` GUC can be set to `SCROLL` or `SERIALIZABLE` at the server level in `postgresql.conf` file. It can also be set at session level using the `SET` command, but the setting will not be applied to existing dblink connections due to dblink connection caching.
     -  When executing `SELECT` on LOB data of more than 4000 characters, it is advisable to use `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding the `PGA_AGGREGATE_LIMIT`.
 

--- a/product_docs/docs/epas/13/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/13/epas_compat_sql/21_create_public_database_link.mdx
@@ -39,7 +39,7 @@ For information about high availability, load balancing, and replication for Pos
 <https://www.postgresql.org/docs/current/static/high-availability.html>
 
 !!! Note
-    -  For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
+    -  For Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), Oracle version 18c Release 1 (18.2) and  Oracle version 19c (all minor versions).
     -  The `edb_dblink_oci.rescans` GUC can be set to `SCROLL` or `SERIALIZABLE` at the server level in `postgresql.conf` file. It can also be set at session level using the `SET` command, but the setting will not be applied to existing dblink connections due to dblink connection caching.
     -  When executing `SELECT` on LOB data of more than 4000 characters, it is advisable to use `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding the `PGA_AGGREGATE_LIMIT`.
 

--- a/product_docs/docs/epas/14/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/14/epas_compat_sql/21_create_public_database_link.mdx
@@ -38,7 +38,7 @@ You must be connected to the local database when you issue a SQL command contain
     For information about high availability, load balancing, and replication for Postgres database servers, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/high-availability.html).
 
 !!! Note
-    -  For EDB Postgres Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), and Oracle version 12c Release 1 (12.1).
+    -  For EDB Postgres Advanced Server 12, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), Oracle version 18c Release 1 (18.2) and  Oracle version 19c (all minor versions).
     -  You can set the `edb_dblink_oci.rescans` GUC to `SCROLL` or `SERIALIZABLE` at the server level in the `postgresql.conf` file. You can also set it at the session level using the `SET` command. However, the setting isn't applied to existing dblink connections due to dblink connection caching.
     -  When executing `SELECT` on LOB data of more than 4000 characters, we recommend using `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding `PGA_AGGREGATE_LIMIT`.
     

--- a/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/15/reference/oracle_compatibility_reference/epas_compat_sql/21_create_public_database_link.mdx
@@ -40,7 +40,7 @@ You must be connected to the local database when you issue a SQL command contain
     For information about high availability, load balancing, and replication for Postgres database servers, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/high-availability.html).
 
 !!! Note
-    -  For EDB Postgres Advanced Server 15, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), and Oracle version 18c Release 1 (18.2).
+    -  For EDB Postgres Advanced Server 15, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), Oracle version 18c Release 1 (18.2), and  Oracle version 19c (all minor versions).
     -  You can set the `edb_dblink_oci.rescans` GUC to `SCROLL` or `SERIALIZABLE` at the server level in the `postgresql.conf` file. You can also set it at the session level using the `SET` command. However, the setting isn't applied to existing dblink connections due to dblink connection caching.
     -  When executing `SELECT` on LOB data of more than 4000 characters, we recommend using `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding `PGA_AGGREGATE_LIMIT`.
     

--- a/product_docs/docs/epas/16/reference/oracle_compatibility_reference/epas_compat_sql/21_create_public_database_link.mdx
+++ b/product_docs/docs/epas/16/reference/oracle_compatibility_reference/epas_compat_sql/21_create_public_database_link.mdx
@@ -40,7 +40,7 @@ You must be connected to the local database when you issue a SQL command contain
     For information about high availability, load balancing, and replication for Postgres database servers, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/high-availability.html).
 
 !!! Note
-    -  For EDB Postgres Advanced Server 15, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), and Oracle version 18c Release 1 (18.2).
+    -  For EDB Postgres Advanced Server 15, the `CREATE DATABASE LINK` command is tested against and certified for use with Oracle version 10g Release 2 (10.2), Oracle version 11g Release 2 (11.2), Oracle version 12c Release 1 (12.1), Oracle version 18c Release 1 (18.2), and  Oracle version 19c (all minor versions).
     -  You can set the `edb_dblink_oci.rescans` GUC to `SCROLL` or `SERIALIZABLE` at the server level in the `postgresql.conf` file. You can also set it at the session level using the `SET` command. However, the setting isn't applied to existing dblink connections due to dblink connection caching.
     -  When executing `SELECT` on LOB data of more than 4000 characters, we recommend using `edb_dblink_oci.rescans=serializable` to free up the temporary PGA memory and avoid exceeding `PGA_AGGREGATE_LIMIT`.
     


### PR DESCRIPTION
## What Changed?

Added Oracle 19c is now supported for the Database link in all versions of EPAS as per [DOCS-554](https://enterprisedb.atlassian.net/browse/DOCS-554).



