### PR TITLE
Update 5.6 docs to reflect multi-row conflicts possibility given unblocked EXCLUDE constraints in 5.6

### DIFF
--- a/product_docs/docs/pgd/5.6/conflict-management/conflicts/02_types_of_conflict.mdx
+++ b/product_docs/docs/pgd/5.6/conflict-management/conflicts/02_types_of_conflict.mdx
@@ -326,9 +326,12 @@ You can take one of the following actions:
 
 ## Exclusion constraint conflicts
 
-With the addition of `EXCLUDE` constraint support in PGD 5.6, there's an increased risk of replication issues due to  multi-row conflicts. If a replicated row violates an `EXCLUDE` constraint by conflicting with multiple existing rows on the target node, replication can halt until the conflict is resolved. 
+With the addition of `EXCLUDE` constraint support in PGD 5.6, there's an increased risk of replication issues due to  multi-row conflicts.
+If a replicated row violates an `EXCLUDE` constraint by conflicting with an existing row on the target node, replication can halt until the conflict is resolved.
 
-In case of such a conflict, whether from and `INSERT` or `UPDATE`, you must remove some rows for replication to continue. Depending on the resolver setting for `multiple_unique_conflicts`, the apply process either exits with error, skips the incoming row, or deletes some of the rows. The deletion tries to preserve the row with the correct `PRIMARY KEY` and delete the others.
+In case of such a conflict, whether from and `INSERT` or `UPDATE`, you must remove some rows for replication to continue.
+Depending on the resolver setting for `multiple_unique_conflicts`, the apply process either exits with error, skips the incoming row, or deletes some of the rows.
+The deletion tries to preserve the row with the correct `PRIMARY KEY` and delete the others.
 
 ## Data conflicts for roles and tablespace differences
 

