### PR TITLE
Update relnote_5.6.1.yml

### DIFF
--- a/product_docs/docs/pgd/5.6/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/5.6/rel_notes/index.mdx
@@ -2,10 +2,12 @@
 title: EDB Postgres Distributed 5.6+ release notes
 navTitle: Release notes
 description: Release notes for EDB Postgres Distributed 5.6 and later
+indexCards: none
 navigation:
   - pgd_5.6.1_rel_notes
   - pgd_5.6.0_rel_notes
 ---
+
 
 The EDB Postgres Distributed documentation describes the latest version of EDB Postgres Distributed 5, including minor releases and patches. The release notes provide information on what was new in each release. For new functionality introduced in a minor or patch release, the content also indicates the release that introduced the feature.
 
@@ -14,4 +16,3 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 |---|---|---|---|---|
 | 25 Nov 2024 | [5.6.1](./pgd_5.6.1_rel_notes) | 5.6.1 | 5.6.1 | 5.6.1 |
 | 15 Oct 2024 | [5.6.0](./pgd_5.6.0_rel_notes) | 5.6.0 | 5.6.0 | 5.6.0 |
-

--- a/product_docs/docs/pgd/5.6/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/5.6/rel_notes/index.mdx
@@ -6,6 +6,7 @@ indexCards: none
 navigation:
   - pgd_5.6.1_rel_notes
   - pgd_5.6.0_rel_notes
+  - pgd_5.6.2_rel_notes
 ---
 
 
@@ -16,3 +17,4 @@ The EDB Postgres Distributed documentation describes the latest version of EDB P
 |---|---|---|---|---|
 | 25 Nov 2024 | [5.6.1](./pgd_5.6.1_rel_notes) | 5.6.1 | 5.6.1 | 5.6.1 |
 | 15 Oct 2024 | [5.6.0](./pgd_5.6.0_rel_notes) | 5.6.0 | 5.6.0 | 5.6.0 |
+| 25 undefined undefined | [5.6.2](./pgd_5.6.2_rel_notes) | 5.6.2 | 5.6.2 | 5.6.2 |

--- a/product_docs/docs/pgd/5.6/rel_notes/pgd_5.6.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/5.6/rel_notes/pgd_5.6.1_rel_notes.mdx
@@ -17,7 +17,8 @@ EDB Postgres Distributed 5.6.1 includes a number of enhancements and bug fixes.
 <table class="table w-100"><thead><tr><th>Component</th><th>Version</th><th>Description</th><th width="10%">Addresses</th></tr></thead><tbody>
 <tr><td>BDR</td><td>5.6.1</td><td><details><summary>Added Postgres 17 support</summary><hr/><p>Support for Postgres 17 has been added for all flavors (PostgreSQL, EDB Postgres Extended,
 and EDB Postgres Advanced Server) starting with version 17.2.</p>
-<p>Additional paragraph to test auto-regeneration.</p>
+<p>Additional paragraph to test auto-regeneration.
+This should trigger the update of a file.</p>
 </details></td><td></td></tr>
 <tr><td>BDR</td><td>5.6.1</td><td><details><summary>Added ARM64 processor Support</summary><hr/><p>Support ARM architecture for EDB Postgres Distributed on Debian 12 and RHEL 9.</p>
 </details></td><td></td></tr>

--- a/product_docs/docs/pgd/5.6/rel_notes/pgd_5.6.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/5.6/rel_notes/pgd_5.6.1_rel_notes.mdx
@@ -17,6 +17,7 @@ EDB Postgres Distributed 5.6.1 includes a number of enhancements and bug fixes.
 <table class="table w-100"><thead><tr><th>Component</th><th>Version</th><th>Description</th><th width="10%">Addresses</th></tr></thead><tbody>
 <tr><td>BDR</td><td>5.6.1</td><td><details><summary>Added Postgres 17 support</summary><hr/><p>Support for Postgres 17 has been added for all flavors (PostgreSQL, EDB Postgres Extended,
 and EDB Postgres Advanced Server) starting with version 17.2.</p>
