### PR TITLE
DOCS-790

### DIFF
--- a/product_docs/docs/pgd/5.6/known_issues.mdx
+++ b/product_docs/docs/pgd/5.6/known_issues.mdx
@@ -38,7 +38,7 @@ Adding or removing a pair doesn't require a restart of Postgres or even a reload
 
 -   Transactions using Eager Replication can't yet execute DDL. The TRUNCATE command is allowed.
 
--   Parallel Apply isn't currently supported in combination with Group Commit. Make sure to disable it when using Group Commit by either (a) Setting `num_writers` to 1 for the node group using [`bdr.alter_node_group_config`](/pgd/latest/reference/nodes-management-interfaces/#bdralter_node_group_config) or (b) using the GUC [`bdr.writers_per_subscription`](/pgd/latest/reference/pgd-settings#bdrwriters_per_subscription). See [Configuration of generic replication](/pgd/latest/reference/pgd-settings#generic-replication).
+-   Parallel Apply isn't currently supported in combination with Group Commit. Make sure to disable it when using Group Commit by either (a) Setting `num_writers` to 1 for the node group using [`bdr.alter_node_group_option`](/pgd/latest/reference/nodes-management-interfaces/#bdralter_node_group_option) or (b) using the GUC [`bdr.writers_per_subscription`](/pgd/latest/reference/pgd-settings#bdrwriters_per_subscription). See [Configuration of generic replication](/pgd/latest/reference/pgd-settings#generic-replication).
 
 -   There currently is no protection against altering or removing a commit scope. 
 Running transactions in a commit scope that's concurrently being altered or removed can lead to the transaction blocking or replication stalling completely due to an error on the downstream node attempting to apply the transaction.

--- a/product_docs/docs/pgd/5.6/reference/pgd-settings.mdx
+++ b/product_docs/docs/pgd/5.6/reference/pgd-settings.mdx
@@ -189,7 +189,7 @@ failover or when using subscribe-only nodes.
 ### `bdr.writers_per_subscription`
 
 Sets the default number of writers per subscription. (In PGD, you can also change
-this with `bdr.alter_node_group_config` for a group.)
+this with `bdr.alter_node_group_option` for a group.)
 
 ### `bdr.max_writers_per_subscription`
 

--- a/product_docs/docs/pgd/5/known_issues.mdx
+++ b/product_docs/docs/pgd/5/known_issues.mdx
@@ -30,7 +30,7 @@ Adding or removing a pair doesn't require a restart of Postgres or even a reload
 
 -   Transactions using Eager Replication can't yet execute DDL. The TRUNCATE command is allowed.
 
--   Parallel Apply isn't currently supported in combination with Group Commit. Make sure to disable it when using Group Commit by either (a) Setting `num_writers` to 1 for the node group using [`bdr.alter_node_group_config`](/pgd/5/reference/nodes-management-interfaces/#bdralter_node_group_config) or (b) using the GUC [`bdr.writers_per_subscription`](/pgd/5/reference/pgd-settings#bdrwriters_per_subscription). See [Configuration of generic replication](/pgd/5/reference/pgd-settings#generic-replication).
+-   Parallel Apply isn't currently supported in combination with Group Commit. Make sure to disable it when using Group Commit by either (a) Setting `num_writers` to 1 for the node group using [`bdr.alter_node_group_option`](/pgd/5/reference/nodes-management-interfaces/#bdralter_node_group_option) or (b) using the GUC [`bdr.writers_per_subscription`](/pgd/5/reference/pgd-settings#bdrwriters_per_subscription). See [Configuration of generic replication](/pgd/5/reference/pgd-settings#generic-replication).
 
 -   There currently is no protection against altering or removing a commit scope. 
 Running transactions in a commit scope that's concurrently being altered or removed can lead to the transaction blocking or replication stalling completely due to an error on the downstream node attempting to apply the transaction.

--- a/product_docs/docs/pgd/5/node_management/decoding_worker.mdx
+++ b/product_docs/docs/pgd/5/node_management/decoding_worker.mdx
@@ -13,7 +13,7 @@ since the WAL sender process now spends more time on communication.
 ## Enabling
 
 `enable_wal_decoder` is an option for each PGD group, which is currently
-disabled by default. You can use [`bdr.alter_node_group_config()`](../reference/nodes-management-interfaces/#bdralter_node_group_config) to enable or
+disabled by default. You can use [`bdr.alter_node_group_option()`](../reference/nodes-management-interfaces/#bdralter_node_group_option) to enable or
 disable the decoding worker for a PGD group.
 
 When the decoding worker is enabled, PGD stores logical change record (LCR)

--- a/product_docs/docs/pgd/5/reference/pgd-settings.mdx
+++ b/product_docs/docs/pgd/5/reference/pgd-settings.mdx
@@ -189,7 +189,7 @@ failover or when using subscribe-only nodes.
 ### `bdr.writers_per_subscription`
 
 Sets the default number of writers per subscription. (In PGD, you can also change
-this with `bdr.alter_node_group_config` for a group.)
+this with `bdr.alter_node_group_option` for a group.)
 
 ### `bdr.max_writers_per_subscription`
 


### PR DESCRIPTION
## What Changed?

- fixed instances of using bdr.alter_node_group_config and replaced with bdr.alter_node_group_option where referenced.