### PR TITLE
Fixed typo

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/connection_pooling.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/connection_pooling.mdx
@@ -375,7 +375,7 @@ are the ones directly set by PgBouncer.
 -   [`server_reset_query_always`](https://www.pgbouncer.org/config.html#server_reset_query_always)
 -   [`server_round_robin`](https://www.pgbouncer.org/config.html#server_round_robin)
 -   [`server_tls_ciphers`](https://www.pgbouncer.org/config.html#server_tls_ciphers)
--   [`server_tls_server_tls_protocols`](https://www.pgbouncer.org/config.html#server_tls_protocols)
+-   [`server_tls_protocols`](https://www.pgbouncer.org/config.html#server_tls_protocols)
 -   [`stats_period`](https://www.pgbouncer.org/config.html#stats_period)
 -   [`suspend_timeout`](https://www.pgbouncer.org/config.html#suspend_timeout)
 -   [`tcp_defer_accept`](https://www.pgbouncer.org/config.html#tcp_defer_accept)


### PR DESCRIPTION
## What Changed?
-server_tls_server_tls_protocols was changed to the correct parameter name server_tls_protocols
-I have already submitted a PR to the open source upstream repo, but in the mean time while waiting for that to merge and come downstream, I wanted the fix to be in place.

[DOCS-1164](https://enterprisedb.atlassian.net/browse/DOCS-1164)

[DOCS-1164]: https://enterprisedb.atlassian.net/browse/DOCS-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