### PR TITLE
docs(ET-1813): add object storage configuration of reader

### DIFF
--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -176,7 +176,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 ### `AWS_CA_BUNDLE (Optional)`
 Set this value only if you are using a self-signed certificate for your object storage. Specify the path to the CA bundle file.
 
-You don't need to set this if you are using AWS S3 or s3 compatible storage with publicly-trusted CAs.
+This setting is not required if you are using AWS S3 or S3-compatible storage with publicly trusted certificate authorities (CAs).
 
 ### `AWS_ENDPOINT_URL_S3`
 1) If you are using AWS S3, you can find the endpoint url in: https://docs.aws.amazon.com/general/latest/gr/s3.html

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -169,7 +169,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 2) If you are using S3-compatible storage, like MinIO, set this value to the secret key for your object storage.
 
 ### `AWS_REGION` (Optional)
-1) If you are using AWS S3, set this value to match the region specified in AWS_ENDPOINT_URL_S3.
+1) If you are using AWS S3, set this value to match the region specified in `AWS_ENDPOINT_URL_S3`.
 
 2) If you are using S3-compatible storage, such as MinIO, this setting is not required.
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -169,7 +169,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 2) If you are using S3-compatible storage, like MinIO, set this value to the secret key for your object storage.
 
 ### `AWS_REGION` (Optional)
-1) If you are using AWS S3, You need to set this according to the region in AWS_ENDPOINT_URL_S3
+1) If you are using AWS S3, set this value to match the region specified in AWS_ENDPOINT_URL_S3.
 
 2) If you are using s3 compatible storage like minio, you don't need to set this.
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -161,7 +161,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 ### `AWS_ACCESS_KEY_ID`
 1) If you are using AWS S3, set this value to an access key ID that has read and write permissions for the S3 bucket.
 
-2) If you are using s3 compatible storage like minio, you need to set the access key of your object storage.
+2) If you are using S3-compatible storage, like MinIO, set this value to the access key for your object storage.
 
 ### `AWS_SECRET_ACCESS_KEY`
 1) If you are using AWS S3, You need to set the secret access key with the read and write permission of the bucket.

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -168,7 +168,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 
 2) If you are using S3-compatible storage, like MinIO, set this value to the secret key for your object storage.
 
-### `AWS_REGION (Optional)`
+### `AWS_REGION` (Optional)
 1) If you are using AWS S3, You need to set this according to the region in AWS_ENDPOINT_URL_S3
 
 2) If you are using s3 compatible storage like minio, you don't need to set this.

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -181,7 +181,7 @@ This setting is not required if you are using AWS S3 or S3-compatible storage wi
 ### `AWS_ENDPOINT_URL_S3`
 1) If you are using AWS S3, you can find the endpoint URL in the AWS documentation: [AWS S3 Endpoints](https://docs.aws.amazon.com/general/latest/gr/s3.html).
 
-2) If you are using s3 compatible storage like minio, you need to set according to your object storage configuration.
+2) If you are using S3-compatible storage, like MinIO, set this value according to your object storage configuration.
 
 ### `BUCKET_NAME`
 The bucket name you want to use for the migration. The bucket need to be created before the migration.

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuring and running the EDB DMS Reader"
 deepToC: true
-redirects: 
+redirects:
   - /purl/dms/configure_source
 ---
 
@@ -19,7 +19,7 @@ redirects:
 
 ## Configuring the reader
 
