### PR TITLE
EPRS: added PG and EPAS 17 support

### DIFF
--- a/product_docs/docs/eprs/7/01_introduction/03_certified_supported_versions.mdx
+++ b/product_docs/docs/eprs/7/01_introduction/03_certified_supported_versions.mdx
@@ -4,8 +4,8 @@ title: "Certified and supported product versions"
 
 You can use the following database product versions with Replication Server:
 
--   PostgreSQL versions 12, 13, 14, 15, and 16
--   EDB Postgres Advanced Server versions 12, 13, 14, 15, and 16
+-   PostgreSQL versions 12, 13, 14, 15, 16 and 17
+-   EDB Postgres Advanced Server versions 12, 13, 14, 15, 16 and 17
 -   Oracle 11g Release 2 version 11.2.0.2.0 is explicitly certified. Newer minor versions in the 11.2 line are supported as well.
 -   Oracle 12c version 12.1.0.2.0 is explicitly certified. Newer minor versions in the 12.1 line are supported as well.
 -   Oracle 18c version 18.1.0.2.0 is explicitly certified. Newer minor versions in the 18.1 line are supported as well.
@@ -16,7 +16,7 @@ You can use the following database product versions with Replication Server:
 
 All PostgreSQL and EDB Postgres Advanced Server versions available as EDB Postgres AI Cloud Service single-node and primary/standby high-availability cluster types are also supported for SMR configurations. See the Cloud Service [documentation](/edb-postgres-ai/cloud-service/) for more information about Cloud Service’s [supported cluster types](/edb-postgres-ai/cloud-service/references/supported_cluster_types/). See the [database version policy documentation](/edb-postgres-ai/cloud-service/references/supported_database_versions/) for the versions of PostgreSQL and EDB Postgres Advanced Server available in Cloud Service.
 
-EDB Postgres Distributed (PGD) v5.3.0 is explicitly certified as a Publishing database for trigger mode and as Subscription database for both trigger and wal modes.
+EDB Postgres Distributed (PGD) v5.6.0 is explicitly certified as a Publishing database for trigger mode and as Subscription database for both trigger and wal modes.
 !!!
 
 As of Replication Server 7.1.0:

--- a/product_docs/docs/eprs/7/01_introduction/03_certified_supported_versions.mdx
+++ b/product_docs/docs/eprs/7/01_introduction/03_certified_supported_versions.mdx
@@ -4,8 +4,8 @@ title: "Certified and supported product versions"
 
 You can use the following database product versions with Replication Server:
 
--   PostgreSQL versions 12, 13, 14, 15, 16 and 17
--   EDB Postgres Advanced Server versions 12, 13, 14, 15, 16 and 17
+-   PostgreSQL versions 13, 14, 15, 16, and 17
+-   EDB Postgres Advanced Server versions 13, 14, 15, 16, and 17
 -   Oracle 11g Release 2 version 11.2.0.2.0 is explicitly certified. Newer minor versions in the 11.2 line are supported as well.
 -   Oracle 12c version 12.1.0.2.0 is explicitly certified. Newer minor versions in the 12.1 line are supported as well.
 -   Oracle 18c version 18.1.0.2.0 is explicitly certified. Newer minor versions in the 18.1 line are supported as well.
@@ -16,7 +16,7 @@ You can use the following database product versions with Replication Server:
 
 All PostgreSQL and EDB Postgres Advanced Server versions available as EDB Postgres AI Cloud Service single-node and primary/standby high-availability cluster types are also supported for SMR configurations. See the Cloud Service [documentation](/edb-postgres-ai/cloud-service/) for more information about Cloud Service’s [supported cluster types](/edb-postgres-ai/cloud-service/references/supported_cluster_types/). See the [database version policy documentation](/edb-postgres-ai/cloud-service/references/supported_database_versions/) for the versions of PostgreSQL and EDB Postgres Advanced Server available in Cloud Service.
 
-EDB Postgres Distributed (PGD) v5.6.0 is explicitly certified as a Publishing database for trigger mode and as Subscription database for both trigger and wal modes.
+EDB Postgres Distributed (PGD) v5.3.0 is explicitly certified as a Publishing database for trigger mode and as Subscription database for both trigger and wal modes.
 !!!
 
 As of Replication Server 7.1.0:


### PR DESCRIPTION
## What Changed?
Short PR that adds PostgreSQL 17 and EPAS 17 to the supported database versions. 

https://enterprisedb.atlassian.net/browse/DOCS-975 

This PR can be merged to the eprs_7.10 release branch, where the content will be staged until release.
