### PR TITLE
Release: 2025-02-05a

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_1.0.7_rel_notes.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_1.0.7_rel_notes.mdx
@@ -1,6 +1,8 @@
 ---
 title: AI Accelerator - Pipelines 1.0.7 release notes
 navTitle: Version 1.0.7
+originalFilePath: advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_1.0.7.yml
+editTarget: originalFilePath
 ---
 
 Released: 10 December 2024

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_2.0.0_rel_notes.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_2.0.0_rel_notes.mdx
@@ -1,6 +1,8 @@
 ---
 title: AI Accelerator - Pipelines 2.0.0 release notes
 navTitle: Version 2.0.0
+originalFilePath: advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_2.0.0.yml
+editTarget: originalFilePath
 ---
 
 Released: 13 January 2025

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_2.1.1_rel_notes.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_2.1.1_rel_notes.mdx
@@ -1,6 +1,8 @@
 ---
 title: AI Accelerator - Pipelines 2.1.1 release notes
 navTitle: Version 2.1.1
+originalFilePath: advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_2.1.1.yml
+editTarget: originalFilePath
 ---
 
 Released: 3 February 2025

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/index.mdx
@@ -7,6 +7,8 @@ navigation:
   - ai-accelerator_2.1.1_rel_notes
   - ai-accelerator_2.0.0_rel_notes
   - ai-accelerator_1.0.7_rel_notes
+originalFilePath: advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/meta.yml
+editTarget: originalFilePath
 ---
 
 

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_1.0.7.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_1.0.7.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/automation/josh/validation-for-relgen/tools/automation/generators/relgen/relnote-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
 product: AI Accelerator - Pipelines
 version: 1.0.7
 date: 10 December 2024
@@ -21,7 +21,6 @@ relnotes:
   jira: AID-17
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Support for external models with OpenAI API
   details: |
@@ -29,7 +28,6 @@ relnotes:
   jira: 
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Secure management of API credentials via postgres "user mapping" feature
   details: |
@@ -45,7 +43,6 @@ relnotes:
   jira: AID-76
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: PGFS allows working with external data from S3 object stores and file systems
   details: |
@@ -53,7 +50,6 @@ relnotes:
   jira: AID-77
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: "Low-level primitives for models: encode, transform for image and text data"
   details: |
@@ -61,7 +57,6 @@ relnotes:
   jira: AID-49
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Enhanced retriever concept for data retrieval
   details: |
@@ -72,7 +67,6 @@ relnotes:
   jira: AID-84
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Support image and text data
   details: |
@@ -83,7 +77,6 @@ relnotes:
   jira: AID-108
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Support for building fully custom AI workflows/pipelines
   details: |
@@ -93,7 +86,6 @@ relnotes:
   jira: AID-41
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 
 

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_2.0.0.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_2.0.0.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
 product: AI Accelerator - Pipelines
 version: 2.0.0
 date: 13 January 2025

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_2.1.1.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_2.1.1.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
 product: AI Accelerator - Pipelines
 version: 2.1.1
 date: 3 February 2025

