### PR TITLE
Add install instructions for RHEL9 on ARM64 architecture for all products

### DIFF
--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/installing/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/installing/index.mdx
@@ -30,3 +30,11 @@ Select a link to access the applicable installation instructions:
 - [Ubuntu 22.04](linux_x86_64/edb-dms-reader_ubuntu_22), [Ubuntu 20.04](linux_x86_64/edb-dms-reader_ubuntu_20)
 
 - [Debian 12](linux_x86_64/edb-dms-reader_debian_12), [Debian 11](linux_x86_64/edb-dms-reader_debian_11)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/edb-dms-reader_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/edb-dms-reader_rhel_9)

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/installing/linux_arm64/edb-dms-reader_rhel_9.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/installing/linux_arm64/edb-dms-reader_rhel_9.mdx
@@ -1,0 +1,36 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Data Migration Service Reader on RHEL 9 or OL 9 arm64
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+Install the EDB DMS Reader (packaged as `cdcreader`):
+
+```shell
+sudo dnf install cdcreader
+```

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/installing/linux_arm64/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/installing/linux_arm64/index.mdx
@@ -1,0 +1,16 @@
+---
+title: "Installing EDB Data Migration Service Reader on Linux AArch64 (ARM64)"
+navTitle: "On Linux ARM64"
+indexCards: none
+
+navigation:
+  - edb-dms-reader_rhel_9
+---
+
+Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](edb-dms-reader_rhel_9)
+
+- [Oracle Linux (OL) 9](edb-dms-reader_rhel_9)

--- a/advocacy_docs/supported-open-source/postgresql/installing/index.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/index.mdx
@@ -57,6 +57,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/postgresql_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/postgresql_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/postgresql_debian_12)

--- a/advocacy_docs/supported-open-source/postgresql/installing/linux_arm64/index.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/linux_arm64/index.mdx
@@ -4,10 +4,17 @@ navTitle: "On Linux ARM64"
 indexCards: none
 
 navigation:
+  - postgresql_rhel_9
   - postgresql_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](postgresql_rhel_9)
+
+- [Oracle Linux (OL) 9](postgresql_rhel_9)
 
 ### Debian and derivatives
 

