### PR TITLE
Fix copy-paste error in logic for checking image URLs

### DIFF
--- a/product_docs/docs/net_connector/8.0.5.1/12_using_advanced_queueing.mdx
+++ b/product_docs/docs/net_connector/8.0.5.1/12_using_advanced_queueing.mdx
@@ -76,6 +76,7 @@ To enqueue a message on your .NET application, you must:
 The following code shows using the `queue.Enqueue` method.
 
 !!! Note
+
     This code creates the message and serializes it. This is example code and doesn't compile if copied as it is. You must serialize the message as XML.
 
 ```csharp
@@ -199,6 +200,7 @@ To dequeue a message on your .NET application, you must:
 3.  Call the `queue.Dequeue` method.
 
 !!! Note
+
     The following code creates the message and serializes it. This is example code and doesn't compile if copied as it is. You must serialize the message as XML.
 
 ```csharp
@@ -371,7 +373,7 @@ The `EDBAQDequeueMode` class lists all the dequeuer modes available.
 
 | Value         | Description                                                   |
 | ------------- | ------------------------------------------------------------- |
-| Browse        | Reads the message without locking.                             |
+| Browse        | Reads the message without locking.                            |
 | Locked        | Reads and gets a write lock on the message.                   |
 | Remove        | Deletes the message after reading. This is the default value. |
 | Remove_NoData | Confirms receipt of the message.                              |
@@ -380,58 +382,58 @@ The `EDBAQDequeueMode` class lists all the dequeuer modes available.
 
 The `EDBAQDequeueOptions` class lists the options available when dequeuing a message.
 
-| Property       | Description                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| ConsumerName   | The name of the consumer for which to dequeue the message.                                                                     |
-| DequeueMode    | Set from `EDBAQDequeueMode`. It represents the locking behavior linked with the dequeue option.                          |
-| Navigation     | Set from `EDBAQNavigationMode`. It represents the position of the message to fetch.                          |
+| Property       | Description                                                                                                       |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| ConsumerName   | The name of the consumer for which to dequeue the message.                                                        |
+| DequeueMode    | Set from `EDBAQDequeueMode`. It represents the locking behavior linked with the dequeue option.                   |
+| Navigation     | Set from `EDBAQNavigationMode`. It represents the position of the message to fetch.                               |
 | Visibility     | Set from `EDBAQVisibility`. It represents whether the new message is dequeued as part of the current transaction. |
-| Wait           | The wait time for a message as per the search criteria.                                                                        |
-| Msgid          | The message identifier.                                                                                                        |
-| Correlation    | The correlation identifier.                                                                                                    |
-| DeqCondition   | The dequeuer condition. It's a Boolean expression.                                                                            |
-| Transformation | The transformation to apply before dequeuing the message.                                                          |
-| DeliveryMode   | The delivery mode of the dequeued message.                                                                                     |
+| Wait           | The wait time for a message as per the search criteria.                                                           |
+| Msgid          | The message identifier.                                                                                           |
+| Correlation    | The correlation identifier.                                                                                       |
+| DeqCondition   | The dequeuer condition. It's a Boolean expression.                                                                |
+| Transformation | The transformation to apply before dequeuing the message.                                                         |
+| DeliveryMode   | The delivery mode of the dequeued message.                                                                        |
 
 ### EDBAQEnqueueOptions
 
 The `EDBAQEnqueueOptions` class lists the options available when enqueuing a message.
 
-| Property          | Description                                                                                                                    |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Property          | Description                                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
 | Visibility        | Set from `EDBAQVisibility`. It represents whether the new message is enqueued as part of the current transaction. |
-| RelativeMsgid     | The relative message identifier.                                                                                               |
-| SequenceDeviation | The sequence when to dequeue the message.                                                                              |
-| Transformation    | The transformation to apply before enqueuing the message.                                                          |
-| DeliveryMode      | The delivery mode of the enqueued message.                                                                                     |
+| RelativeMsgid     | The relative message identifier.                                                                                  |
+| SequenceDeviation | The sequence when to dequeue the message.                                                                         |
+| Transformation    | The transformation to apply before enqueuing the message.                                                         |
+| DeliveryMode      | The delivery mode of the enqueued message.                                                                        |
 
 ### EDBAQMessage
 
 The `EDBAQMessage` class lists a message to enqueue/dequeue.
 
-| Property     | Description                      |
-| ------------ | -------------------------------- |
-| Payload      | The actual message to queue. |
-| MessageId    | The ID of the queued message.    |
+| Property  | Description                   |
+| --------- | ----------------------------- |
+| Payload   | The actual message to queue.  |
+| MessageId | The ID of the queued message. |
 
 ### EDBAQMessageProperties
 
 The `EDBAQMessageProperties` lists the message properties available.
 
-| Property         | Description                                                                                   |
-| ---------------- | --------------------------------------------------------------------------------------------- |
-| Priority         | The priority of the message.                                                                  |
+| Property         | Description                                                                  |
+| ---------------- | ---------------------------------------------------------------------------- |
+| Priority         | The priority of the message.                                                 |
 | Delay            | The duration after which the message is available for dequeuing, in seconds. |
