### PR TITLE
PGD: document compatibility with EPAS automatic partitioning

### DIFF
--- a/product_docs/docs/pgd/5.6/scaling.mdx
+++ b/product_docs/docs/pgd/5.6/scaling.mdx
@@ -184,3 +184,21 @@ to enable autopartitioning on the given table. If autopartitioning is already
 enabled, then no action occurs. Similarly, use
 [`bdr.autopartition_disable()`](/pgd/latest/reference/autopartition#bdrautopartition_disable)
 to disable autopartitioning on the given table.
+
+## Restrictions on EPAS-native automatic partitioning
+
+EPAS-native automatic partitioning is not supported on PGD.
+
+If the PGD extension is active on an EPAS database, DDL commands to configure
+EPAS automatic partitioning (`ALTER TABLE ... SET AUTOMATIC` and `ALTER TABLE ... SET INTERVAL`)
+will be rejected.
+
+Note that while it is possible to enable the PGD extension on an EPAS database
+containing tables configured to use EPAS-native automatic partitioning, it
+will not be possible to join further nodes using this node as a source node.
+
+EPAS-native automatic partitioning can be disabled with one of the following
+commands:
+
+- `ALTER TABLE ... SET MANUAL` (for list partitioned tables)
+- `ALTER TABLE ... SET INTERVAL ()` (for interval partitioned tables)


### PR DESCRIPTION
## What Changed?

Currently this doesn't work at all with PGD, so add some basic notes documenting this. Absence of such notes caused some confusion during a recent support ticket.

BDR-5756