--- a/advocacy_docs/supported-open-source/postgresql/installing/linux_arm64/postgresql_rhel_9.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/linux_arm64/postgresql_rhel_9.mdx
@@ -1,0 +1,55 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing PostgreSQL on RHEL 9 or OL 9 arm64
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  !!! Note
+  Rather than use the EDB repository, you can obtain PostgreSQL installers and installation packages from the [PostgreSQL community downloads page](https://www.postgresql.org/download/).
+  !!!
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- Enable additional repositories to resolve dependencies:
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```
+- Disable the built-in PostgreSQL module:
+  ```shell
+  dnf -qy module disable postgresql
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install postgresql<xx>-server postgresql<xx>-contrib
+```
+
+Where `<xx>` is the version of PostgreSQL you are installing. For example, if you are installing version 16, the package name would be `postgresql16-server postgresql16-contrib`.

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -83,6 +83,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [55]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [55]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
         supported versions: [55]
@@ -220,7 +223,10 @@ products:
         supported versions: [1]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [1]      
+        supported versions: [1]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [1]  
       - name: Debian 11
         arch: x86_64
         supported versions: [1]
@@ -262,6 +268,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [4]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [4]  
       - name: Debian 11
         arch: x86_64
         supported versions: [4]
@@ -303,6 +312,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [4]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [4]  
       - name: Debian 11
         arch: x86_64
         supported versions: [4]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -514,6 +514,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [2]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [2]  
       - name: RHEL 9
         arch: ppc64le
         supported versions: [2]
@@ -555,6 +558,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [5]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [5]  
       - name: RHEL 9
         arch: ppc64le
         supported versions: [5]
@@ -596,6 +602,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [2]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [2]  
       - name: Ubuntu 22.04
         arch: x86_64
         supported versions: [2]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -325,7 +325,10 @@ products:
         supported versions: [11, 12, 13, 14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [11, 12, 13, 14, 15, 16]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [13, 14, 15, 16]
       - name: RHEL 9
         arch: ppc64le
         supported versions: [11, 12, 13, 14, 15, 16, 17]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -369,7 +369,10 @@ products:
         supported versions: [15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [15, 16, 17]
+        supported versions: [15, 16]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [15, 16]
       - name: Debian 12
         arch: x86_64
         supported versions: [16, 17]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -646,6 +646,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [3.4.2]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [3.4.2]  
       - name: Ubuntu 22.04
         arch: x86_64
         supported versions: [3.4.2]
@@ -813,6 +816,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [7]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [7]  
       - name: Debian 11
         arch: x86_64
         supported versions: [7]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -10,6 +10,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [2]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [2]
       - name: Debian 11
         arch: x86_64
         supported versions: [2]
@@ -38,7 +41,10 @@ products:
         supported versions: [42.7.3.2]
       - name: RHEL 9
         arch: ppc64le
-        supported versions: [42.7.3.2]
+        supported versions: [42.7.3.1]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [42.7.3.1]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
         supported versions: [42.7.3.2]
@@ -126,7 +132,10 @@ products:
         supported versions: [14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [14, 15, 16, 17]
+        supported versions: [14, 15, 16]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [14, 15, 16]
       - name: Debian 11
         arch: x86_64
         supported versions: [14, 15, 16, 17]
@@ -167,6 +176,9 @@ products:
         supported versions: [13, 16]
       - name: RHEL 9 or OL 9
         arch: x86_64
+        supported versions: [13, 16]
+      - name: RHEL 9 or OL 9
+        arch: arm64
         supported versions: [13, 16]
       - name: Debian 11
         arch: x86_64

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -690,6 +690,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [9]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [9]  
       - name: RHEL 9
         arch: ppc64le
         supported versions: [9]
@@ -731,6 +734,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [9]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [9]  
       - name: RHEL 9
         arch: ppc64le
         supported versions: [9]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -41,10 +41,10 @@ products:
         supported versions: [42.7.3.2]
       - name: RHEL 9
         arch: ppc64le
-        supported versions: [42.7.3.1]
+        supported versions: [42.7.3.2]
       - name: RHEL 9 or OL 9
         arch: arm64
-        supported versions: [42.7.3.1]
+        supported versions: [42.7.3.2]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
         supported versions: [42.7.3.2]
@@ -135,10 +135,10 @@ products:
         supported versions: [14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [14, 15, 16]
+        supported versions: [14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: arm64
-        supported versions: [14, 15, 16]
+        supported versions: [14, 15, 16, 17]
       - name: Debian 11
         arch: x86_64
         supported versions: [14, 15, 16, 17]
@@ -349,10 +349,10 @@ products:
         supported versions: [11, 12, 13, 14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16]
+        supported versions: [11, 12, 13, 14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: arm64
-        supported versions: [13, 14, 15, 16]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 9
         arch: ppc64le
         supported versions: [11, 12, 13, 14, 15, 16, 17]
@@ -393,10 +393,10 @@ products:
         supported versions: [15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [15, 16]
+        supported versions: [15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: arm64
-        supported versions: [15, 16]
+        supported versions: [15, 16, 17]
       - name: Debian 12
         arch: x86_64
         supported versions: [16, 17]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -736,6 +736,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [15, 16]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [15, 16]
       - name: Debian 12
         arch: x86_64
         supported versions: [15, 16]

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -426,6 +426,9 @@ products:
       - name: RHEL 9 or OL 9
         arch: x86_64
         supported versions: [41]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [41]  
       - name: RHEL 9
         arch: ppc64le
         supported versions: [41]
@@ -470,6 +473,9 @@ products:
       - name: RHEL 9
         arch: ppc64le
         supported versions: [4]
+      - name: RHEL 9 or OL 9
+        arch: arm64
+        supported versions: [4]  
       - name: RHEL 8
         arch: ppc64le
         supported versions: [4]

--- a/install_template/templates/platformBase/index.njk
+++ b/install_template/templates/platformBase/index.njk
@@ -79,7 +79,7 @@ Select a link to access the applicable installation instructions:
 
 {{archInstall("IBM Power (ppc64le)", "ppc64le", ["RHEL", "SLES"])}}
 
-{{archInstall("AArch64 (ARM64)", "arm64", ["Debian"])}}
+{{archInstall("AArch64 (ARM64)", "arm64", ["RHEL", "Debian"])}}
 {% endblock linuxinstall %}
 
 {% block otherosinstall %}

--- a/install_template/templates/platformBase/index.njk
+++ b/install_template/templates/platformBase/index.njk
@@ -79,7 +79,7 @@ Select a link to access the applicable installation instructions:
 
 {{archInstall("IBM Power (ppc64le)", "ppc64le", ["RHEL", "SLES"])}}
 
-{{archInstall("AArch64 (ARM64)", "arm64", ["RHEL", "Debian"])}}
+{{archInstall("AArch64 (ARM64)", "arm64", ["RHEL", "OL", "Debian"])}}
 {% endblock linuxinstall %}
 
 {% block otherosinstall %}

--- a/install_template/templates/products/edb*plus/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb*plus/rhel-9_arm64.njk
@@ -1,0 +1,3 @@
+{% extends "products/edb*plus/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}
+{% block prerequisites %}{% endblock prerequisites %}

--- a/install_template/templates/products/edb-data-migration-service-reader/arm64_index.njk
+++ b/install_template/templates/products/edb-data-migration-service-reader/arm64_index.njk
@@ -1,0 +1,7 @@
+{% extends "platformBase/arm64_index.njk" %}
+{% set productShortname="edb-dms-reader" %}
+
+{% block frontmatter %}
+deployPath: advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/installing/linux_arm64/index.mdx
+indexCards: none
+{% endblock frontmatter %}

--- a/install_template/templates/products/edb-data-migration-service-reader/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-data-migration-service-reader/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-data-migration-service-reader/rhel-9-or-ol-9.njk" %}
+

--- a/install_template/templates/products/edb-jdbc-connector/arm64_index.njk
+++ b/install_template/templates/products/edb-jdbc-connector/arm64_index.njk
@@ -4,3 +4,4 @@
 {% block frontmatter %}
 deployPath: jdbc_connector/{{ product.version }}/installing/linux_arm64/index.mdx
 {% endblock frontmatter %}
+

--- a/install_template/templates/products/edb-jdbc-connector/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-jdbc-connector/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-jdbc-connector/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/edb-ocl-connector/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-ocl-connector/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-ocl-connector/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/edb-odbc-connector/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-odbc-connector/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-odbc-connector/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/edb-pgbouncer/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-pgbouncer/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-pgbouncer/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/edb-pgpool-ii-extensions/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-pgpool-ii-extensions/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-pgpool-ii-extensions/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/edb-pgpool-ii/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-pgpool-ii/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-pgpool-ii/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/edb-postgres-advanced-server/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-postgres-advanced-server/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-postgres-advanced-server/rhel-9-or-ol-9.njk" %}
+

--- a/install_template/templates/products/edb-postgres-extended-server/rhel-9_arm64.njk
+++ b/install_template/templates/products/edb-postgres-extended-server/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/edb-postgres-extended-server/rhel-9-or-ol-9.njk" %}
+

--- a/install_template/templates/products/failover-manager/rhel-9_arm64.njk
+++ b/install_template/templates/products/failover-manager/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/failover-manager/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/hadoop-foreign-data-wrapper/rhel-9_arm64.njk
+++ b/install_template/templates/products/hadoop-foreign-data-wrapper/rhel-9_arm64.njk
@@ -1,0 +1,9 @@
+{% extends "products/hadoop-foreign-data-wrapper/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}
+{% block prerequisites %}
+{{ super() }}
+- Enable additional repositories to resolve dependencies:
+  ```shell
+  sudo dnf config-manager --set-enabled PowerTools
+  ```
+{% endblock prerequisites %}

--- a/install_template/templates/products/migration-toolkit/rhel-9_arm64.njk
+++ b/install_template/templates/products/migration-toolkit/rhel-9_arm64.njk
@@ -1,0 +1,3 @@
+{% extends "products/migration-toolkit/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}
+{% block prerequisites %}{% endblock prerequisites %}

--- a/install_template/templates/products/mongodb-foreign-data-wrapper/rhel-9_arm64.njk
+++ b/install_template/templates/products/mongodb-foreign-data-wrapper/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/mongodb-foreign-data-wrapper/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/mysql-foreign-data-wrapper/rhel-9_arm64.njk
+++ b/install_template/templates/products/mysql-foreign-data-wrapper/rhel-9_arm64.njk
@@ -1,0 +1,2 @@
+{% extends "products/mysql-foreign-data-wrapper/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}

--- a/install_template/templates/products/postgis/rhel-9_arm64.njk
+++ b/install_template/templates/products/postgis/rhel-9_arm64.njk
@@ -1,0 +1,29 @@
+{% extends "products/postgis/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}
+{% block prerequisites %}
+{{ super() }}
+- Enable additional repositories to resolve dependencies:
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```    
+  !!!note
+
+  If you are using a public cloud RHEL image, `subscription manager` may not be enabled and enabling it may incur unnecessary charges. Equivalent packages may be available under a different name such as `codeready-builder-for-rhel-8-rhui-rpms`. Consult the documentation for the RHEL image you are using to determine how to install `codeready-builder`.
+  
+  !!!
+{% endblock prerequisites %}
+{% block installCommand %}
+```shell
+# To install PostGIS 3.4:
+sudo dnf -y install edb-as<xx>-postgis34
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 13-15:
+sudo dnf -y install edb-as<xx>-postgis3
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 11-12:
+sudo dnf -y install edb-as<xx>-postgis
+```
+{% include "./_epasVersionInPostGISPackageName.njk" %}
+{% endblock installCommand %}
+
+

--- a/install_template/templates/products/postgres-enterprise-manager-agent/rhel-9_arm64.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-agent/rhel-9_arm64.njk
@@ -1,0 +1,3 @@
+{% extends "products/postgres-enterprise-manager-agent/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}
+{% block prerequisites %}{% endblock prerequisites %}

--- a/install_template/templates/products/postgres-enterprise-manager-server/rhel-9_arm64.njk
+++ b/install_template/templates/products/postgres-enterprise-manager-server/rhel-9_arm64.njk
@@ -1,0 +1,11 @@
+{% extends "products/postgres-enterprise-manager-server/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}
+{% set ssutilsName %}sslutils_<x> postgresql<x>-contrib{% endset %}
+{% set ssutilsExtendedName %}edb-postgresextended<x>-contrib{% endset %}
+{% set ssutilsExtendedFirstName %}edb-postgresextended<x>-sslutils{% endset %}
+{% block prerequisites %}{% endblock prerequisites %}
+{% block firewallCommand %}```shell
+   firewall-cmd --permanent --zone=public --add-port=8443/tcp
+         
+   firewall-cmd --reload
+   ```{% endblock firewallCommand %}

--- a/install_template/templates/products/postgresql/rhel-9_arm64.njk
+++ b/install_template/templates/products/postgresql/rhel-9_arm64.njk
@@ -1,0 +1,1 @@
+{% extends "products/postgresql/rhel-9-or-ol-9.njk" %}

--- a/install_template/templates/products/replication-server/rhel-9_arm64.njk
+++ b/install_template/templates/products/replication-server/rhel-9_arm64.njk
@@ -1,0 +1,3 @@
+{% extends "products/replication-server/base.njk" %}
+{% set platformBaseTemplate = "rhel-9-or-ol-9" %}
+{% block prerequisites %}{% endblock prerequisites %}

--- a/product_docs/docs/edb_plus/41/installing/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/index.mdx
@@ -12,8 +12,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
   - windows
   - configuring_linux_installation
 ---
@@ -53,6 +53,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/edbplus_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/edbplus_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/edbplus_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/edb_plus/41/installing/linux_arm64/edbplus_rhel_9.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_arm64/edbplus_rhel_9.mdx
@@ -1,0 +1,49 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB*Plus on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /edb_plus/41/03_installing_edb_plus/install_on_linux/arm64/edbplus_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-edbplus
+```
+
+## Initial configuration
+
+After performing a Linux installation of EDB\*Plus, you must set the values of environment variables that allow EDB\*Plus to locate your Java installation:
+
+```shell
+export JAVA_HOME=<path_to_java>
+export PATH=<path_to_java>/bin:$PATH
+```

--- a/product_docs/docs/edb_plus/41/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB*Plus on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - edbplus_rhel_9
   - edbplus_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](edbplus_rhel_9)
+
+- [Oracle Linux (OL) 9](edbplus_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/efm/4/installing/index.mdx
+++ b/product_docs/docs/efm/4/installing/index.mdx
@@ -72,6 +72,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/efm_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/efm_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/efm_debian_12)

--- a/product_docs/docs/efm/4/installing/linux_arm64/efm_rhel_9.mdx
+++ b/product_docs/docs/efm/4/installing/linux_arm64/efm_rhel_9.mdx
@@ -1,0 +1,66 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing Failover Manager on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /efm/4/03_installing_efm/arm64/efm_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host (not needed for witness nodes).
+
+  - See [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - See [PostgreSQL Downloads](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-efm<4x>
+```
+
+Where `<4x>` is the version of Failover Manager that you're installing. For example, if you're installing version 4.10, the package name is `edb-efm410`.
+
+The installation process creates a user named efm that has privileges to invoke scripts that control the Failover Manager service for clusters owned by enterprisedb or postgres.
+
+## Initial configuration
+
+If you're using Failover Manager to monitor a cluster owned by a user other than enterprisedb or postgres, see [Extending Failover Manager permissions](../../04_configuring_efm/04_extending_efm_permissions/#extending_efm_permissions).
+
+After installing on each node of the cluster:
+
+1.  Modify the [cluster properties file](../../04_configuring_efm/01_cluster_properties/#cluster_properties) on each node.
+2.  Modify the [cluster members file](../../04_configuring_efm/03_cluster_members/#cluster_members) on each node.
+3.  If applicable, configure and test virtual IP address settings and any scripts that are identified in the cluster properties file.
+4.  Start the agent on each node of the cluster. For more information, see [Controlling the Failover Manager service](../../08_controlling_efm_service/).

--- a/product_docs/docs/efm/4/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/efm/4/installing/linux_arm64/index.mdx
@@ -10,10 +10,17 @@ navTitle: "On Linux ARM64"
 redirects:
 
 navigation:
+  - efm_rhel_9
   - efm_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](efm_rhel_9)
+
+- [Oracle Linux (OL) 9](efm_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/13/installing/index.mdx
+++ b/product_docs/docs/epas/13/installing/index.mdx
@@ -14,6 +14,7 @@ redirects:
 
 navigation:
   - linux_x86_64
+  - linux_arm64
   - linux_ppc64le
   - windows
   - linux_install_details
@@ -53,6 +54,14 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/epas_sles_15)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/epas_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/epas_rhel_9)
 
 ## Windows
 

--- a/product_docs/docs/epas/13/installing/linux_arm64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/13/installing/linux_arm64/epas_rhel_9.mdx
@@ -1,0 +1,157 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Advanced Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/13/epas_inst_linux/installing_epas_using_edb_repository/arm64/epas_rhel9_arm
+  - /epas/13/epas_inst_linux/installing_epas_using_edb_repository/arm/epas_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- If you are also installing PostGIS, enable additional repositories to resolve dependencies:
+
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```
+
+  !!!note
+
+  If you are using a public cloud RHEL image, `subscription manager` may not be enabled and enabling it may incur unnecessary charges. Equivalent packages may be available under a different name such as `codeready-builder-for-rhel-9-rhui-rpms`. Consult the documentation for the RHEL image you are using to determine how to install `codeready-builder`.
+
+  !!!
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced Server you're installing. For example, if you're installing version 13, the package name is `edb-as13-server`.
+
+To install an individual component:
+
+```shell
+sudo dnf -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/13/installing/linux_install_details/rpm_packages/).
+
+Installing the server package creates an operating system user named enterprisedb. The user is assigned a user ID (UID) and a group ID (GID). The user has no default password. Use the `passwd` command to assign a password for the user. The default shell for the user is `bash`, and the user's home directory is `/var/lib/edb/as13`.
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-13-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as13/bin/edb-as-13-setup initdb
+
+sudo systemctl start edb-as-13
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (13.0.0, server 13.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/13/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/epas/13/installing/linux_arm64/index.mdx
@@ -4,7 +4,6 @@ navTitle: "On Linux ARM64"
 
 navigation:
   - epas_rhel_9
-  - epas_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -14,7 +13,3 @@ Operating system-specific install instructions are described in the correspondin
 - [RHEL 9](epas_rhel_9)
 
 - [Oracle Linux (OL) 9](epas_rhel_9)
-
-### Debian and derivatives
-
-- [Debian 12](epas_debian_12)

--- a/product_docs/docs/epas/14/installing/index.mdx
+++ b/product_docs/docs/epas/14/installing/index.mdx
@@ -14,6 +14,7 @@ redirects:
 
 navigation:
   - linux_x86_64
+  - linux_arm64
   - linux_ppc64le
   - windows
   - linux_install_details
@@ -53,6 +54,14 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/epas_sles_15)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/epas_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/epas_rhel_9)
 
 ## Windows
 

--- a/product_docs/docs/epas/14/installing/linux_arm64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/14/installing/linux_arm64/epas_rhel_9.mdx
@@ -1,0 +1,157 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Advanced Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/14/epas_inst_linux/installing_epas_using_edb_repository/arm64/epas_rhel9_arm
+  - /epas/14/epas_inst_linux/installing_epas_using_edb_repository/arm/epas_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- If you are also installing PostGIS, enable additional repositories to resolve dependencies:
+
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```
+
+  !!!note
+
+  If you are using a public cloud RHEL image, `subscription manager` may not be enabled and enabling it may incur unnecessary charges. Equivalent packages may be available under a different name such as `codeready-builder-for-rhel-9-rhui-rpms`. Consult the documentation for the RHEL image you are using to determine how to install `codeready-builder`.
+
+  !!!
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced Server you're installing. For example, if you're installing version 14, the package name is `edb-as14-server`.
+
+To install an individual component:
+
+```shell
+sudo dnf -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/14/installing/linux_install_details/rpm_packages/).
+
+Installing the server package creates an operating system user named enterprisedb. The user is assigned a user ID (UID) and a group ID (GID). The user has no default password. Use the `passwd` command to assign a password for the user. The default shell for the user is `bash`, and the user's home directory is `/var/lib/edb/as14`.
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-14-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as14/bin/edb-as-14-setup initdb
+
+sudo systemctl start edb-as-14
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../epas_guide/03_database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (14.0.0, server 14.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/14/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/epas/14/installing/linux_arm64/index.mdx
@@ -4,7 +4,6 @@ navTitle: "On Linux ARM64"
 
 navigation:
   - epas_rhel_9
-  - epas_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -14,7 +13,3 @@ Operating system-specific install instructions are described in the correspondin
 - [RHEL 9](epas_rhel_9)
 
 - [Oracle Linux (OL) 9](epas_rhel_9)
-
-### Debian and derivatives
-
-- [Debian 12](epas_debian_12)

--- a/product_docs/docs/epas/15/installing/index.mdx
+++ b/product_docs/docs/epas/15/installing/index.mdx
@@ -18,6 +18,7 @@ redirects:
 
 navigation:
   - linux_x86_64
+  - linux_arm64
   - linux_ppc64le
   - windows
   - linux_install_details
@@ -57,6 +58,14 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/epas_sles_15)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/epas_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/epas_rhel_9)
 
 ## Windows
 

