### PR TITLE
EFM-1698 Remove "Agent" column from cluster-status output.

### DIFF
--- a/product_docs/docs/efm/4/06_monitoring_efm_cluster.mdx
+++ b/product_docs/docs/efm/4/06_monitoring_efm_cluster.mdx
@@ -23,11 +23,11 @@ The `efm cluster-status` [cluster properties file](07_using_efm_utility/#efm_clu
 The following status report is for a cluster named edb that has three nodes running:
 
 ```text
-Agent Type  Address               Agent   DB        VIP
------------------------------------------------------------------------
-Standby     172.19.10.2            UP     UP        192.168.225.190
-Standby     172.19.12.163          UP     UP        192.168.225.190
-Primary     172.19.14.9            UP     UP        192.168.225.190*
+Agent Type  Address               DB        VIP
+---------------------------------------------------------------
+Standby     172.19.10.2           UP        192.168.225.190
+Standby     172.19.12.163         UP        192.168.225.190
+Primary     172.19.14.9           UP        192.168.225.190*
 
 
 Allowed node host list:
@@ -55,11 +55,11 @@ Standby database(s) in sync with primary. It is safe to promote.
 The cluster status section provides an overview of the status of the agents that reside on each node of the cluster:
 
 ```text
-Agent Type  Address             Agent   DB        VIP
------------------------------------------------------------------------
-Standby     172.19.10.2          UP     UP        192.168.225.190
-Standby     172.19.12.163        UP     UP        192.168.225.190
-Primary     172.19.14.9          UP     UP        192.168.225.190*
+Agent Type  Address             DB        VIP
+---------------------------------------------------------------
+Standby     172.19.10.2         UP        192.168.225.190
+Standby     172.19.12.163       UP        192.168.225.190
+Primary     172.19.14.9         UP        192.168.225.190*
 ```
 
 The asterisk (\*) after the VIP address indicates that the address is available for connections. If a VIP address is not followed by an asterisk, the address was associated with the node in the properties file, but the address isn't currently in use.
@@ -90,9 +90,9 @@ Standby  172.19.10.2     0/4000638          0/4000638
 If a database is down or if the database was restarted, but the resume command was not yet invoked, the state of the agent that resides on that host is idle. If an agent is idle, the cluster status report includes a summary of the condition of the idle node. For example:
 
 ```text
-Agent Type Address Agent DB VIP
------------------------------------------------------
-Idle 172.19.18.105 UP UP 172.19.13.105
+Agent Type  Address             DB        VIP
+---------------------------------------------------------------
+Idle        172.19.18.105       UP        172.19.13.105
 ```
 
 ### Exit codes


### PR DESCRIPTION
This column was removed ~4 years ago, see EFM-993.

## What Changed?

