### PR TITLE
Release: 2024-11-05b

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -195,7 +195,6 @@
 # BigAnimal
 /docs/edbcloud/* /docs/biganimal/:splat  301
 /docs/biganimal/release/* /docs/biganimal/latest/:splat 302 # allow fine-grained redirects a shot at resolution first
-/docs/biganimal/latest/* /docs/edb-postgres-ai/cloud-service/ 301 # catch-all
 
 # Language Pack breakout from EPAS
 /docs/epas/latest/language_pack/* /docs/language_pack/2/:splat 301


### PR DESCRIPTION
## What Changed?

- Remove catch-all redirect for /docs/biganimal/* path until we can ensure it isn't too greedy!