### PR TITLE
Fix IP addresses for Docker

### DIFF
--- a/product_docs/docs/pgd/5.6/quickstart/connecting_applications.mdx
+++ b/product_docs/docs/pgd/5.6/quickstart/connecting_applications.mdx
@@ -43,7 +43,7 @@ chmod 0600 ~/.pgpass
 
 ### Docker
 
-Your Docker quick start cluster is by default accessible on the IP addresses 172.17.0.2 (kaboom), 172.17.0.3 (kaftan), 172.17.04 (kaolin), and 172.17.0.5 (kapok). Docker generates these addresses.
+Your Docker quick start cluster is by default accessible on the IP addresses 10.33.111.18 (kaboom), 10.33.111.19 (kaftan), 10.33.111.20 (kaolin), and 10.33.111.21 (kapok). TPA generates these addresses.
 
 ### AWS
 


### PR DESCRIPTION
TPA changes Docker IP addresses

## What Changed?

This brings the IP addresses in sync again.