--- a/product_docs/docs/pgd/5.6/conflict-management/conflicts/02_types_of_conflict.mdx
+++ b/product_docs/docs/pgd/5.6/conflict-management/conflicts/02_types_of_conflict.mdx
@@ -31,16 +31,22 @@ To resolve this conflict type, you can also use column-level conflict resolution
 
 You can effectively eliminate this type of conflict by using [global sequences](../../sequences/#pgd-global-sequences).
 
-### INSERT operations that violate multiple UNIQUE constraints
+### INSERT operations that violate UNIQUE or EXCLUDE constraints
 
-An `INSERT`/`INSERT` conflict can violate more than one `UNIQUE` constraint, of which one might be the `PRIMARY KEY`. If a new row violates more than one `UNIQUE` constraint and that results in a conflict against more than one other row, then applying the replication change produces a `multiple_unique_conflicts` conflict.
+An `INSERT`/`INSERT` conflict can violate more than one `UNIQUE` constraint, of which one might be the `PRIMARY KEY`. 
+With the addition of `EXCLUDE` constraint support in PGD 5.6, an `INSERT`/`INSERT`conflict can also violate one or more `EXCLUDE` constraints. 
 
-In case of such a conflict, you must remove some rows for replication to continue. Depending on the resolver setting for `multiple_unique_conflicts`, the apply process either exits with error, skips the incoming row, or deletes some of the rows. The deletion tries to preserve the row with the correct `PRIMARY KEY` and delete the others.
+If a new row violates more than one `UNIQUE` constraint and that results in a conflict against more than one other row, or a new row violates more than one `EXCLUDE` constraint or a single `EXCLUDE` constraint, either of which results in a conflict against more than one other row, then applying the replication change produces a `multiple_unique_conflicts` conflict.
+
+In case of such a conflict, you must remove some rows for replication to continue. 
+Depending on the resolver setting for `multiple_unique_conflicts`, the apply process either exits with error, skips the incoming row, or deletes some of the rows. 
+The deletion tries to preserve the row with the correct `PRIMARY KEY` and delete the others.
 
 !!! Warning
-    In case of multiple rows conflicting this way, if the result of conflict resolution is to proceed with the insert operation, some of the data is always deleted.
+In case of multiple rows conflicting this way, if the result of conflict resolution is to proceed with the insert operation, some of the data is always deleted.
+!!!
 
-You can also define a different behavior using a conflict trigger.
+You can also define a different behavior using a [conflict trigger](/pgd/latest/striggers/#conflict-triggers).
 
 ### UPDATE/UPDATE conflicts
 
@@ -165,9 +171,9 @@ changes, make those changes using Eager Replication.
 !!! Warning
     In case the conflict resolution of `update_pkey_exists` conflict results in update, one of the rows is always deleted.
 
-### UPDATE operations that violate multiple UNIQUE constraints
+### UPDATE operations that violate UNIQUE or EXCLUDE constraints
 
-Like [INSERT operations that violate multiple UNIQUE constraints](#insert-operations-that-violate-multiple-unique-constraints), when an incoming `UPDATE` violates more than one `UNIQUE` index (or the `PRIMARY KEY`), PGD raises a `multiple_unique_conflicts` conflict.
+Like [INSERT operations that violate multiple UNIQUE/EXLUDE constraints](#insert-operations-that-violate-unique-or-exclude-constraints), when an incoming `UPDATE` violates more than one `UNIQUE`/`EXCLUDE index (including the `PRIMARY KEY`) or violates a single `EXCLUDE` index such that more than one row is in conflict, PGD raises a `multiple_unique_conflicts` conflict.
 
 PGD supports deferred unique constraints. If a transaction can commit on the source, then it applies cleanly on target, unless it sees conflicts. However, you can't use a deferred primary key as a REPLICA IDENTITY, so the use cases are already limited by that and the warning about using multiple unique constraints.
 
@@ -323,15 +329,6 @@ You can take one of the following actions:
 -   Replace `TRUNCATE` with a `DELETE` statement with no `WHERE` clause. This approach is likely to have poor performance on larger tables.
 
 -   Set `bdr.truncate_locking = 'on'` to set the `TRUNCATE` command’s locking behavior. This setting determines whether `TRUNCATE` obeys the `bdr.ddl_locking` setting. This isn't the default behavior for `TRUNCATE` since it requires all nodes to be up. This configuration might not be possible or wanted in all cases.
-
-## Exclusion constraint conflicts
-
-With the addition of `EXCLUDE` constraint support in PGD 5.6, there's an increased risk of replication issues due to  multi-row conflicts.
-If a replicated row violates an `EXCLUDE` constraint by conflicting with an existing row on the target node, replication can halt until the conflict is resolved.
-
-In case of such a conflict, whether from and `INSERT` or `UPDATE`, you must remove some rows for replication to continue.
-Depending on the resolver setting for `multiple_unique_conflicts`, the apply process either exits with error, skips the incoming row, or deletes some of the rows.
-The deletion tries to preserve the row with the correct `PRIMARY KEY` and delete the others.
 
 ## Data conflicts for roles and tablespace differences
 

--- a/product_docs/docs/pgd/5.6/conflict-management/conflicts/02_types_of_conflict.mdx
+++ b/product_docs/docs/pgd/5.6/conflict-management/conflicts/02_types_of_conflict.mdx
@@ -324,6 +324,12 @@ You can take one of the following actions:
 
 -   Set `bdr.truncate_locking = 'on'` to set the `TRUNCATE` command’s locking behavior. This setting determines whether `TRUNCATE` obeys the `bdr.ddl_locking` setting. This isn't the default behavior for `TRUNCATE` since it requires all nodes to be up. This configuration might not be possible or wanted in all cases.
 
+## Exclusion constraint conflicts
+
+With the addition of `EXCLUDE` constraint support in PGD 5.6, there's an increased risk of replication issues due to  multi-row conflicts. If a replicated row violates an `EXCLUDE` constraint by conflicting with multiple existing rows on the target node, replication can halt until the conflict is resolved. 
+
+In case of such a conflict, whether from and `INSERT` or `UPDATE`, you must remove some rows for replication to continue. Depending on the resolver setting for `multiple_unique_conflicts`, the apply process either exits with error, skips the incoming row, or deletes some of the rows. The deletion tries to preserve the row with the correct `PRIMARY KEY` and delete the others.
+
 ## Data conflicts for roles and tablespace differences
 
 Conflicts can also arise where nodes have global (Postgres-system-wide) data, like roles, that differ. This conflict can result in operations&mdash;mainly `DDL`&mdash;that can run successfully and commit on one node but then fail to apply to other nodes.

--- a/product_docs/docs/pgd/5.6/reference/conflicts.mdx
+++ b/product_docs/docs/pgd/5.6/reference/conflicts.mdx
@@ -18,7 +18,7 @@ PGD recognizes the following conflict types, which can be used as the `conflict_
 | `update_missing`          | An incoming update is trying to modify a row that doesn't exist.                              |
 | `update_recently_deleted` | An incoming update is trying to modify a row that was recently deleted.                       |
 | `update_pkey_exists`      | An incoming update has modified the `PRIMARY KEY` to a value that already exists on the node that's applying the change. |
-| `multiple_unique_conflicts` | The incoming row conflicts with either multiple `UNIQUE` constraints/indexes, a single `UNIQUE` constraint and a single `EXCLUDE` constraint, or with multiple rows per an `EXCLUDE` index in the target table. |
+| `multiple_unique_conflicts`| An incoming row conflicts with multiple rows per UNIQUE/EXCLUDE indexes of the target table. |
 | `delete_recently_updated` | An incoming delete with an older commit timestamp than the most recent update of the row on the current node or when using [row version conflict detection](../conflict-management/conflicts/03_conflict_detection/#row-version-conflict-detection). |
 | `delete_missing`          | An incoming delete is trying to remove a row that doesn't exist.                              |
 | `target_column_missing`   | The target table is missing one or more columns present in the incoming row.                  |

--- a/product_docs/docs/pgd/5.6/reference/conflicts.mdx
+++ b/product_docs/docs/pgd/5.6/reference/conflicts.mdx
@@ -18,7 +18,7 @@ PGD recognizes the following conflict types, which can be used as the `conflict_
 | `update_missing`          | An incoming update is trying to modify a row that doesn't exist.                              |
 | `update_recently_deleted` | An incoming update is trying to modify a row that was recently deleted.                       |
 | `update_pkey_exists`      | An incoming update has modified the `PRIMARY KEY` to a value that already exists on the node that's applying the change. |
-| `multiple_unique_conflicts` | The incoming row conflicts with multiple UNIQUE constraints/indexes in the target table. |
+| `multiple_unique_conflicts` | The incoming row conflicts with multiple UNIQUE constraints/indexes in the target table and/or with multiple rows per an `EXCLUDE` index. |
 | `delete_recently_updated` | An incoming delete with an older commit timestamp than the most recent update of the row on the current node or when using [row version conflict detection](../conflict-management/conflicts/03_conflict_detection/#row-version-conflict-detection). |
 | `delete_missing`          | An incoming delete is trying to remove a row that doesn't exist.                              |
 | `target_column_missing`   | The target table is missing one or more columns present in the incoming row.                  |

--- a/product_docs/docs/pgd/5.6/reference/conflicts.mdx
+++ b/product_docs/docs/pgd/5.6/reference/conflicts.mdx
@@ -18,7 +18,7 @@ PGD recognizes the following conflict types, which can be used as the `conflict_
 | `update_missing`          | An incoming update is trying to modify a row that doesn't exist.                              |
 | `update_recently_deleted` | An incoming update is trying to modify a row that was recently deleted.                       |
 | `update_pkey_exists`      | An incoming update has modified the `PRIMARY KEY` to a value that already exists on the node that's applying the change. |
-| `multiple_unique_conflicts` | The incoming row conflicts with multiple UNIQUE constraints/indexes in the target table and/or with multiple rows per an `EXCLUDE` index. |
+| `multiple_unique_conflicts` | The incoming row conflicts with either multiple `UNIQUE` constraints/indexes, a single `UNIQUE` constraint and a single `EXCLUDE` constraint, or with multiple rows per an `EXCLUDE` index in the target table. |
 | `delete_recently_updated` | An incoming delete with an older commit timestamp than the most recent update of the row on the current node or when using [row version conflict detection](../conflict-management/conflicts/03_conflict_detection/#row-version-conflict-detection). |
 | `delete_missing`          | An incoming delete is trying to remove a row that doesn't exist.                              |
 | `target_column_missing`   | The target table is missing one or more columns present in the incoming row.                  |


### PR DESCRIPTION
[DOCS-1080
](https://enterprisedb.atlassian.net/browse/DOCS-1080)
Updating 5.6 docs to reflect multi-row conflicts possibility given unblocked EXCLUDE constraints in 5.6.