### PR TITLE
Edits to docs-1082 - LiveCompare Docs update #6157

### DIFF
--- a/product_docs/docs/livecompare/3/command_line_usage.mdx
+++ b/product_docs/docs/livecompare/3/command_line_usage.mdx
@@ -34,11 +34,11 @@ dsn = port=5432 dbname=liveoutput user=postgres
 schemas = schema_name = 'public'
 ```
 
-This basic template compares three connections, `live1`, `live2`, and `live3`, and outputs the results to the `liveoutput` database. LiveCompare only uses the `public` schema in the comparison.
+This basic template compares three connections, `live1`, `live2`, and `live3`, and outputs the results to the `liveoutput` database. LiveCompare uses only the `public` schema in the comparison.
 
 ### Running the comparison
 
-To run the comparison, run livecompare and pass it the name of your settings file as an argument. If you have created a `my_project.ini` file, execute the following command:
+To run the comparison, run livecompare and pass it the name of your settings file as an argument. If you created a `my_project.ini` file, execute the following command:
 
 ```
 livecompare my_project.ini
@@ -173,7 +173,7 @@ dsn = dbname=liveoutpu
 schemas = schema_name = 'public'
 ```
 
-As the DSN under `Output Connection` (the LiveCompare cache database) is incorrect due to a mis-spelling of `liveoutput`, running LiveCompare initially fails with:
+As the DSN under `Output Connection` (the LiveCompare cache database) is incorrect due to a misspelling of `liveoutput`, running LiveCompare initially fails with:
 
 ```
 Output connection is not reachable.


### PR DESCRIPTION
Minor edit to correct spelling of "misspelling" and a couple other small edits.

