### PR TITLE
PGD 5.6: update description for "bdr.join_node_group()"

### DIFF
--- a/product_docs/docs/pgd/5.6/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/5.6/reference/nodes-management-interfaces.mdx
@@ -291,11 +291,12 @@ bdr.join_node_group (
      node.
 -   `wait_for_completion` &mdash; Wait for the join process to complete before
      returning. Defaults to `true`.
--   `synchronize_structure` &mdash; Set the kind of structure (schema) synchronization
-     to do during the join.  The default setting is `all`, which synchronizes
-     the complete database structure, The other available setting is `none`, which doesn't
-     synchronize any structure. However, it still synchronizes data (except for witness
-     nodes, which by design don't synchronize data).
+-   `synchronize_structure` &mdash; Specifies whether to perform database structure (schema)
+     synchronization during the join. `all`, the default setting, synchronizes
+     the complete database structure. `none` does not synchronize any structure.
+     However, data will still be synchronized, meaning the database structure must already
+     be present on the joining node. Note that by design, neither schema nor data will
+     ever be synchronized to witness nodes.
 -   `pause_in_standby` &mdash; Optionally tells the join process to join only as a
      logical standby node, which can be later promoted to a full member.
      This option is deprecated and will be disabled or removed in future


### PR DESCRIPTION
## What Changed?

From PGD 5.6, database structure will never be synchronized to a witness server, which represents a minor behaviour change compared to previous versions, and means the "synchronize_structure" parameter, if explicitly set to "all", will be forcibly overridden (a NOTICE will be emitted noting that).

DOCS-1029.



