### PR TITLE
DOCS-1181 - LiveCompare version fixes

### DIFF
--- a/product_docs/docs/livecompare/3/supported_technologies.mdx
+++ b/product_docs/docs/livecompare/3/supported_technologies.mdx
@@ -33,14 +33,14 @@ The table shows versions and details about supported technologies and the contex
 
 | Technology                          | Versions                               | Possible connections      |
 |-------------------------------------|----------------------------------------|---------------------------|
-| PostgreSQL                          | 10[^1], 11[^1], 12, 13, 14, 15, and 16 | Data and output           |
-| EDB Postgres Extended (PGE)         | 10[^1], 11[^1], 12, 13, 14, 15, and 16 | Data and output           |
-| EDB Postgres Advanced Server (EPAS) | 11[^1], 12, 13, 14, 15, and 16         | Data and output           |
+| PostgreSQL                          | 10¹, 11¹, 12¹, 13, 14, 15, 16 and 17 | Data and output           |
+| EDB Postgres Extended (PGE)         | 10¹, 11¹, 12¹, 13, 14, 15, 16 and 17 | Data and output           |
+| EDB Postgres Advanced Server (EPAS) | 11¹, 12¹, 13, 14, 15, 16 and 17         | Data and output           |
 | pglogical                           | 2 and 3                                | Initial, data, and output |
 | EDB Postgres Distributed (PGD)      | 1, 2, 3, 4, and 5                      | Initial, data, and output |
 | Oracle                              | 11g, 12c, 18c, 19c, and 21c            | A single data connection  |
 
-[^1]:LiveCompare only supports the use of LiveCompare with older versions of Postgres (PostgreSQL, EDB Postgres Extended, or EDB Postgres Advanced Server) that have reached end of life in support of performing a major version upgrade to a newer supported version of Postgres.
+¹:LiveCompare only supports the use of LiveCompare with older versions of Postgres (PostgreSQL, EDB Postgres Extended, or EDB Postgres Advanced Server) that have reached end of life in support of performing a major version upgrade to a newer supported version of Postgres.
 
 !!! Note
 EDB no longer tests LiveCompare with Oracle 10g. As such, it's no longer on the list of Oracle versions officially supported with LiveCompare. Oracle 10g was previously supported and is expected to continue to work in most cases. However, some limitations may exist. One known limitation is that LiveCompare requires the `comparison_algorithm` parameter to be set to `full_row` (for example, `comparison_algorithm = full_row`).

--- a/product_docs/docs/livecompare/3/supported_technologies.mdx
+++ b/product_docs/docs/livecompare/3/supported_technologies.mdx
@@ -40,7 +40,7 @@ The table shows versions and details about supported technologies and the contex
 | EDB Postgres Distributed (PGD)      | 1, 2, 3, 4, and 5                      | Initial, data, and output |
 | Oracle                              | 11g, 12c, 18c, 19c, and 21c            | A single data connection  |
 
-¹:LiveCompare only supports the use of LiveCompare with older versions of Postgres (PostgreSQL, EDB Postgres Extended, or EDB Postgres Advanced Server) that have reached end of life in support of performing a major version upgrade to a newer supported version of Postgres.
+¹ LiveCompare only supports the use of LiveCompare with older versions of Postgres (PostgreSQL, EDB Postgres Extended, or EDB Postgres Advanced Server) that have reached end of life in support of performing a major version upgrade to a newer supported version of Postgres.
 
 !!! Note
 EDB no longer tests LiveCompare with Oracle 10g. As such, it's no longer on the list of Oracle versions officially supported with LiveCompare. Oracle 10g was previously supported and is expected to continue to work in most cases. However, some limitations may exist. One known limitation is that LiveCompare requires the `comparison_algorithm` parameter to be set to `full_row` (for example, `comparison_algorithm = full_row`).


### PR DESCRIPTION
## What Changed?

Fixed versions (PG17, EPAS17, PGE17 added, 12 moved to migration only), transitioned footnotes to an explicit superscript 1 to avoid Gatsby's desire to move the footnote to the bottom of the page, not the bottom of the table.

