### PR TITLE
Edits to EPAS - Feb 2025 Minor release #6485

### DIFF
--- a/product_docs/docs/epas/17/epas_rel_notes/epas17_2_rel_notes.mdx
+++ b/product_docs/docs/epas/17/epas_rel_notes/epas17_2_rel_notes.mdx
@@ -8,11 +8,11 @@ Released: 22 Nov 2024
 EDB Postgres Advanced Server 17.2 includes the following enhancements and bug fixes:
 
 !!! Note Deprecation
-With the release of EPAS 17, the DRITA is being deprecated and will not be included in EPAS 18. This decision follows the introduction of [EDB’s PWR](/pwr/latest/) and [`edb_wait_states`](/pg_extensions/wait_states/) extensions, which offer improved diagnostic capabilities compared to DRITA. These new extensions provide a diagnostic experience more closely aligned with Oracle’s AWR reports, making DRITA obsolete.
+With the release of EDB Postgres Advanced Server 17, the DRITA is being deprecated and will not be included in EDB Postgres Advanced Server 18. This decision follows the introduction of [EDB’s PWR](/pwr/latest/) and [`edb_wait_states`](/pg_extensions/wait_states/) extensions, which offer improved diagnostic capabilities compared to DRITA. These new extensions provide a diagnostic experience more closely aligned with Oracle’s AWR reports, making DRITA obsolete.
 !!!
 
 !!! Note 
-The `pgAgent` and `adminpack` packages are end of life in EPAS 17 and later.
+The `pgAgent` and `adminpack` packages are end of life in EDB Postgres Advanced Server 17 and later.
 !!!
 
 | Type              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                       | Addresses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                                                                                                                                                                                                                                                  |

--- a/product_docs/docs/epas/17/epas_rel_notes/epas17_3_rel_notes.mdx
+++ b/product_docs/docs/epas/17/epas_rel_notes/epas17_3_rel_notes.mdx
@@ -8,11 +8,11 @@ Released: 13 Feb 2025
 EDB Postgres Advanced Server 17.3 includes the following enhancements and bug fixes:
 
 !!! Note Deprecation
-With the release of EPAS 17, the DRITA is being deprecated and will not be included in EPAS 18. This decision follows the introduction of [EDB’s PWR](/pwr/latest/) and [`edb_wait_states`](/pg_extensions/wait_states/) extensions, which offer improved diagnostic capabilities compared to DRITA. These new extensions provide a diagnostic experience more closely aligned with Oracle’s AWR reports, making DRITA obsolete.
+With the release of EDB Postgres Advanced Server 17, the DRITA is being deprecated and will not be included in EDB Postgres Advanced Server 18. This decision follows the introduction of [EDB’s PWR](/pwr/latest/) and [`edb_wait_states`](/pg_extensions/wait_states/) extensions, which offer improved diagnostic capabilities compared to DRITA. These new extensions provide a diagnostic experience more closely aligned with Oracle’s AWR reports, making DRITA obsolete.
 !!!
 
 !!! Note 
-The `pgAgent` and `adminpack` packages are end of life in EPAS 17 and later.
+The `pgAgent` and `adminpack` packages are end of life in EDB Postgres Advanced Server 17 and later.
 !!!
 
 | Type           | Description                                                                                                                                                                                                                                                      | Addresses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |

--- a/product_docs/docs/epas/17/epas_rel_notes/index.mdx
+++ b/product_docs/docs/epas/17/epas_rel_notes/index.mdx
@@ -18,7 +18,7 @@ The EDB Postgres Advanced Server documentation describes the latest version of E
 
 ## Component certification
 
-This components are included in the EDB Postgres Advanced Server v17 release:
+These components are included in the EDB Postgres Advanced Server v17 release:
 
 -   PL Debugger 1.8
 -   pg_catcheck 1.6.0


### PR DESCRIPTION
Fixed typo and spelled out EPAS.

## What Changed?

