### PR TITLE
pgd: clarify joining nodes with non-default extensions

### DIFF
--- a/product_docs/docs/pgd/5/node_management/creating_and_joining.mdx
+++ b/product_docs/docs/pgd/5/node_management/creating_and_joining.mdx
@@ -56,7 +56,7 @@ The node that's joining the cluster must not contain any schema or data
 that already exists on databases in the PGD group. We recommend that the
 newly joining database be empty except for the BDR extension. However,
 it's important that all required database users and roles are created.
-Additionally, if the joining operation will be carried out by a non-superuser,
+Additionally, if the joining operation is to be carried out by a non-superuser,
 extensions requiring superuser permission will need to be manually created. For
 more details see [Connections and roles](../security/role-management#connections-and-roles).
 

--- a/product_docs/docs/pgd/5/node_management/creating_and_joining.mdx
+++ b/product_docs/docs/pgd/5/node_management/creating_and_joining.mdx
@@ -56,6 +56,9 @@ The node that's joining the cluster must not contain any schema or data
 that already exists on databases in the PGD group. We recommend that the
 newly joining database be empty except for the BDR extension. However,
 it's important that all required database users and roles are created.
+Additionally, if the joining operation will be carried out by a non-superuser,
+extensions requiring superuser permission will need to be manually created. For
+more details see [Connections and roles](../security/role-management#connections-and-roles).
 
 Optionally, you can skip the schema synchronization using the
 `synchronize_structure` parameter of the

--- a/product_docs/docs/pgd/5/security/role-management.mdx
+++ b/product_docs/docs/pgd/5/security/role-management.mdx
@@ -62,7 +62,7 @@ In PostgreSQL 13 and later, extensions requiring superuser permission and which
 therefore need to be manually installed, can be identified by executing (on the
 source node):
 
-```
+```sql
     SELECT name, (trusted IS FALSE AND superuser) AS superuser_only
       FROM pg_available_extension_versions
      WHERE installed AND name != 'bdr';

--- a/product_docs/docs/pgd/5/security/role-management.mdx
+++ b/product_docs/docs/pgd/5/security/role-management.mdx
@@ -53,6 +53,21 @@ nodes, such that following stipulations are satisfied:
 -   It owns all database objects to replicate, either directly or from
     permissions from the owner roles.
 
+Additionally, if any non-default extensions (excluding the `bdr` extension
+itself) are present on the source node, and any of these can only be installed
+by a superuser, these extensions must be created manually (by a superuser) on
+the join target node, otherwise the join process will fail.
+
+In PostgreSQL 13 and later, extensions requiring superuser permission and which
+therefore need to be manually installed, can be identified by executing (on the
+source node):
+
+```
+    SELECT name, (trusted IS FALSE AND superuser) AS superuser_only
+      FROM pg_available_extension_versions
+     WHERE installed AND name != 'bdr';
+```
+
 Once all nodes are joined, to continue to allow DML and DDL replication, you can reduce the permissions further to the following:
 
 -   The user has the `REPLICATION` attribute.


### PR DESCRIPTION
## What Changed?

If a node is joined with a user who does not have superuser permissions, the presence of any extensions on the source node which require superuser permissions to install, will cause the join operation to fail.

Clarify that such extensions will need to be created manually on the joining node if the user is not a superuser.

Note: this is one of those situation which gets kind of wordy to explain, improvements welcome.

[BDR-5519](https://enterprisedb.atlassian.net/browse/BDR-5519).



[BDR-5519]: https://enterprisedb.atlassian.net/browse/BDR-5519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