### PR TITLE
EPRS: added relase notes for 7.10

### DIFF
--- a/product_docs/docs/eprs/7/eprs_rel_notes/eprs_rel_notes_7.10.0.mdx
+++ b/product_docs/docs/eprs/7/eprs_rel_notes/eprs_rel_notes_7.10.0.mdx
@@ -1,0 +1,37 @@
+---
+title: "Replication Server 7.10.0 release notes"
+navTitle: Version 7.10.0
+---
+
+Released: 21 Nov 2024
+
+New features, enhancements, bug fixes, and other changes in Replication Server 7.10.0 include the following:
+
+| Type         | Description                                                                                                                                                                                                                                                                                                                | Ticket               |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| Enhancement  | EDB Postgres Replication Server (EPRS) is now certified to work with EDB Postgres Advanced Server version 17 and PostgreSQL version 17, both as source Publication and/or target Subscription databases in trigger and WAL based replication cluster configurations.               |  |
+| Enhancement  | Enhanced to map virtual columns in the source database to virtual columns in the target database for all supported databases. |   #38897                   |
+| Bug&nbsp;fix | Fixed a corner case issue for an MMR cluster where conflicts were not detected, resulting in inconsistent data in the cluster.                                                                                                                                                                                                                            | #39369 |
+| Bug&nbsp;fix | Fixed an issue that caused inconsistencies when mapping Oracle `DATE` to `TIMESTAMP WITHOUT TIME ZONE` for PostgreSQL target databases.                              |         #39901             |
+| Bug&nbsp;fix | Fixed a corner case issue where parallel snapshot parameters were ignored for certain values. | #40191 |
+
+## Windows installer availability
+
+EDB Postgres Replication Server (EPRS) version 7.10.0 is currently available for deployment on the supported Linux distributions. The Windows installer will be made available for download from the EDB website a few days after the Linux packages.
+
+## End-of-support notice
+
+Replication Server 6.2 is no longer a supported version.
+
+To ensure that your usage of Replication Server is supported, upgrade any installations with version 6.2 to version 7. See the end-of-support notes that follow:
+
+**Software:** Replication Server 
+
+**Version:** 6.2
+
+**End of Standard Support:** June 1, 2023
+
+Additional details can be found at [EDB Platform Compatibility](https://www.enterprisedb.com/resources/platform-compatibility).
+
+!!! Note
+    Version 7.x provides a non-breaking upgrade path for existing 6.2.x-based cluster deployments. However, we strongly recommend that the upgrade be verified in a staging or non-production environment before applying the upgrade in a production environment.

--- a/product_docs/docs/eprs/7/eprs_rel_notes/index.mdx
+++ b/product_docs/docs/eprs/7/eprs_rel_notes/index.mdx
@@ -3,6 +3,7 @@ title: "Release notes"
 redirects:
   - ../01_whats_new/
 navigation:
+ - eprs_rel_notes_7.10.0
  - eprs_rel_notes_7.9.0
  - eprs_rel_notes_7.8.0
  - eprs_rel_notes_7.7.0
@@ -17,6 +18,7 @@ The Replication Server documentation describes the latest version including mino
 
 | Version                          | Release Date |
 |----------------------------------|--------------|
+| [7.10.0](eprs_rel_notes_7.10.0)  | 21 Nov 2024  |
 | [7.9.0](eprs_rel_notes_7.9.0)    | 22 Aug 2024  |
 | [7.8.0](eprs_rel_notes_7.8.0)    | 17 May 2024  |
 | [7.7.0](eprs_rel_notes_7.7.0)    | 14 Dec 2023  |


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/XDB-2311

Added release notes for EPRS. This can be merged to the release branch `eprs_7.10` upon approval to be staged before pushing to production.