### PR TITLE
Added new admonition regarding outdated images and security risks to PG4K docs.

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/security.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/security.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'Security'
-originalFilePath: 'src/security.md'
 ---
 
 This section contains information about security for EDB Postgres for Kubernetes,
@@ -63,7 +62,7 @@ please use this medium to report it.
 Every container image in EDB Postgres for Kubernetes is automatically built via CI/CD
 pipelines following every commit. These images include not only the operator's
 image but also the operands' images, specifically for every supported
-PostgreSQL version. During the CI/CD process, images undergo scanning with the
+PostgreSQL version (including [EDB Postgres Extended](/pge/latest/) and [EDB Postgres Advanced](/epas/latest/)). During the CI/CD process, images undergo scanning with the
 following tools:
 
 -   **[Dockle](https://github.com/goodwithtech/dockle):** Ensures best practices
@@ -72,9 +71,12 @@ following tools:
     and reports findings via the GitHub interface.
 
 !!! Important
-    All operand images are automatically rebuilt daily by our pipelines to
-    incorporate security updates at the base image and package level, providing
-    **patch-level updates** for the container images distributed to the community.
+All operand images are automatically rebuilt daily by our pipelines to incorporate security updates at the base image and package level, providing **patch-level updates** for the container images distributed to EDB download sites.
+!!!
+
+!!! Warning
+Running outdated images can expose your environment to security risks and performance issues. We highly recommend that you update to the latest image version and keep your images up to date. This will ensure that you take advantage of the latest updates and patches available.
+!!!
 
 ### Guidelines and Frameworks for Container Security
 


### PR DESCRIPTION
## What Changed?

Added new admonition regarding outdated images and security risks to PG4K docs. This forks from upstream and will no longer automatically receive upstream changes. 