-| Expiration       | The duration for which the message is available for dequeuing, in seconds.  |
-| Correlation      | The correlation identifier.                                                                   |
-| Attempts         | The number of attempts taken to dequeue the message.                                          |
-| RecipientList    | The recipients list that overthrows the default queue subscribers.                           |
-| ExceptionQueue   | The name of the queue to move the unprocessed messages to.                         |
-| EnqueueTime      | The time when the message was enqueued.                                                       |
-| State            | The state of the message while dequeued.                                                       |
-| OriginalMsgid    | The message identifier in the last queue.                                                     |
-| TransactionGroup | The transaction group for the dequeued messages.                                              |
-| DeliveryMode     | The delivery mode of the dequeued message.                                                    |
+| Expiration       | The duration for which the message is available for dequeuing, in seconds.   |
+| Correlation      | The correlation identifier.                                                  |
+| Attempts         | The number of attempts taken to dequeue the message.                         |
+| RecipientList    | The recipients list that overthrows the default queue subscribers.           |
+| ExceptionQueue   | The name of the queue to move the unprocessed messages to.                   |
+| EnqueueTime      | The time when the message was enqueued.                                      |
+| State            | The state of the message while dequeued.                                     |
+| OriginalMsgid    | The message identifier in the last queue.                                    |
+| TransactionGroup | The transaction group for the dequeued messages.                             |
+| DeliveryMode     | The delivery mode of the dequeued message.                                   |
 
 ### EDBAQMessageState
 
@@ -448,11 +450,11 @@ The `EDBAQMessageState` class represents the state of the message during dequeue
 
 The `EDBAQMessageType` class represents the types for payload.
 
-| Value     | Description                                                                           |
-| --------- | ------------------------------------------------------------------------------------- |
-| Raw       | The raw message type.<br /><br />Note: Currently, this payload type isn't supported. |
-| UDT       | The user-defined type message.                                                        |
-| XML       | The XML type message.<br /><br />Note: Currently, this payload type isn't supported. |
+| Value | Description                                                                          |
+| ----- | ------------------------------------------------------------------------------------ |
+| Raw   | The raw message type.<br /><br />Note: Currently, this payload type isn't supported. |
+| UDT   | The user-defined type message.                                                       |
+| XML   | The XML type message.<br /><br />Note: Currently, this payload type isn't supported. |
 
 ### EDBAQNavigationMode
 
@@ -468,25 +470,26 @@ The `EDBAQNavigationMode` class represents the different types of navigation mod
 
 The `EDBAQQueue` class represents a SQL statement to execute `DMBS_AQ` functionality on a PostgreSQL database.
 
-| Property          | Description                                                                                   |
-| ----------------- | --------------------------------------------------------------------------------------------- |
-| Connection        | The connection to use.                                                                    |
-| Name              | The name of the queue.                                                                        |
+| Property          | Description                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------- |
+| Connection        | The connection to use.                                                                         |
+| Name              | The name of the queue.                                                                         |
 | MessageType       | The message type that's enqueued/dequeued from this queue, for example `EDBAQMessageType.Udt`. |
-| UdtTypeName       | The user-defined type name of the message type.                                              |
-| EnqueueOptions    | The enqueue options to use.                                                               |
-| DequeuOptions     | The dequeue options to use.                                                               |
-| MessageProperties | The message properties to use.                                                            |
+| UdtTypeName       | The user-defined type name of the message type.                                                |
+| EnqueueOptions    | The enqueue options to use.                                                                    |
+| DequeuOptions     | The dequeue options to use.                                                                    |
+| MessageProperties | The message properties to use.                                                                 |
 
 ### EDBAQVisibility
 
 The `EDBAQVisibility` class represents the visibility options available.
 
-| Value     | Description                                                 |
-| --------- | ----------------------------------------------------------- |
+| Value     | Description                                                |
+| --------- | ---------------------------------------------------------- |
 | Immediate | The enqueue/dequeue isn't part of the ongoing transaction. |
-| On_Commit | The enqueue/dequeue is part of the current transaction.     |
+| On_Commit | The enqueue/dequeue is part of the current transaction.    |
 
 !!! Note
-    -   To review the default options for these parameters, see [DBMS_AQ](../../epas/latest/epas_compat_bip_guide/03_built-in_packages/02_dbms_aq/).
+
+    -   To review the default options for these parameters, see [DBMS_AQ](/epas/latest/reference/oracle_compatibility_reference/epas_compat_bip_guide/03_built-in_packages/02_dbms_aq/).
     -   EDB advanced queueing functionality uses user-defined types for calling enqueue/dequeue operations. `Server Compatibility Mode=NoTypeLoading` can't be used with advanced queueing because `NoTypeLoading` doesn't load any user-defined types.

--- a/tools/automation/actions/link-check/index.js
+++ b/tools/automation/actions/link-check/index.js
@@ -489,7 +489,7 @@ function cleanup() {
           );
         else if (
           node.type === "element" &&
-          node.tagName === "a" &&
+          node.tagName === "img" &&
           node.properties.src
         )
           node.properties.src = mapUrlToCanonical(


### PR DESCRIPTION
## What Changed?

Fix copy-paste error in logic for checking image URLs (only applies to HTML `<img>` tags)

Also update old EPAS URL in .NET connector docs
