### PR TITLE
EDBPlus 41.3.0: release notes, version bumps, supported dbs

### DIFF
--- a/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.3_rel_notes.mdx
+++ b/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.3_rel_notes.mdx
@@ -1,0 +1,17 @@
+---
+title: "EDB*Plus 41.3.0 release notes"
+navTitle: Version 41.3.0
+---
+
+Released: 22 Nov 2024
+
+New features, enhancements, bug fixes, and other changes in EDB\*Plus 41.3.0 include:
+
+| Type         | Description                                                                                                                                                                                           | Addresses             |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
+| Enhancement  | EDB\*Plus has been certified for use with EDB Postgres Advanced Server version 17.                                                                                                                    |                       |
+| Enhancement  | Enhanced the behavior where the `SET LINESIZE` command doesn't behave as expected when set to a value greater than 10. This enhancement mainly applies to the constants used in the select statement. | #103591 <br/>  #35673 |
+| Bug&nbsp;fix | Corrected the behavior where `SPOOL` was introducing redundant blank lines after each output.                                                                                                         | #37846                |
+| Bug&nbsp;fix | Fixed the issue where EDB\*Plus is unable to process the command when `--` is used in between `/* */`.                                                                                                | #100496               |
+| Bug&nbsp;fix | Fixed the issue causing the execution of a trivial procedural script to perform quite slowly in EDB\*Plus.                                                                                            | #37747                |
+| Bug&nbsp;fix | Fixed an issue related to the configuration of EDB\*Plus with SSL certificate authentication method when the password is not specified.                                                               | #37970                |

--- a/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.3_rel_notes.mdx
+++ b/product_docs/docs/edb_plus/41/02_release_notes/edbplus_41.3_rel_notes.mdx
@@ -3,7 +3,7 @@ title: "EDB*Plus 41.3.0 release notes"
 navTitle: Version 41.3.0
 ---
 
-Released: 22 Nov 2024
+Released: 27 Nov 2024
 
 New features, enhancements, bug fixes, and other changes in EDB\*Plus 41.3.0 include:
 

--- a/product_docs/docs/edb_plus/41/02_release_notes/index.mdx
+++ b/product_docs/docs/edb_plus/41/02_release_notes/index.mdx
@@ -2,6 +2,7 @@
 title: "Release notes"
 
 navigation: 
+- edbplus_41.3_rel_notes
 - edbplus_41.2_rel_notes
 - edbplus_41.1_rel_notes
 - edbplus_41.0_rel_notes
@@ -11,8 +12,9 @@ EDB\*Plus is a utility program that provides a command line interface to EDB Pos
 
 The EDB\*Plus documentation describes the latest version of EDB\*Plus Version 41. The release notes provide information on what was new in each release. 
 
-|                Version                | Release Date |
-| ------------------------------------- | ------------ |
+| Version                              | Release Date |
+|--------------------------------------|--------------|
+| [41.3.0](edbplus_41.3_rel_notes.mdx) | 22 Nov 2024  |
 | [41.2.0](edbplus_41.2_rel_notes.mdx) | 23 Aug 2023  |
 | [41.1.0](edbplus_41.1_rel_notes.mdx) | 20 Apr 2023  |
 | [41.0.0](edbplus_41.0_rel_notes.mdx) | 14 Feb 2023  |

--- a/product_docs/docs/edb_plus/41/02_release_notes/index.mdx
+++ b/product_docs/docs/edb_plus/41/02_release_notes/index.mdx
@@ -14,7 +14,7 @@ The EDB\*Plus documentation describes the latest version of EDB\*Plus Version 41
 
 | Version                              | Release Date |
 |--------------------------------------|--------------|
-| [41.3.0](edbplus_41.3_rel_notes.mdx) | 22 Nov 2024  |
+| [41.3.0](edbplus_41.3_rel_notes.mdx) | 27 Nov 2024  |
 | [41.2.0](edbplus_41.2_rel_notes.mdx) | 23 Aug 2023  |
 | [41.1.0](edbplus_41.1_rel_notes.mdx) | 20 Apr 2023  |
 | [41.0.0](edbplus_41.0_rel_notes.mdx) | 14 Feb 2023  |

--- a/product_docs/docs/edb_plus/41/02a_supported_platforms.mdx
+++ b/product_docs/docs/edb_plus/41/02a_supported_platforms.mdx
@@ -7,8 +7,8 @@ EDB\*Plus is supported on the same platforms as EDB Postgres Advanced Server. To
 ## Supported database versions
 
 The following list of EDB Postgres Advanced Server (EPAS) versions are currently supported for use with EDB\*Plus:
+- EPAS 17
+- EPAS 16
 - EPAS 15
 - EPAS 14
 - EPAS 13
-- EPAS 12
-- EPAS 11

--- a/product_docs/docs/edb_plus/41/04_using_edb_plus.mdx
+++ b/product_docs/docs/edb_plus/41/04_using_edb_plus.mdx
@@ -78,9 +78,9 @@ The following example shows user `enterprisedb` with password `password` connect
 
 ```text
 C:\Program Files\edb\edbplus>edbplus enterprisedb/password
-Connected to EnterpriseDB 14.1.0 (localhost:5444/edb) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (localhost:5444/edb) AS enterprisedb
 
-EDB*Plus: Release 14 (Build 40.0.0)
+EDB*Plus: (Build 41.3.0)
 Copyright (c) 2008-2021, EnterpriseDB Corporation. All rights reserved.
 
 SQL>
@@ -90,9 +90,9 @@ The following example shows user `enterprisedb` with password `password` connect
 
 ```text
 C:\Program Files\edb\edbplus>edbplus enterprisedb/password@localhost:5445/edb