--- a/product_docs/docs/epas/15/installing/linux_arm64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/15/installing/linux_arm64/epas_rhel_9.mdx
@@ -1,0 +1,157 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Advanced Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/15/epas_inst_linux/installing_epas_using_edb_repository/arm64/epas_rhel9_arm
+  - /epas/15/epas_inst_linux/installing_epas_using_edb_repository/arm/epas_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- If you are also installing PostGIS, enable additional repositories to resolve dependencies:
+
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```
+
+  !!!note
+
+  If you are using a public cloud RHEL image, `subscription manager` may not be enabled and enabling it may incur unnecessary charges. Equivalent packages may be available under a different name such as `codeready-builder-for-rhel-9-rhui-rpms`. Consult the documentation for the RHEL image you are using to determine how to install `codeready-builder`.
+
+  !!!
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced Server you're installing. For example, if you're installing version 15, the package name is `edb-as15-server`.
+
+To install an individual component:
+
+```shell
+sudo dnf -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/15/installing/linux_install_details/rpm_packages/).
+
+Installing the server package creates an operating system user named enterprisedb. The user is assigned a user ID (UID) and a group ID (GID). The user has no default password. Use the `passwd` command to assign a password for the user. The default shell for the user is `bash`, and the user's home directory is `/var/lib/edb/as15`.
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-15-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/specifying_cluster_options/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as15/bin/edb-as-15-setup initdb
+
+sudo systemctl start edb-as-15
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (15.0.0, server 15.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/15/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/epas/15/installing/linux_arm64/index.mdx
@@ -4,7 +4,6 @@ navTitle: "On Linux ARM64"
 
 navigation:
   - epas_rhel_9
-  - epas_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -14,7 +13,3 @@ Operating system-specific install instructions are described in the correspondin
 - [RHEL 9](epas_rhel_9)
 
 - [Oracle Linux (OL) 9](epas_rhel_9)
-
-### Debian and derivatives
-
-- [Debian 12](epas_debian_12)

--- a/product_docs/docs/epas/16/installing/index.mdx
+++ b/product_docs/docs/epas/16/installing/index.mdx
@@ -14,8 +14,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
   - windows
   - linux_install_details
   - windows_install_details
@@ -56,6 +56,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/epas_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/epas_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/epas_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/16/installing/linux_arm64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/16/installing/linux_arm64/epas_rhel_9.mdx
@@ -1,0 +1,157 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Advanced Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/16/epas_inst_linux/installing_epas_using_edb_repository/arm64/epas_rhel9_arm
+  - /epas/16/epas_inst_linux/installing_epas_using_edb_repository/arm/epas_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- If you are also installing PostGIS, enable additional repositories to resolve dependencies:
+
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```
+
+  !!!note
+
+  If you are using a public cloud RHEL image, `subscription manager` may not be enabled and enabling it may incur unnecessary charges. Equivalent packages may be available under a different name such as `codeready-builder-for-rhel-9-rhui-rpms`. Consult the documentation for the RHEL image you are using to determine how to install `codeready-builder`.
+
+  !!!
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced Server you're installing. For example, if you're installing version 16, the package name is `edb-as16-server`.
+
+To install an individual component:
+
+```shell
+sudo dnf -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/16/installing/linux_install_details/rpm_packages/).
+
+Installing the server package creates an operating system user named enterprisedb. The user is assigned a user ID (UID) and a group ID (GID). The user has no default password. Use the `passwd` command to assign a password for the user. The default shell for the user is `bash`, and the user's home directory is `/var/lib/edb/as16`.
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-16-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/specifying_cluster_options/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as16/bin/edb-as-16-setup initdb
+
+sudo systemctl start edb-as-16
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (16.0.0, server 16.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/17/installing/index.mdx
+++ b/product_docs/docs/epas/17/installing/index.mdx
@@ -14,8 +14,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
   - windows
   - linux_install_details
   - windows_install_details
@@ -56,6 +56,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/epas_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/epas_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/epas_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/epas/17/installing/linux_arm64/epas_rhel_9.mdx
+++ b/product_docs/docs/epas/17/installing/linux_arm64/epas_rhel_9.mdx
@@ -1,0 +1,157 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Advanced Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /epas/17/epas_inst_linux/installing_epas_using_edb_repository/arm64/epas_rhel9_arm
+  - /epas/17/epas_inst_linux/installing_epas_using_edb_repository/arm/epas_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- If you are also installing PostGIS, enable additional repositories to resolve dependencies:
+
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```
+
+  !!!note
+
+  If you are using a public cloud RHEL image, `subscription manager` may not be enabled and enabling it may incur unnecessary charges. Equivalent packages may be available under a different name such as `codeready-builder-for-rhel-9-rhui-rpms`. Consult the documentation for the RHEL image you are using to determine how to install `codeready-builder`.
+
+  !!!
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as<xx>-server
+```
+
+Where `<xx>` is the version of the EDB Postgres Advanced Server you're installing. For example, if you're installing version 17, the package name is `edb-as17-server`.
+
+To install an individual component:
+
+```shell
+sudo dnf -y install <package_name>
+```
+
+Where `package_name` can be any of the available packages from the [available package list](/epas/17/installing/linux_install_details/rpm_packages/).
+
+Installing the server package creates an operating system user named enterprisedb. The user is assigned a user ID (UID) and a group ID (GID). The user has no default password. Use the `passwd` command to assign a password for the user. The default shell for the user is `bash`, and the user's home directory is `/var/lib/edb/as17`.
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-as-17-setup` script creates a cluster in Oracle-compatible mode with the `edb` sample database in the cluster. To create a cluster in Postgres mode, see [Initializing the cluster in Postgres mode](../linux_install_details/managing_an_advanced_server_installation/specifying_cluster_options/#initializing-the-cluster-in-postgres-mode).
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/as17/bin/edb-as-17-setup initdb
+
+sudo systemctl start edb-as-17
+```
+
+To work in your cluster, log in as the enterprisedb user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo su - enterprisedb
+
+psql edb
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, enterprisedb. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../database_administration/01_configuration_parameters/01_setting_new_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE enterprisedb IDENTIFIED BY password;
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+psql (17.0.0, server 17.0.0)
+You are now connected to database "hr" as user "enterprisedb".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/epas/17/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/epas/17/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB Postgres Advanced Server on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - epas_rhel_9
   - epas_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](epas_rhel_9)
