### PR TITLE
Edits to MP: terminated DDL assessment due to EPAS-reserved words #6424

### DIFF
--- a/product_docs/docs/migration_portal/4/known_issues_notes.mdx
+++ b/product_docs/docs/migration_portal/4/known_issues_notes.mdx
@@ -231,19 +231,17 @@ While using the Oracle default case, you may experience a lower compatibility ra
    Character: 58
    ```
 
-### Incomplete Object Definition
+### Incomplete object definition
 
-While assessing source schemas with Migration Portal, in rare scenarios, the converted Object Definitions are incomplete when the source DDL contains reserved words.
+While assessing source schemas with Migration Portal, in rare scenarios, the converted object definitions are incomplete when the source DDL contains reserved words.
 
-If you encounter an issue where some part of the Object Definition is missing or the definition gets terminated before reaching the actual end of the statement, you are possibly using keywords reserved by EDB Postgres Advanced Server. For example, when you use `CONSTRAINT` as a column name in a `TABLE` definition and then reference it in `VIEW` or `MVIEW` definitions, Migration Portal could terminate that DDL statement abruptly and skip to the next definition without successfully assessing or converting it.
+If you encounter an issue where some part of the object definition is missing or the definition gets terminated before reaching the actual end of the statement, you might be using keywords reserved by EDB Postgres Advanced Server. For example, when you use `CONSTRAINT` as a column name in a `TABLE` definition and then reference it in `VIEW` or `MVIEW` definitions, Migration Portal might terminate that DDL statement abruptly and skip to the next definition without successfully assessing or converting it.
 
-To work around this issue, you have these options: 
+To work around this issue, you can either: 
 
 - Rename the column name in the Oracle database, then reextract the DDL and upload it to Migration Portal.
 
-or
-
-- Rename the column name in the extracted DDL file, and then upload it to Migration Portal.
+- Rename the column name in the extracted DDL file and then upload it to Migration Portal.
 
 ## EDB DDL Extractor
 


### PR DESCRIPTION
I didn't see any cases where object definition was capitalized, but let me know if it should be for some reason.


