### PR TITLE
EPRS 7.11: Added 7.11.0 release notes

### DIFF
--- a/product_docs/docs/eprs/7/eprs_rel_notes/eprs_rel_notes_7.11.0.mdx
+++ b/product_docs/docs/eprs/7/eprs_rel_notes/eprs_rel_notes_7.11.0.mdx
@@ -1,0 +1,37 @@
+---
+title: "Replication Server 7.11.0 release notes"
+navTitle: Version 7.11.0
+---
+
+Released: 21 Feb 2025
+
+New features, enhancements, bug fixes, and other changes in Replication Server 7.11.0 include the following:
+
+| Type         | Description                                                                                                                                                                                                                                                                                                                          | Ticket |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|
+| Enhancement  | EDB Postgres Replication Server (EPRS) is now certified to support replication slot failover when the publication source database is a Postgres 17.x (or later) primary cluster in a physical streaming replication, high-availability configuration, and one of the standby clusters is promoted to act as the new primary cluster. |        |
+| Enhancement  | Added certification for installation and use on RHEL 9 ARM64 architectures.                                                                                                                                                                                                                                                          |        |
+| Bug&nbsp;fix | Fixed an issue that caused the shadow table cleanup operation to fail with an `ArrayIndexOutOfBounds` exception when triggered concurrently for multiple publications.                                                                                                                                                               | #41958 |
+| Bug&nbsp;fix | Fixed an issue where non-primary key tables with case-sensitive names containing special character(s) caused the creation of the publication to fail.                                                                                                                                                                                |        |
+| Bug&nbsp;fix | Fixed an issue that prevented setting the `targetDBQueryTimeout` configuration option to zero to disable it.                                                                                                                                                                                                                         | #41958 |
+| Bug&nbsp;fix | Fixed an issue where snapshot replication failed with a `NoClassDefFoundError` error for publications with an EDB Postgres Advanced Server database configured in non-redwood mode as the source database.                                                                                                                           | #42949 |
+| Bug&nbsp;fix | Fixed an issue where the registration of a PostgreSQL/EDB Postgres Advanced Server publication database failed in an existing Oracle to EDB Postgres Advanced Server SMR cluster.                                                                                                                                                    |        |
+| Bug&nbsp;fix | Fixed an issue that caused foreign key constraints for certain control tables to be recreated upon restarting the EPRS publication server. This also addresses the `Error occurred during version 7 upgrade process, shutting down Rep Server…` issue that had been observed in certain cases when EPRS was restarted.               |        |
+| Bug&nbsp;fix | Fixed an issue that could result in the creation of redundant foreign keys when an Oracle publication database is registered in an existing EDB Postgres Advanced Server to Oracle SMR cluster.                                                                                                                                      |        |
+
+## End-of-support notice
+
+Replication Server 6.2 is no longer a supported version.
+
+To ensure that your usage of Replication Server is supported, upgrade any installations with version 6.2 to version 7. See the end-of-support notes that follow:
+
+**Software:** Replication Server 
+
+**Version:** 6.2
+
+**End of Standard Support:** June 1, 2023
+
+Additional details can be found at [EDB Platform Compatibility](https://www.enterprisedb.com/resources/platform-compatibility).
+
+!!! Note
+    Version 7.x provides a non-breaking upgrade path for existing 6.2.x-based cluster deployments. However, we strongly recommend that the upgrade be verified in a staging or non-production environment before applying the upgrade in a production environment.

--- a/product_docs/docs/eprs/7/eprs_rel_notes/index.mdx
+++ b/product_docs/docs/eprs/7/eprs_rel_notes/index.mdx
@@ -3,6 +3,7 @@ title: "Release notes"
 redirects:
   - ../01_whats_new/
 navigation:
+ - eprs_rel_notes_7.11.0
  - eprs_rel_notes_7.10.0
  - eprs_rel_notes_7.9.0
  - eprs_rel_notes_7.8.0
@@ -18,6 +19,7 @@ The Replication Server documentation describes the latest version including mino
 
 | Version                          | Release Date |
 |----------------------------------|--------------|
+| [7.11.0](eprs_rel_notes_7.11.0)  | 21 Feb 2025  |
 | [7.10.0](eprs_rel_notes_7.10.0)  | 22 Nov 2024  |
 | [7.9.0](eprs_rel_notes_7.9.0)    | 22 Aug 2024  |
 | [7.8.0](eprs_rel_notes_7.8.0)    | 17 May 2024  |


### PR DESCRIPTION
## What Changed?

A few notes: 
- I replaced the "primary/secondary" wording with "primary/standby" to be consistent with #6504
-  I removed the mention of XDB-2328 ticket, as its an internal Jira ticket

https://enterprisedb.atlassian.net/browse/XDB-2355
https://enterprisedb.atlassian.net/browse/DOCS-1218

