### PR TITLE
Docs/beacon agent/yaml change

### DIFF
--- a/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
@@ -114,16 +114,16 @@ Entries under `databases` utilize the following format:
 
 ```yaml
 databases:
-    <database_name_1>:
-        dsn: "$DSN1"
-        tags:
-            - "<tag-one>"
-            - "<tag-two>"
-    <database_name_2>:
-        dsn: "$DSN2"
-        tags: 
-            - "<tag-one>"
-            - "<tag-two>"
+  - resource_id: "database_name_1"
+    dsn: "$DSN1"
+    tags:
+        - "<tag-one>"
+        - "<tag-two>"
+  - resource_id: "database_name_2"
+    dsn: "$DSN2"
+    tags: 
+        - "<tag-one>"
+        - "<tag-two>"
 ```
 
 Here is an example `beacon_agent.yaml` file configured for a database named `sales_reporting`:
@@ -142,11 +142,11 @@ agent:
 provider:
   onprem:
     databases: 
-      sales_reporting:
+      - resource_id: "sales_reporting"
         dsn: "$DSN"
         tags:
-            - "sales"
-            - "reports"
+          - "sales"
+          - "reports"
     host:
       resource_id: "postgresql.lan"
       tags: []

--- a/product_docs/docs/pem/9/considerations/index.mdx
+++ b/product_docs/docs/pem/9/considerations/index.mdx
@@ -2,6 +2,7 @@
 title: "Deployment considerations"
 navigation:
 
+- licensing
 - setup_ha_using_efm
 - pem_pgbouncer
 - authentication_options
@@ -13,6 +14,7 @@ There are a number of things to consider before deploying Postgres Enterprise Ma
 
 | Considerations                                                                     | Implementation instructions                                                                                                                         |
 | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Does your EDB subscription cover your planned use of PEM?                          | [Licensing](licensing)
 | Is a standalone server sufficient or do you need a high availability architecture? | [Installing the server](../installing/) or [Deploying high availability](setup_ha_using_efm/) |
 | Do you need to implement connection pooling?                                       | [Deploying connection pooling](pem_pgbouncer/)                                                                    |
 | What type of authentication to use?                                                | [Authentication options](authentication_options/)                                                                 |

--- a/product_docs/docs/pem/9/considerations/licensing.mdx
+++ b/product_docs/docs/pem/9/considerations/licensing.mdx
@@ -1,0 +1,42 @@
+---
+title: "How PEM is licensed"
+navTitle: "Licensing"
+redirects:
+- /pem/latest/pem_ha_setup/
+- /pem/latest/pem_ha_setup/setup_ha_using_efm/
+---
+To use PEM, you must have an EDB Standard or Enterprise subscription.
+
+Any Postgres servers you monitor using PEM (whether by installing the
+PEM Agent locally, through Remote Monitoring, or by making a client
+connection from the PEM web application) must be covered by an EDB
+Standard or Enterprise subscription.
+
+Non-Postgres servers (for example PGD Proxy nodes)
+
+The Postgres instance used as the PEM backend does not consume cores
+from your subscription. Likewise, no cores are consumed by any other PEM
+components. Nevertheless, all these components are covered by your
+support agreement.
+
+## Examples
+
+### Adding PEM
+A customer with an Enterprise subscription for 32 cores has 8 x 4-core
+servers running EDB Postgres Advanced Server (EPAS), thereby fully
+consuming their 32 cores. This customer may install PEM on a fifth
+server and use it to monitor their 8 EPAS servers. This requires no
+change to their subscription as the PEM server does not consume cores
+and the monitored EPAS instances are already fully covered. 
+
+### Unsupported monitored servers
+A customer with a Standard subscription for 36 cores has PEM and 6 x
+6-core servers running PostgreSQL covered by EDB support - thereby
+consuming their 36 cores as in the example above.
+
+The customer also has 10 x 2-core PostgreSQL servers that are not
+covered by any EDB subscription. These servers must not be monitored by
+PEM as they are not covered by a Standard or Enterprise subscription. If the customer wishes to monitor these servers they must add a further 20 cores to their subscription.
+
+!!! Note
+A Community 360 subscription for the additional 20 cores is not sufficient. Servers monitored by PEM must


### PR DESCRIPTION
The upcoming release of Beacon Agent uses a slightly different YAML format. Updated the docs to match.
