### PR TITLE
PGE 17: version bumps

### DIFF
--- a/product_docs/docs/pge/17/installing/component_locations.mdx
+++ b/product_docs/docs/pge/17/installing/component_locations.mdx
@@ -15,19 +15,19 @@ The RPM installers place EDB Postgres Extended Server components in the director
 
 | Component                   | Location                       |
 |-----------------------------|--------------------------------|
-| Executables                 | `/usr/edb/pge16/bin`           |
-| Libraries                   | `/usr/edb/pge16/lib`           |
-| Cluster configuration files | `/var/lib/edb-pge/16`          |
-| Documentation               | `/usr/edb/pge16/share/man`     |
-| Contrib                     | `/usr/edb/pge16/share/contrib` |
-| Data                        | `/var/lib/edb-pge/16/data`     |
-| Logs                        | `/var/log/edb/pge16`           |
-| Lock files                  | `/var/lock/edb/pge16`          |
-| Backup area                 | `/var/lib/edb-pge/16/backups`  |
-| Templates                   | `/usr/edb/pge16/share`         |
-| Procedural Languages        | `/usr/edb/pge16/lib`           |
-| Development Headers         | `/usr/edb/pge16/include`       |
-| Shared data                 | `/usr/edb/pge16/share`         |
+| Executables                 | `/usr/edb/pge17/bin`           |
+| Libraries                   | `/usr/edb/pge17/lib`           |
+| Cluster configuration files | `/var/lib/edb-pge/17`          |
+| Documentation               | `/usr/edb/pge17/share/man`     |
+| Contrib                     | `/usr/edb/pge17/share/contrib` |
+| Data                        | `/var/lib/edb-pge/17/data`     |
+| Logs                        | `/var/log/edb/pge17`           |
+| Lock files                  | `/var/lock/edb/pge17`          |
+| Backup area                 | `/var/lib/edb-pge/17/backups`  |
+| Templates                   | `/usr/edb/pge17/share`         |
+| Procedural Languages        | `/usr/edb/pge17/lib`           |
+| Development Headers         | `/usr/edb/pge17/include`       |
+| Shared data                 | `/usr/edb/pge17/share`         |
 
 ## Debian/Ubuntu Locations
 
@@ -35,9 +35,9 @@ The Debian package manager places EDB Postgres Extended Server components in the
 
 | Component                   | Location                           |
 |-----------------------------|------------------------------------|
-| Executables                 | `/usr/lib/edb-pge/16/bin`          |
-| Libraries                   | `/usr/lib/edb-pge/16/lib`          |
-| Cluster configuration files | `/var/lib/edb-pge/16/main`         |
-| Data                        | `/var/lib/edb-pge/16/main`         |
+| Executables                 | `/usr/lib/edb-pge/17/bin`          |
+| Libraries                   | `/usr/lib/edb-pge/17/lib`          |
+| Cluster configuration files | `/var/lib/edb-pge/17/main`         |
+| Data                        | `/var/lib/edb-pge/17/main`         |
 | Logs                        | `/var/log/edb-pge/`                |
-| Lock files                  | `/var/lock/edb/pge16`              |
+| Lock files                  | `/var/lock/edb/pge17`              |

