### PR TITLE
Update 05_building_executing_dynamic_sql_statements.mdx

### DIFF
--- a/product_docs/docs/epas/16/application_programming/ecpgplus_guide/05_building_executing_dynamic_sql_statements.mdx
+++ b/product_docs/docs/epas/16/application_programming/ecpgplus_guide/05_building_executing_dynamic_sql_statements.mdx
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 
   EXEC SQL WHENEVER SQLERROR DO handle_error();
 
-  EXEC SQL CONNECT :argv[1];
+  EXEC SQL CONNECT TO edb;
 
   insertStmt = "INSERT INTO dept VALUES(50, 'ACCTG', 'SEATTLE')";
 
@@ -92,7 +92,7 @@ EXEC SQL WHENEVER SQLERROR DO handle_error();
 Then, the example connects to the database using the credentials specified on the command line:
 
 ```sql
-EXEC SQL CONNECT :argv[1];
+EXEC SQL CONNECT edb;
 ```
 
 Next, the program uses an `EXECUTE IMMEDIATE` statement to execute a SQL statement, adding a row to the `dept` table:
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 
   EXEC SQL WHENEVER SQLERROR DO handle_error();
 
-  EXEC SQL CONNECT :argv[1];
+  EXEC SQL CONNECT TO :argv[1];
 
   stmtText = "INSERT INTO dept VALUES(?, ?, ?)";
 
@@ -203,7 +203,7 @@ EXEC SQL WHENEVER SQLERROR DO handle_error();
 Then, the example connects to the database using the credentials specified on the command line:
 
 ```sql
-EXEC SQL CONNECT :argv[1];
+EXEC SQL CONNECT TO :argv[1];
 ```
 
 Next, the program uses a `PREPARE` statement to parse and plan a statement that includes three parameter markers. If the `PREPARE` statement succeeds, it creates a statement handle that you can use to execute the statement. (In this example, the statement handle is named `stmtHandle`.) You can execute a given statement multiple times using the same statement handle.
@@ -261,12 +261,14 @@ static void handle_error(void);
 
 int main(int argc, char *argv[])
 {
+  EXEC SQL BEGIN DECLARE SECTION;
   VARCHAR  empno[10];
   VARCHAR  ename[20];
+  EXEC SQL END DECLARE SECTION;
 
   EXEC SQL WHENEVER SQLERROR DO handle_error();
 
-  EXEC SQL CONNECT :argv[1];
+  EXEC SQL CONNECT TO :argv[1];
 
   EXEC SQL PREPARE queryHandle
     FROM "SELECT empno, ename FROM emp WHERE deptno = ?";
@@ -318,8 +320,10 @@ static void handle_error(void);
 
 int main(int argc, char *argv[])
 {
-  VARCHAR empno[10];
-  VARCHAR ename[20];
+  EXEC SQL BEGIN DECLARE SECTION;
+  VARCHAR  empno[10];
+  VARCHAR  ename[20];
+  EXEC SQL END DECLARE SECTION;
 ```
 
 The example then sets up an error handler. ECPGPlus calls the `handle_error()` function whenever a SQL error occurs:
@@ -331,7 +335,7 @@ EXEC SQL WHENEVER SQLERROR DO handle_error();
 Then, the example connects to the database using the credentials specified on the command line:
 
 ```sql
-EXEC SQL CONNECT :argv[1];
+EXEC SQL CONNECT TO :argv[1];
 ```
 
 Next, the program uses a `PREPARE` statement to parse and plan a query that includes a single parameter marker. If the `PREPARE` statement succeeds, it creates a statement handle that you can use to execute the statement. (In this example, the statement handle is named `stmtHandle`.) You can execute a given statement multiple times using the same statement handle.


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

Unfortunately, I may find some mistakes in the sample codes

## What Changed?
a) EXEC SQL CONNECT query needs TO to indicate the database. My apologies that the second change should be 'CONNECT TO edb' not 'CONNECT edb'.
b) The first code sample uses argument despite it is an example without argument. So the argv[1] should be edb or some sort of specific value.
c) The SQL variables such as "VARCHAR hogehoge" should be enclosed by "EXEC SQL BEGIN/END DECLARE SECTION" query.

Kind Regards,
Yuki Tei