+
+- [Oracle Linux (OL) 9](epas_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/eprs/7/installing/index.mdx
+++ b/product_docs/docs/eprs/7/installing/index.mdx
@@ -59,6 +59,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/eprs_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/eprs_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/eprs_debian_12)

--- a/product_docs/docs/eprs/7/installing/linux_arm64/eprs_rhel_9.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_arm64/eprs_rhel_9.mdx
@@ -1,0 +1,62 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing Replication Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /eprs/7/03_installation/03_installing_rpm_package/arm64/eprs_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+You can install all Replication Server components with a single install command, or you may choose to install selected, individual components by installing only those particular packages.
+
+To install all Replication Server components:
+
+```shell
+sudo dnf  -y install edb-xdb
+```
+
+To install an individual component:
+
+```shell
+sudo dnf  -y install <package_name>
+```
+
+Where `<package_name>` is:
+
+| Package name         | Component                                                             |
+| -------------------- | --------------------------------------------------------------------- |
+| `edb-xdb-console`    | Replication console and the Replication Server command line interface |
+| `edb-xdb-publisher`  | Publication server                                                    |
+| `edb-xdb-subscriber` | Subscription server                                                   |
+
+## Initial configuration
+
+Before using Replication Server, you must download and install JDBC drivers. See [Installing a JDBC driver](/eprs/7/installing/installing_jdbc_driver) for details.

