### PR TITLE
PostGIS: 3.4 updates

### DIFF
--- a/product_docs/docs/postgis/3/installing/upgrading.mdx
+++ b/product_docs/docs/postgis/3/installing/upgrading.mdx
@@ -30,16 +30,16 @@ To avoid accidental upgrades, PostGIS versions 3.3 and 3.4 use different package
 
 1. Uninstall PostGIS version 3.3. 
    
-   For EDB Posgres Advanced Server version 16:
+   For EDB Posgres Advanced Server version 15:
 
    ```shell
-   dnf -y erase edb-as16-postgis3
+   dnf -y erase edb-as15-postgis33
    ```
 
    For earlier versions of EDB Postgres Advanced Server:
 
    ```shell
-   dnf erase edb-as<xx>-postgis3
+   dnf erase edb-as<xx>-postgis33
    ```
    
    Where `<xx>` is the version of EDB Postgres Advanced Server. 

--- a/product_docs/docs/postgis/3/installing/upgrading.mdx
+++ b/product_docs/docs/postgis/3/installing/upgrading.mdx
@@ -12,52 +12,56 @@ legacyRedirectsGenerated:
 
 These examples show upgrading for RHEL/CentOS 7 platforms:
 
-- [Example 1: Upgrading from PostGIS version 3.1 to 3.2](/postgis/latest/installing/upgrading/#example-1-upgrading-from-postgis-version-31-to-32)
+- [Example 1: Upgrading from PostGIS version 3.3 to 3.4](/postgis/latest/installing/upgrading/#example-1-upgrading-from-postgis-version-33-to-34)
 - [Example 2: Upgrading from PostGIS versions 2.5 or later to 3.1.4 on the same EDB Postgres Advanced Server version](/postgis/latest/installing/upgrading/#example-2-upgrading-from-postgis-versions-25-or-later-to-314-on-the-same-edb-postgres-advanced-server-version)
 - [Example 3: Upgrading from PostGIS versions earlier than 2.5 to 3.1.4 on a different EDB Postgres Advanced Server version](/postgis/latest/installing/upgrading/#example-3-upgrading-from-postgis-versions-earlier-than-25-to-314-on-a-different-edb-postgres-advanced-server-version)
 
-## Example 1: Upgrading from PostGIS version 3.1 to 3.2
+## Example 1: Upgrading from PostGIS version 3.3 to 3.4
 
-This example upgrades from PostGIS version 3.1 to version 3.2 for EDB Postgres Advanced Server 14.
+This example upgrades from PostGIS version 3.3 to version 3.4 for EDB Postgres Advanced Server 16.
 
-To avoid accidental upgrades, PostGIS versions 3.1 and 3.2 use different package names. So, upgrading to version 3.2 requires that you first uninstall version 3.1. After you install version 3.2, you can upgrade the PostGIS extensions. 
+!!!note Upgrades from 3.1.4 and later versions
+   You can perform upgrades from PostGIS versions 3.1.4 and later (including skip upgrades, e.g. 3.1.4 to 3.4) as described in this example. Ensure you replace the source and target PostGIS versions, as well as the EDB Postgres Advanced Server version in commands accordingly.
+!!!
 
-1. If you haven't already, create the PostGIS extensions in PostGIS version 3.1. For instructions, see [Creating extensions](/postgis/latest/02_creating_extensions/).
+To avoid accidental upgrades, PostGIS versions 3.3 and 3.4 use different package names. So, upgrading to version 3.4 requires that you first uninstall version 3.3. After you install version 3.4, you can upgrade the PostGIS extensions. 
 
-1. Uninstall PostGIS version 3.1. 
+1. If you haven't already, create the PostGIS extensions in PostGIS version 3.3. For instructions, see [Creating extensions](/postgis/latest/02_creating_extensions/).
+
+1. Uninstall PostGIS version 3.3. 
    
-   For EDB Posgres Advanced Server version 14:
+   For EDB Posgres Advanced Server version 16:
 
    ```shell
-   yum -y erase edb-as14-postgis3
+   dnf -y erase edb-as16-postgis3
    ```
 
    For earlier versions of EDB Postgres Advanced Server:
 
    ```shell
-   yum erase edb-as<xx>-postgis3
+   dnf erase edb-as<xx>-postgis3
    ```
    
    Where `<xx>` is the version of EDB Postgres Advanced Server. 
 
    For more information, see [Uninstalling PostGIS](/postgis/latest/installing/uninstalling/).
 
-1. Install PostGIS version 3.2. For instructions, see [Installing PostGIS](/postgis/latest/installing/).
+1. Install PostGIS version 3.4. For instructions, see [Installing PostGIS](/postgis/latest/installing/).
 
 1. Upgrade the PostGIS extensions: 
 
    !!! Note
-   If you first upgraded from a PostGIS version earlier than 2.5 to PostGIS version 3.1, then you must `DROP` the `postgis_raster extension` before executing the command. 
+   If you first upgraded from a PostGIS version earlier than 2.5 to PostGIS version 3.1, then you must `DROP` the `postgis_raster extension` before executing the command.
    !!!
 
    ```sql
    SELECT postgis_extensions_upgrade();
    __OUTPUT__
-   NOTICE:  Updating extension postgis from 3.1.4 to 3.2.1
-   NOTICE:  Updating extension postgis_sfcgal from 3.1.4 to 3.2.1
-   NOTICE:  Updating extension postgis_raster from 3.1.4 to 3.2.1
-   NOTICE:  Updating extension postgis_topology from 3.1.4 to 3.2.1
-   NOTICE:  Updating extension postgis_tiger_geocoder from 3.1.4 to 3.2.1
+   NOTICE:  Updating extension postgis from 3.3.2 to 3.4.2
+   NOTICE:  Updating extension postgis_sfcgal from 3.3.2 to 3.4.2
+   NOTICE:  Updating extension postgis_raster from 3.3.2 to 3.4.2
+   NOTICE:  Updating extension postgis_topology from 3.3.2 to 3.4.2
+   NOTICE:  Updating extension postgis_tiger_geocoder from 3.3.2 to 3.4.2
                        postgis_extensions_upgrade
    -------------------------------------------------------------------
     Upgrade completed, run SELECT postgis_full_version(); for details
@@ -75,7 +79,7 @@ This example upgrades from PostGIS version 2.5.5 to PostGIS version 3.1.4 for ED
 1.  To upgrade PostGIS version 2.5.5 to PostGIS version 3.1.4 for EDB Postgres Advanced Server 12, assume superuser privileges and invoke:
 
     ```shell
-    yum upgrade edb-as12-postgis-3.1.4 -y
+    dnf upgrade edb-as12-postgis-3.1.4 -y
     ```
 
 2. To update extensions, switch to the enterprisedb user, connect to the database where you already created extensions with the psql client application, and invoke:
@@ -131,7 +135,7 @@ Step 1 &mdash; To upgrade PostGIS version 2.4.6 to 3.1.4, you need to upgrade it
 2.  Assume superuser privileges and upgrade to PostGIS version 3.1.1:
 
     ```shell
-    yum upgrade edb-as10-postgis-3.1.1 -y
+    dnf upgrade edb-as10-postgis-3.1.1 -y
     ```
 
     !!! Note
@@ -170,7 +174,7 @@ Step 2 &mdash; Upgrade to PostGIS version 3.1.4:
 1.  To upgrade PostGIS version 3.1.1 to 3.1.4, invoke the following command for EDB Postgres Advanced Server 10:
 
     ```shell
-    yum upgrade edb-as10-postgis-3.1.4 -y
+    dnf upgrade edb-as10-postgis-3.1.4 -y
     ```
 
 2. To update extensions, switch to the enterprisedb user and invoke:
@@ -229,7 +233,7 @@ Step 3 &mdash; Upgrade EDB Postgres Advanced Server version 10 to 14:
 2.  Install the EDB Postgres Advanced Server version 14:
 
     ```shell
-    yum install edb-as14-server -y
+    dnf install edb-as14-server -y
     ```
 
 3.  Navigate to the `/bin` directory of EDB Advanced Server 14 and initialize the cluster:
@@ -243,7 +247,7 @@ Step 3 &mdash; Upgrade EDB Postgres Advanced Server version 10 to 14:
 4. Install PostGIS version 3.1.4 for EDB Postgres Advanced Server version 14.0:
 
     ```shell
-    yum install edb-as14-postgis3-3.1.4 -y
+    dnf install edb-as14-postgis3-3.1.4 -y
     ```
 
 5. Assume superuser privileges and stop the EDB Postgres Advanced Server 14.0 service:

--- a/product_docs/docs/postgis/3/installing/upgrading.mdx
+++ b/product_docs/docs/postgis/3/installing/upgrading.mdx
@@ -18,7 +18,7 @@ These examples show upgrading for RHEL/CentOS 7 platforms:
 
 ## Example 1: Upgrading from PostGIS version 3.3 to 3.4
 
-This example upgrades from PostGIS version 3.3 to version 3.4 for EDB Postgres Advanced Server 16.
+This example upgrades from PostGIS version 3.3 to version 3.4 for EDB Postgres Advanced Server 15.
 
 !!!note Upgrades from 3.1.4 and later versions
    You can perform upgrades from PostGIS versions 3.1.4 and later (including skip upgrades, e.g. 3.1.4 to 3.4) as described in this example. Ensure you replace the source and target PostGIS versions, as well as the EDB Postgres Advanced Server version in commands accordingly.

--- a/product_docs/docs/postgis/3/supported_platforms.mdx
+++ b/product_docs/docs/postgis/3/supported_platforms.mdx
@@ -11,10 +11,10 @@ This table lists the latest PostGIS versions and their supported corresponding E
 | PostGIS | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 | EPAS 12 |
 |---------|---------|---------|---------|---------|---------|
 | 3.4     | Y       | Y       | Y       | Y       | Y       |
-| 3.3     | Y       | Y       | Y       | Y       | Y       |
+| 3.3     | N       | Y       | Y       | Y       | Y       |
 | 3.2     | N       | Y       | Y       | Y       | Y       |
-| 3.1     | N       | N       | Y       | Y       | Y       | 
+| 3.1     | N       | N       | Y       | Y       | Y       |
 | 3.0     | N       | N       | N       | Y       | Y       |
-| 2.5     | N       | N       | N       | N       | Y       | 
+| 2.5     | N       | N       | N       | N       | Y       |
 | 2.4     | N       | N       | N       | N       | N       |
 | 2.3     | N       | N       | N       | N       | N       |

--- a/product_docs/docs/postgis/3/supported_platforms.mdx
+++ b/product_docs/docs/postgis/3/supported_platforms.mdx
@@ -8,12 +8,13 @@ EDB PostGIS is supported on the same platforms as EDB Postgres Advanced Server. 
 
 This table lists the latest PostGIS versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. 
 
-| PostGIS | EPAS 15 | EPAS 14 | EPAS 13 | EPAS 12 | EPAS 11 |  
-| ------- | ------- | ------- | ------- | ------- | ------- | 
+| PostGIS | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 | EPAS 12 |
+|---------|---------|---------|---------|---------|---------|
+| 3.4     | Y       | Y       | Y       | Y       | Y       |
 | 3.3     | Y       | Y       | Y       | Y       | Y       |
-| 3.2     | N       | Y       | Y       | Y       | Y       | 
-| 3.1     | N       | Y       | Y       | Y       | Y       | 
-| 3.0     | N       | Y       | Y       | Y       | Y       | 
-| 2.5     | N       | N       | N       | Y       | Y       | 
-| 2.4     | N       | N       | N       | N       | Y       |
+| 3.2     | N       | N       | Y       | Y       | Y       |
+| 3.1     | N       | N       | Y       | Y       | Y       | 
+| 3.0     | N       | N       | Y       | Y       | Y       |
+| 2.5     | N       | N       | N       | N       | Y       | 
+| 2.4     | N       | N       | N       | N       | N       |
 | 2.3     | N       | N       | N       | N       | N       |

--- a/product_docs/docs/postgis/3/supported_platforms.mdx
+++ b/product_docs/docs/postgis/3/supported_platforms.mdx
@@ -12,9 +12,9 @@ This table lists the latest PostGIS versions and their supported corresponding E
 |---------|---------|---------|---------|---------|---------|
 | 3.4     | Y       | Y       | Y       | Y       | Y       |
 | 3.3     | Y       | Y       | Y       | Y       | Y       |
-| 3.2     | N       | N       | Y       | Y       | Y       |
+| 3.2     | N       | Y       | Y       | Y       | Y       |
 | 3.1     | N       | N       | Y       | Y       | Y       | 
-| 3.0     | N       | N       | Y       | Y       | Y       |
+| 3.0     | N       | N       | N       | Y       | Y       |
 | 2.5     | N       | N       | N       | N       | Y       | 
 | 2.4     | N       | N       | N       | N       | N       |
 | 2.3     | N       | N       | N       | N       | N       |


### PR DESCRIPTION
## What Changed?

- Updated support matrix with a row for 3.4.2 and a column for EPAS 16. Removed EPAS 11 column. 
- Replaced `yum` instances with `dnf` as it is the current package manager
- Updated upgrade example and included a note clarifying that the example applies to all upgrades from versions after 3.1.4. 
https://enterprisedb.atlassian.net/browse/DB-2753

