### PR TITLE
Docs/tpa/fix/importforlightweight

### DIFF
--- a/product_docs/docs/tpa/23/architecture-PGD-Lightweight.mdx
+++ b/product_docs/docs/tpa/23/architecture-PGD-Lightweight.mdx
@@ -1,4 +1,5 @@
 ---
+navTitle: PGD-Lightweight
 description: Configuring a PGD Lightweight cluster with TPA.
 title: PGD Lightweight
 originalFilePath: architecture-PGD-Lightweight.md
@@ -8,13 +9,13 @@ originalFilePath: architecture-PGD-Lightweight.md
 !!! Note
 
     This architecture is for Postgres Distributed 5 only.
-    If you require PGD 4 or 3.7 please use [BDR-Always-ON](../architecture-BDR-Always-ON/).
+    If you require PGD 4 or 3.7 please use [BDR-Always-ON](architecture-BDR-Always-ON/).
 
     EDB Postgres Distributed 5 in a Lightweight configuration,
     suitable for use in test and production.
 
     This architecture requires an EDB subscription.
-    All software will be sourced from [EDB Repos 2.0](edb_repositories/).
+    All software will be sourced from [EDB Repos 2.0](reference/edb_repositories/).
 
 ## Cluster configuration
 
@@ -44,10 +45,10 @@ More detail on the options is provided in the following section.
 
 #### Mandatory Options
 
-| Options                                               | Description                                                                                  |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `--architecture` (`-a`)                               | Must be set to `Lightweight`                                                                 |
-| Postgres flavour and version (e.g. `--postgresql 15`) | A valid [flavour and version specifier](../tpaexec-configure/#postgres-flavour-and-version). |
+| Options                                               | Description                                                                               |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `--architecture` (`-a`)                               | Must be set to `Lightweight`                                                              |
+| Postgres flavour and version (e.g. `--postgresql 15`) | A valid [flavour and version specifier](tpaexec-configure/#postgres-flavour-and-version). |
 
 <br/><br/>
 
@@ -100,4 +101,4 @@ You may optionally specify `--enable-pgd-probes [{http, https}]` to
 enable http(s) api endpoints that will allow to easily probe proxy's health.
 
 You may also specify any of the options described by
-[`tpaexec help configure-options`](../tpaexec-configure/).
+[`tpaexec help configure-options`](tpaexec-configure/).

--- a/product_docs/docs/tpa/23/index.mdx
+++ b/product_docs/docs/tpa/23/index.mdx
@@ -13,6 +13,7 @@ navigation:
   - tpaexec-test
   - '#Architectures'
   - architecture-PGD-Always-ON
+  - architecture-PGD-Lightweight
   - architecture-BDR-Always-ON
   - architecture-M1
   - '#Platforms'
@@ -229,12 +230,11 @@ on a TPA cluster that you could do on any other Postgres installation.
 ## Versioning in TPA
 
 TPA previously used a date-based versioning scheme whereby the major
-version was derived from the year. From version 23 we have moved to a
-derivative of semantic versioning. For historical reasons, we are not
-using the full three-part semantic version number. Instead TPA uses a
-two-part `major.minor` format. The minor version is incremented on every
-release, the major version is only incremented where required to comply
-with the backward compatibility principle below.
+version was derived from the year. From version 23 TPA transitioned to
+semantic versioning, initially using a two-part `major-minor` pattern,
+then adopting full three-part semantic versioning in version 23.34.1.
+Under this scheme, the major version is only incremented where required
+to comply with the backward compatibility principle below.
 
 ### Backwards compatibility
 

--- a/product_docs/docs/tpa/23/index.mdx
+++ b/product_docs/docs/tpa/23/index.mdx
@@ -230,7 +230,7 @@ on a TPA cluster that you could do on any other Postgres installation.
 ## Versioning in TPA
 
 TPA previously used a date-based versioning scheme whereby the major
-version was derived from the year. From version 23 TPA transitioned to
+version was derived from the year. From version 23, TPA transitioned to
 semantic versioning, initially using a two-part `major-minor` pattern,
 then adopting full three-part semantic versioning in version 23.34.1.
 Under this scheme, the major version is only incremented where required

--- a/scripts/source/process-tpa-docs.sh
+++ b/scripts/source/process-tpa-docs.sh
@@ -33,4 +33,4 @@ node $DESTINATION_CHECKOUT/scripts/source/merge-indexes.mjs \
   "$SOURCE_CHECKOUT/docs/src/reference/index.mdx" \
   >> $SOURCE_CHECKOUT/files-to-ignore.txt
 
-rsync -av --delete --exclude="*.md" --exclude="architectures" --exclude="templates" --exclude-from=$SOURCE_CHECKOUT/files-to-ignore.txt src/ $DESTINATION_CHECKOUT/product_docs/docs/tpa/$TPAVERSION/
+rsync -av --delete --exclude="*.md" --exclude="architectures" --exclude="templates" --exclude-from=$SOURCE_CHECKOUT/files-to-ignore.txt --exclude="rel_notes" src/ $DESTINATION_CHECKOUT/product_docs/docs/tpa/$TPAVERSION/


### PR DESCRIPTION
Signed-off-by: Dj Walker-Morgan <dj.walker-morgan@enterprisedb.com>

## What Changed?

Small fix to bring the architectures for lightweight out of the reference.

Also PR upstream to stop that happening again and fixed to the non-auto import script to stop it trashing the new release notes regen src file.
