### PR TITLE
pgd: document node synchronisation catalogue objects

### DIFF
--- a/product_docs/docs/pgd/5.6/reference/catalogs-internal.mdx
+++ b/product_docs/docs/pgd/5.6/reference/catalogs-internal.mdx
@@ -274,3 +274,42 @@ An internal state table storing the type of each non-local sequence. We recommen
 |---------|------|-----------------------------------------------------------------------------|
 | seqid   | oid  | Internal OID of the sequence                                                |
 | seqkind | char | Internal sequence kind (`l`=local,`t`=timeshard,`s`=snowflakeid,`g`=galloc) |
+
+
+### `bdr.sync_node_requests`
+
+An internal state table storing the state of node synchronization requests. The view
+[`bdr.sync_node_requests_summary`](catalogs-internal#bdrsync_node_requests_summary)
+provides a human-readable representation of this table.
+
+### `bdr.sync_node_requests` columns
+
+| Name              | Type        | Description                                       |
+| ----------------- | ----------- | ------------------------------------------------- |
+| sn_origin_node_id | oid         | Unavailable node with changes to be synchronized  |
+| sn_target_node_id | oid         | Node with the origin node's changes               |
+| sn_source_node_id | oid         | Target node for the sync request                  |
+| sn_sync_start_lsn | pg_lsn      | Start LSN of the sync request                     |
+| sn_sync_start_ts  | timestamptz | Start timestamp of the sync request               |
+| sn_sync_end_lsn   | pg_lsn      | End LSN of the sync request                       |
+| sn_sync_end_ts    | timestamptz | End timestamp of the sync request                 |
+| sn_sync_status    | text        | Status of the sync request                        |
+
+### `bdr.sync_node_requests_summary`
+
+A view providing a human-readable version of the underlying [`bdr.sync_node_requests`](catalogs-internal#bdrsync_node_requests)
+table.
+
+#### `bdr.sync_node_requests_summary` columns
+
+| Name           | Type        | Description                                       |
+| -------------- | ----------- | ------------------------------------------------- |
+| origin         | text        | Unavailable node with changes to be synchronized  |
+| source         | text        | Node with the origin node's changes               |
+| target         | text        | Target node for the sync request                  |
+| sync_start_lsn | pg_lsn      | Start LSN of the sync request                     |
+| sync_start_ts  | timestamptz | Start timestamp of the sync request               |
+| sync_end_lsn   | pg_lsn      | End LSN of the sync request                       |
+| sync_end_ts    | timestamptz | End timestamp of the sync request                 |
+| sync_status    | text        | Status of the sync request                        |
+

--- a/product_docs/docs/pgd/5.6/reference/functions-internal.mdx
+++ b/product_docs/docs/pgd/5.6/reference/functions-internal.mdx
@@ -421,6 +421,24 @@ bdr.show_workers(
 
 Function used in the `bdr.writers` view.
 
+### `bdr.sync_status_name`
+
+Converts sync state code into a textual representation.
+Used mainly to implement the [`bdr.sync_node_requests_summary`](catalogs-internal#bdrsync_node_requests_summary)
+view.
+
+#### Synopsis
+
+```sql
+bdr.sync_status_name(sync_state oid)
+```
+
+#### Parameters
+
+| Parameter    | Description                   |
+|--------------|-------------------------------|
+| `sync_state` | Oid code of the sync state.   |
+
 ## Task manager functions
 
 ### `bdr.taskmgr_set_leader`


### PR DESCRIPTION
**** Note: changes valid for PG 5.7.0 ****

## What Changed?

BDR issue 5548 added a view and a helper function:

 - bdr.sync_status_name()
 - bdr.sync_node_requests_summary

to provide a human-readable version of the "bdr.sync_node_requests" catalogue table. Document that as well while we're there.

BDR-5805 / DOCS-1166.