--- a/product_docs/docs/eprs/7/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/eprs/7/installing/linux_arm64/index.mdx
@@ -11,10 +11,17 @@ redirects:
   - /eprs/latest/03_installation/03_installing_rpm_package/arm64/
 
 navigation:
+  - eprs_rhel_9
   - eprs_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](eprs_rhel_9)
+
+- [Oracle Linux (OL) 9](eprs_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/hadoop_data_adapter/2/installing/index.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/index.mdx
@@ -15,8 +15,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
 ---
 
 Select a link to access the applicable installation instructions:
@@ -54,6 +54,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/hadoop_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/hadoop_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/hadoop_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_arm64/hadoop_rhel_9.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_arm64/hadoop_rhel_9.mdx
@@ -1,0 +1,59 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing Hadoop Foreign Data Wrapper on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /hadoop_data_adapter/2/05_installing_the_hadoop_data_adapter/arm64/hadoop_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- Enable additional repositories to resolve dependencies:
+  ```shell
+  sudo dnf config-manager --set-enabled PowerTools
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as15-hdfs_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced Server. Replace `15` with the version of EDB Postgres Advanced Server you are using.

--- a/product_docs/docs/hadoop_data_adapter/2/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/hadoop_data_adapter/2/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing Hadoop Foreign Data Wrapper on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - hadoop_rhel_9
   - hadoop_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](hadoop_rhel_9)
+
+- [Oracle Linux (OL) 9](hadoop_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/jdbc_connector/42.7.3.2/installing/index.mdx
+++ b/product_docs/docs/jdbc_connector/42.7.3.2/installing/index.mdx
@@ -68,6 +68,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/jdbc_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/jdbc_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/jdbc_debian_12)

--- a/product_docs/docs/jdbc_connector/42.7.3.2/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/jdbc_connector/42.7.3.2/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB JDBC Connector on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - jdbc_rhel_9
   - jdbc_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](jdbc_rhel_9)
+
+- [Oracle Linux (OL) 9](jdbc_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/jdbc_connector/42.7.3.2/installing/linux_arm64/jdbc_rhel_9.mdx
+++ b/product_docs/docs/jdbc_connector/42.7.3.2/installing/linux_arm64/jdbc_rhel_9.mdx
@@ -1,0 +1,55 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB JDBC Connector on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /jdbc_connector/42.5.4.1/04_installing_and_configuring_the_jdbc_connector/01_installing_the_connector_with_an_rpm_package/arm64/jdbc42_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Ensure that Java is installed on your system. You can download a Java installer that matches your environment from the Oracle Java Downloads [website](http://www.oracle.com/technetwork/java/javase/downloads/index.html). Documentation that contains detailed installation instructions is available through the associated `Installation Instruction` links on the same page.
+
+- Review [Supported JDBC distributions](/jdbc_connector/latest/02_requirements_overview/#supported-jdk-distribution).
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-jdbc
+```

--- a/product_docs/docs/migration_toolkit/55/installing/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/index.mdx
@@ -71,6 +71,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/mtk_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/mtk_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/mtk_debian_12)

--- a/product_docs/docs/migration_toolkit/55/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing Migration Toolkit on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - mtk_rhel_9
   - mtk_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](mtk_rhel_9)
+
+- [Oracle Linux (OL) 9](mtk_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/migration_toolkit/55/installing/linux_arm64/mtk_rhel_9.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/linux_arm64/mtk_rhel_9.mdx
@@ -1,0 +1,44 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing Migration Toolkit on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /migration_toolkit/55/05_installing_mtk/install_on_linux/arm64/mtk55_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-migrationtoolkit
+```
+
+## Initial configuration
+
+Before invoking Migration Toolkit, you must download and install JDBC drivers for connecting to the source and target databases. See [Installing a JDBC driver](/migration_toolkit/latest/installing/installing_jdbc_driver/) for details.

--- a/product_docs/docs/mongo_data_adapter/5/installing/index.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/index.mdx
@@ -15,8 +15,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
 ---
 
 Select a link to access the applicable installation instructions:
@@ -54,6 +54,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/mongo_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/mongo_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/mongo_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing MongoDB Foreign Data Wrapper on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - mongo_rhel_9
   - mongo_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](mongo_rhel_9)
+
+- [Oracle Linux (OL) 9](mongo_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/mongo_data_adapter/5/installing/linux_arm64/mongo_rhel_9.mdx
+++ b/product_docs/docs/mongo_data_adapter/5/installing/linux_arm64/mongo_rhel_9.mdx
@@ -1,0 +1,53 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing MongoDB Foreign Data Wrapper on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /mongo_data_adapter/5/04_installing_the_mongo_data_adapter/arm64/mongo_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as15-mongo_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced Server. Replace `15` with the version of EDB Postgres Advanced Server you are using.

--- a/product_docs/docs/mysql_data_adapter/2/installing/index.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/index.mdx
@@ -14,8 +14,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
 ---
 
 Select a link to access the applicable installation instructions:
@@ -53,6 +53,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/mysql_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/mysql_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/mysql_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing MySQL Foreign Data Wrapper on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - mysql_rhel_9
   - mysql_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](mysql_rhel_9)
+
+- [Oracle Linux (OL) 9](mysql_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/mysql_data_adapter/2/installing/linux_arm64/mysql_rhel_9.mdx
+++ b/product_docs/docs/mysql_data_adapter/2/installing/linux_arm64/mysql_rhel_9.mdx
@@ -1,0 +1,53 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing MySQL Foreign Data Wrapper on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /mysql_data_adapter/2/04_installing_the_mysql_data_adapter/arm64/mysql_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as15-mysql8_fdw
+```
+
+Where `15` is the version of EDB Postgres Advanced server and `8` is the version of MySQL to be installed.

--- a/product_docs/docs/ocl_connector/14/installing/index.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/index.mdx
@@ -16,6 +16,7 @@ redirects:
 navigation:
   - linux_ppc64le
   - linux_x86_64
+  - linux_arm64
   - windows
   - upgrading
 ---
@@ -53,6 +54,14 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/ocl_sles_15)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/ocl_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/ocl_rhel_9)
 
 ## Windows
 

--- a/product_docs/docs/ocl_connector/14/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_arm64/index.mdx
@@ -4,7 +4,6 @@ navTitle: "On Linux ARM64"
 
 navigation:
   - ocl_rhel_9
-  - ocl_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -14,7 +13,3 @@ Operating system-specific install instructions are described in the correspondin
 - [RHEL 9](ocl_rhel_9)
 
 - [Oracle Linux (OL) 9](ocl_rhel_9)
-
-### Debian and derivatives
-
-- [Debian 12](ocl_debian_12)

--- a/product_docs/docs/ocl_connector/14/installing/linux_arm64/ocl_rhel_9.mdx
+++ b/product_docs/docs/ocl_connector/14/installing/linux_arm64/ocl_rhel_9.mdx
@@ -1,0 +1,52 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB OCL Connector on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/14/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/arm64/ocl_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-oci
+sudo dnf -y install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/15/installing/index.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/index.mdx
@@ -16,6 +16,7 @@ redirects:
 navigation:
   - linux_ppc64le
   - linux_x86_64
+  - linux_arm64
   - windows
   - upgrading
 ---
@@ -53,6 +54,14 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/ocl_sles_15)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/ocl_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/ocl_rhel_9)
 
 ## Windows
 

--- a/product_docs/docs/ocl_connector/15/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_arm64/index.mdx
@@ -4,7 +4,6 @@ navTitle: "On Linux ARM64"
 
 navigation:
   - ocl_rhel_9
-  - ocl_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -14,7 +13,3 @@ Operating system-specific install instructions are described in the correspondin
 - [RHEL 9](ocl_rhel_9)
 
 - [Oracle Linux (OL) 9](ocl_rhel_9)
-
-### Debian and derivatives
-
-- [Debian 12](ocl_debian_12)

