### PR TITLE
PGD: Fix link to EDB Postgres Extended Server

### DIFF
--- a/product_docs/docs/pgd/3.6/index.mdx
+++ b/product_docs/docs/pgd/3.6/index.mdx
@@ -19,7 +19,7 @@ cluster work.
 Two different Postgres distributions can be used:
 
 - [PostgreSQL](https://www.postgresql.org/) - open source
-- [EDB Postgres Extended Server](https://techsupport.enterprisedb.com/customer_portal/sw/2ndqpostgres/) - PostgreSQL compatible and optimized for replication
+- [EDB Postgres Extended Server](/pge/latest) - PostgreSQL compatible and optimized for replication
 
 What Postgres distribution and version is right for you depends on the features you need.
 See the feature matrix in [Choosing a Postgres distribution](/pgd/latest/planning/choosing_server/) for detailed comparison.

--- a/product_docs/docs/pgd/3.7/index.mdx
+++ b/product_docs/docs/pgd/3.7/index.mdx
@@ -12,7 +12,7 @@ EDB Postgres Distributed consists of several components that make the whole clus
 Three different Postgres distributions can be used:
 
 - [PostgreSQL](https://www.postgresql.org/) - open source
-- [EDB Postgres Extended Server](https://techsupport.enterprisedb.com/customer_portal/sw/2ndqpostgres/) - Postgres compatible and optimized for replication (formerly known as 2nd Quadrant Postgres)
+- [EDB Postgres Extended Server](/pge/latest) - Postgres compatible and optimized for replication (formerly known as 2nd Quadrant Postgres)
 - [EDB Postgres Advanced Server](/epas/latest) - Postgres or Oracle compatible, optimized for replication, and additional enterprise features
 
 What Postgres distribution and version is right for you depends on the features you need. See [Postgres-specific features](/pgd/3.7/bdr/#postgres-specific-features) for detailed information.

--- a/product_docs/docs/pgd/4/overview/index.mdx
+++ b/product_docs/docs/pgd/4/overview/index.mdx
@@ -15,7 +15,7 @@ cluster work.
 Three different Postgres distributions can be used:
 
 - [PostgreSQL](https://www.postgresql.org/) - open source
-- [EDB Postgres Extended Server](https://techsupport.enterprisedb.com/customer_portal/sw/2ndqpostgres/) - PostgreSQL compatible and optimized for replication
+- [EDB Postgres Extended Server](/pge/latest) - PostgreSQL compatible and optimized for replication
 - [EDB Postgres Advanced Server](/epas/latest) - Oracle compatible, optimized for replication, and additional enterprise features
 
 What Postgres distribution and version is right for you depends on the features you need.

--- a/product_docs/docs/pgd/5.6/overview/index.mdx
+++ b/product_docs/docs/pgd/5.6/overview/index.mdx
@@ -100,7 +100,7 @@ In the future, one node will be elected as the main replicator to other groups, 
 
 ### Supported Postgres database servers
 
-PGD is compatible with [PostgreSQL](https://www.postgresql.org/), [EDB Postgres Extended Server](https://techsupport.enterprisedb.com/customer_portal/sw/2ndqpostgres/), and [EDB Postgres Advanced Server](/epas/latest) and is deployed as a standard Postgres extension named BDR. See [Compatibility](../#compatibility) for details about supported version combinations.
+PGD is compatible with [PostgreSQL](https://www.postgresql.org/), [EDB Postgres Extended Server](/pge/latest), and [EDB Postgres Advanced Server](/epas/latest) and is deployed as a standard Postgres extension named BDR. See [Compatibility](../#compatibility) for details about supported version combinations.
 
 Some key PGD features depend on certain core capabilities being available in the target Postgres database server. Therefore, PGD users must also adopt the Postgres database server distribution that's best suited to their business needs. For example, if having the PGD feature Commit At Most Once (CAMO) is mission critical to your use case, don't adopt the community PostgreSQL distribution. It doesn't have the core capability required to handle CAMO. See the full feature matrix compatibility in [Choosing a Postgres distribution](../planning/choosing_server/).
 

--- a/product_docs/docs/pgd/5/overview/index.mdx
+++ b/product_docs/docs/pgd/5/overview/index.mdx
@@ -100,7 +100,7 @@ In the future, one node will be elected as the main replicator to other groups, 
 
 ### Supported Postgres database servers
 
-PGD is compatible with [PostgreSQL](https://www.postgresql.org/), [EDB Postgres Extended Server](https://techsupport.enterprisedb.com/customer_portal/sw/2ndqpostgres/), and [EDB Postgres Advanced Server](/epas/latest) and is deployed as a standard Postgres extension named BDR. See [Compatibility](../#compatibility) for details about supported version combinations.
+PGD is compatible with [PostgreSQL](https://www.postgresql.org/), [EDB Postgres Extended Server](/pge/latest), and [EDB Postgres Advanced Server](/epas/latest) and is deployed as a standard Postgres extension named BDR. See [Compatibility](../#compatibility) for details about supported version combinations.
 
 Some key PGD features depend on certain core capabilities being available in the target Postgres database server. Therefore, PGD users must also adopt the Postgres database server distribution that's best suited to their business needs. For example, if having the PGD feature Commit At Most Once (CAMO) is mission critical to your use case, don't adopt the community PostgreSQL distribution. It doesn't have the core capability required to handle CAMO. See the full feature matrix compatibility in [Choosing a Postgres distribution](../planning/choosing_server/).
 


### PR DESCRIPTION
## What Changed?

Replace links to legacy, non-existent portal page with a direct reference to the public documentation, as is done with EPAS.

DOCS-1134


