### PR TITLE
MTK: clarify that 2 drivers are required.

### DIFF
--- a/product_docs/docs/migration_toolkit/55/installing/installing_jdbc_driver.mdx
+++ b/product_docs/docs/migration_toolkit/55/installing/installing_jdbc_driver.mdx
@@ -3,12 +3,12 @@ title: "Installing a JDBC driver"
 redirects:
   - /migration_toolkit/latest/05_installing_mtk/installing_jdbc_driver/
 ---
-<div id="installing_drivers" class="registered_link"></div>
 
 Migration Toolkit requires Java version 1.8.0 or later.
 
 ## Choosing a driver
-Which JDBC driver you use depends on the what database you are migrating from or to:
+
+Which JDBC drivers you use depends on the databases you are migrating from and to. For example, if you are migrating from Oracle to EDB Postgres Advanced Server, you will need the Oracle JDBC driver and the EDB JDBC driver. 
 
 - If you're migrating to or from EDB Postgres Advanced Server, use the EDB JDBC driver. To download the latest driver, see [EDB Connectors](https://enterprisedb.com/software-downloads-postgres#edb-connectors) on the EDB Downloads page. For installation instructions, see [Installing and configuring EDB JDBC Connector](/jdbc_connector/latest/installing/).
 
@@ -17,14 +17,14 @@ Which JDBC driver you use depends on the what database you are migrating from or
 
 - If you're migrating to or from PostgreSQL, use the PostgreSQL JDBC driver. To download the latest supported driver, see the [JDBC drivers section](https://jdbc.postgresql.org/download/) on the PostgreSQL Downloads page. 
 
-- If you're migrating from Oracle, MySQL, Microsoft SQL Server or Sybase, use the freely available source-specific JDBC driver. 
+- If you're migrating from Oracle, MySQL, Microsoft SQL Server, or Sybase, use the freely available source-specific JDBC driver. 
   - [Oracle JDBC](https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html)
   - [MySQL JDBC](https://dev.mysql.com/downloads/connector/j/)
   - [Microsoft SQL Server JDBC](https://learn.microsoft.com/en-us/sql/connect/jdbc/release-notes-for-the-jdbc-driver?view=sql-server-ver16#102)
   - [Sybase ASE (jTDS) JDBC](https://sourceforge.net/projects/jtds/files/)
     
   !!! Note
-      The open source jTDS driver also supports older versions of Microsoft SQL Server (version 2012 and earlier) and may be used with Migration Toolkit.  The Microsoft provided JDBC driver for SQL Server is recommended for the newer versions of SQL Server supported by Migration Toolkit.
+      The open-source jTDS driver also supports older versions of Microsoft SQL Server (version 2012 and earlier) and may be used with Migration Toolkit. The Microsoft-provided JDBC driver for SQL Server is recommended for the newer versions of SQL Server supported by Migration Toolkit.
 
 ## Adding the driver to `lib`
 After downloading the driver, move the driver file into the `<mtk_install_dir>/lib` directory.


### PR DESCRIPTION
## What Changed?

When working on a compatibility matrix for [DOCS-1154](https://enterprisedb.atlassian.net/browse/DOCS-1154), I realized that the MTK documentation does not clearly state that it requires not one, but two JDBC drivers. 

[DOCS-1154]: https://enterprisedb.atlassian.net/browse/DOCS-1154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