--- a/product_docs/docs/pge/17/upgrading/major_upgrade.mdx
+++ b/product_docs/docs/pge/17/upgrading/major_upgrade.mdx
@@ -29,7 +29,7 @@ If a problem occurs during the upgrade process, you can [revert to the previous 
 
 ## Worked example
 
-This worked example upgrades an EDB Postgres Extended Server 15 database to EDB Postgres Extended Server 16. 
+This worked example upgrades an EDB Postgres Extended Server 16 database to EDB Postgres Extended Server 17. 
 
 !!!note
    You can perform major upgrades of EDB Postgres Extended Server instances in the same way you upgrade an EDB Postgres Advanced Server installation. If you need more information about the pg_upgrade utility, command line options, troubleshooting, and more, see [Upgrading an installation with pg_upgrade](/epas/latest/upgrading/major_upgrade/).
@@ -40,7 +40,7 @@ Use [pg_dumpall](https://www.postgresql.org/docs/current/app-pg-dumpall.html), [
 
 ### Installing the target EDB Postgres Extended Server version
 
-[Install EDB Postgres Extended Server](../installing/) version 16. Only install the packages. Don't perform any other configurations.
+[Install EDB Postgres Extended Server](../installing/) version 17. Only install the packages. Don't perform any other configurations.
 
 ### Creating a target server
 
@@ -49,20 +49,20 @@ If you don't want to create a new target instance but want to reuse an existing 
 1.  As postgres, create an empty directory for the new server: 
 
     ```
-    mkdir /var/lib/edb-pge/16/upgrade_target 
+    mkdir /var/lib/edb-pge/17/upgrade_target 
     ```
 
 1.  As root, ensure the postgres user owns the directory:
 
     ```
-    sudo chown postgres /var/lib/edb-pge/16/upgrade_target
-    sudo chgrp postgres /var/lib/edb-pge/16/upgrade_target
+    sudo chown postgres /var/lib/edb-pge/17/upgrade_target
+    sudo chgrp postgres /var/lib/edb-pge/17/upgrade_target
     ```
 
 1.  As postgres, initialize the new server: 
 
     ```
-    /usr/lib/edb-pge/16/bin/initdb -D /var/lib/edb-pge/16/upgrade_target
+    /usr/lib/edb-pge/17/bin/initdb -D /var/lib/edb-pge/17/upgrade_target
     ```
 
     This command initializes a CONFIG directory with all configuration files for the encrypted server.
@@ -72,19 +72,19 @@ If you don't want to create a new target instance but want to reuse an existing 
 1.  Start the target server: 
 
     ```
-    /usr/lib/edb-pge/16/bin/pg_ctl -D /var/lib/edb-pge/16/upgrade_target start
+    /usr/lib/edb-pge/17/bin/pg_ctl -D /var/lib/edb-pge/17/upgrade_target start
     ```
 
     !!!note
        You can also start the server with the `logfile` option enabled to print errors into a logfile: 
-       `/usr/lib/edb-pge/16/bin/pg_ctl -D /var/lib/edb-pge/16/upgrade_target -l logfile start` 
+       `/usr/lib/edb-pge/17/bin/pg_ctl -D /var/lib/edb-pge/17/upgrade_target -l logfile start` 
 
        In this case, ensure the postgres user has rights to write to the log directory. 
 
 1.  Connect to the server:
 
     ```
-    /usr/lib/edb-pge/16/bin/psql -p 5432
+    /usr/lib/edb-pge/17/bin/psql -p 5432
     ```
 
     !!!note
@@ -97,8 +97,8 @@ If you don't want to create a new target instance but want to reuse an existing 
 1.  Stop both the source and target servers:
 
     ```
-    /usr/lib/edb-pge/15/bin/pg_ctl -D /var/lib/edb-pge/15/upgrade-source stop
-    /usr/lib/edb-pge/16/bin/pg_ctl -D /var/lib/edb-pge/16/upgrade-target stop
+    /usr/lib/edb-pge/16/bin/pg_ctl -D /var/lib/edb-pge/16/upgrade-source stop
+    /usr/lib/edb-pge/17/bin/pg_ctl -D /var/lib/edb-pge/17/upgrade-target stop
     ```
 
 1.  To test for incompatibilities, run the `pg_upgrade` command in check mode. 
@@ -106,7 +106,7 @@ If you don't want to create a new target instance but want to reuse an existing 
     With `-b` and `-B`, specify the source and target BIN directories. With `-d` and `-D`, specify the source and target CONFIG directories:
 
     ```
-    /usr/lib/edb-pge/16/bin/pg_upgrade -b /usr/lib/edb-pge/15/bin -B /usr/lib/edb-pge/16/bin -d /var/lib/edb-pge/15/upgrade-source -D /var/lib/edb-pge/16/upgrade-target --check
+    /usr/lib/edb-pge/17/bin/pg_upgrade -b /usr/lib/edb-pge/16/bin -B /usr/lib/edb-pge/17/bin -d /var/lib/edb-pge/16/upgrade-source -D /var/lib/edb-pge/17/upgrade-target --check
     ```
 
     !!!note
@@ -115,19 +115,19 @@ If you don't want to create a new target instance but want to reuse an existing 
 1.  To copy data from the source server to the target server, run the `pg_upgrade` command in normal mode: 
 
     ```
-    /usr/lib/edb-pge/16/bin/pg_upgrade -b /usr/lib/edb-pge/15/bin -B /usr/lib/edb-pge/16/bin -d /var/lib/edb-pge/15/upgrade-source -D /var/lib/edb-pge/16/upgrade-target
+    /usr/lib/edb-pge/17/bin/pg_upgrade -b /usr/lib/edb-pge/16/bin -B /usr/lib/edb-pge/17/bin -d /var/lib/edb-pge/16/upgrade-source -D /var/lib/edb-pge/17/upgrade-target
     ```
 
 1.  Start the target server: 
 
     ```
-    /usr/lib/edb-pge/16/bin/pg_ctl -D /var/lib/edb-pge/16/upgrade-target start
+    /usr/lib/edb-pge/17/bin/pg_ctl -D /var/lib/edb-pge/17/upgrade-target start
     ```
 
 1.  Connect to the target database server:
 
     ```
-    /usr/lib/edb-as/16/bin/psql -p 5432
+    /usr/lib/edb-as/17/bin/psql -p 5432
     ```
 
 1.  Perform a spot check to ensure the databases, tables, schemas, and resources you had in the unencrypted server are available in the new server. For example, list all databases, explore the database objects, views, and so on.
@@ -141,7 +141,7 @@ After you verify that pg_upgrade migrated the data successfully, and the service
 1.  Clean up the database and its statistics:
 
     ```
-    /usr/lib/edb-pge/16/bin/vacuumdb --all --analyze-in-stages
+    /usr/lib/edb-pge/17/bin/vacuumdb --all --analyze-in-stages
     ```
 
 1.  Remove all data files of the unencrypted server with the script generated by `pg_upgrade`:

--- a/product_docs/docs/pge/17/upgrading/minor_upgrade/apt_upgrade.mdx
+++ b/product_docs/docs/pge/17/upgrading/minor_upgrade/apt_upgrade.mdx
@@ -22,10 +22,10 @@ If you used `apt-get` to install a Debian package of EDB Postgres Extended Serve
     sudo apt-get install <package_name>
     ```
 
-    For example, if you want to upgrade to the latest minor version of EDB Postgres Extended Server 16, run:
+    For example, if you want to upgrade to the latest minor version of EDB Postgres Extended Server 17, run:
     
     ```shell
-    sudo apt-get install edb-postgresextended-16
+    sudo apt-get install edb-postgresextended-17
     ```
 
     !!!Note
@@ -38,19 +38,19 @@ If you used `apt-get` to install a Debian package of EDB Postgres Extended Serve
 1.  To finalize the upgrade, restart the server. Replace `<path_to_data_directory>` with the path to the data directory of the server or servers you're upgrading:
 
     ```shell
-    /usr/lib/edb-pge/16/bin/pg_ctl -D <path_to_data_directory> restart
+    /usr/lib/edb-pge/17/bin/pg_ctl -D <path_to_data_directory> restart
     ```
 
     For example: 
 
     ```shell
-    /usr/lib/edb-pge/16/bin/pg_ctl -D /var/lib/edb-pge/16/upgrade restart
+    /usr/lib/edb-pge/17/bin/pg_ctl -D /var/lib/edb-pge/17/upgrade restart
     ```
 
 1.  Verify the expected database version is running by connecting to psql: 
 
     ```shell
-    /usr/lib/edb-pge/16/bin/psql
+    /usr/lib/edb-pge/17/bin/psql
     ```
     
     Check the server version: 
@@ -60,6 +60,6 @@ If you used `apt-get` to install a Debian package of EDB Postgres Extended Serve
     __OUTPUT__
                                server_version
     --------------------------------------------------------------------
-     16.3 (EDB Postgres Extended Server 16.3.0) (Ubuntu 0:16.3-1.jammy)
+     17.2 (EDB Postgres Extended Server 17.2.0) (Ubuntu 0:17.2-1.jammy)
     (1 row)
     ```

--- a/product_docs/docs/pge/17/upgrading/minor_upgrade/dnf_upgrade.mdx
+++ b/product_docs/docs/pge/17/upgrading/minor_upgrade/dnf_upgrade.mdx
@@ -24,10 +24,10 @@ If you used `dnf` to install an RPM package of EDB Postgres Extended Server (on 
     sudo dnf check-update <package_name>
     ```
 
-    For example, if you want to upgrade to the latest minor version of EDB Postgres Extended Server 16, run: 
+    For example, if you want to upgrade to the latest minor version of EDB Postgres Extended Server 17, run: 
 
     ```shell
-    sudo dnf check-update edb-postgresextended16
+    sudo dnf check-update edb-postgresextended17
     ```
 
     !!!Note
@@ -36,16 +36,16 @@ If you used `dnf` to install an RPM package of EDB Postgres Extended Server (on 
 1.  Once you've figured the name and version of the package you want to install, use `dnf update` to install the package:
 
     ```shell
-    sudo dnf update edb-postgresextended16
+    sudo dnf update edb-postgresextended17
     __OUTPUT__
     ================================================================================
     Package                        Arch   Version    Repository               Size
     ================================================================================
     Upgrading:
-     edb-postgresextended16         x86_64 16.3-2.el9 enterprisedb-enterprise 1.7 M
-     edb-postgresextended16-contrib x86_64 16.3-2.el9 enterprisedb-enterprise 724 k
-     edb-postgresextended16-libs    x86_64 16.3-2.el9 enterprisedb-enterprise 330 k
-     edb-postgresextended16-server  x86_64 16.3-2.el9 enterprisedb-enterprise 6.8 M
+     edb-postgresextended17         x86_64 17.2-1.el9 enterprisedb-enterprise 1.7 M
+     edb-postgresextended17-contrib x86_64 17.2-1.el9 enterprisedb-enterprise 724 k
+     edb-postgresextended17-libs    x86_64 17.2-1.el9 enterprisedb-enterprise 330 k
+     edb-postgresextended17-server  x86_64 17.2-1.el9 enterprisedb-enterprise 6.8 M
 
     Transaction Summary
     ================================================================================
@@ -60,28 +60,28 @@ If you used `dnf` to install an RPM package of EDB Postgres Extended Server (on 
     ```shell
     y
     __OUTPUT__
-    edb-postgresextended16-16.3-2.el9.x86_64
-    edb-postgresextended16-contrib-16.3-2.el9.x86_64
-    edb-postgresextended16-libs-16.3-2.el9.x86_64
-    edb-postgresextended16-server-16.3-2.el9.x86_64
+    edb-postgresextended17-17.2-1.el9.x86_64
+    edb-postgresextended17-contrib-17.2-1.el9.x86_64
+    edb-postgresextended17-libs-17.2-1.el9.x86_64
+    edb-postgresextended17-server-17.2-1.el9.x86_64
     ```
 
 1.  To finalize the upgrade, restart the server. Replace `<path_to_data_directory>` with the path to the data directory of the server or servers you're upgrading:
 
     ```shell
-    /usr/edb/pge16/bin/pg_ctl -D <path_to_data_directory> restart
+    /usr/edb/pge17/bin/pg_ctl -D <path_to_data_directory> restart
     ```
 
     For example: 
 
     ```shell
-    /usr/edb/pge16/bin/pg_ctl -D /var/lib/edb-pge/16/upgrade restart
+    /usr/edb/pge17/bin/pg_ctl -D /var/lib/edb-pge/17/upgrade restart
     ```
 
 1.  Verify the expected database version is running by connecting to psql: 
 
     ```shell
-    /usr/edb/pge16/bin/psql
+    /usr/edb/pge17/bin/psql
     ```
     
     Check the server version: 
@@ -91,6 +91,6 @@ If you used `dnf` to install an RPM package of EDB Postgres Extended Server (on 
     __OUTPUT__
                    server_version
     --------------------------------------------
-     16.3 (EDB Postgres Extended Server 16.3.0)
+     17.2 (EDB Postgres Extended Server 17.2.0)
     ```
     


### PR DESCRIPTION
## What Changed?

Bumping the version number from 16 to 17 in the new documentation folder added for 17.2. 
Also updated the examples in the upgrade topic to go from 15>16 to 16>17. 
