### PR TITLE
Use precise version (when available) for PDF download filename

### DIFF
--- a/product_docs/docs/pgd/3.6/index.mdx
+++ b/product_docs/docs/pgd/3.6/index.mdx
@@ -4,6 +4,8 @@ navigation:
 - release-notes
 - rel_notes-pglogical
 hidePDF: true
+directoryDefaults:
+  version: "3.6.33"
 ---
 
 EDB Postgres Distributed provides loosely-coupled multi-master logical replication

--- a/product_docs/docs/pgd/3.7/index.mdx
+++ b/product_docs/docs/pgd/3.7/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: "EDB Postgres Distributed"
 pdf: true
+directoryDefaults:
+  version: "3.7.25"
 ---
 EDB Postgres Distributed provides multi-master replication and data distribution with advanced conflict management, data-loss protection, and [throughput up to 5X faster than native logical replication](https://www.enterprisedb.com/blog/performance-improvements-edb-postgres-distributed), and enables distributed PostgreSQL clusters with high availability up to five 9s.
 

--- a/product_docs/docs/pgd/4/index.mdx
+++ b/product_docs/docs/pgd/4/index.mdx
@@ -26,6 +26,8 @@ navigation:
   - monitoring
   - cli
 pdf: true
+directoryDefaults:
+  version: "4.3.6"
 ---
 
 

--- a/src/components/left-nav.js
+++ b/src/components/left-nav.js
@@ -99,7 +99,6 @@ const LeftNav = ({
   hideEmptySections = false,
   hideVersion = false,
   hidePDF = false,
-  preciseVersion,
 }) => {
   return (
     <ul className="list-unstyled mt-0">
@@ -111,7 +110,7 @@ const LeftNav = ({
           iconName={iconName}
           product={product}
           hideVersion={hideVersion}
-          preciseVersion={preciseVersion}
+          preciseVersion={version}
         />
       ) : (
         <SectionHeading

--- a/src/components/version-dropdown.js
+++ b/src/components/version-dropdown.js
@@ -8,24 +8,14 @@ const DropdownItem = ({ to, active, children }) => (
   </Link>
 );
 
-const VersionDropdown = ({
-  versionArray,
-  pathVersions,
-  preciseVersion,
-  path,
-}) => {
+const VersionDropdown = ({ versionArray, preciseVersion, path }) => {
   const activeVersion = path.split("/")[2];
-  let roundedVersion = "";
-  if (!preciseVersion) {
-    roundedVersion = activeVersion;
-  } else {
-    roundedVersion = preciseVersion.split(".")[0];
-  }
+  const isActive = (version) => version === activeVersion;
 
   return (
     <Dropdown>
       <Dropdown.Toggle variant="outline-primary" size="sm">
-        Version {preciseVersion ? preciseVersion : activeVersion}&nbsp;
+        Version {preciseVersion || activeVersion}&nbsp;
         {
           // must be a better way to get space between the text and caret
         }
@@ -36,10 +26,10 @@ const VersionDropdown = ({
           <DropdownItem
             to={version.url}
             key={version.url}
-            active={activeVersion === version.version}
+            active={isActive(version.version)}
           >
             Version {version.version}{" "}
-            {version.version === roundedVersion && preciseVersion
+            {isActive(version.version) && preciseVersion !== activeVersion
               ? `(${preciseVersion})`
               : ""}
           </DropdownItem>

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -231,8 +231,7 @@ const DocTemplate = ({ data, pageContext }) => {
             hideVersion={frontmatter.hideVersion}
             hidePDF={hidePDF}
             product={product}
-            version={version}
-            preciseVersion={preciseVersion}
+            version={preciseVersion || version}
           />
         </SideNavigation>
         <MainContent searchProduct={product} searchVersion={version}>


### PR DESCRIPTION
## What Changed?

The PDF generator already did this, resulting in a 404 when precise version was used - e.g. download link points to `pgd_v5_documentation.pdf` but actual filename is `pgd_v5.6.1_documentation.pdf` (reported by @pnkrepps in Slack)

Also: use path version for identifying "active" version in selector - don't round precise version, as this would fail to produce the correct results when the path version already included a minor or patch version.

Added precise version for the other published PGD versions, primarily as a more thorough testbed for this stuff, but also... a bit of consistency is nice!