### PR TITLE
PGE 13.x: corrected semantic versioning

### DIFF
--- a/product_docs/docs/pge/13/release_notes/index.mdx
+++ b/product_docs/docs/pge/13/release_notes/index.mdx
@@ -4,7 +4,7 @@ navTitle: Release notes
 description: Release notes for EDB Postgres Extended Server 13.
 --- 
 
-## 2ndQuadrant Postgres 13.18.24
+## 2ndQuadrant Postgres 13.18
 
 Release date: 2024-11-21
 


### PR DESCRIPTION
## What Changed?
Minor fix due to PGE using `MAJOR.MINOR` versioning for 13.x and earlier versions, unlike EPAS, that uses `MAJOR.MINOR.PATCH` semantic versioning in versions 13 and earlier. 