--- a/product_docs/docs/ocl_connector/15/installing/linux_arm64/ocl_rhel_9.mdx
+++ b/product_docs/docs/ocl_connector/15/installing/linux_arm64/ocl_rhel_9.mdx
@@ -1,0 +1,52 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB OCL Connector on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/15/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/arm64/ocl_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-oci
+sudo dnf -y install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/16/installing/index.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/index.mdx
@@ -57,6 +57,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/ocl_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/ocl_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/ocl_debian_12)

--- a/product_docs/docs/ocl_connector/16/installing/linux_arm64/ocl_rhel_9.mdx
+++ b/product_docs/docs/ocl_connector/16/installing/linux_arm64/ocl_rhel_9.mdx
@@ -1,0 +1,52 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB OCL Connector on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/16/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/arm64/ocl_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-oci
+sudo dnf -y install edb-oci-devel
+```

--- a/product_docs/docs/ocl_connector/17/installing/index.mdx
+++ b/product_docs/docs/ocl_connector/17/installing/index.mdx
@@ -57,6 +57,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/ocl_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/ocl_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/ocl_debian_12)

--- a/product_docs/docs/ocl_connector/17/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/ocl_connector/17/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB OCL Connector on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - ocl_rhel_9
   - ocl_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](ocl_rhel_9)
+
+- [Oracle Linux (OL) 9](ocl_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/ocl_connector/17/installing/linux_arm64/ocl_rhel_9.mdx
+++ b/product_docs/docs/ocl_connector/17/installing/linux_arm64/ocl_rhel_9.mdx
@@ -1,0 +1,52 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB OCL Connector on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /ocl_connector/17/04_open_client_library/01_installing_and_configuring_the_ocl_connector/install_on_linux_using_edb_repo/arm64/ocl_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-oci
+sudo dnf -y install edb-oci-devel
+```

--- a/product_docs/docs/odbc_connector/13/installing/index.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/index.mdx
@@ -16,6 +16,7 @@ redirects:
 navigation:
   - linux_ppc64le
   - linux_x86_64
+  - linux_arm64
   - windows
   - upgrading
 ---
@@ -53,6 +54,14 @@ Select a link to access the applicable installation instructions:
 ### SUSE Linux Enterprise (SLES)
 
 - [SLES 15](linux_ppc64le/odbc_sles_15)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/odbc_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/odbc_rhel_9)
 
 ## Windows
 

--- a/product_docs/docs/odbc_connector/13/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_arm64/index.mdx
@@ -4,7 +4,6 @@ navTitle: "On Linux ARM64"
 
 navigation:
   - odbc_rhel_9
-  - odbc_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -14,7 +13,3 @@ Operating system-specific install instructions are described in the correspondin
 - [RHEL 9](odbc_rhel_9)
 
 - [Oracle Linux (OL) 9](odbc_rhel_9)
-
-### Debian and derivatives
-
-- [Debian 12](odbc_debian_12)

--- a/product_docs/docs/odbc_connector/13/installing/linux_arm64/odbc_rhel_9.mdx
+++ b/product_docs/docs/odbc_connector/13/installing/linux_arm64/odbc_rhel_9.mdx
@@ -1,0 +1,52 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB ODBC Connector on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /odbc_connector/13/03_installing_edb_odbc/01_installing_linux/arm64/odbc13_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-odbc
+sudo dnf -y install edb-odbc-devel
+```

--- a/product_docs/docs/odbc_connector/16/installing/index.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/index.mdx
@@ -57,6 +57,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/odbc_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/odbc_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/odbc_debian_12)

--- a/product_docs/docs/odbc_connector/16/installing/linux_arm64/odbc_rhel_9.mdx
+++ b/product_docs/docs/odbc_connector/16/installing/linux_arm64/odbc_rhel_9.mdx
@@ -1,0 +1,52 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB ODBC Connector on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /odbc_connector/16/03_installing_edb_odbc/01_installing_linux/arm64/odbc13_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on a host that the product can connect to using a connection string. It doesn't need to be on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-odbc
+sudo dnf -y install edb-odbc-devel
+```

--- a/product_docs/docs/pem/9/installing/index.mdx
+++ b/product_docs/docs/pem/9/installing/index.mdx
@@ -18,8 +18,8 @@ navigation:
   - prerequisites
   - dependencies
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
   - windows
   - creating_pem_repository_in_isolated_network
   - configuring_the_pem_server_on_linux
@@ -60,6 +60,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/pem_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pem_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pem_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/9/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/pem/9/installing/linux_arm64/index.mdx
@@ -10,10 +10,17 @@ navTitle: "On Linux ARM64"
 redirects:
 
 navigation:
+  - pem_rhel_9
   - pem_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](pem_rhel_9)
