### PR TITLE
Docs 1229 update PGD 5.7.0 release notes

### DIFF
--- a/product_docs/docs/pgd/5.6/index.mdx
+++ b/product_docs/docs/pgd/5.6/index.mdx
@@ -45,7 +45,7 @@ navigation:
 pdf: true
 directoryDefaults:
   version: "5.6.1"
-  displayBanner: '<b>Warning</b>: You are not reading the most recent version of this documentation.<br/>Documentation improvements are made only to the latest version.<br/>As per semantic versioning, PGD minor releases remain backward compatible and may include important bug fixes and enhancements.<br/> We recommend upgrading the latest minor release as soon as possible.<br/>If you want up-to-date information, read the <a href="/pgd/latest/">latest PGD documentation</a>.'
+  displayBanner: '<b>Warning</b>: You are not reading the most recent version of this documentation.<br/>Documentation improvements are made only to the latest version.<br/>As per semantic versioning, PGD minor releases remain backward compatible and may include important bug fixes and enhancements.<br/> We recommend upgrading the latest minor release as soon as possible.<br/>If you want up-to-date information, read the <a href="https://www.enterprisedb.com/docs/pgd/latest/">latest PGD documentation</a>.'
 ---
 
 

--- a/product_docs/docs/pgd/5.7/rel_notes/pgd_5.7.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5.7/rel_notes/pgd_5.7.0_rel_notes.mdx
@@ -11,9 +11,10 @@ EDB Postgres Distributed 5.7.0 includes a number of enhancements and bug fixes.
 
 ## Highlights
 
-- **Improved 3rd Party CDC Tool Integration**: PGD 5.7.0 now supports failover of logical slots used by CDC tools with standard plugins (such as test_decoding, pgoutput, and wal2json) within a PGD cluster. This enhancement eliminates the need for 3rd party subscribers to reseed their tables during a lead Primary change.
-- **PGD Compatibility Assessment**: Ensure a seamless migration to PGD with the new Assess command in the PGD CLI. This tool proactively reports any PostgreSQL incompatibilities—especially those affecting logical replication—so you can address them before upgrading to PGD.
-- **Upgrade PGD and Postgres with a Single Command**: Leverage the new `pgd node upgrade` command in the PGD CLI to upgrade a node to the latest versions of PGD and Postgres.
+- **Improved 3rd Party CDC Tool Integration**: PGD 5.7.0 now supports [failover of logical slots used by CDC tools](/pgd/latest/cdc-failover) with standard plugins (such as test_decoding, pgoutput, and wal2json) within a PGD cluster. This enhancement eliminates the need for 3rd party subscribers to reseed their tables during a lead Primary change.
+- **PGD Compatibility Assessment**: Ensure a seamless migration to PGD with the new [Assess](/pgd/latest/cli/command_ref/assess/) command in the PGD CLI. This tool proactively reports any PostgreSQL incompatibilities—especially those affecting logical replication—so you can address them before upgrading to PGD.
+- **Upgrade PGD and Postgres with a Single Command**: Leverage the new [`pgd node upgrade`](/pgd/latest/cli/command_ref/node/upgrade
+) command in the PGD CLI to upgrade a node to the latest versions of PGD and Postgres.
 
 ## Features
 
@@ -61,6 +62,8 @@ guarantees that every transaction is decoded and sent at least once.</p>
 <table class="table w-100"><thead><tr><th>Component</th><th>Version</th><th>Description</th><th width="10%">Addresses</th></tr></thead><tbody>
 <tr><td>BDR</td><td>5.7.0</td><td>Fixed a server panic by ensuring that catalog lookups aren't performed in a callback that gets called very late in the commit cycle.</td><td></td></tr>
 <tr><td>BDR</td><td>5.7.0</td><td>Fixed an unintentional timed wait for a synchronous logical replication that resulted in unusually high latency for some transactions.</td><td>42273</td></tr>
+<tr><td>BDR</td><td>5.7.0</td><td><details><summary>The <code>bdr.group_camo_details</code> view now only lists data nodes belonging to the CAMO group.</summary><hr/><p>The <code>bdr.group_camo_details</code> view now only lists data nodes belonging to the CAMO commit scope group. Previously, the view could include logical standby nodes.</p>
+</details></td><td>45354</td></tr>
 <tr><td>BDR</td><td>5.7.0</td><td><details><summary>Improved PostgreSQL 17 compatibility.</summary><hr/><p>Internal tables managed by autopartition that were created before the upgrade to PG17 were missing a <code>rowtype</code> entry into <code>pg_depend</code>. This issue caused errors after upgrading to PG17.</p>
 </details></td><td>44401</td></tr>
 <tr><td>BDR</td><td>5.7.0</td><td><details><summary>Fixed a bug where parting stopped responding with consensus timeout or consensus errors.</summary><hr/><p>This fix also ensures parting doesn't stop responding when any of the nodes restart when part is in progress. Origin LSNs don't show up as 0/0 in log messages.</p>

