### PR TITLE
Update indentation for the example yaml file

### DIFF
--- a/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
@@ -143,7 +143,7 @@ provider:
   onprem:
     databases: 
       sales_reporting:
-        dsn: $DSN
+        dsn: "$DSN"
         tags:
             - "sales"
             - "reports"

--- a/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
@@ -130,26 +130,27 @@ Here is an example `beacon_agent.yaml` file configured for a database named `sal
 
 ```yaml
 agent:
-access_key: $BEACON_AGENT_ACCESS_KEY
-access_key_grpc_header: "x-access-key"
-batch_size: 100
-beacon_server: "beacon.biganimal.com:443"
-feature_flag_interval: 10m0s
-project_id: "<project ID>"
-providers:
-- "onprem"
+  access_key: "$BEACON_AGENT_ACCESS_KEY"
+  access_key_grpc_header: "x-access-key"
+  batch:
+    size: 100
+  beacon_server: "beacon.biganimal.com:443"
+  feature_flag_interval: 10m0s
+  project_id: "<project ID>"
+  providers:
+    - "onprem"
 provider:
-onprem:
-databases:
-    sales_reporting:
-    dsn: “$DSN”
-    tags:
-        - "sales"
-        - "reports"
-host:
-    resource_id: "postgresql.lan"
-    tags: []
-poll_interval: 5m0s
+  onprem:
+    databases: 
+      sales_reporting:
+        dsn: $DSN
+        tags:
+            - "sales"
+            - "reports"
+    host:
+      resource_id: "postgresql.lan"
+      tags: []
+    poll_interval: 5m0s
 ```
 
 ## Test Beacon Agent locally.


### PR DESCRIPTION
The previous example doesn't work due to the improper indentation.

## What Changed?
Update the indentation for the example yaml file

