### PR TITLE
Fix package name for dnf

### DIFF
--- a/advocacy_docs/pg_extensions/wait_states/installing.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/installing.mdx
@@ -35,7 +35,7 @@ To install EDB Wait States on any Linux operating system except Debian or Ubuntu
   For example, to install EDB Wait States for EDB Postgres Advanced Server 16 on a RHEL 9 platform:
 
   ```shell
-  sudo dnf -y install edb-as16-server-edb-wait-states
+  sudo dnf -y install edb-as16-server-edb_wait_states
   ```
   
 1. To launch the worker, register it in the `postgresql.conf` file using the `shared_preload_libraries` parameter. For example:


### PR DESCRIPTION
The rpm package name for edb_wait_states has underscores instead of dashes

## What Changed?