+
+- [Oracle Linux (OL) 9](pem_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/9/installing/linux_arm64/pem_rhel_9.mdx
+++ b/product_docs/docs/pem/9/installing/linux_arm64/pem_rhel_9.mdx
@@ -1,0 +1,97 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing Postgres Enterprise Manager server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/9/installing_pem_server/pem_server_inst_linux/installing_pem_server_using_edb_repository/arm64/pem_server_rhel9_arm
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/ibm_power_ppc64le/pem_server_rhel9_arm/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/ppc64le/pem_server_rhel9_arm/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/x86_amd64/pem_server_rhel9_arm/
+  - /pem/9/installing_pem_server/installing_on_linux/using_edb_repository/x86/pem_server_rhel9_arm/
+---
+
+You can install PEM on a single server, or you can install the web application server and the backend database on two separate servers. You must prepare your servers for PEM installation.
+
+After fulfilling the prerequisites and completing the installation procedure described in the following steps, you must [configure](/pem/9/installing/configuring_the_pem_server_on_linux.mdx) PEM. If you're using two servers, install and configure PEM on both servers.
+
+## Prerequisites
+
+Before you begin the installation process:
+
+1. Install a [supported Postgres instance](/pem/latest/#postgres-compatibility) for PEM to use as a backend database.
+
+   You can install this instance on the same server to be used for the PEM web application or on a separate server. You can also use an existing Postgres instance if it is configured as detailed in the next steps.
+
+2. Configure authentication on the Postgres backend database by updating the `pg_hba.conf` file.
+
+   Make the following changes manually, prior to configuration. (Additional changes are necessary during [configuration](../configuring_the_pem_server_on_linux.mdx).)
+
+   - To create the relations required for PEM, the PEM configuration script connects to the Postgres backend database as a superuser of your choice using password authentication. This requires you to permit your chosen superuser to authenticate using a password. This user must be able to connect from any location where you run the configuration script. In practice, this means the server where the backend database is located and the server where the PEM web application is to be installed, if they're different.
+
+   - To allow the chosen superuser to connect using password authentication, add a line to `pg_hba.conf` that allows `host` connections using `md5` or `scram-sha-256` authentication, such as `host all superusername 127.0.0.1/32 scram-sha-256`.
+
+   !!! Note
+   If you're using EDB Postgres Advanced Server, see [Modifying the pg_hba.conf file](/pem/latest/managing_database_server/#modifying-the-pg_hbaconf-file).
+
+   If you're using PostgreSQL, see [Client Authentication](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
+   !!!
+
+3. Verify that the `sslutils` extension is installed on your Postgres server.
+
+   If you're using PostgreSQL or EDB Postgres Extended Server on RHEL/AlmaLinux/Rocky Linux or SLES, you also need to install the `hstore contrib` module.
+
+   - If you're using EDB Postgres Advanced Server, you can install the `sslutils` extension as follows, where `<x>` is the EDB Postgres Advanced server version.
+
+     ```shell
+     sudo dnf install edb-as<x>-server-sslutils
+     ```
+
+   - If you're using PostgreSQL, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the PostgreSQL version.
+     ```shell
+     sudo dnf install sslutils_<x> postgresql<x>-contrib
+     ```
+   - If you're using EDB Postgres Extended Server, you can install the `sslutils` and, if required, `hstore` modules as follows, where `<x>` is the EDB Postgres Extended Server version.
+     ```shell
+     sudo dnf install edb-postgresextended<x>-sslutils edb-postgresextended<x>-contrib
+     ```
+
+4. If you're using a firewall, allow access to port 8443 on the server where the PEM web application will be located:
+
+   ```shell
+   firewall-cmd --permanent --zone=public --add-port=8443/tcp
+
+   firewall-cmd --reload
+   ```
+
+5. Make sure the components Postgres Enterprise Manager depends on are up to date on all servers. You can do this by updating the whole system using your package manager as shown below.
+   If you prefer to update individual packages, a full list of dependencies is provided in [Dependencies of the PEM Server and Agent on Linux](../dependencies.md).
+
+   ```shell
+   sudo dnf upgrade
+   ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-pem
+```
+
+## Initial configuration
+
+```shell
+# You can configure the PEM server using the following command:
+sudo /usr/edb/pem/bin/configure-pem-server.sh
+```
+
+For more details, see [Configuring the PEM server on Linux](../configuring_the_pem_server_on_linux/).
+
+!!! Note
+
+    - The operating system user pem is created while installing the PEM server. The PEM server web application is a WSGI application, which runs under Apache HTTPD. The pem application data and the session is saved to this user's home directory.
+
+## Supported locales
+
+Currently, the Postgres Enterprise Manager server and web interface support a locale of `English(US) en_US` and use of a period (.) as a language separator character. Using an alternate locale or a separator character other than a period might cause errors.

--- a/product_docs/docs/pem/9/installing_pem_agent/index.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/index.mdx
@@ -15,8 +15,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
   - windows_agent
 ---
 
@@ -55,6 +55,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/pem_agent_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pem_agent_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pem_agent_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_arm64/index.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_arm64/index.mdx
@@ -10,10 +10,17 @@ redirects:
   - /pem/latest/installing_pem_agent/installing_on_linux/arm64/
 
 navigation:
+  - pem_agent_rhel_9
   - pem_agent_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](pem_agent_rhel_9)
+
+- [Oracle Linux (OL) 9](pem_agent_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pem/9/installing_pem_agent/linux_arm64/pem_agent_rhel_9.mdx
+++ b/product_docs/docs/pem/9/installing_pem_agent/linux_arm64/pem_agent_rhel_9.mdx
@@ -1,0 +1,42 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing Postgres Enterprise Manager agent on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pem/9/installing_pem_agent/installing_on_linux/arm64/pem_agent_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-pem-agent
+```
+
+After installing PEM agent, you need to register the PEM agent. For detailed information see [Registering an agent](../../registering_agent/).

--- a/product_docs/docs/pgbouncer/1/installing/index.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/index.mdx
@@ -57,6 +57,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pgbouncer_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pgbouncer_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/pgbouncer_debian_12)

--- a/product_docs/docs/pgbouncer/1/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB pgBouncer on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - pgbouncer_rhel_9
   - pgbouncer_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](pgbouncer_rhel_9)
+
+- [Oracle Linux (OL) 9](pgbouncer_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pgbouncer/1/installing/linux_arm64/pgbouncer_rhel_9.mdx
+++ b/product_docs/docs/pgbouncer/1/installing/linux_arm64/pgbouncer_rhel_9.mdx
@@ -1,0 +1,53 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB pgBouncer on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgbouncer/1/01_installation/install_on_linux/arm64/pgbouncer_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-pgbouncer<xx>
+```
+
+Where `<xx>` is the version of EDB PgBouncer you are installing. For example, if you are installing version 1.22, the package name would be `edb-pgbouncer122`.

--- a/product_docs/docs/pge/15/installing/index.mdx
+++ b/product_docs/docs/pge/15/installing/index.mdx
@@ -6,6 +6,7 @@ description: Installation instructions for EDB Postgres Extended Server on Linux
 
 navigation:
   - linux_x86_64
+  - linux_arm64
 ---
 
 Select a link to access the applicable installation instructions:
@@ -27,3 +28,11 @@ Select a link to access the applicable installation instructions:
 - [Ubuntu 22.04](linux_x86_64/pge_ubuntu_22), [Ubuntu 20.04](linux_x86_64/pge_ubuntu_20)
 
 - [Debian 11](linux_x86_64/pge_debian_11)
+
+## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pge_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pge_rhel_9)

--- a/product_docs/docs/pge/15/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/pge/15/installing/linux_arm64/index.mdx
@@ -4,7 +4,6 @@ navTitle: "On Linux ARM64"
 
 navigation:
   - pge_rhel_9
-  - pge_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
@@ -14,7 +13,3 @@ Operating system-specific install instructions are described in the correspondin
 - [RHEL 9](pge_rhel_9)
 
 - [Oracle Linux (OL) 9](pge_rhel_9)
-
-### Debian and derivatives
-
-- [Debian 12](pge_debian_12)

--- a/product_docs/docs/pge/15/installing/linux_arm64/pge_rhel_9.mdx
+++ b/product_docs/docs/pge/15/installing/linux_arm64/pge_rhel_9.mdx
@@ -1,0 +1,129 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Extended Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-postgresextended15-server edb-postgresextended15-contrib
+```
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-pge-15-setup` script creates a cluster.
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/pge15/bin/edb-pge-15-setup initdb
+
+sudo systemctl start edb-pge-15
+```
+
+To work in your cluster, log in as the postgres user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo -iu postgres
+
+psql postgres
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, postgres. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../administration/01_setting_configuration_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE postgres with PASSWORD 'password';
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+You are now connected to database "hr" as user "postgres".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/pge/16/installing/index.mdx
+++ b/product_docs/docs/pge/16/installing/index.mdx
@@ -31,6 +31,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pge_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pge_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/pge_debian_12)

--- a/product_docs/docs/pge/16/installing/linux_arm64/pge_rhel_9.mdx
+++ b/product_docs/docs/pge/16/installing/linux_arm64/pge_rhel_9.mdx
@@ -1,0 +1,129 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Extended Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-postgresextended16-server edb-postgresextended16-contrib
+```
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-pge-16-setup` script creates a cluster.
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/pge16/bin/edb-pge-16-setup initdb
+
+sudo systemctl start edb-pge-16
+```
+
+To work in your cluster, log in as the postgres user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo -iu postgres
+
+psql postgres
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, postgres. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../administration/01_setting_configuration_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE postgres with PASSWORD 'password';
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+You are now connected to database "hr" as user "postgres".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/pge/17/installing/index.mdx
+++ b/product_docs/docs/pge/17/installing/index.mdx
@@ -31,6 +31,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pge_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pge_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/pge_debian_12)

--- a/product_docs/docs/pge/17/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/pge/17/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB Postgres Extended Server on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - pge_rhel_9
   - pge_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](pge_rhel_9)
