### PR TITLE
Added info about the Promote Status section of cluster status output

### DIFF
--- a/product_docs/docs/efm/4/06_monitoring_efm_cluster.mdx
+++ b/product_docs/docs/efm/4/06_monitoring_efm_cluster.mdx
@@ -76,7 +76,9 @@ Standby priority host list:
 172.19.12.163 172.19.10.2
 ```
 
-The `Promote Status` section of the report is the result of a direct query from the node on which you are invoking the `cluster-status` command to each database in the cluster. The query also returns the transaction log location of each database. Because the queries to each database return at different times, the LSNs might not match even if streaming replication is working normally for the cluster. To get the latest view of replication, connect to the primary database, and execute SQL command `SELECT * FROM pg_stat_replication;`.
+The `Promote Status` section of the report includes information related to promotion in the cluster. The LSN information is used, along with the `Standby priority host list`, when choosing a standby to promote. If there is a mismatch in replay LSNs, Failover Manager will not allow a switchover (though the promotion of a standby is always allowed).
+
+The LSN information is the result of a direct query from the node on which you are invoking the `cluster-status` command to each database in the cluster. The query also returns the transaction log location of each database. Because the queries to each database return at different times, the LSNs might not match even if streaming replication is working normally for the cluster. To get the latest view of replication, connect to the primary database, and execute SQL command `SELECT * FROM pg_stat_replication;`.
 ```text
 Promote Status:
 


### PR DESCRIPTION
This leaves the existing info mostly alone, but adds an explanation of the Promote Status output and why it's there. The info that efm collects here is all related to whether or not a promotion would be safe (or a switchover allowed) and how a standby would be picked. It's not meant to be the place a user monitors replication. The existing text goes into detail a little about this, but the new text explains why this particular info is here if not meant to check replication.

## What Changed?
