### PR TITLE
EPAS: removing 11 and 12 templates

### DIFF
--- a/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_ubuntu_20.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_ubuntu_20.mdx
@@ -1,0 +1,40 @@
+---
+navTitle: Ubuntu 20.04
+title: Installing PostgreSQL on Ubuntu 20.04 x86_64
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  !!! Note
+  Rather than use the EDB repository, you can obtain PostgreSQL installers and installation packages from the [PostgreSQL community downloads page](https://www.postgresql.org/download/).
+  !!!
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo apt-get -y install postgresql-<xx>
+```
+
+Where `<xx>` is the version of PostgreSQL you are installing. For example, if you are installing version 16, the package name would be `postgresql-16`.

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -340,25 +340,25 @@ products:
     platforms:
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: arm64
         supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 9
         arch: ppc64le
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: Debian 12
         arch: x86_64
         supported versions: [16, 17]
@@ -367,19 +367,19 @@ products:
         supported versions: [16, 17]
       - name: Debian 11
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16]
+        supported versions: [13, 14, 15, 16]
       - name: SLES 15
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
   - name: EDB Postgres Extended Server
     platforms:
       - name: AlmaLinux 8 or Rocky Linux 8


### PR DESCRIPTION
## What Changed?

- Removed EPAS 11 and 12 from install templates.
- PostgreSQL for Ubuntu 20 was missing, but I don't think there is a reason for it to be missing.
