### PR TITLE
Fix releasenotes gen for cloud service

### DIFF
--- a/tools/user/import/bareleasenotes/barelease.js
+++ b/tools/user/import/bareleasenotes/barelease.js
@@ -41,11 +41,11 @@ function getShortMonthName(monthNumber) {
 
 function printReleaseNotesHeader(currentMonth, currentYear) {
   return `---
-title: BigAnimal ${getMonthName(currentMonth)} ${currentYear} release notes
+title: Cloud Service ${getMonthName(currentMonth)} ${currentYear} release notes
 navTitle: ${getMonthName(currentMonth)} ${currentYear}
 ---
 
-BigAnimal's ${getMonthName(
+EDB Postgres AI Cloud Service's ${getMonthName(
     currentMonth,
   )} ${currentYear} release includes the following enhancements and bug fixes:
 

--- a/tools/user/import/bareleasenotes/barelease.js
+++ b/tools/user/import/bareleasenotes/barelease.js
@@ -45,7 +45,7 @@ title: Cloud Service ${getMonthName(currentMonth)} ${currentYear} release notes
 navTitle: ${getMonthName(currentMonth)} ${currentYear}
 ---
 
-EDB Postgres AI Cloud Service's ${getMonthName(
+EDB Postgres® AI Cloud Service's ${getMonthName(
     currentMonth,
   )} ${currentYear} release includes the following enhancements and bug fixes:
 


### PR DESCRIPTION
Signed-off-by: Dj Walker-Morgan <dj.walker-morgan@enterprisedb.com>

## What Changed?

Switched the BigAnimal naming to CloudService in the generated output.