### PR TITLE
Update epas16_rel_notes.mdx

### DIFF
--- a/product_docs/docs/epas/16/epas_rel_notes/epas16_rel_notes.mdx
+++ b/product_docs/docs/epas/16/epas_rel_notes/epas16_rel_notes.mdx
@@ -8,7 +8,7 @@ Released: 09 Nov 2023
 EDB Postgres Advanced Server 16.1 includes the following enhancements and bug fixes:
 
 !!! Note Deprecation
-This release removes support for Index Advisor and `edb_partition_pruning` GUC parameter.
+This release removes support for Index Advisor and `edb_enable_pruning` GUC parameter.
 Index Advisor features are now included in the [EDB Query Advisor](/pg_extensions/query_advisor/).
 !!!
 


### PR DESCRIPTION
found a mistake in name of the deprecated parameter

## What Changed?
Hi team,
Greetings. Hope you are doing well and healthy.

The correct parameter name seems to be "edb_enable_pruning", not "edb_partition_pruning".
Reference(quote from v15's postgres.conf)

$ less data15/postgresql.conf | grep edb_enable_pruning
#edb_enable_pruning = off       # fast pruning for EDB-partitioned tables

And also, I found this parameter is disappeared from v16's postgresql.conf.
Since it is also not found in v16 database, is this deprecated or no longer supported?
psql (16.2.0)
Type "help" for help.

edb=# SELECT * FROM pg_settings where name like '%pruning%';
           name           | setting | unit |                  category                   |                       short_desc                        |
                        extra_desc                                                                  | context | vartype | source  | min_val | max_val | enumvals | boot_val | reset_val | sou
rcefile | sourceline | pending_restart
--------------------------+---------+------+---------------------------------------------+---------------------------------------------------------+-----------------------------------------
----------------------------------------------------------------------------------------------------+---------+---------+---------+---------+---------+----------+----------+-----------+----
--------+------------+-----------------
 enable_partition_pruning | on      |      | Query Tuning / Planner Method Configuration | Enables plan-time and execution-time partition pruning. | Allows the query planner and executor to
 compare partition bounds to conditions in the query to determine which partitions must be scanned. | user    | bool    | default |         |         |          | on       | on        |
        |            | f
(1 row)

Kind Regards,
Yuki Tei

