### PR TITLE
add links to event tables

### DIFF
--- a/advocacy_docs/pg_extensions/wait_states/using.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/using.mdx
@@ -319,9 +319,9 @@ In addition to the common parameters described previously, each row of the outpu
 
 `sample_time` &mdash; The time when wait event data was collected.
 
-`wait_event_type` &mdash; The type of wait event on which the session is waiting.
+`wait_event_type` &mdash; The type of wait event on which the session is waiting. For more information, see [Wait Event Types](https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-TABLE) in the PostgreSQL documentation.
 
-`wait_event` &mdash; The wait event on which the session (backend) is waiting.
+`wait_event` &mdash; The wait event on which the session (backend) is waiting. For more information, see [Wait Events](https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-ACTIVITY-TABLE) in the PostgreSQL documentation. 
 
 `sampling_interval` &mdash;  The time interval at which the sample is taken.
 

--- a/advocacy_docs/pg_extensions/wait_states/using.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/using.mdx
@@ -94,9 +94,9 @@ In addition to the common parameters described previously, each row of the outpu
 
 `sample_time` &mdash; The time when wait event data was collected.
 
-`wait_event_type` &mdash; The type of wait event the session (backend) is waiting on.
+`wait_event_type` &mdash; The type of wait event the session (backend) is waiting on. For more information, see [Wait Event Types](https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-TABLE) in the PostgreSQL documentation.
 
-`wait_event` &mdash; The wait event the session (backend) is waiting on.
+`wait_event` &mdash; The wait event the session (backend) is waiting on. For more information, see [Wait Events](https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-ACTIVITY-TABLE) in the PostgreSQL documentation.
 
 ### Example
 
@@ -513,7 +513,7 @@ In addition to the common parameters described previously, each row of the outpu
 
 `waitevent` &mdash; The name of the wait event.
 
-`wait_event_type` &mdash; The type of wait event.
+`wait_event_type` &mdash; The type of wait event. For more information, see [Wait Event Types](https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-TABLE) in the PostgreSQL documentation.
 
 `waittime` &mdash; The approximate wait time of this wait event (in seconds) based on the number of samples and the sampling interval from `edb_wait_states_samples`.
 


### PR DESCRIPTION
EDB wait states - add links to wait event tables in PG docs.

