### PR TITLE
Edits to Added note on non-ascii characters not being supported PR6024

### DIFF
--- a/advocacy_docs/supported-open-source/postgresql/installing/windows.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/windows.mdx
@@ -31,7 +31,7 @@ To perform an installation using the graphical installation wizard, you need sup
 
 !!!note Notes
    - EDB doesn't support all non-ASCII, multi-byte characters in user or machine names. Use ASCII characters only to avoid installation errors related to unsupported path names.
-   - If you're using the graphical installation wizard to perform a system ***upgrade***, the installer preserves the configuration options specified during the previous installation.
+   - If you're using the graphical installation wizard to perform a system upgrade, the installer preserves the configuration options specified during the previous installation.
 !!!
 
 1.  To start the installation wizard, assume sufficient privileges, and double-click the installer icon. If prompted, provide a password. (In some versions of Windows, to invoke the installer with administrator privileges, you must select **Run as Administrator** from the installer icon's context menu.)


### PR DESCRIPTION
Removed bold-italic emphasis. If there's something that needs to be called out here, use additional words rather than emphasis, which we don't have any standard for, and it doesn't seem apt in this case anyhow. For example, you could do something like this:

- If you're using the installation wizard to perform a system upgrade rather than a fresh install...

The added context will provide the emphasis if the concern is that readers might not see that this is referring to an upgrade. Alternatively, keep this text in its own note rather than combining with the new one and place each note more precisely within the content.