-1.  Open the EDB DMS reader located in `/opt/cdcreader/run-cdcreader.sh` and ensure you have write permissions. 
+1.  Open the EDB DMS reader located in `/opt/cdcreader/run-cdcreader.sh` and ensure you have write permissions.
 
 1.  Set the variables according to your environment and uncomment the edited lines. See [parameters](#parameters) for further guidance. The script is reproduced below.
 
@@ -71,7 +71,7 @@ redirects:
 # The CATALOG is the database name
 #export DBZ_DATABASES_0__CATALOG=source
 #export DBZ_DATABASES_0__USERNAME=postgres
-# The password env can be set without specifing it here
+# The password env can be set without specifying it here
 # but the env structure looks like this
 #export DBZ_DATABASES_0__PASSWORD=password
 
@@ -86,6 +86,16 @@ redirects:
 # The password env can be set without specifing it here
 # but the env structure looks like this
 #export DBZ_DATABASES_1__PASSWORD=password
+
+##############################################################################
+# DMS Reader Object storage config, only necessary for appliance       #
+##############################################################################
+#export AWS_ACCESS_KEY_ID=
+#export AWS_SECRET_ACCESS_KEY=
+#export AWS_REGION=
+#export AWS_CA_BUNDLE=
+#export AWS_ENDPOINT_URL_S3=
+#export BUCKET_NAME=
 
 ##########################################
 # Optional Parameters Below              #
@@ -105,7 +115,7 @@ java ${JAVA_OPTS} -jar quarkus-run.jar
 
 ### `DBZ_ID`
 
-This is the name you assign to identify a source. This name will later appear as a _source_ in the **Migrate** > **Sources** section of the EDB Postgres AI Console. 
+This is the name you assign to identify a source. This name will later appear as a _source_ in the **Migrate** > **Sources** section of the EDB Postgres AI Console.
 
 Consider the following ID guidelines:
 
@@ -119,7 +129,7 @@ Specifies the URL of the service that will host the migration. `transporter-rw-s
 
 ### `TLS_PRIVATE_KEY_PATH`
 
-Directory path to the `client-key.pem` private key you downloaded from the EDB Postgres AI Console. 
+Directory path to the `client-key.pem` private key you downloaded from the EDB Postgres AI Console.
 
 The HTTP client of the EDB DMS Reader uses it to perform mTLS authentication with the `transporter-rw-service`.
 
@@ -148,9 +158,35 @@ Created from the Certificate Authority configured in `TLS_CA_PATH`.
 
 The Apicurio client uses it to perform mTLS authentication with the `transporter-rw-service`.
 
+### `AWS_ACCESS_KEY_ID`
+1) If you are using AWS S3, You need to set the access key id with the read and write permission of the bucket.
+
+2) If you are using s3 compatible storage like minio, you need to set the access key of your object storage.
+
+### `AWS_SECRET_ACCESS_KEY`
+1) If you are using AWS S3, You need to set the secret access key with the read and write permission of the bucket.
+
+2) If you are using s3 compatible storage like minio, you need to set the secret key of your object storage.
+
+### `AWS_REGION (Optional)`
+1) If you are using AWS S3, You need to set this according to the region in AWS_ENDPOINT_URL_S3
+
+2) If you are using s3 compatible storage like minio, you don't need to set this.
+
+### `AWS_CA_BUNDLE (Optional)`
+This is only needed if you are using a self-signed certificate for the object storage. You need to set the path to the CA bundle file.
+
+### `AWS_ENDPOINT_URL_S3`
+1) If you are using AWS S3, you can find the endpoint url in: https://docs.aws.amazon.com/general/latest/gr/s3.html
+
+2) If you are using s3 compatible storage like minio, you need to set according to your object storage configuration.
+
+### `BUCKET_NAME`
+The bucket name you want to use for the migration. The bucket need to be created before the migration.
+
 ### `DBZ_DATABASES`
 
-This is a list of source database information you require for the EDB DMS Reader be able to read the correct source database information for the migration. 
+This is a list of source database information you require for the EDB DMS Reader be able to read the correct source database information for the migration.
 
 You can configure the EDB DMS Reader to migrate multiple databases. The `DBZ_DATABASES_0__TYPE` section delimits the information for the first database. You can use `DBZ_DATABASES_1__TYPE` to provide data for a second database. Add more sections to the EDB DMS Reader (`DBZ_DATABASES_2__TYPE`, `DBZ_DATABASES_3__TYPE`) by increasing the index manully.
 
@@ -181,7 +217,7 @@ The password for the database username of the source database.
 
 ## Running the EDB DMS Reader
 
-1.  Start the migration: 
+1.  Start the migration:
 
     ```shell
     cd /opt/cdcreader

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -164,7 +164,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 2) If you are using S3-compatible storage, like MinIO, set this value to the access key for your object storage.
 
 ### `AWS_SECRET_ACCESS_KEY`
-1) If you are using AWS S3, You need to set the secret access key with the read and write permission of the bucket.
+1) If you are using AWS S3, set this value to a secret access key that has read and write permissions for the specified S3 bucket.
 
 2) If you are using s3 compatible storage like minio, you need to set the secret key of your object storage.
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -88,7 +88,7 @@ redirects:
 #export DBZ_DATABASES_1__PASSWORD=password
 
 ##############################################################################
