### PR TITLE
MTK: Privileges for using parallel loading in migrations from Oracle

### DIFF
--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -576,7 +576,7 @@ When dealing with a relatively large number of tables or large tables, normal da
 Parallel data migration at the schema level uses multiple threads to migrate several tables at the same time. Parallel data loading at the table level uses multiple threads to migrate a single table from the source database to the target database more efficiently and in a shorter time.
 
 
-!!! Note
+!!!note Notes
     - Parallel loading is useful only for large tables. For small tables, parallel threads might take more time. Thus we recommend using parallel data loading at the table level for relatively large tables.
 
     - Parallel data loading doesn't apply to tables without a primary/unique key.
@@ -584,6 +584,10 @@ Parallel data migration at the schema level uses multiple threads to migrate sev
     - You can't use the`fastCopy` parameter with parallel data loading.
 
     - Parallel loading functionality applies only to the source Oracle, EDB Postgres Advanced Server, and PostgreSQL databases.
+
+!!!warning Migrations from Oracle databases 
+Because parallel data loading uses Oracle Flashback queries to perform data loading, ensure the user performing the migration has `FLASHBACK` and `READ` / `SELECT` privileges to the table objects to migrate. To allow queries on all tables, grant the `FLASHBACK ANY TABLE` privilege.
+!!!
 
 The following options control the way MTK migrates data in parallel.
 


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/MTK-392 

Adding note for migrations from Oracle, as additional user privileges are required.