### PR TITLE
Added milliseconds to description of double precision types in 5.6 docs for new commit scope statistics views

### DIFF
--- a/product_docs/docs/pgd/5.6/reference/catalogs-visible.mdx
+++ b/product_docs/docs/pgd/5.6/reference/catalogs-visible.mdx
@@ -868,10 +868,10 @@ A view containing statistics for each commit scope.
 | ncalls              | bigint                   | The number of times the commit scope was used
 | ncommits            | bigint                   | The number of successful commits were made with the commit scope
 | naborts             | bigint                   | The number of times the commit scope used was eventually aborted
-| total_commit_time   | double precision         | Total time spent committing using the commit scope
-| min_commit_time     | double precision         | Minimum time spent committing using the commit scope
-| max_commit_time     | double precision         | Maximum time spend committing using the commit scope
-| mean_commit_time    | double precision         | Mean time spent committing using the commit scope
+| total_commit_time   | double precision         | Total time spent committing using the commit scope, in milliseconds
+| min_commit_time     | double precision         | Minimum time spent committing using the commit scope, in milliseconds
+| max_commit_time     | double precision         | Maximum time spend committing using the commit scope, in milliseconds
+| mean_commit_time    | double precision         | Mean time spent committing using the commit scope, in milliseconds
 | stats_reset         | timestamp with time zone | Time at which all statistics in the view were last reset
 
 ### `bdr.stat_commit_scope_state`
@@ -983,7 +983,7 @@ You can reset the stored relation statistics by calling
 | nspname             | name                     | Name of the relation's schema                                                                                                   |
 | relname             | name                     | Name of the relation                                                                                                            |
 | relid               | oid                      | OID of the relation                                                                                                             |
-| total_time          | double precision         | Total time spent processing replication for the relation                                                                        |
+| total_time          | double precision         | Total time spent processing replication for the relation, in milliseconds                                                                        |
 | ninsert             | bigint                   | Number of inserts replicated for the relation                                                                                   |
 | nupdate             | bigint                   | Number of updates replicated for the relation                                                                                   |
 | ndelete             | bigint                   | Number of deletes replicated for the relation                                                                                   |


### PR DESCRIPTION
Added milliseconds to the description of double precision types in 5.6 docs for new commit scope statistics views