-# DMS Reader Object storage config, only necessary for appliance       #
+# DMS Reader object storage config, only necessary for the HCP       #
 ##############################################################################
 #export AWS_ACCESS_KEY_ID=
 #export AWS_SECRET_ACCESS_KEY=

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -166,7 +166,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 ### `AWS_SECRET_ACCESS_KEY`
 1) If you are using AWS S3, set this value to a secret access key that has read and write permissions for the specified S3 bucket.
 
-2) If you are using s3 compatible storage like minio, you need to set the secret key of your object storage.
+2) If you are using S3-compatible storage, like MinIO, set this value to the secret key for your object storage.
 
 ### `AWS_REGION (Optional)`
 1) If you are using AWS S3, You need to set this according to the region in AWS_ENDPOINT_URL_S3

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -173,7 +173,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 
 2) If you are using s3 compatible storage like minio, you don't need to set this.
 
-### `AWS_CA_BUNDLE (Optional)`
+### `AWS_CA_BUNDLE` (Optional)
 Set this value only if you are using a self-signed certificate for your object storage. Specify the path to the CA bundle file.
 
 This setting is not required if you are using AWS S3 or S3-compatible storage with publicly trusted certificate authorities (CAs).

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -179,7 +179,7 @@ Set this value only if you are using a self-signed certificate for your object s
 This setting is not required if you are using AWS S3 or S3-compatible storage with publicly trusted certificate authorities (CAs).
 
 ### `AWS_ENDPOINT_URL_S3`
-1) If you are using AWS S3, you can find the endpoint url in: https://docs.aws.amazon.com/general/latest/gr/s3.html
+1) If you are using AWS S3, you can find the endpoint URL in the AWS documentation: [AWS S3 Endpoints](https://docs.aws.amazon.com/general/latest/gr/s3.html).
 
 2) If you are using s3 compatible storage like minio, you need to set according to your object storage configuration.
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -176,6 +176,8 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 ### `AWS_CA_BUNDLE (Optional)`
 This is only needed if you are using a self-signed certificate for the object storage. You need to set the path to the CA bundle file.
 
+You don't need to set this if you are using AWS S3 or s3 compatible storage with publicly-trusted CAs.
+
 ### `AWS_ENDPOINT_URL_S3`
 1) If you are using AWS S3, you can find the endpoint url in: https://docs.aws.amazon.com/general/latest/gr/s3.html
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -184,7 +184,7 @@ This setting is not required if you are using AWS S3 or S3-compatible storage wi
 2) If you are using S3-compatible storage, like MinIO, set this value according to your object storage configuration.
 
 ### `BUCKET_NAME`
-The bucket name you want to use for the migration. The bucket need to be created before the migration.
+Specify the name of the bucket you want to use for the migration. The bucket must be created before starting the migration.
 
 ### `DBZ_DATABASES`
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -159,7 +159,7 @@ Created from the Certificate Authority configured in `TLS_CA_PATH`.
 The Apicurio client uses it to perform mTLS authentication with the `transporter-rw-service`.
 
 ### `AWS_ACCESS_KEY_ID`
-1) If you are using AWS S3, You need to set the access key id with the read and write permission of the bucket.
+1) If you are using AWS S3, set this value to an access key ID that has read and write permissions for the S3 bucket.
 
 2) If you are using s3 compatible storage like minio, you need to set the access key of your object storage.
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -174,7 +174,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 2) If you are using s3 compatible storage like minio, you don't need to set this.
 
 ### `AWS_CA_BUNDLE (Optional)`
-This is only needed if you are using a self-signed certificate for the object storage. You need to set the path to the CA bundle file.
+Set this value only if you are using a self-signed certificate for your object storage. Specify the path to the CA bundle file.
 
 You don't need to set this if you are using AWS S3 or s3 compatible storage with publicly-trusted CAs.
 

--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_reader.mdx
@@ -171,7 +171,7 @@ The Apicurio client uses it to perform mTLS authentication with the `transporter
 ### `AWS_REGION` (Optional)
 1) If you are using AWS S3, set this value to match the region specified in AWS_ENDPOINT_URL_S3.
 
-2) If you are using s3 compatible storage like minio, you don't need to set this.
+2) If you are using S3-compatible storage, such as MinIO, this setting is not required.
 
 ### `AWS_CA_BUNDLE` (Optional)
 Set this value only if you are using a self-signed certificate for your object storage. Specify the path to the CA bundle file.


### PR DESCRIPTION
## What Changed?


The latest reader needs the user to configure the s3/s3 compatible object storage information.