### PR TITLE
Update updating_an_rpm_installation.mdx

### DIFF
--- a/product_docs/docs/epas/16/installing/linux_install_details/updating_an_rpm_installation.mdx
+++ b/product_docs/docs/epas/16/installing/linux_install_details/updating_an_rpm_installation.mdx
@@ -8,16 +8,16 @@ If you have an existing EDB Postgres Advanced Server RPM installation, you can u
 To update the `edb.repo` file, assume superuser privileges and enter:
 
 ```text
-dnf upgrade edb-repo
+dnf update edb-repo
 ```
 
 `dnf` updates the `edb.repo` file to enable access to the current EDB repository, configured to connect with the credentials specified in your `edb.repo` file. Then, you can use `dnf` to upgrade all packages whose names include the expression `edb`:
 
 ```text
-dnf upgrade edb*
+dnf update edb*
 ```
 
 !!! Note
-    The `dnf upgrade` command performs an update only between minor releases. To update between major releases, use `pg_upgrade`.
+    The `dnf update` command performs an update only between minor releases. To update between major releases, use `pg_upgrade`.
 
 For more information about using dnf commands and options, see the [dnf documentation](https://docs.fedoraproject.org/en-US/quick-docs/dnf/).


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

Recently I found that, 
Recently we found that dnf command is different from this page.
https://www.enterprisedb.com/docs/epas/latest/upgrading/minor_upgrade/05_performing_a_minor_version_update_of_an_rpm_installation/
As dnf upgrade and update have a little bit different behavior, I suggest to merge to 'dnf update'.

## What Changed?
dnf upgrade => dnf update

Kind Regards,
Miyuki Nakashima