### PR TITLE
Removed Windows Server 2019 from link

### DIFF
--- a/install_template/templates/products/edb*plus/index.njk
+++ b/install_template/templates/products/edb*plus/index.njk
@@ -20,5 +20,5 @@ redirects:
 
 {% block otherosinstall %}
 ## Windows
-- [Windows Server 2019, 2022, and Windows 11](windows)
+- [Windows Server 2022 and Windows 11](windows)
 {% endblock otherosinstall %}

--- a/product_docs/docs/edb_plus/41/installing/index.mdx
+++ b/product_docs/docs/edb_plus/41/installing/index.mdx
@@ -66,4 +66,4 @@ Select a link to access the applicable installation instructions:
 
 ## Windows
 
-- [Windows Server 2019, 2022, and Windows 11](windows)
+- [Windows Server 2022 and Windows 11](windows)


### PR DESCRIPTION
The link to the Windows installation page, listed Windows Server 2019, 2022, and Windows 11.  Removed Windows Server 2019 from the list and adjusted the rest of the link label accordingly since Windows Server 2019 went end of life over a year ago and we no longer support EDB*Plus or any of our products on it.

## What Changed?

