### PR TITLE
Add PGD to HA Platform/Tools section on front page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -429,6 +429,10 @@ const Page = () => {
               headingText="High Availability"
             />
 
+            <BannerWideLink to="/pgd/latest">
+              EDB Postgres Distributed (PGD)
+            </BannerWideLink>
+
             <BannerWideLink to="/repmgr/latest">
               Replication Manager (repmgr)
             </BannerWideLink>


### PR DESCRIPTION
Signed-off-by: Dj Walker-Morgan <dj.walker-morgan@enterprisedb.com>

## What Changed?

Puts PGD on the front page twice to avoid confusion
