### PR TITLE
Fix `pgaa.create_storage_location` docs

### DIFF
--- a/advocacy_docs/edb-postgres-ai/analytics/external_tables.mdx
+++ b/advocacy_docs/edb-postgres-ai/analytics/external_tables.mdx
@@ -37,13 +37,23 @@ For example, in the options, you can specify the access key ID and secret access
 The following example creates an external table that references a public S3-compatible object storage location:
 
 ```sql
-SELECT pgaa.create_storage_location('sample-data', 's3://pgaa-sample-data-eu-west-1');
+SELECT pgaa.create_storage_location(
+  name => 'sample-data',
+  url => 's3://pgaa-sample-data-eu-west-1',
+  options => '{}',
+  msl_id => NULL
+);
 ```
 
 The next example creates an external storage location that references a private S3-compatible object storage location:
 
 ```sql
-SELECT pgaa.create_storage_location('private-data', 's3://my-private-bucket', '{"access_key_id": "my-access-key-id","secret_access_key": "my-secret-access-key"}');
+SELECT pgaa.create_storage_location(
+  name => 'private-data',
+  url => 's3://my-private-bucket',
+  options => '{"access_key_id": "my-access-key-id","secret_access_key": "my-secret-access-key"}',
+  msl_id => NULL
+);
 ```
 
 ## Creating an External Table


### PR DESCRIPTION
## What Changed?

When creating a storage location, all parameters are required in 0.1.x of pgaa, so make them explicit and use the `=>` syntax so that it's obvious which one goes where.