### PR TITLE
Migration Portal: 4.12.0 release

### DIFF
--- a/product_docs/docs/migration_portal/4/01_mp_release_notes/index.mdx
+++ b/product_docs/docs/migration_portal/4/01_mp_release_notes/index.mdx
@@ -4,6 +4,7 @@ redirects:
   - ../01_whats_new/
   - 09_mp_3.5.1_rel_notes
 navigation:
+- mp_4.12.0_rel_notes
 - mp_4.11.0_rel_notes
 - mp_4.10.0_rel_notes
 - mp_4.9.0_rel_notes
@@ -24,6 +25,7 @@ The Migration Portal documentation describes the latest version of Migration Por
 
 | Version                       | Release date |
 |-------------------------------|--------------|
+| [4.12.0](mp_4.12.0_rel_notes) | 25 Nov 2024  |
 | [4.11.0](mp_4.11.0_rel_notes) | 20 Aug 2024  |
 | [4.10.0](mp_4.10.0_rel_notes) | 27 Jun 2024  |
 | [4.9.0](mp_4.9.0_rel_notes)   | 21 May 2024  |

--- a/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.12.0_rel_notes.mdx
+++ b/product_docs/docs/migration_portal/4/01_mp_release_notes/mp_4.12.0_rel_notes.mdx
@@ -1,0 +1,18 @@
+---
+title: "Migration Portal 4.12.0 release notes"
+navTitle: Version 4.12.0
+---
+
+Released: 25 Nov 2024
+
+New features, enhancements, bug fixes, and other changes in Migration Portal 4.12.0 include the following:
+
+| Type              | Description                                                                                                                                                                                                                                                          |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Enhancement       | Added support for EDB Postgres Advanced Server (EPAS) version 17, which introduced several new Oracle compatibility features. Migration Portal users can now assess their Oracle schemas against EPAS 17 and subsequently migrate the schema to an EPAS 17 database. |
+| Enhancement       | The assessment notification message now informs users about possible delays when a partitioned table contains a large number of partitions.                                                                                                                          |
+| Enhancement       | The ERH-2107 repair handler has been enhanced to remove the `COMPUTE STATISTICS` keyword from `CREATE INDEX` statements.                                                                                                                                             |
+| Bug&nbsp;fix      | Fixed an issue where Migration Portal skipped a portion of an object’s DDL due to a rare parsing failure.                                                                                                                                                            |
+| Bug&nbsp;fix      | Fixed a minor UI issue where the **Reassess** button was displaced when the target DDL had a long line of code without a new line.                                                                                                                                   |
+| Bug&nbsp;fix      | Fixed an EDB DDL Extractor script issue that resulted in `PUBLIC SYNONYMS` not being extracted. The fix is included in a new version (2.4.5) of the EDB DDL Extractor script which can be downloaded from the Migration Portal.                                      |
+| Security&nbsp;fix | Updated software libraries and implemented other security improvements.                                                                                                                                                                                              |

--- a/product_docs/docs/migration_portal/4/02_supported_platforms.mdx
+++ b/product_docs/docs/migration_portal/4/02_supported_platforms.mdx
@@ -6,7 +6,7 @@ title: "Supported platforms"
 
 <div id="supported_platforms" class="registered_link"></div>
 
-The Migration Portal supports assessment and migration from Oracle 11g, 12c, 18c, and 19c to EDB Postgres Advanced Server 12, 13, 14, 15, and 16. Migration Portal is supported on the following browsers.
+The Migration Portal supports assessment and migration from Oracle 11g, 12c, 18c, and 19c to EDB Postgres Advanced Server 13, 14, 15, 16, and 17. Migration Portal is supported on the following browsers.
 
 ## Supported browsers
 


### PR DESCRIPTION
## What Changed?
https://enterprisedb.atlassian.net/browse/MIG-5318

- added release notes for 4.12.0 
- updated supported databases list 
- set release date to 25 Nov, but we can update it if the date changes