-Connected to EnterpriseDB 14.1.0 (localhost:5445/edb) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (localhost:5445/edb) AS enterprisedb
 
-EDB*Plus: Release 14 (Build 40.0.0)
+EDB*Plus: (Build 41.3.0)
 Copyright (c) 2008-2021, EnterpriseDB Corporation. All rights reserved.
 
 SQL>
@@ -102,9 +102,9 @@ Using variable `hr_5445` in the `login.sql` file, the following shows how it is 
 
 ```text
 C:\Program Files\edb\edbplus>edbplus enterprisedb/password@hr_5445
-Connected to EnterpriseDB 14.0.0 (localhost:5445/hr) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (localhost:5445/hr) AS enterprisedb
 
-EDB*Plus: Release 14 (Build 40.1.0)
+EDB*Plus: (Build 41.3.0)
 Copyright (c) 2008-2021, EnterpriseDB Corporation. All rights reserved.
 
 SQL>
@@ -127,7 +127,7 @@ The following example executes a script file, `dept_query.sql`, after connecting
 
 ```sql
 C:\Program Files\edb\edbplus>edbplus enterprisedb/password @dept_query
-Connected to EnterpriseDB 14.1.0 (localhost:5444/edb) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (localhost:5444/edb) AS enterprisedb
 
 SQL> SELECT * FROM dept;
 

--- a/product_docs/docs/edb_plus/41/05_using_edb_plus_with_ssl.mdx
+++ b/product_docs/docs/edb_plus/41/05_using_edb_plus_with_ssl.mdx
@@ -284,9 +284,9 @@ $ export PGSSLCERTPASS=keypass
 $ export PGSSLKEYPASS=exppass
 $ cd /usr/edb/edbplus
 $ ./edbplus.sh enterprisedb/password@192.168.2.22:5444/edb?ssl=true
-Connected to EnterpriseDB 14.0.0 (192.168.2.22:5444/edb) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (192.168.2.22:5444/edb) AS enterprisedb
 
-EDB*Plus: Release 14 (Build 40.0.1)
+EDB*Plus: (Build 41.3.0)
 Copyright (c) 2008-2021, EnterpriseDB Corporation. All rights reserved.
 
 SQL>
@@ -301,9 +301,9 @@ $ export PGSSLCERTPASS=keypass
 $ export PGSSLKEYPASS=exppass
 $ cd /usr/edb/edbplus
 $ ./edbplus.sh enterprisedb/password@192.168.2.22:5444/edb?ssl=true
-Connected to EnterpriseDB 14.0.0 (192.168.2.22:5444/edb) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (192.168.2.22:5444/edb) AS enterprisedb
 
-EDB*Plus: Release 14 (Build 40.0.1)
+EDB*Plus: (Build 41.3.0)
 Copyright (c) 2008-2021, EnterpriseDB Corporation. All rights reserved.
 
 SQL>

--- a/product_docs/docs/edb_plus/41/06_command_summary.mdx
+++ b/product_docs/docs/edb_plus/41/06_command_summary.mdx
@@ -320,7 +320,7 @@ In this example, the database connection is changed to database `edb` on the loc
 ```sql
 SQL> CONNECT smith/mypassword@localhost:5445/edb
 Disconnected from EnterpriseDB Database.
-Connected to EnterpriseDB 14.0.0 (localhost:5445/edb) AS smith
+Connected to EnterpriseDB 16.4.1 (localhost:5445/edb) AS smith
 ```
 
 In this session, the connection is changed to the username `enterprisedb`. The host defaults to the localhost, the port defaults to `5444` (which isn't the same as the port previously used), and the database defaults to `edb`.
@@ -328,7 +328,7 @@ In this session, the connection is changed to the username `enterprisedb`. The h
 ```sql
 SQL> CONNECT enterprisedb/password
 Disconnected from EnterpriseDB Database.
-Connected to EnterpriseDB 14.0.0 (localhost:5444/edb) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (localhost:5444/edb) AS enterprisedb
 ```
 
 This example shows connectivity for a multi-node cluster (one primary node and two secondary nodes) setup. The given multi-host `connectstring` syntax is used to establish a connection with the active primary database server. In this case, using `CONNECT` command, the connection is established with the primary database node on host `192.168.22.24` at port `5444`.
@@ -336,7 +336,7 @@ This example shows connectivity for a multi-node cluster (one primary node and t
 ```sql
 SQL> CONNECT enterprisedb/edb@192.168.22.24:5444,192.168.22.25:5445,192.168.22.26:5446/edb?targetServerType=primary
 Disconnected from EnterpriseDB Database.
-Connected to EnterpriseDB 15.3.0 (192.168.22.24:5444/edb) AS enterprisedb
+Connected to EnterpriseDB 16.4.1 (192.168.22.24:5444/edb) AS enterprisedb
 ```
 
 ## DEFINE


### PR DESCRIPTION
## What Changed?

https://enterprisedb.atlassian.net/browse/ED-301
https://enterprisedb.atlassian.net/browse/DOCS-1124

- adds release notes 
- bumps versions in code snippets
- updates compatibility/supported dbs page

Planned for 27 Nov, possibly later.