+<p>Additional paragraph to test auto-regeneration.</p>
 </details></td><td></td></tr>
 <tr><td>BDR</td><td>5.6.1</td><td><details><summary>Added ARM64 processor Support</summary><hr/><p>Support ARM architecture for EDB Postgres Distributed on Debian 12 and RHEL 9.</p>
 </details></td><td></td></tr>

--- a/product_docs/docs/pgd/5.6/rel_notes/pgd_5.6.2_rel_notes.mdx
+++ b/product_docs/docs/pgd/5.6/rel_notes/pgd_5.6.2_rel_notes.mdx
@@ -1,0 +1,22 @@
+---
+title: EDB Postgres Distributed 5.6.2 release notes
+navTitle: Version 5.6.2
+---
+
+Released: 25 Never
+
+EDB Postgres Distributed 5.6.2 doesn't exist.
+
+## Highlights
+
+- Future release
+- Maybe. Probably not
+
+## Features
+
+<table class="table w-100"><thead><tr><th>Component</th><th>Version</th><th>Description</th><th width="10%">Addresses</th></tr></thead><tbody>
+<tr><td>BDR</td><td>5.6.2</td><td><details><summary>This didn't happen</summary><hr/><p>This isn't a real release. But it should trigger generation of a new file.</p>
+</details></td><td></td></tr>
+</tbody></table>
+
+

--- a/product_docs/docs/pgd/5.6/rel_notes/src/relnote_5.6.1.yml
+++ b/product_docs/docs/pgd/5.6/rel_notes/src/relnote_5.6.1.yml
@@ -17,6 +17,8 @@ relnotes:
   details: |
     Support for Postgres 17 has been added for all flavors (PostgreSQL, EDB Postgres Extended, 
     and EDB Postgres Advanced Server) starting with version 17.2.
+
+    Additional paragraph to test auto-regeneration.
   jira: BDR-5410
   addresses: ""
   type: Feature

--- a/product_docs/docs/pgd/5.6/rel_notes/src/relnote_5.6.1.yml
+++ b/product_docs/docs/pgd/5.6/rel_notes/src/relnote_5.6.1.yml
@@ -19,6 +19,7 @@ relnotes:
     and EDB Postgres Advanced Server) starting with version 17.2.
 
     Additional paragraph to test auto-regeneration.
+    This should trigger the update of a file.
   jira: BDR-5410
   addresses: ""
   type: Feature

--- a/product_docs/docs/pgd/5.6/rel_notes/src/relnote_5.6.2.yml
+++ b/product_docs/docs/pgd/5.6/rel_notes/src/relnote_5.6.2.yml
@@ -1,0 +1,19 @@
+product: EDB Postgres Distributed
+version: 5.6.2
+date: 25 Never
+meta:
+  bdrextension: 5.6.2
+  pgdcli: 5.6.2
+  pgdproxy: 5.6.2
+intro: |
+ EDB Postgres Distributed 5.6.2 doesn't exist.
+highlights: |
+  - Future release
+  - Maybe. Probably not
+relnotes:
+- relnote: This didn't happen
+  component: BDR
+  component_version: 5.6.2
+  details: |
+    This isn't a real release. But it should trigger generation of a new file.
+  type: Feature

--- a/product_docs/docs/tpa/23/rel_notes/index.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/index.mdx
@@ -2,6 +2,7 @@
 title: Trusted Postgres Architect release notes
 navTitle: Release notes
 description: Release notes for Trusted Postgres Architect and later
+indexCards: none
 navigation:
   - tpa_23.35.0_rel_notes
   - tpa_23.34.1_rel_notes


### PR DESCRIPTION
## What Changed?

Ignore this. Used to test relnotes regen workflow.