### PR TITLE
Remove references to text-embedding-3-large

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/models/supported-models/embeddings.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/models/supported-models/embeddings.mdx
@@ -32,7 +32,7 @@ Based on the name of the model, the model provider sets defaults accordingly:
 
 ### Supported OpenAI models
 
-* Any text-embedding model that's supported by OpenAI. This includes `text-embedding-3-small`, `text-embedding-3-large`, and `text-embedding-ada-002`. See a list of supported OpenAI models [here](https://platform.openai.com/docs/guides/embeddings#embedding-models).
+* Any text-embedding model that's supported by OpenAI. This includes `text-embedding-3-small`, and `text-embedding-ada-002`. See a list of supported OpenAI models [here](https://platform.openai.com/docs/guides/embeddings#embedding-models).
 * The default is `text-embedding-3-small`.
 
 ### Supported NIM models
@@ -51,13 +51,13 @@ As this example is defaulting the model to `text-embedding-3-small`, you don't n
 
 ## Creating a specific model
 
-You can create any supported OpenAI embedding model using the `aidb.create_model` function. This example creates a `text-embedding-3-large` model with the name `my_openai_model`:
+You can create any supported OpenAI embedding model using the `aidb.create_model` function. This example creates a `text-embedding-3-small` model with the name `my_openai_model`:
 
 ```sql
 SELECT aidb.create_model(
   'my_openai_model',
   'openai_embeddings',
-  '{"model": "text-embedding-3-large"}'::JSONB,
+  '{"model": "text-embedding-3-small"}'::JSONB,
   '{"api_key": "sk-abc123xyz456def789ghi012jkl345mn"}'::JSONB 
 );
 ```

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/models/using-models.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/models/using-models.mdx
@@ -111,12 +111,12 @@ Creating the OpenAI embeddings model is similar to creating the completions mode
 SELECT aidb.create_model(
   'my_openai_embeddings',
   'openai_embeddings',
-  '{"model": "text-embedding-3-large"}'::JSONB,
+  '{"model": "text-embedding-3-small"}'::JSONB,
   '{"api_key": "sk-abc123xyz456def789ghi012jkl345mn"}'::JSONB
   );
 ```
 
-This command creates the `text-embedding-3-large` model with the name `my_openai_embeddings`. You can then use this model in your Pipelines functions to generate embeddings for text data.
+This command creates the `text-embedding-3-small` model with the name `my_openai_embeddings`. You can then use this model in your Pipelines functions to generate embeddings for text data.
 
 Where models do use credentials, the credentials set in the first use of `create_model` for the model provider are used with all subsequent uses of that model. You can't use different credentials for different models that use the same provider.
 


### PR DESCRIPTION
## What Changed?

- Removes references to unsupported text-embedding-3-large model.