### PR TITLE
PG4K: Patch to correct LTS status and remove backslashes

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/index.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/index.mdx
@@ -126,18 +126,19 @@ You need a valid EDB subscription to use EDB Postgres for Kubernetes in producti
 ### Long Term Support
 
 EDB is committed to declaring a Long Term Support (LTS) version of EDB
-Postgres for Kubernetes annually. 1.22 is the current LTS version. 1.18 was our
+Postgres for Kubernetes annually. 1.25 is the current LTS version. 1.18 was the
 first. Each LTS version will
 receive maintenance releases and be supported for an additional 12 months beyond
 the last community release of CloudNativePG for the same version.
 
-For example, the 1.22 release of CloudNativePG will reach End-of-Life on July
+For example, the 1.22 release of CloudNativePG reached End-of-Life on July
 24, 2024, for the open source community.
 Because it was declared an LTS version of EDB Postgres for Kubernetes, it
 will be supported for an additional 12 months, until July 24, 2025.
 
-In addition, customers will always have at least 6 months to move between LTS versions. This
-means a new LTS version will be available by January 24, 2025 at the latest.
+In addition, customers will always have at least 6 months to move between LTS versions.
+For example, the 1.25 LTS version was released on December 23 2024, giving ample
+time to users to migrate from the 1.22 LTS ahead of the End-of-life on July 2025.
 
 While we encourage customers to regularly upgrade to the latest version of the operator to take
 advantage of new features, having LTS versions allows customers desiring additional stability to stay on the same
@@ -181,9 +182,9 @@ The following versions of Postgres are currently supported:
 -   EDB Postgres Extended: 12 - 16
 
 PostgreSQL and EDB Postgres Advanced are available on the following platforms:
-`linux/amd64`, `linux/ppc64le`, `linux/s390x`. \\
-In addition, PostgreSQL is also supported on `linux/arm64`. \\
-EDB Postgres Extended is supported only on `linux/amd64`. \\
+`linux/amd64`, `linux/ppc64le`, `linux/s390x`.  
+In addition, PostgreSQL is also supported on `linux/arm64`.  
+EDB Postgres Extended is supported only on `linux/amd64`.  
 EDB supports operand images for `linux/ppc64le` and `linux/s390x` architectures
 on OpenShift only.
 


### PR DESCRIPTION
## What Changed?

Fixed LTS status (did not appear to get imported) 

Also removed \\ from text, replaced with double spaces though maybe migrate to a bulleted list upstream?

