### PR TITLE
Change YAML format to match upcoming agent release

### DIFF
--- a/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
+++ b/advocacy_docs/edb-postgres-ai/console/estate/agent/install-agent.mdx
@@ -114,16 +114,16 @@ Entries under `databases` utilize the following format:
 
 ```yaml
 databases:
-    <database_name_1>:
-        dsn: "$DSN1"
-        tags:
-            - "<tag-one>"
-            - "<tag-two>"
-    <database_name_2>:
-        dsn: "$DSN2"
-        tags: 
-            - "<tag-one>"
-            - "<tag-two>"
+  - resource_id: "database_name_1"
+    dsn: "$DSN1"
+    tags:
+        - "<tag-one>"
+        - "<tag-two>"
+  - resource_id: "database_name_2"
+    dsn: "$DSN2"
+    tags: 
+        - "<tag-one>"
+        - "<tag-two>"
 ```
 
 Here is an example `beacon_agent.yaml` file configured for a database named `sales_reporting`:
@@ -142,11 +142,11 @@ agent:
 provider:
   onprem:
     databases: 
-      sales_reporting:
+      - resource_id: "sales_reporting"
         dsn: "$DSN"
         tags:
-            - "sales"
-            - "reports"
+          - "sales"
+          - "reports"
     host:
       resource_id: "postgresql.lan"
       tags: []


### PR DESCRIPTION
The upcoming release of Beacon Agent uses a slightly different YAML format. Updated the docs to match.

