### PR TITLE
update firewall information for efm

### DIFF
--- a/product_docs/docs/efm/4/installing/prerequisites.mdx
+++ b/product_docs/docs/efm/4/installing/prerequisites.mdx
@@ -79,7 +79,7 @@ If a Linux firewall (that is, iptables) is enabled on the host of a Failover Man
 /sbin/service iptables save
 ```
 
-This command opens the port 7800. Failover Manager connects by way of the port that corresponds to the port specified by `bind.address` in the cluster properties file. The port specified by `admin.port` does not need to be open. It is only used for local communication when the `efm` command line process is run.
+This command opens the port 7800. Failover Manager connects by way of the port that corresponds to the port specified by `bind.address` in the cluster properties file. The port specified by `admin.port` does not need to be open. It is only used for local communication when the `efm` utility is run.
 
 ## Ensure that the database user has sufficient privileges
 

--- a/product_docs/docs/efm/4/installing/prerequisites.mdx
+++ b/product_docs/docs/efm/4/installing/prerequisites.mdx
@@ -79,7 +79,7 @@ If a Linux firewall (that is, iptables) is enabled on the host of a Failover Man
 /sbin/service iptables save
 ```
 
-This command opens the port 7800. Failover Manager connects by way of the port that corresponds to the port specified in the cluster properties file.
+This command opens the port 7800. Failover Manager connects by way of the port that corresponds to the port specified by `bind.address` in the cluster properties file. The port specified by `admin.port` does not need to be open. It is only used for local communication when the `efm` command line process is run.
 
 ## Ensure that the database user has sufficient privileges
 


### PR DESCRIPTION
This updates the firewall prereqs text to make it clear that:

1. the port that needs to be open is the one used with the bind.address property
2. the admin.port port doesn't need to be opened.