--- a/product_docs/docs/pgd/5.7/rel_notes/pgd_5.7.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5.7/rel_notes/pgd_5.7.0_rel_notes.mdx
@@ -62,7 +62,7 @@ guarantees that every transaction is decoded and sent at least once.</p>
 <table class="table w-100"><thead><tr><th>Component</th><th>Version</th><th>Description</th><th width="10%">Addresses</th></tr></thead><tbody>
 <tr><td>BDR</td><td>5.7.0</td><td>Fixed a server panic by ensuring that catalog lookups aren't performed in a callback that gets called very late in the commit cycle.</td><td></td></tr>
 <tr><td>BDR</td><td>5.7.0</td><td>Fixed an unintentional timed wait for a synchronous logical replication that resulted in unusually high latency for some transactions.</td><td>42273</td></tr>
-<tr><td>BDR</td><td>5.7.0</td><td><details><summary>The <code>bdr.group_camo_details</code> view now only lists data nodes belonging to the CAMO group.</summary><hr/><p>The <code>bdr.group_camo_details</code> view now only lists data nodes belonging to the CAMO commit scope group. Previously, the view could include logical standby nodes.</p>
+<tr><td>BDR</td><td>5.7.0</td><td><details><summary>The <code>bdr.group_camo_details</code> view now only lists data nodes belonging to the CAMO group.</summary><hr/><p>The <code>bdr.group_camo_details</code> view now only lists data nodes belonging to the CAMO commit scope group. Previously, the view could include data nodes were not part of the CAMO group, logical standby nodes, Subscriber-Only nodes and witness nodes.</p>
 </details></td><td>45354</td></tr>
 <tr><td>BDR</td><td>5.7.0</td><td><details><summary>Improved PostgreSQL 17 compatibility.</summary><hr/><p>Internal tables managed by autopartition that were created before the upgrade to PG17 were missing a <code>rowtype</code> entry into <code>pg_depend</code>. This issue caused errors after upgrading to PG17.</p>
 </details></td><td>44401</td></tr>

--- a/product_docs/docs/pgd/5.7/rel_notes/src/relnote_5.7.0.yml
+++ b/product_docs/docs/pgd/5.7/rel_notes/src/relnote_5.7.0.yml
@@ -289,7 +289,7 @@ relnotes:
 - relnote: The `bdr.group_camo_details` view now only lists data nodes belonging to the CAMO group.
   component: BDR
   details: |
-    The `bdr.group_camo_details` view now only lists data nodes belonging to the CAMO commit scope group. Previously, the view could include logical standby nodes.
+    The `bdr.group_camo_details` view now only lists data nodes belonging to the CAMO commit scope group. Previously, the view could include data nodes were not part of the CAMO group, logical standby nodes, Subscriber-Only nodes and witness nodes.
   jira: BDR-6049
   addresses: 45354
   type: Bug Fix

--- a/product_docs/docs/pgd/5.7/rel_notes/src/relnote_5.7.0.yml
+++ b/product_docs/docs/pgd/5.7/rel_notes/src/relnote_5.7.0.yml
@@ -10,9 +10,10 @@ components:
 intro: |
  EDB Postgres Distributed 5.7.0 includes a number of enhancements and bug fixes.
 highlights: |
-  - **Improved 3rd Party CDC Tool Integration**: PGD 5.7.0 now supports failover of logical slots used by CDC tools with standard plugins (such as test_decoding, pgoutput, and wal2json) within a PGD cluster. This enhancement eliminates the need for 3rd party subscribers to reseed their tables during a lead Primary change.
-  - **PGD Compatibility Assessment**: Ensure a seamless migration to PGD with the new Assess command in the PGD CLI. This tool proactively reports any PostgreSQL incompatibilities—especially those affecting logical replication—so you can address them before upgrading to PGD.
-  - **Upgrade PGD and Postgres with a Single Command**: Leverage the new `pgd node upgrade` command in the PGD CLI to upgrade a node to the latest versions of PGD and Postgres.
+  - **Improved 3rd Party CDC Tool Integration**: PGD 5.7.0 now supports [failover of logical slots used by CDC tools](/pgd/latest/cdc-failover) with standard plugins (such as test_decoding, pgoutput, and wal2json) within a PGD cluster. This enhancement eliminates the need for 3rd party subscribers to reseed their tables during a lead Primary change.
+  - **PGD Compatibility Assessment**: Ensure a seamless migration to PGD with the new [Assess](/pgd/latest/cli/command_ref/assess/) command in the PGD CLI. This tool proactively reports any PostgreSQL incompatibilities—especially those affecting logical replication—so you can address them before upgrading to PGD.
+  - **Upgrade PGD and Postgres with a Single Command**: Leverage the new [`pgd node upgrade`](/pgd/latest/cli/command_ref/node/upgrade
+  ) command in the PGD CLI to upgrade a node to the latest versions of PGD and Postgres.
 relnotes:
 - relnote: Improved performance of DML and other operations on partitioned tables.
   component: BDR
@@ -285,4 +286,11 @@ relnotes:
   addresses: ""
   type: Bug Fix
   impact: Medium
-  
+- relnote: The `bdr.group_camo_details` view now only lists data nodes belonging to the CAMO group.
+  component: BDR
+  details: |
+    The `bdr.group_camo_details` view now only lists data nodes belonging to the CAMO commit scope group. Previously, the view could include logical standby nodes.
+  jira: BDR-6049
+  addresses: 45354
+  type: Bug Fix
+  impact: High


### PR DESCRIPTION
## What Changed?

Fix up for release notes for 5.7.0, adding omitted note and including links.