### PR TITLE
AI: clarify model dimensions

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/models/openai-api-compatibility.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/models/openai-api-compatibility.mdx
@@ -57,7 +57,7 @@ If the endpoint requires an API key, that would be passed in the credentials par
 
 
 !!!Note Note 
-When using indexing in pgvector, consider the [pgvector indexing limitations](https://github.com/pgvector/pgvector?tab=readme-ov-file#what-if-i-want-to-index-vectors-with-more-than-2000-dimensions). Aidb does not automatically configure an index today but if you add one manually, make sure it supports the number of dimensions you model uses.
+When using indexing in pgvector, consider the [pgvector indexing limitations](https://github.com/pgvector/pgvector?tab=readme-ov-file#what-if-i-want-to-index-vectors-with-more-than-2000-dimensions). Aidb does not automatically configure an index today but if you add one manually, make sure it supports the number of dimensions your model uses.
 
 !!!
 

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/models/openai-api-compatibility.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/models/openai-api-compatibility.mdx
@@ -22,7 +22,7 @@ The starting point for this process is creating a model. When you create a model
 select aidb.create_model(
 'my_local_ollama',
 'embeddings',
-'{"model":"llama3.1", "url":"http://llama.local:11434/v1/embeddings", "dimensions":2000}'::JSONB);
+'{"model":"llama3.2", "url":"http://llama.local:11434/v1/embeddings", "dimensions":3072}'::JSONB);
 ```
 
 ### Model name and model provider
@@ -36,10 +36,10 @@ We specify the model provider as “embeddings” which is the provider that def
 The next parameter is the configuration. This is a JSON string, which when expanded has three parameters, the model, the url and the dimensions.
 
 ```json
-'{"model":"llama3.1", "url":"http://llama.local:11434/v1/embeddings", "dimensions":2000}'::JSONB
+'{"model":"llama3.2", "url":"http://llama.local:11434/v1/embeddings", "dimensions":3072}'::JSONB
 ```
 
-In this case, we are setting the model to [“llama3.3”](https://ollama.com/library/llama3.3), a relatively new and powerful model. Remember to run `ollama run llama3.3` to pull and start the model on the server.
+In this case, we are setting the model to [“llama3.2”](https://ollama.com/library/llama3.2), a relatively new and powerful model. Remember to run `ollama run llama3.2` to pull and start the model on the server.
 
 The next json setting is the important one, overriding the endpoint that the aidb model will use.
 
@@ -49,11 +49,17 @@ The next json setting is the important one, overriding the endpoint that the aid
 
 Putting those components together we get `http://llama.local:11434/v1/embeddings` as our end point.
 
-The last JSON parameter in this example is “dimensions” which is a hint to the system about how many vector values to expect from the model. If we [look up llama3.3’s properties](https://ollama.com/library/llama3.3/blobs/4824460d29f2) we can see the `llama.embedding_length` value is 8192. The provider defaults to 1536 (with some hard-wired exceptions depending on model) but it doesn’t know about llama3.3's max. Another factor is [pgvector is limited to 2000 dimensions](https://github.com/pgvector/pgvector?tab=readme-ov-file#what-if-i-want-to-index-vectors-with-more-than-2000-dimensions). So we pass a  dimension value of 2000 in the configuration, to get the maximum dimensions available with pgvector.
+The last JSON parameter in this example is “dimensions” which is a hint to the system about how many vector values to expect from the model. If we [look up llama3.2’s properties](https://ollama.com/library/llama3.2/blobs/dde5aa3fc5ff) we can see the `llama.embedding_length` value is 3072. The provider defaults to 1536 (with some hard-wired exceptions depending on model) but it doesn’t know about llama3.2's embedding length. So in this case, we need to pass `"dimensions":3072` to configure aidb accordingly.
 
 That completes the configuration parameter.
 
 If the endpoint requires an API key, that would be passed in the credentials parameter. As this is a local model, we don’t need to pass any credentials.
+
+
+!!!Note Note 
+When using indexing in pgvector, consider the [pgvector indexing limitations](https://github.com/pgvector/pgvector?tab=readme-ov-file#what-if-i-want-to-index-vectors-with-more-than-2000-dimensions). Aidb does not automatically configure an index today but if you add one manually, make sure it supports the number of dimensions you model uses.
+
+!!!
 
 ## Using the model
 


### PR DESCRIPTION
## What Changed?

I found a mistake/ambiguity in the docs for model dimensions at https://www.enterprisedb.com/docs/edb-postgres-ai/ai-accelerator/models/openai-api-compatibility/#configuration

- this implies that the setting `"dimensions":2000` will limit how many dimensions we get from the model; which isn't the case (i.e. `So we pass a dimension value of 2000 in the configuration, to get the maximum dimensions available with pgvector.`)
- text mentions that pgvector only support 2000 dimensions but that only applies to the standard index type. We don't use indexing right now so it doesn't apply to us at all. Even with indexing, you'd have to use the "halfvec" types to get more dimensions
