### PR TITLE
Create index.mdx

### DIFF
--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -13,7 +13,7 @@ The following features are deprecated from this release. Please check and migrat
 ## Deprecated extensions
 This release doesn't include any deprecated extensions.
 
-## Deprecated Parameters
+## Deprecated parameters
 Below parameters are deprecated from this release, please chacke and plan for migrating to the alternative parameter.
 
 |         Feature          | Description |                      Alternative                       |

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -8,7 +8,7 @@ Below features are deprecated from this release, please check and plan for migra
 
 |         Feature          | Description |                      Alternative                       |
 | ------------------------ | ------------ | ---------------------------------------------------------- |
-| Index Advisor | The Index Advisor utility helps determine the columns to index to improve performance in a given workload.  |  Index Advisor features are now included in the [EDB Query Advisor](/pg_extensions/query_advisor/).
+| Index Advisor | The Index Advisor utility helps determine the columns you can index to improve performance in a given workload. |  Index Advisor features are now included in the [EDB Query Advisor](/pg_extensions/query_advisor/). |
 
 ## Deprecated Extenstions
 Currently there is no deprecated extension in this release.

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -14,7 +14,7 @@ The following features are deprecated from this release. Please check and migrat
 This release doesn't include any deprecated extensions.
 
 ## Deprecated parameters
-Below parameters are deprecated from this release, please chacke and plan for migrating to the alternative parameter.
+The following parameters are deprecated from this release. Please check and migrate to the alternative parameter.
 
 |         Feature          | Description |                      Alternative                       |
 | ------------------------ | ------------ | ---------------------------------------------------------- |

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -10,7 +10,7 @@ Below features are deprecated from this release, please check and plan for migra
 | ------------------------ | ------------ | ---------------------------------------------------------- |
 | Index Advisor | The Index Advisor utility helps determine the columns you can index to improve performance in a given workload. |  Index Advisor features are now included in the [EDB Query Advisor](/pg_extensions/query_advisor/). |
 
-## Deprecated Extenstions
+## Deprecated extensions
 Currently there is no deprecated extension in this release.
 
 ## Deprecated Parameters

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Deprecates"
+title: "Deprecations"
 description: "Provides a list of deprecated features, extensions and parameters for upgrading or migrating to EDB Postgres Advanced Server 16.x. "
 ---
 

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -3,7 +3,7 @@ title: "Deprecations"
 description: "Provides a list of deprecated features, extensions and parameters for upgrading or migrating to EDB Postgres Advanced Server 16.x. "
 ---
 
-## Deprecated Features
+## Deprecated features
 The following features are deprecated from this release. Please check and migrate to the alternative feature.
 
 |         Feature          | Description |                      Alternative                       |

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -1,0 +1,21 @@
+---
+title: "Deprecates"
+description: "Provides a list of deprecated features, extensions and parameters for upgrading or migrating to EDB Postgres Advanced Server 16.x. "
+---
+
+## Deprecated Features
+Below features are deprecated from this release, please check and plan for migrating to the alternative feature.
+
+|         Feature          | Description |                      Alternative                       |
+| ------------------------ | ------------ | ---------------------------------------------------------- |
+| Index Advisor | The Index Advisor utility helps determine the columns to index to improve performance in a given workload.  |  Index Advisor features are now included in the [EDB Query Advisor](/pg_extensions/query_advisor/).
+
+## Deprecated Extenstions
+Currently there is no deprecated extension in this release.
+
+## Deprecated Parameters
+Below parameters are deprecated from this release, please chacke and plan for migrating to the alternative parameter.
+
+|         Feature          | Description |                      Alternative                       |
+| ------------------------ | ------------ | ---------------------------------------------------------- |
+| edb_enable_pruning    | fast pruning for EDB-partitioned tables | None                          |

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -4,7 +4,7 @@ description: "Provides a list of deprecated features, extensions and parameters 
 ---
 
 ## Deprecated Features
-Below features are deprecated from this release, please check and plan for migrating to the alternative feature.
+The following features are deprecated from this release. Please check and migrate to the alternative feature.
 
 |         Feature          | Description |                      Alternative                       |
 | ------------------------ | ------------ | ---------------------------------------------------------- |

--- a/product_docs/docs/epas/16/epas_deprecates/index.mdx
+++ b/product_docs/docs/epas/16/epas_deprecates/index.mdx
@@ -11,7 +11,7 @@ Below features are deprecated from this release, please check and plan for migra
 | Index Advisor | The Index Advisor utility helps determine the columns you can index to improve performance in a given workload. |  Index Advisor features are now included in the [EDB Query Advisor](/pg_extensions/query_advisor/). |
 
 ## Deprecated extensions
-Currently there is no deprecated extension in this release.
+This release doesn't include any deprecated extensions.
 
 ## Deprecated Parameters
 Below parameters are deprecated from this release, please chacke and plan for migrating to the alternative parameter.


### PR DESCRIPTION
Deprecated Features across the same major version is better to have an individual page, in order to ease customers accesses.

## What Changed?

Hi team,
Greetings. Hope you are doing well and healthy.
Since there are many deprecated major features or functionalities etc. to be checked before migrating to a new major version.
These information may be better to put onto an individual page, not a part of release notes.

This avoids customers to overlook these critical deprecations. without checking all minor release's release notes.

Kind Regards,
Yuki Tei