### PR TITLE
Update 04_using_descriptors.mdx

### DIFF
--- a/product_docs/docs/epas/16/application_programming/ecpgplus_guide/04_using_descriptors.mdx
+++ b/product_docs/docs/epas/16/application_programming/ecpgplus_guide/04_using_descriptors.mdx
@@ -74,9 +74,9 @@ For example, a user might invoke the sample with the following command:
 Sample Program:
 ```c
 /************************************************************
-/* exec_stmt.pgc
-*
-*/
+ * exec_stmt.pgc
+ *
+ */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/product_docs/docs/epas/16/application_programming/ecpgplus_guide/04_using_descriptors.mdx
+++ b/product_docs/docs/epas/16/application_programming/ecpgplus_guide/04_using_descriptors.mdx
@@ -67,10 +67,12 @@ When invoking the application, an end user must provide the name of the database
 
 For example, a user might invoke the sample with the following command:
 
-```c
+```
 ./exec_stmt edb "SELECT * FROM emp"
+```
 
-
+Sample Program:
+```c
 /************************************************************
 /* exec_stmt.pgc
 *
@@ -102,7 +104,7 @@ int main( int argc, char *argv[] )
   EXEC SQL ALLOCATE DESCRIPTOR parse_desc;
   EXEC SQL PREPARE query FROM :stmt;
   EXEC SQL DESCRIBE query INTO SQL DESCRIPTOR parse_desc;
-  EXEC SQL GET DESCRIPTOR 'parse_desc' :col_count = COUNT;
+  EXEC SQL GET DESCRIPTOR parse_desc :col_count = COUNT;
 
 if( col_count == 0 )
 {
@@ -143,7 +145,7 @@ else
              varchar name[20+1];
            EXEC SQL END DECLARE SECTION;
 
-           EXEC SQL GET DESCRIPTOR 'row_desc'
+           EXEC SQL GET DESCRIPTOR row_desc
              VALUE :col
              :val = DATA, :ind = INDICATOR, :name = NAME;
 
@@ -228,7 +230,7 @@ for( col = 1; col <= col_count; col++ )
 printf( "\n" );
 }
 
-/************************************************************
+/************************************************************/
 ```
 
 The code sample begins by including the prototypes and type definitions for the C `stdio` and `stdlib` libraries, SQL data type symbols, and the `SQLCA` (SQL communications area) structure:


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

Unfortunately, there might be some issues in the sample code on this page.

## Summery
a) Descriptor name right after identifier DESCRIPTOR should not be enclosed by '', that would lead to error. 
b) Comment in the end of the program is not enclosed by */ .
c) Exec command and program content is in the same code block, that might confuse customers who want to copy program,
    using "Copy" button.

## What Changed?
Line 32 and 73 of exec_stmt.pgc: Erased unneeded ''.
Last line: added /
Extra: Divided the code block into 2.

Kind Regards,
Yuki Tei 

