### PR TITLE
Sequence range in node2

### DIFF
--- a/product_docs/docs/pgd/5.7/sequences.mdx
+++ b/product_docs/docs/pgd/5.7/sequences.mdx
@@ -353,7 +353,7 @@ SELECT last_value AS range_start, log_cnt AS range_end
 (1 row)
 ```
 
-* Node `Node2` is using range from `2000004` to `4000003`.
+* Node `Node2` is using range from `2000334` to `4000333`.
 
 ```sql
 SELECT last_value AS range_start, log_cnt AS range_end


### PR DESCRIPTION
There is a typo in the range used for NODE2. 

## What Changed?
The correct value should be the one in the example that is coming in the next paragraph (as fixed here):

"Node Node2 is using range from 2000334 to 4000333."