### PR TITLE
DMS/Lakehouse Sync: removal notice

### DIFF
--- a/advocacy_docs/edb-postgres-ai/analytics/how_to_lakehouse_sync.mdx
+++ b/advocacy_docs/edb-postgres-ai/analytics/how_to_lakehouse_sync.mdx
@@ -2,6 +2,8 @@
 title: Lakehouse Sync
 navTitle: Lakehouse Sync
 description: How to perform a Lakehouse Sync.
+directoryDefaults:
+  displayBanner: "Notice: Lakehouse Sync capabilities are no longer available in Cloud Service deployments. The documentation remains available for historical reference and will be removed in the future."
 deepToC: true
 ---
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/index.mdx
@@ -6,6 +6,7 @@ directoryDefaults:
   description: "EDB Data Migration Service is a solution that enables secure, fault-tolerant, and performant migrations to EDB Postgres AI Cloud Service."
   product: "data migration service"
   iconName: EdbTransporter
+  displayBanner: "Notice: Data Migration Service capabilities are now only available as part of the EDB Postgres AI Hybrid Control Plane, which is currently in tech preview."
 navigation:
   - "#Concepts"
   - terminology
@@ -18,6 +19,9 @@ navigation:
 ---
 
 **EDB Postgres® AI migrations powered by EDB Data Migration Service**
+
+!!!note Notice
+  Data Migration Service capabilities are now only available as part of the EDB Postgres AI Hybrid Control Plane, which is currently in tech preview.
 
 EDB Data Migration Service (DMS) offers a secure and fault-tolerant way to migrate database data to the EDB Postgres AI platform. Using change data capture or CDC and event streaming, source database row changes are replicated to the migration destination. You can select a subset of your schemas' tables to migrate including support for schema, table, and column name remapping.
 


### PR DESCRIPTION
## What Changed?

As of 28.01.2025 Cloud Service no longer offers Data Migration Service and Lakehouse Sync capabilities. 

The Data Migration Service will only be available in HCP deployments. 
For the Lakehouse Sync, it is not yet clear if we'll eventually move it to the HCP or if there will be no support at all. 
Hence the differentiated Notice banners.  

https://enterprisedb.atlassian.net/browse/DOCS-1182