### PR TITLE
PGD4K adhoc - Data Migration update

### DIFF
--- a/product_docs/docs/postgres_distributed_for_kubernetes/1/known_issues.mdx
+++ b/product_docs/docs/postgres_distributed_for_kubernetes/1/known_issues.mdx
@@ -11,7 +11,8 @@ This version of EDB Postgres Distributed for Kubernetes **doesn't support** majo
 
 ## Data migration
 
-This version of EDB Postgres Distributed for Kubernetes **doesn't support** migrating from existing Postgres databases.
+This version of EDB Postgres Distributed for Kubernetes does not support declarative import of data from other Postgres database. 
+To migrate schemas and data, you can use `pg_dump ...` on the source database and pipe the command's output to your target database with `psql -c`.
 
 ## Connectivity with PgBouncer
 

--- a/product_docs/docs/postgres_distributed_for_kubernetes/1/known_issues.mdx
+++ b/product_docs/docs/postgres_distributed_for_kubernetes/1/known_issues.mdx
@@ -12,7 +12,8 @@ This version of EDB Postgres Distributed for Kubernetes **doesn't support** majo
 ## Data migration
 
 This version of EDB Postgres Distributed for Kubernetes does not support declarative import of data from other Postgres database. 
-To migrate schemas and data, you can use `pg_dump ...` on the source database and pipe the command's output to your target database with `psql -c`.
+To migrate schemas and data, you can use traditional Postgres Migration tools such as [EDB*Loader](https://www.enterprisedb.com/docs/pgd/latest/data_migration/edbloader/) or MTK/xDB. 
+You can also use `pg_dump ...` on the source database and pipe the command's output to your target database with `psql -c`.
 
 ## Connectivity with PgBouncer
 


### PR DESCRIPTION
## What Changed?

Clarified the intent of the limitation on data migration (i.e. no declarative data migration managed by the operator) and made it clear that traditional transfers work.