+
+- [Oracle Linux (OL) 9](pge_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pge/17/installing/linux_arm64/pge_rhel_9.mdx
+++ b/product_docs/docs/pge/17/installing/linux_arm64/pge_rhel_9.mdx
@@ -1,0 +1,129 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Postgres Extended Server on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-postgresextended17-server edb-postgresextended17-contrib
+```
+
+## Initial configuration
+
+Getting started with your cluster involves logging in, ensuring the installation and initial configuration was successful, connecting to your cluster, and creating the user password.
+
+First, you need to initialize and start the database cluster. The `edb-pge-17-setup` script creates a cluster.
+
+```shell
+sudo PGSETUP_INITDB_OPTIONS="-E UTF-8" /usr/edb/pge17/bin/edb-pge-17-setup initdb
+
+sudo systemctl start edb-pge-17
+```
+
+To work in your cluster, log in as the postgres user. Connect to the database server using the psql command-line client. Alternatively, you can use a client of your choice with the appropriate connection string.
+
+```shell
+sudo -iu postgres
+
+psql postgres
+```
+
+The server runs with the `peer` or `ident` permission by default. You can change the authentication method by modifying the `pg_hba.conf` file.
+
+Before changing the authentication method, assign a password to the database superuser, postgres. For more information on changing the authentication, see [Modifying the pg_hba.conf file](../../administration/01_setting_configuration_parameters/#modifying-the-pg_hbaconf-file).
+
+```sql
+ALTER ROLE postgres with PASSWORD 'password';
+```
+
+## Experiment
+
+Now you're ready to create and connect to a database, create a table, insert data in a table, and view the data from the table.
+
+First, use psql to create a database named `hr` to hold human resource information.
+
+```sql
+# running in psql
+CREATE DATABASE hr;
+__OUTPUT__
+CREATE DATABASE
+```
+
+Connect to the `hr` database inside psql:
+
+```
+\c hr
+__OUTPUT__
+You are now connected to database "hr" as user "postgres".
+```
+
+Create columns to hold department numbers, unique department names, and locations:
+
+```
+CREATE TABLE public.dept (deptno numeric(2) NOT NULL CONSTRAINT dept_pk
+PRIMARY KEY, dname varchar(14) CONSTRAINT dept_dname_uq UNIQUE, loc
+varchar(13));
+__OUTPUT__
+CREATE TABLE
+```
+
+Insert values into the `dept` table:
+
+```
+INSERT INTO dept VALUES (10,'ACCOUNTING','NEW YORK');
+__OUTPUT__
+INSERT 0 1
+```
+
+```
+INSERT into dept VALUES (20,'RESEARCH','DALLAS');
+__OUTPUT__
+INSERT 0 1
+```
+
+View the table data by selecting the values from the table:
+
+```
+SELECT * FROM dept;
+__OUTPUT__
+deptno  |   dname    |   loc
+--------+------------+----------
+10      | ACCOUNTING | NEW YORK
+20      | RESEARCH   | DALLAS
+(2 rows)
+```

--- a/product_docs/docs/pgpool/4/installing/index.mdx
+++ b/product_docs/docs/pgpool/4/installing/index.mdx
@@ -61,6 +61,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pgpool_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pgpool_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/pgpool_debian_12)

--- a/product_docs/docs/pgpool/4/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB Pgpool-II on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - pgpool_rhel_9
   - pgpool_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](pgpool_rhel_9)
+
+- [Oracle Linux (OL) 9](pgpool_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pgpool/4/installing/linux_arm64/pgpool_rhel_9.mdx
+++ b/product_docs/docs/pgpool/4/installing/linux_arm64/pgpool_rhel_9.mdx
@@ -1,0 +1,53 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Pgpool-II on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgpool/4/01_installing_and_configuring_the_pgpool-II/arm64/pgpool_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-pgpool<xx>
+```
+
+Where `<xx>` is the version of EDB PgPool-II you are installing. For example, if you are installing version 4.3, the package name would be `edb-pgpool43`.

--- a/product_docs/docs/pgpool/4/installing_extensions/index.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/index.mdx
@@ -58,6 +58,12 @@ Select a link to access the applicable installation instructions:
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
 
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/pgpoolext_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/pgpoolext_rhel_9)
+
 ### Debian and derivatives
 
 - [Debian 12](linux_arm64/pgpoolext_debian_12)

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_arm64/index.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_arm64/index.mdx
@@ -3,10 +3,17 @@ title: "Installing EDB Pgpool-II Extensions on Linux AArch64 (ARM64)"
 navTitle: "On Linux ARM64"
 
 navigation:
+  - pgpoolext_rhel_9
   - pgpoolext_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](pgpoolext_rhel_9)
+
+- [Oracle Linux (OL) 9](pgpoolext_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/pgpool/4/installing_extensions/linux_arm64/pgpoolext_rhel_9.mdx
+++ b/product_docs/docs/pgpool/4/installing_extensions/linux_arm64/pgpoolext_rhel_9.mdx
@@ -1,0 +1,53 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing EDB Pgpool-II Extensions on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /pgpool/4/02_extensions/arm64/pgpoolext_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+## Install the package
+
+```shell
+sudo dnf -y install edb-as<xx>-pgpool<yy>-extensions
+```
+
+Where `<xx>` is the EDB Postgres Advanced Server version and `<yy>` is the EDB Pgpool-II version you are installing. For example, if you are installing EDB Pgpool-II version 4.4 and EDB Postgres Advanced Server version 15, the package name would be `edb-as15-pgpool44-extensions`.

--- a/product_docs/docs/postgis/3/installing/index.mdx
+++ b/product_docs/docs/postgis/3/installing/index.mdx
@@ -14,8 +14,8 @@ redirects:
 
 navigation:
   - linux_x86_64
-  - linux_ppc64le
   - linux_arm64
+  - linux_ppc64le
   - windows
   - upgrading
   - uninstalling
@@ -56,6 +56,12 @@ Select a link to access the applicable installation instructions:
 - [SLES 15](linux_ppc64le/postgis_sles_15)
 
 ## Linux [AArch64 (ARM64)](linux_arm64)
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](linux_arm64/postgis_rhel_9)
+
+- [Oracle Linux (OL) 9](linux_arm64/postgis_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/postgis/3/installing/linux_arm64/index.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_arm64/index.mdx
@@ -9,10 +9,17 @@ navTitle: "On Linux ARM64"
 redirects:
 
 navigation:
+  - postgis_rhel_9
   - postgis_debian_12
 ---
 
 Operating system-specific install instructions are described in the corresponding documentation:
+
+### Red Hat Enterprise Linux (RHEL) and derivatives
+
+- [RHEL 9](postgis_rhel_9)
+
+- [Oracle Linux (OL) 9](postgis_rhel_9)
 
 ### Debian and derivatives
 

--- a/product_docs/docs/postgis/3/installing/linux_arm64/postgis_rhel_9.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_arm64/postgis_rhel_9.mdx
@@ -1,0 +1,73 @@
+---
+navTitle: RHEL 9 or OL 9
+title: Installing PostGIS on RHEL 9 or OL 9 arm64
+# This topic is generated from templates. If you have feedback on it, instead of
+# editing the page and creating a pull request, please enter a GitHub issue and
+# the documentation team will update the templates accordingly.
+
+redirects:
+  - /postgis/latest/01a_installing_postgis/installing_on_linux/arm64/postgis_rhel9_arm
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Install Postgres on the same host. See:
+
+  - [Installing EDB Postgres Advanced Server](/epas/latest/installing/)
+
+  - [Installing PostgreSQL](https://www.postgresql.org/download/)
+
+- Set up the EDB repository.
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `dnf repolist | grep enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+- Install the EPEL repository:
+
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
+- Enable additional repositories to resolve dependencies:
+
+  ```shell
+  ARCH=$( /bin/arch ) subscription-manager repos --enable "codeready-builder-for-rhel-9-${ARCH}-rpms"
+  ```
+
+  !!!note
+
+  If you are using a public cloud RHEL image, `subscription manager` may not be enabled and enabling it may incur unnecessary charges. Equivalent packages may be available under a different name such as `codeready-builder-for-rhel-8-rhui-rpms`. Consult the documentation for the RHEL image you are using to determine how to install `codeready-builder`.
+
+  !!!
+
+## Install the package
+
+```shell
+# To install PostGIS 3.4:
+sudo dnf -y install edb-as<xx>-postgis34
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 13-15:
+sudo dnf -y install edb-as<xx>-postgis3
+
+# To install PostGIS 3.1 using EDB Postgres Advanced Server 11-12:
+sudo dnf -y install edb-as<xx>-postgis
+```
+
+Where `<xx>` is the version of EDB Postgres Advanced Server. Replace `<xx>` with the version of EDB Postgres Advanced Server you are using. For example, `edb-as15-postgis34`.


### PR DESCRIPTION
Modified templates to create install instructions for RHEL 9 on ARM64 architecture for all products

Addresses https://enterprisedb.atlassian.net/browse/DOCS-1087