### PR TITLE
Update cluster definition in  terminology.mdx

### DIFF
--- a/product_docs/docs/pgd/5.6/terminology.mdx
+++ b/product_docs/docs/pgd/5.6/terminology.mdx
@@ -27,7 +27,7 @@ How [Raft](#replicated-available-fault-tolerance-raft) makes group-wide decision
 
 #### Cluster
 
-Generically, a cluster is a group of multiple redundant systems arranged to appear to end users as one system. See also [PGD cluster](#pgd-cluster) and [Postgres cluster](#postgres-cluster).
+Generically, a cluster is a group of multiple systems arranged to appear to end users as one system. See also [PGD cluster](#pgd-cluster) and [Postgres cluster](#postgres-cluster).
 
 ####  DDL (data definition language)
 


### PR DESCRIPTION
The current documentation describes a "cluster" as a group of "multiple redundant systems," which is not universally accurate in the broader computing context. Clusters are generally defined as a group of interconnected systems working together to function as a single cohesive unit. While redundancy may be a feature of some clusters, it is not inherent to the definition. This change revises the wording to reflect a more accurate and generic definition of a cluster in computing.

## What Changed?

Cluster
Generically, a cluster is a group of multiple redundant systems arranged to appear to end users as one system. See also [PGD cluster](https://www.enterprisedb.com/docs/pgd/latest/terminology/#pgd-cluster) and [Postgres cluster](https://www.enterprisedb.com/docs/pgd/latest/terminology/#postgres-cluster).

-->

Cluster
Generically, a cluster is a group of multiple systems arranged to appear to end users as one system. See also [PGD cluster](https://www.enterprisedb.com/docs/pgd/latest/terminology/#pgd-cluster) and [Postgres cluster](https://www.enterprisedb.com/docs/pgd/latest/terminology/#postgres-cluster).