--- a/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_ubuntu_20.mdx
+++ b/advocacy_docs/supported-open-source/postgresql/installing/linux_x86_64/postgresql_ubuntu_20.mdx
@@ -1,0 +1,40 @@
+---
+navTitle: Ubuntu 20.04
+title: Installing PostgreSQL on Ubuntu 20.04 x86_64
+---
+
+## Prerequisites
+
+Before you begin the installation process:
+
+- Set up the EDB repository.
+
+  !!! Note
+  Rather than use the EDB repository, you can obtain PostgreSQL installers and installation packages from the [PostgreSQL community downloads page](https://www.postgresql.org/download/).
+  !!!
+
+  Setting up the repository is a one-time task. If you have already set up your repository, you don't need to perform this step.
+
+  To determine if your repository exists, enter this command:
+
+  `apt-cache search enterprisedb`
+
+  If no output is generated, the repository isn't installed.
+
+  To set up the EDB repository:
+
+  1. Go to [EDB repositories](https://www.enterprisedb.com/repos-downloads).
+
+  1. Select the button that provides access to the EDB repository.
+
+  1. Select the platform and software that you want to download.
+
+  1. Follow the instructions for setting up the EDB repository.
+
+## Install the package
+
+```shell
+sudo apt-get -y install postgresql-<xx>
+```
+
+Where `<xx>` is the version of PostgreSQL you are installing. For example, if you are installing version 16, the package name would be `postgresql-16`.

--- a/install_template/config.yaml
+++ b/install_template/config.yaml
@@ -340,25 +340,25 @@ products:
     platforms:
       - name: AlmaLinux 8 or Rocky Linux 8
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: AlmaLinux 9 or Rocky Linux 9
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 8 or OL 8
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 9 or OL 9
         arch: arm64
         supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 9
         arch: ppc64le
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: RHEL 8
         arch: ppc64le
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: Debian 12
         arch: x86_64
         supported versions: [16, 17]
@@ -367,19 +367,19 @@ products:
         supported versions: [16, 17]
       - name: Debian 11
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: Ubuntu 22.04
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: Ubuntu 20.04
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16]
+        supported versions: [13, 14, 15, 16]
       - name: SLES 15
         arch: x86_64
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
       - name: SLES 15
         arch: ppc64le
-        supported versions: [11, 12, 13, 14, 15, 16, 17]
+        supported versions: [13, 14, 15, 16, 17]
   - name: EDB Postgres Extended Server
     platforms:
       - name: AlmaLinux 8 or Rocky Linux 8

--- a/product_docs/docs/net_connector/8.0.5.1/18_api_reference.mdx
+++ b/product_docs/docs/net_connector/8.0.5.1/18_api_reference.mdx
@@ -3,11 +3,10 @@ title: "API reference"
 
 ---
 
-<div id="api_reference" class="registered_link"></div>
-
 For information about using the API, see the [Npgsql documentation](http://www.npgsql.org/doc/api/Npgsql.html).
 
 Usage notes:
 
 -   When using the API, replace references to `Npgsql` with `EnterpriseDB.EDBClient`.
 -   When referring to classes, replace `Npgsql` with `EDB`. For example, use the `EDBBinaryExporter` class instead of the `NpgsqlBinaryExporter` class.
+-   To determine which Npgsql API version was included with a specific EDB .NET release, refer to the [EDB .NET release notes](release_notes). The release notes specify the upstream Npgsql version that was merged. This is important because the availability of certain API features may vary between versions.

--- a/product_docs/docs/pem/9/considerations/pem_security_best_practices/pem_application_configuration.mdx
+++ b/product_docs/docs/pem/9/considerations/pem_security_best_practices/pem_application_configuration.mdx
@@ -86,16 +86,10 @@ For detailed information on roles, see [PEM Roles](../../managing_pem_server/#us
 
 ## SQL/Protect plugin
 
-Often, preventing an SQL injection attack is the responsibility of the application developer, while the database administrator has little or no control over the potential threat. The difficulty for database administrators is that the application must have access to the data to function properly.
-
 SQL/Protect is a module that allows a database administrator to protect a database from SQL injection attacks. SQL/Protect examines incoming queries for typical SQL injection profiles in addition to the standard database security policies.
 
-Attackers can perpetrate SQL injection attacks with several different techniques. A specific signature characterizes each technique. SQL/Protect examines queries for unauthorized relations, utility commands, SQL tautology, and unbounded DML statements. SQL/Protect gives the control back to the database administrator by alerting the administrator to potentially dangerous queries and then blocking those queries.
+For more information, see [SQL/Protect](/epas/latest/epas_security_guide/02_protecting_against_sql_injection_attacks/01_sql_protect_overview/).
 
-!!! Note
-    This plugin works only on the EDB Postgres Advanced Server server, so this is useful only when your PEM database is hosted on the EDB Postgres Advanced Server server.
-
-For detailed information about the SQL Profiler plugin, see [SQL Profiler](../../profiling_workloads/).
 
 ## Password management
 

--- a/product_docs/docs/pem/9/profiling_workloads/installing_sql_profiler.mdx
+++ b/product_docs/docs/pem/9/profiling_workloads/installing_sql_profiler.mdx
@@ -44,7 +44,11 @@ Before you begin the installation process:
 The syntax to install SQL Profiler on EDB Postgres Advanced Server and EDB Postgres Extended is:
 
 ```shell
-sudo <package-manager> -y install edb-<postgres><postgres_version>-server-sqlprofiler
+# For EDB Postgres Advanced Server:
+sudo <package-manager> -y install edb-as<postgres_version>-server-sqlprofiler
+
+# For EDB Postgres Extended:
+sudo <package-maanger> -y install edb-postgresextended<postgres_version>-sqlprofiler
 ```
 
 Where:
@@ -56,13 +60,6 @@ Where:
   | dnf             | RHEL 8 and derivatives           |
   | zypper          | SLES                             |
   | apt-get         | Debian and derivatives           |
-
-- `<postgres>` is the distribution of Postgres you're using:
-
-  | Postgres distribution        | Value            |
-  |------------------------------|------------------|
-  | EDB Postgres Advanced Server | as               |
-  | EDB Postgres Extended        | postgresextended |
 
 - `<postgres_version>` is the version of Postgres you're using. 
 
@@ -76,13 +73,13 @@ The syntax to install SQL Profiler on PostgreSQL is:
 
 ```shell
 # For RHEL 8 and its derivatives:
-sudo dnf -y install sqlprofiler_<version>
+sudo dnf -y install sqlprofiler_<postgres_version>
 
 # For Debian/Ubuntu:
-apt-get -y install postgresql-<version>-sqlprofiler
+sudo apt-get -y install postgresql-<postres_version>-sqlprofiler
 ```
 
-Where `<version>` is the version of PostgreSQL you're using.
+Where `<postgres_version>` is the version of PostgreSQL you're using.
 
 
 ## Enabling the extension

--- a/product_docs/docs/pgd/5/rel_notes/index.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/index.mdx
@@ -15,6 +15,8 @@ navigation:
   - pgd_5.1.0_rel_notes
   - pgd_5.0.1_rel_notes
   - pgd_5.0.0_rel_notes
+originalFilePath: product_docs/docs/pgd/5/rel_notes/src/meta.yml
+editTarget: originalFilePath
 ---
 
 

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.6.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.6.0_rel_notes.mdx
@@ -1,6 +1,8 @@
 ---
 title: EDB Postgres Distributed 5.6.0 release notes
 navTitle: Version 5.6.0
+originalFilePath: product_docs/docs/pgd/5/rel_notes/src/relnote_5.6.0.yml
+editTarget: originalFilePath
 ---
 
 Released: 15 October 2024

--- a/product_docs/docs/pgd/5/rel_notes/pgd_5.6.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/5/rel_notes/pgd_5.6.1_rel_notes.mdx
@@ -1,6 +1,8 @@
 ---
 title: EDB Postgres Distributed 5.6.1 release notes
 navTitle: Version 5.6.1
+originalFilePath: product_docs/docs/pgd/5/rel_notes/src/relnote_5.6.1.yml
+editTarget: originalFilePath
 ---
 
 Released: 25 November 2024

--- a/product_docs/docs/pgd/5/rel_notes/src/meta.yml
+++ b/product_docs/docs/pgd/5/rel_notes/src/meta.yml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/automation/josh/validation-for-relgen/tools/automation/generators/relgen/meta-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/meta-schema.json
+
 product: EDB Postgres Distributed
 shortname: pgd
 title: EDB Postgres Distributed 5 release notes
@@ -14,59 +15,59 @@ columns:
   key: version-link
 - 2:
   label: "BDR extension"
-  key: $bdrextension
+  key: "$BDR"
 - 3:
   label: "PGD CLI"
-  key: $pgdcli
+  key: "$PGD CLI"
 - 4:
   label: "PGD Proxy"
-  key: $pgdproxy
+  key: "$PGD Proxy"
 components: [ "BDR", "PGD CLI", "PGD Proxy", "Utilities" ]
 precursor:
 - date: 31 May 2024
   version: "5.5.1"  
-  bdrextension: "5.5.1"
-  pgdcli: 5.5.0
-  pgdproxy: 5.5.0
+  "BDR": "5.5.1"
+  "PGD CLI": 5.5.0
+  "PGD Proxy": 5.5.0
 - date: 16 May 2024
   version: "5.5.0"
-  bdrextension: 5.5.0
-  pgdcli: 5.5.0
-  pgdproxy: 5.5.0
+  "BDR": 5.5.0
+  "PGD CLI": 5.5.0
+  "PGD Proxy": 5.5.0
 - date: 03 April 2024
   version: "5.4.1"
-  bdrextension: 5.4.1
-  pgdcli: 5.4.0
-  pgdproxy: 5.4.0
+  "BDR": 5.4.1
+  "PGD CLI": 5.4.0
+  "PGD Proxy": 5.4.0
 - date: 05 March 2024
   version: "5.4.0"
-  bdrextension: 5.4.0
-  pgdcli: 5.4.0
-  pgdproxy: 5.4.0
+  "BDR": 5.4.0
+  "PGD CLI": 5.4.0
+  "PGD Proxy": 5.4.0
 - date: 14 November 2023
   version: "5.3.0"
-  bdrextension: 5.3.0
-  pgdcli: 5.3.0
-  pgdproxy: 5.3.0
+  "BDR": 5.3.0
+  "PGD CLI": 5.3.0
+  "PGD Proxy": 5.3.0
 - date: 04 August 2023
   version: "5.2.0"
-  bdrextension: 5.2.0
-  pgdcli: 5.2.0
-  pgdproxy: 5.2.0
+  "BDR": 5.2.0
+  "PGD CLI": 5.2.0
+  "PGD Proxy": 5.2.0
 - date: 16 May 2023
   version: "5.1.0"
-  bdrextension: 5.1.0
-  pgdcli: 5.1.0
-  pgdproxy: 5.1.0
+  "BDR": 5.1.0
+  "PGD CLI": 5.1.0
+  "PGD Proxy": 5.1.0
 - date: 21 Mar 2023
   version: "5.0.1"
-  bdrextension: 5.0.0
-  pgdcli: 5.0.1
-  pgdproxy: 5.0.1
+  "BDR": 5.0.0
+  "PGD CLI": 5.0.1
+  "PGD Proxy": 5.0.1
 - date: 21 Feb 2023
   version: "5.0.0"
-  bdrextension: 5.0.0
-  pgdcli: 5.0.0
-  pgdproxy: 5.0.0
+  "BDR": 5.0.0
+  "PGD CLI": 5.0.0
+  "PGD Proxy": 5.0.0
 
   

--- a/product_docs/docs/pgd/5/rel_notes/src/relnote_5.6.0.yml
+++ b/product_docs/docs/pgd/5/rel_notes/src/relnote_5.6.0.yml
@@ -1,11 +1,12 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/automation/josh/validation-for-relgen/tools/automation/generators/relgen/relnote-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
 product: EDB Postgres Distributed
 version: 5.6.0
 date: 15 October 2024
-meta:
-  bdrextension: 5.6.0
-  pgdcli: 5.6.0
-  pgdproxy: 5.6.0
+components:
+  "BDR": 5.6.0
+  "PGD CLI": 5.6.0
+  "PGD Proxy": 5.6.0
+  "Utilities": 5.6.0
 intro: |
  EDB Postgres Distributed 5.6.0 includes a number of enhancements and bug fixes.
 highlights: |
@@ -26,7 +27,6 @@ highlights: |
 relnotes:
 - relnote: Decoding Worker supports Streaming Transactions
   component: BDR
-  component_version: 5.6.0
   details: |
     One of the main advantages of streaming is that the WAL sender sends the partial transaction before it commits, which reduces replication lag. Now, with streaming support, the WAL decoder does the same thing, but it streams to the LCRs segments. Eventually, the WAL sender will read the LCRs and mimic the same behavior of streaming large transactions before they commit. This provides the benefits of decoding worker, such as reduced CPU and disk space, as well as the benefits of streaming, such as reduced lag and disk space, since ".spill" files are not generated.
     The WAL decoder always streams the transaction to LCRs, but based on downstream requests, the WAL sender either streams the transaction or just mimics the normal BEGIN..COMMIT scenario.
@@ -34,11 +34,9 @@ relnotes:
   jira: BDR-5123
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Introduce several new monitoring views
   component: BDR
-  component_version: 5.6.0
   details: |
    There are several view providing new information as well as making some
    existing information easier to discover:
@@ -53,50 +51,40 @@ relnotes:
     - [`bdr.stat_routing_candidate_state`](/pgd/latest/reference/catalogs-visible#bdrstat_routing_candidate_state) : Information about routing candidate nodes on the Raft leader node (empty on other nodes).
   jira: BDR-5316
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Support conflict detection for exclusion constraints
   component: BDR
-  component_version: 5.6.0
   details: |
    This allows defining `EXCLUDE` constraint on table replicated by PGD either with
    `CREATE TABLE` or with `ALTER TABLE` and uses similar conflict detection to resolve
    conflicts as for `UNIQUE` constraints.
   jira: BDR-4851
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Fixed buffer overrun in the writer
   component: BDR
-  component_version: 5.6.0
   details: |
     Include an extra zero byte at the end of a column value allocation in shared memory queue insert/update/delete messages.
   jira: BDR-5188
   addresses: 98966
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Fixes for some race conditions to prevent node sync from entering a hung state with the main subscription disabled.
   component: BDR
-  component_version: 5.6.0
   jira: BDR-5041
   addresses: ""
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Detect and resolve deadlocks between synchronous replication wait-for-disconnected sessions and replication writer.
   component: BDR
-  component_version: 5.6.0
   details: |
     This will cancel synchronous replication wait on disconnected sessions if it deadlocks against replication, preventing deadlocks on failovers when using synchronous replication. This only affects commit scopes, not synchronous replication configured via `synchronous_standby_names`.
   jira: BDR-5445, BDR-5445, BDR-4104
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Do not accidentally drop the autopartition rule when a column of the autopartitioned table is dropped.
   component: BDR
-  component_version: 5.6.0
   details: |
     When ALTER TABLE .. DROP COLUMN is used, the object_access_hook is fired with `classId` set to RelationRelationId, but the `subId` is set to the attribute number to differentiate it from the DROP TABLE command.
 
@@ -104,31 +92,25 @@ relnotes:
   jira: BDR-5418
   addresses: 40258
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Adjust `bdr.alter_table_conflict_detection()` to propagate correctly to all nodes
   component: BDR
-  component_version: 5.6.0
   details: |
     Ensure that the propagation of `bdr.alter_table_conflict_detection()` (as well as the related, deprecated `bdr.column_timestamps_(en|dis)able()` functions) is carried out correctly to all logical standbys. Previously, this propagation did not occur if the logical standby was not directly attached to the node on which the functions were executed.
   jira: BDR-3850
   addresses: 40258
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Prevent a node group from being created with a duplicate name
   component: BDR
-  component_version: 5.6.0
   details: |
     Ensure that a nodegroup is not inadvertently created with the same name as an existing nodegroup. Failure to do so may result in a complete shutdown of the top-level Raft on all nodes, with no possibility of recovery.
   jira: BDR-5355
   addresses: ""
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Add bdr.bdr_show_all_file_settings() and bdr.bdr_file_settings view
   component: BDR
-  component_version: 5.6.0
   details: |
     Fix: Correct privileges for bdr_superuser.  Creating wrapper SECURITY DEFINER functions in the bdr schema and granting access to bdr_superuser to use those:
     - bdr.bdr_show_all_file_settings
@@ -136,82 +118,66 @@ relnotes:
   jira: BDR-5070
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Add create/drop_commit_scope functions
   component: BDR
-  component_version: 5.6.0
   details: |
     Add functions for creating and dropping commit scopes that will eventually deprecate the non-standard functions for adding and removing commit scopes. Notify the user that these will be deprecated in a future version, suggesting the use of the new versions.
   jira: BDR-4073
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Grant additional object permissions to role "bdr_monitor".
   component: BDR
-  component_version: 5.6.0
   details: |
     Permissions for the following objects have been updated to include SELECT permissions for role "bdr_monitor": bdr.node_config
   jira: BDR-4885, BDR-5354
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Add `bdr.raft_vacuum_interval` and `bdr.raft_vacuum_full_interval` GUCs to control frequency of automatic Raft catalog vacuuming.
   component: BDR
-  component_version: 5.6.0
   details: |
     This update introduces GUCs to regulate the frequency of automatic vacuuming on the specified catalogs. The GUC `bdr.raft_vacuum_interval` determines the frequency at which tables are examined for VACUUM and ANALYZE. Autovacuum GUCs and table reloptions are utilized to ascertain the necessity of VACUUM/ANALYZE.
     The `bdr.raft_vacuum_full_interval` initiates VACUUM FULL on the tables. Users have the ability to deactivate VACUUM FULL if regular VACUUM suffices to manage bloat.
   jira: BDR-5424
   addresses: 40412
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Prevent spurious "local info ... not found" errors when parting nodes
   component: BDR
-  component_version: 5.6.0
   details: |
     Handle the absence of the expected node record gracefully when a node is being removed, the local node record might have already been deleted, but an attempt could be made to update it anyway. This resulted in harmless "BDR node local info for node ... not found" errors.
   jira: BDR-5350
   addresses: ""
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Prevent a corner-case situation from being misdiagnosed as a PGD version problem
   component: BDR
-  component_version: 5.6.0
   details: |
     Improve Raft error messages to handle cases where nodes may not be correctly participating in Raft.
   jira: BDR-5362
   addresses: ""
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Add "node_name" to "bdr.node_config_summary"
   component: BDR
-  component_version: 5.6.0
   details: |
     Add "node_name" to the view "bdr.node_config_summary". This makes it consistent with other summary views, which report the name of the object (node, group, etc.) for which the summary is being generated.
   jira: BDR-4818
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: "bdr_init_physical: improve local node connection failure logging"
   component: BDR
-  component_version: 5.6.0
   details: |
     Ensure that bdr_init_physical emits details about connection failure if the "--local-dsn" parameter is syntactically correct but invalid, e.g., due to an incorrect host or port setting.
   jira:
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: "`bdr_config`: add PG_FLAVOR output"
   component: BDR
-  component_version: 5.6.0
   details: |
     `bdr_config` now shows the PostgreSQL "flavor" which BDR was built against, one of:
       - COMMUNITY
@@ -221,51 +187,41 @@ relnotes:
   jira: BDR-4428
   addresses: 
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Enhance warning messages
   component: BDR
-  component_version: 5.6.0
   details: |
     Enhance messages issued during DML and DDL lock acquisition.
   jira: BDR-4200
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Handling duplicate requests in RAFT preventing protocol breakage
   component: BDR
-  component_version: 5.6.0
   details: |
     When processing RAFT entries, it's crucial to handle duplicate requests properly to prevent Raft protocol issues. Duplicate requests can occur when a client retries a request that has already been accepted and applied by the Raft leader. The problem arose when the leader failed to detect the duplicate request due to historical evidence being pruned.
   jira: BDR-5275, BDR-4091
   addresses: 37725
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: "Handling Raft Snapshots: Consensus Log"
   component: BDR
-  component_version: 5.6.0
   details: |
     When installing or importing a Raft snapshot, discard the consensus log unless it contains an entry matching the snapshot's last included entry and term.
   jira: BDR-5285
   addresses: 37725
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Do not send Raft snapshot very aggressively
   component: BDR
-  component_version: 5.6.0
   details: |
     Avoid sending Raft snapshots too frequently as it can slow down follower nodes. Limit the snapshot rate to once in every election timeout, unless there is no other communication between the nodes, in which case send a snapshot every 1/3rd of the election timeout. This will help all nodes keep pace with the leader and improve CPU utilization.
   jira: BDR-5288
   addresses: 37725
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Group-Specific Configuration Options
   component: BDR
-  component_version: 5.6.0
   details: |
     It is now possible to set akk top-level and subgroup level options. The following options are available for top-both groups:
     - check\_constraints
@@ -277,69 +233,55 @@ relnotes:
   jira: BDR-4954
   addresses: 37725
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Subscriber-only node groups have a leader
   component: BDR
-  component_version: 5.6.0
   details: |
    Subscriber-only node groups have a leader elected by top-level Raft. There is now a bdr.leader catalog that tracks leadership of subgroups and subscriber-only nodes. If the node that is the leader of a subscriber-only node group goes down or becomes unreachable, a new leader is elected from that group.
   jira: BDR-5089
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Optimized topology for subscriber-only nodes via the leader of the subscriber-only node group
   component: BDR
-  component_version: 5.6.0
   details: |
    Subscriber-only nodes earlier used to have subscriptions to each data node. Now if optimized topology is enabled, only the leaders of subscriber-only node groups have subscriptions to routing leaders of data node subsgroups. The subscriber only nodegroup leaders route data to other nodes of that subscriber-only nodegroup. This reduces the load on all data nodes so they do not have to send data to all subscriber-only nodes. The GUC `bdr.force_full_mesh=off` enables this optimized topology. This GUC variable is on by default, retaining pre-5.6.0 behavior. 
   jira: BDR-5214
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Introduce new subscription types to support optimized topology
   component: BDR
-  component_version: 5.6.0
   details: |
    New subscription types that forward data from all nodes of the subgroup via a routing leader (mode: l), and those that forward data from the entire cluster via a subscriber-only group leader (mode: w) are introduced.
   jira: BDR-5186
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Introduce version number and timestamp for write leader
   component: BDR
-  component_version: 5.6.0
   details: |
    A write leader has a version. Every time a new leader is elected, the version is incremented and timestamp noted via Raft. This is to build a foundation for better conflict resolution.
   jira: BDR-3589
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Be more restrictive about which index to use during replication for REPLICA IDENTITY FULL tables
   component: BDR
-  component_version: 5.6.0
   details: |
    This fixes various index related errors during replication like:
    'could not lookup equality operator for type, optype in opfamily'
    or 'function "amgettuple" is not defined for index "brinidx"'
   jira: BDR-5523 , BDR-5361
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Allow use of column reference in DEFAULT expressions
   component: BDR
-  component_version: 5.6.0
   details: |
    Using column references in default expressions is now supported, this is particularly
    useful with generated columns, for example:
    `ALTER TABLE gtest_tableoid ADD COLUMN c regclass GENERATED ALWAYS AS (tableoid) STORED;`
   jira: BDR-5385
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Support `createrole_self_grant`
   component: BDR
-  component_version: 5.6.0
   details: |
    The `createrole_self_grant` configuration option affects inherited grants
    by newly created roles. In previous versions `CREATE ROLE`/`CREATE USER`
@@ -347,62 +289,50 @@ relnotes:
    role privileges on different nodes.
   jira: BDR-5403
   type: Bug fix
-  severity: High
   impact: High
 - relnote:  Allow `CREATE SCHEMA AUTHORIZATION ...` combined with other create operations
   component: BDR
-  component_version: 5.6.0
   details: |
    Previously, this would throw "cannot change current role within security-restricted operation" error
   jira: BDR-5368
   type: Bug fix
-  severity: High
   impact: High
 - relnote: Support replication of REINDEX
   component: BDR
-  component_version: 5.6.0
   details: |
    Both REINDEX and REINDEX CONCURRENTLY are now replicated commands.
   jira: BDR-5363
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Use base type instead of domain type while casting values
   component: BDR
-  component_version: 5.6.0
   details: |
    This prevents errors when replicating UPDATEs for domains defined as NOT VALID
    where tables contain data which would not be allowed by current definition
    of such domain.
   jira: BDR-5369
   type: Bug fix
-  severity: High
   impact: High
 - relnote: Fix receiver worker being stuck when exiting
   component: BDR
-  component_version: 5.6.0
   details: |
    Receiver worker could get stuck when exiting, waiting for a writer that never
    actually started. This could on rare occasions break replication after
    configuration changes until Postgres was restarted.
   jira:
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Reduce performance impact of PGD specific configuration parameters that are sent to client
   component: BDR
-  component_version: 5.6.0
   details: |
    Changes to values of variables `bdr.last_committed_lsn`, `transaction_id`
    and `bdr.local_node_id` are automatically reported to clients when using
    CAMO or GROUP COMMIT. This has now been optimized to use less resources.
   jira: BDR-3212
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Allow use of commit scopes defined in parent groups
   component: BDR
-  component_version: 5.6.0
   details: |
    When there is a commit scope defined for top-level group, it can be used by
    any node in a subgroup and does not need to be redefined for every subgroup
@@ -410,21 +340,16 @@ relnotes:
    keyword to reduce the complexity of commit scope setup.
   jira: BDR-5433
   type: Enhancement
-  severity: High
   impact: High
 - relnote: bdr_pg_upgrade - Create logical slot with twophase set to true for PG 14+
   component: Utilities
-  component_version: 5.6.0
   jira: BDR-5306
   type: Bug Fix
-  severity: High
   impact: High
 - relnote: Use bdr.bdr_file_settings view in verify-settings
   component: PGD CLI
-  component_version: 5.6.0
   details: |
     Use bdr.bdr_file_settings view to get the current settings for the proxy.
   jira: BDR-5049
   type: Enhancement
-  severity: High
   impact: High

--- a/product_docs/docs/pgd/5/rel_notes/src/relnote_5.6.1.yml
+++ b/product_docs/docs/pgd/5/rel_notes/src/relnote_5.6.1.yml
@@ -1,11 +1,12 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/automation/josh/validation-for-relgen/tools/automation/generators/relgen/relnote-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
 product: EDB Postgres Distributed
 version: 5.6.1
 date: 25 November 2024
-meta:
-  bdrextension: 5.6.1
-  pgdcli: 5.6.1
-  pgdproxy: 5.6.1
+components:
+  "BDR": 5.6.1
+  "PGD CLI": 5.6.1
+  "PGD Proxy": 5.6.1
+  "Utilities": 5.6.1
 intro: |
  EDB Postgres Distributed 5.6.1 includes a number of enhancements and bug fixes.
 highlights: |
@@ -14,28 +15,23 @@ highlights: |
 relnotes:
 - relnote: Added Postgres 17 support
   component: BDR
-  component_version: 5.6.1
   details: |
     Support for Postgres 17 has been added for all flavors (PostgreSQL, EDB Postgres Extended, 
     and EDB Postgres Advanced Server) starting with version 17.2.
   jira: BDR-5410
   addresses: ""
   type: Feature
-  severity: High
   impact: High
 - relnote:  Added ARM64 processor Support
   component: BDR
-  component_version: 5.6.1
   details: |
     Support ARM architecture for EDB Postgres Distributed on Debian 12 and RHEL 9.
   jira: BDR-5410
   addresses: ""
   type: Feature
-  severity: High
   impact: High
 - relnote: Addressed walsender crash that happend during configuration reload.
   component: BDR
-  component_version: 5.6.1
   details: |
     Ensure that pglogical GUCs are overridden only when operating within the pglogical worker.
     If this is not the case, MyPGLogicalWorker will be NULL, resulting in a segmentation fault
@@ -44,11 +40,9 @@ relnotes:
   jira: BDR-5661
   addresses: "42100"
   type: Bug-fix
-  severity: High
   impact: High
 - relnote: Fixed unintended eager connection related to consensus connections among Subscriber Only group members
   component: BDR
-  component_version: 5.6.1
   details: |
     The msgbroker module used to establish consensus connections lazily, meaning that connections
     were created only when the first message was sent to a specific destination. This method
@@ -60,33 +54,27 @@ relnotes:
   jira: BDR-5666
   addresses: "42041"
   type: Bug-fix
-  severity: High
   impact: High
 - relnote: Fixed autopatition task scheduling.
   component: BDR
-  component_version: 5.6.1
   details: |
     To improve reliability, shuffle the scheduling of autopartition tasks. This way, tasks
     that are prone to failure won't consistently impact the success of other tasks.
   jira: BDR-5638
   addresses: "41998"
   type: Bug-fix
-  severity: High
   impact: High
 - relnote: Fixed parting subscription with standbys.
   component: BDR
-  component_version: 5.6.1
   details: |
     The parting subscription used to hang, failing to wait for standbys when the
     bdr.standby_slot_names parameter was defined.
   jira: BDR-5658
   addresses: "41821"
   type: Bug-fix
-  severity: High
   impact: High
 - relnote: Added `bdr.wait_node_confirm_lsn()`.
   component: BDR
-  component_version: 5.6.1
   details: |
     The function `bdr.wait_node_confirm_lsn()` has been introduced to wait until a specific node
     reaches a designated Log Sequence Number (LSN). It first checks the `confirmed_flush_lsn` of
@@ -98,11 +86,9 @@ relnotes:
   jira: BDR-5200
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Improvements made in SO Node Management and Progress Tracking.
   component: BDR
-  component_version: 5.6.1
   details: |
     An update addresses the movement of group slots in SO nodes, ensuring they don't appear as peers in
     progress updates. Improvements include enhanced watermark management for SO leaders in the Optimized Topology
@@ -113,11 +99,9 @@ relnotes:
   jira: BDR-5549
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: LSN Progress in Optimized Topology Configurations is now communicated.
   component: BDR
-  component_version: 5.6.1
   details: |
     While there are no connections from non-leader data nodes to subscriber-only nodes in an optimized
     topology configuration, the LSN progress of all data nodes is periodically communicated to these
@@ -125,11 +109,9 @@ relnotes:
   jira: BDR-5549
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Fixed parting SO node with multiple origins.
   component: BDR
-  component_version: 5.6.1
   details: |
     All relevant origins must be removed when parting SO node.
     With Optimized Topology, parting an SO node should result in removing all origins it
@@ -140,45 +122,36 @@ relnotes:
   jira: BDR-5552
   addresses: ""
   type: Bug-fix
-  severity: High
   impact: High
 - relnote: Stopped creation of slots for subscriber only nodes on witness nodes.
   component: BDR
-  component_version: 5.6.1
   details: |
     Subscriber only nodes should not have slots on witness nodes.
   jira: BDR-5618
   addresses: ""
   type: Bug-fix
-  severity: High
   impact: High
 - relnote: Some DDL commands are now allowed by `bdr.permit_unsafe_commands` when set.
   component: BDR
-  component_version: 5.6.1
   details: |
     The `bdr.permit_unsafe_commands` parameter now allows some DDL commands that were previously disallowed. Specifically `ALTER COLUMN...TYPE...USING` can now be permitted if the user knows the operation is safe.
   jira: ""
   addresses: ""
   type: Enhancement
-  severity: High
   impact: High
 - relnote: Ensure no waiting for DEGRADE timeout when in an already degraded state.
   component: BDR
-  component_version: 5.6.1
   details: |
     When using commit scope with DEGRADE clause, if system detects that it's in degraded state, transactions should start in the DEGRADE mode. This ensures that the timeout is not applied on every commit. 
   jira: BDR-5651
   addresses: ""
   type: Bug-fix
-  severity: High
   impact: High
 - relnote: Fixed routing strategy for read nodes.
   component: PGD Proxy
-  component_version: 5.6.1
   details: |
     Corrected routing strategy for read nodes after a network partition.
   jira: BDR-5216
   addresses: ""
   type: Bug-fix
-  severity: Medium
   impact: Medium

--- a/product_docs/docs/tpa/23/rel_notes/index.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/index.mdx
@@ -30,6 +30,8 @@ navigation:
   - tpa_23.13_rel_notes
   - tpa_23.12_rel_notes
   - tpa_23.1-11_rel_notes
+originalFilePath: product_docs/docs/tpa/23/rel_notes/src/meta.yml
+editTarget: originalFilePath
 ---
 
 

--- a/product_docs/docs/tpa/23/rel_notes/src/meta.yml
+++ b/product_docs/docs/tpa/23/rel_notes/src/meta.yml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/automation/josh/validation-for-relgen/tools/automation/generators/relgen/meta-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/meta-schema.json
+
 product: Trusted Postgres Architect
 shortname: tpa
 title: Trusted Postgres Architect release notes

--- a/product_docs/docs/tpa/23/rel_notes/src/tpa_23.35.0_rel_notes.yml
+++ b/product_docs/docs/tpa/23/rel_notes/src/tpa_23.35.0_rel_notes.yml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/automation/josh/validation-for-relgen/tools/automation/generators/relgen/relnote-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
+
 product: Trusted Postgres Architect
 version: 23.35.0
 date: 25 November 2024

--- a/product_docs/docs/tpa/23/rel_notes/tpa_23.35.0_rel_notes.mdx
+++ b/product_docs/docs/tpa/23/rel_notes/tpa_23.35.0_rel_notes.mdx
@@ -1,6 +1,8 @@
 ---
 title: Trusted Postgres Architect 23.35.0 release notes
 navTitle: Version 23.35.0
+originalFilePath: product_docs/docs/tpa/23/rel_notes/src/tpa_23.35.0_rel_notes.yml
+editTarget: originalFilePath
 ---
 
 Released: 25 November 2024

--- a/src/components/edit-link.js
+++ b/src/components/edit-link.js
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from "react";
+import { useStaticQuery, graphql } from "gatsby";
+
+export default function EditLink({
+  editTarget,
+  fileRelativePath,
+  originalFilePath,
+  ...rest
+}) {
+  const data = useStaticQuery(graphql`
+    {
+      edbGit {
+        docsRepoUrl
+        branch
+        sha
+      }
+    }
+  `);
+
+  // to minimize deployment time, static render all paths relative to the develop branch (on staging / draft) or main (production)
+  // then swap in actual ref on first live render.
+  const [editBranch, setEditBranch] = useState("develop");
+  useEffect(() => {
+    // don't encourage folks to edit on main - set the edit links to develop in production builds
+    setEditBranch(
+      data.edbGit.branch === "main" ? "develop" : data.edbGit.branch,
+    );
+  }, [data.edbGit.branch]);
+
+  const githubEditUrl = composeEditURL(
+    editTarget,
+    originalFilePath,
+    data.edbGit.docsRepoUrl,
+    editBranch,
+    fileRelativePath,
+  );
+
+  return (
+    <a
+      href={githubEditUrl}
+      className="btn btn-sm btn-primary px-4 text-nowrap"
+      title="Navigate to the GitHub editor for this file, allowing you to propose changes for review by the EDB Documentation Team"
+      {...rest}
+    >
+      Suggest edits
+    </a>
+  );
+}
+
+function composeEditURL(
+  editTarget,
+  originalFilePath,
+  docsRepoUrl,
+  branch,
+  fileRelativePath,
+) {
+  if (editTarget === "originalFilePath" && originalFilePath) {
+    // two options here:
+    // 1. a full URL (presumably pointing at a file on github, but could be anything)
+    // 2. a path to a file in this repo, relative to the root
+    if (originalFilePath.startsWith("http"))
+      return originalFilePath.replace(/\/blob\//, "/edit/");
+    fileRelativePath = "/" + originalFilePath;
+  }
+
+  return fileRelativePath && `${docsRepoUrl}/edit/${branch}${fileRelativePath}`;
+}

--- a/src/components/feedback-link.js
+++ b/src/components/feedback-link.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { useStaticQuery, graphql } from "gatsby";
+
+export default function FeedbackLink({
+  children,
+  fileRelativePath,
+  title,
+  template = "product-feedback.yaml",
+  labels = ["feedback"],
+  ...rest
+}) {
+  const data = useStaticQuery(graphql`
+    {
+      edbGit {
+        docsRepoUrl
+        branch
+        sha
+      }
+    }
+  `);
+
+  // to minimize deployment time, static render all paths relative to the develop branch (on staging / draft) or main (production)
+  // then swap in actual ref on first live render.
+  const [historyRef, setHistoryRef] = useState(
+    data.edbGit.branch === "main" ? data.edbGit.branch : "develop",
+  );
+  useEffect(() => {
+    setHistoryRef(data.edbGit.sha);
+  }, [data.edbGit.branch, data.edbGit.sha]);
+
+  const githubIssuesUrl = `${data.edbGit.docsRepoUrl}/issues/new?title=${encodeURIComponent(
+    title,
+  )}&context=${encodeURIComponent(
+    `${data.edbGit.docsRepoUrl}/blob/${historyRef}${fileRelativePath}\n`,
+  )}`;
+
+  return (
+    <a
+      href={
+        githubIssuesUrl + `&template=${template}&labels=${labels.join(",")}`
+      }
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -18,13 +18,8 @@ const TimestampLink = ({ timestamp, fileRelativePath }) => {
   const [historyRef, setHistoryRef] = useState(
     data.edbGit.branch === "main" ? data.edbGit.branch : "develop",
   );
-  const [editBranch, setEditBranch] = useState("develop");
   useEffect(() => {
     setHistoryRef(data.edbGit.sha);
-    // don't encourage folks to edit on main - set the edit links to develop in production builds
-    setEditBranch(
-      data.edbGit.branch === "main" ? "develop" : data.edbGit.branch,
-    );
   }, [data.edbGit.branch, data.edbGit.sha]);
 
   const url = `${data.edbGit.docsRepoUrl}/commits/${historyRef}${fileRelativePath}`;

--- a/src/components/icon/iconList.js
+++ b/src/components/icon/iconList.js
@@ -3,9 +3,9 @@ import React from "react";
 import Icon, { iconNames } from "../icon/";
 
 export const IconList = () => (
-  <div class="d-flex flex-wrap">
+  <div className="d-flex flex-wrap">
     {Object.keys(iconNames).map((key) => (
-      <div class="d-flex flex-column mb-5 ">
+      <div className="d-flex flex-column mb-5 ">
         <Icon iconName={iconNames[key]} className="me-5" />
         {iconNames[key]}
       </div>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,72 +1,36 @@
-import Archive from "./archive";
-import AuthenticatedContentPlaceholder from "./authenticated-content-placeholder";
-import BackButton from "./back-button";
-import CardDecks from "./card-decks";
-import CodeBlock from "./code-block";
-import DarkModeToggle from "./dark-mode-toggle";
-import DevOnly from "./dev-only";
-import DevFrontmatter from "./dev-frontmatter";
-import Footer from "./footer";
-import IndexLinks from "./index-links";
-import IndexSubNav from "./index-sub-nav";
-import KatacodaPageEmbed from "./katacoda-page-embed";
-import KatacodaPageLink from "./katacoda-page-link";
-import KatacodaPanel from "./katacoda-panel";
-import Layout from "./layout";
-import LayoutContext from "./layout-context";
-import LeftNav from "./left-nav";
-import Link from "./link";
-import Logo from "./logo";
-import MainContent from "./main-content";
-import PdfDownload from "./pdf-download.js";
-import PrevNext from "./prev-next";
-import PurlAnchor from "./purl-anchor";
-import SearchNavigationLinks from "./search-navigation-links";
-import SearchNavigation from "./search-navigation";
-import SideNavigation from "./side-navigation";
-import StubCards from "./stub-cards";
-import TableOfContents from "./table-of-contents";
-import Tiles, { TileModes } from "./tiles.js";
-import TimedBanner from "./timed-banner";
-import TopBar from "./top-bar";
-import TreeNode from "./tree-node";
-import VersionDropdown from "./version-dropdown";
-import { IconList } from "./icon/iconList";
-
-export {
-  Archive,
-  AuthenticatedContentPlaceholder,
-  BackButton,
-  CardDecks,
-  CodeBlock,
-  DarkModeToggle,
-  DevOnly,
-  DevFrontmatter,
-  Footer,
-  IndexLinks,
-  IndexSubNav,
-  KatacodaPageEmbed,
-  KatacodaPageLink,
-  KatacodaPanel,
-  Layout,
-  LayoutContext,
-  LeftNav,
-  Link,
-  Logo,
-  MainContent,
-  PdfDownload,
-  PrevNext,
-  PurlAnchor,
-  SearchNavigationLinks,
-  SearchNavigation,
-  SideNavigation,
-  StubCards,
-  TableOfContents,
-  Tiles,
-  TileModes,
-  TimedBanner,
-  TopBar,
-  TreeNode,
-  VersionDropdown,
-  IconList,
-};
+export { default as Archive } from "./archive";
+export { default as AuthenticatedContentPlaceholder } from "./authenticated-content-placeholder";
+export { default as BackButton } from "./back-button";
+export { default as CardDecks } from "./card-decks";
+export { default as CodeBlock } from "./code-block";
+export { default as DarkModeToggle } from "./dark-mode-toggle";
+export { default as DevOnly } from "./dev-only";
+export { default as DevFrontmatter } from "./dev-frontmatter";
+export { default as EditLink } from "./edit-link";
+export { default as FeedbackLink } from "./feedback-link";
+export { default as Footer } from "./footer";
+export { default as IndexLinks } from "./index-links";
+export { default as IndexSubNav } from "./index-sub-nav";
+export { default as KatacodaPageEmbed } from "./katacoda-page-embed";
+export { default as KatacodaPageLink } from "./katacoda-page-link";
+export { default as KatacodaPanel } from "./katacoda-panel";
+export { default as Layout } from "./layout";
+export { default as LayoutContext } from "./layout-context";
+export { default as LeftNav } from "./left-nav";
+export { default as Link } from "./link";
+export { default as Logo } from "./logo";
+export { default as MainContent } from "./main-content";
+export { default as PdfDownload } from "./pdf-download.js";
+export { default as PrevNext } from "./prev-next";
+export { default as PurlAnchor } from "./purl-anchor";
+export { default as SearchNavigationLinks } from "./search-navigation-links";
+export { default as SearchNavigation } from "./search-navigation";
+export { default as SideNavigation } from "./side-navigation";
+export { default as StubCards } from "./stub-cards";
+export { default as TableOfContents } from "./table-of-contents";
+export { default as Tiles, TileModes } from "./tiles.js";
+export { default as TimedBanner } from "./timed-banner";
+export { default as TopBar } from "./top-bar";
+export { default as TreeNode } from "./tree-node";
+export { default as VersionDropdown } from "./version-dropdown";
+export { IconList } from "./icon/iconList";

--- a/src/components/left-nav.js
+++ b/src/components/left-nav.js
@@ -73,7 +73,7 @@ const SectionHeadingWithVersions = ({
           {navTree.title}
         </Link>
         {!navTree.hideVersion && versionArray.length > 1 ? (
-          <div style={{ "white-space": "nowrap" }}>
+          <div style={{ whiteSpace: "nowrap" }}>
             <VersionDropdown
               versionArray={versionArray}
               preciseVersion={preciseVersion}

--- a/src/components/pdf-download.js
+++ b/src/components/pdf-download.js
@@ -44,7 +44,7 @@ const PdfDownload = ({ pagePath, product, version, hidePDF }) => {
           iconName={iconNames.PDF}
           className="fill-orange me-1 position-relative top-minus-2"
           width="16"
-          height="auto"
+          height="100%"
         />
         Download PDF
       </a>

--- a/src/components/side-navigation.js
+++ b/src/components/side-navigation.js
@@ -16,7 +16,7 @@ const LogoLink = () => {
   return (
     <h1 className="h3 p-3 d-flex">
       <Link to="https://www.enterprisedb.com/" title="EDB Home">
-        <Logo width="120" height="50" class="me-1" />
+        <Logo width="120" height="50" className="me-1" />
       </Link>
       <DocsLink />
     </h1>

--- a/src/components/tiles.js
+++ b/src/components/tiles.js
@@ -30,6 +30,7 @@ const Tiles = ({ mode, node }) => {
           cards={decks[deckName]}
           cardType={mode}
           deckTitle={deckName}
+          key={deckName}
         />
       );
     });

--- a/src/components/timed-banner.js
+++ b/src/components/timed-banner.js
@@ -3,7 +3,7 @@ import React from "react";
 const TimedBanner = ({ fromDate = 0, toDate = 0, children }) => {
   if (Date.now() >= (fromDate || 0) && Date.now() <= (toDate || Date.now())) {
     return (
-      <div class="alert alert-warning m-0" role="alert">
+      <div className="alert alert-warning m-0" role="alert">
         {children}
       </div>
     );

--- a/src/components/tree-node.js
+++ b/src/components/tree-node.js
@@ -22,10 +22,7 @@ const TreeNode = ({ node, path, hideIfEmpty }) => {
       return null;
     } else {
       return (
-        <li
-          className="mt-3 mb-2 fw-bold text-muted text-uppercase small"
-          key={node.path}
-        >
+        <li className="mt-3 mb-2 fw-bold text-muted text-uppercase small">
           <Title node={node} />
           {/* {node.interactive && <KatacodaBadge />} */}
         </li>
@@ -38,8 +35,7 @@ const TreeNode = ({ node, path, hideIfEmpty }) => {
       <div className="d-flex align-items-center">
         <Link
           to={node.path}
-          className={`d-inline-block py-1 align-middle lh-12
-          ${node.childCount ? "section-title" : ""} ${
+          className={`d-inline-block py-1 align-middle lh-12 ${node.childCount ? "section-title" : ""} ${
             path === node.path ? "active fw-bold text-dark" : ""
           }`}
         >
@@ -50,7 +46,11 @@ const TreeNode = ({ node, path, hideIfEmpty }) => {
       {node.items.length > 0 && (
         <SubList collapsed={!path.includes(node.path)}>
           {node.items.map((subNode) => (
-            <TreeNode node={subNode} path={path} key={subNode.path} />
+            <TreeNode
+              node={subNode}
+              path={path}
+              key={subNode.path || subNode.navTitle || subNode.title}
+            />
           ))}
         </SubList>
       )}

--- a/src/constants/utils.js
+++ b/src/constants/utils.js
@@ -31,3 +31,6 @@ export const getBaseUrl = (path, depth) => {
 
 export const isPathAnIndexPage = (filePath) =>
   filePath.endsWith("/index.mdx") || filePath === "index.mdx";
+
+export const getRelativeFilePathFromPageAbsolutePath = (absolutePath) =>
+  (absolutePath.match(/(?:\/advocacy_docs|\/product_docs\/docs).+$/) || [])[0];

--- a/tools/automation/generators/relgen/relgen.js
+++ b/tools/automation/generators/relgen/relgen.js
@@ -335,6 +335,11 @@ if (meta.precursor !== undefined) {
   }
 }
 
+appendFileSync(
+  relindexfilename,
+  `originalFilePath: ${path.relative(docsBase, metaFilename)}\n`,
+);
+appendFileSync(relindexfilename, `editTarget: originalFilePath\n`);
 appendFileSync(relindexfilename, "---\n");
 appendFileSync(relindexfilename, "\n\n");
 
@@ -378,7 +383,7 @@ for (let [file, relnote] of relnotes) {
       default:
         if (col.key.startsWith("$")) {
           let key = col.key.replace("$", "");
-          line += ` ${relnote.meta[key]} |`;
+          line += ` ${relnote.components[key]} |`;
         } else {
           ghCore.error(`Unknown column key: ${col.key}`, {
             file: path.relative(docsBase, metaFilename),
@@ -423,7 +428,7 @@ if (meta.precursor !== undefined) {
 
 // Now let's make some release notes...
 for (let [file, relnote] of relnotes) {
-  prepareRelnote(meta, file, relnote);
+  prepareRelnote(meta, path.join(argv.path, "src", file), relnote);
 }
 
 function prepareRelnote(meta, file, note) {
@@ -485,6 +490,8 @@ function prepareRelnote(meta, file, note) {
     `title: ${note.product} ${note.version} release notes\n`,
   );
   appendFileSync(rlout, `navTitle: Version ${note.version}\n`);
+  appendFileSync(rlout, `originalFilePath: ${path.relative(docsBase, file)}\n`);
+  appendFileSync(rlout, `editTarget: originalFilePath\n`);
   appendFileSync(rlout, `---\n`);
 
   appendFileSync(rlout, "\n");
@@ -548,7 +555,7 @@ function prepareRelnote(meta, file, note) {
       if (meta.components !== undefined) {
         appendFileSync(
           rlout,
-          `<tr><td>${linenote.component}</td><td>${linenote.component_version}</td><td>${composednote}</td><td>${linenote.addresses}</td></tr>\n`,
+          `<tr><td>${linenote.component}</td><td>${note.components[linenote.component]}</td><td>${composednote}</td><td>${linenote.addresses}</td></tr>\n`,
         );
       } else {
         appendFileSync(


### PR DESCRIPTION
## What Changed?

- PEM 9: [Removed SQL Protect plugin](https://github.com/EnterpriseDB/docs/pull/6448), [SQL Profiler package name correction](https://github.com/EnterpriseDB/docs/pull/6463)
-  NET: [Npgsql API version note](https://github.com/EnterpriseDB/docs/pull/6464)
- EPAS: [removing 11 and 12 templates](https://github.com/EnterpriseDB/docs/pull/6468)
- Housekeeping: [DOCS-1143: Relgen prepush fixes](https://github.com/EnterpriseDB/docs/pull/6465)