### PR TITLE
chore(ET-1872): add config_writer.mdx

### DIFF
--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_writer.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/getting_started/config_writer.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Configuring and running the EDB DMS Reader"
+title: "Configuring and running the EDB DMS Writer"
 deepToC: true
 redirects:
-  - /purl/dms/configure_source
+  - /purl/dms/configure_target
 ---
 
 ## Getting credentials
@@ -15,37 +15,31 @@ redirects:
 
 1.  Select **Create Migration Credential** > **Download Credential**.
 
-1.  Unzip the credentials folder and copy it to the host where the reader is installed.
+1.  Unzip the credentials folder and copy it to the host where the writer is installed.
 
-## Configuring the reader
+## Configuring the writer
 
-1.  Open the EDB DMS reader located in `/opt/cdcreader/run-cdcreader.sh` and ensure you have write permissions.
+1.  Open the EDB DMS writer located in `/opt/cdcwriter/run-cdcwriter.sh` and ensure you have write permissions.
 
 1.  Set the variables according to your environment and uncomment the edited lines. See [parameters](#parameters) for further guidance. The script is reproduced below.
 
 ```shell
 #!/bin/bash -e
-# run_cdcreader.sh
-#
-# This script provides a convenient place to specify
-# environment variables used to configure the
-# EDB Data Migration Service Reader.
-#
-# After env exports, `java` is called to start the
-# software.
+
+### set the following environment variables:
 
 ##########################################
-# DMS Reader General Configuration       #
+# Transporter Cloud Configuration        #
 ##########################################
 
-# This ID is used to identify DMS Reader
+# This ID is used to identify DMS Writer
 # and is specified by the user.
-#export DBZ_ID=
+#export DBCONFIG_ID=
 
 # Supported options include: appliance (the hybrid PG AI platform), aws
 #export CLOUD_PROVIDER=
 
-# This is the DMS backend service used by the Reader
+# This is the DMS backend service used by the Writer
 # If your CLOUD_PROVIDER is `appliance`, consult your system administrators
 # The default value supports the `aws` CLOUD_PROVIDER
 #export RW_SERVICE_HOST=https://transporter-rw-service.biganimal.com
@@ -61,34 +55,22 @@ redirects:
 #export KAFKASECURITY_TRUSTSTORE_LOCATION=$HOME/credentials/int.truststore.p12
 
 ##########################################
-# DMS Reader Source DB Configuration     #
+# DMS Writer Target DB Configuration    #
 ##########################################
 
 # A sample configuration to create a single postgres database connection:
-#export DBZ_DATABASES_0__TYPE=POSTGRES
-#export DBZ_DATABASES_0__HOSTNAME=localhost
-#export DBZ_DATABASES_0__PORT=5432
+#export DBCONFIG_DATABASES_0__TYPE=POSTGRES
+#export DBCONFIG_DATABASES_0__HOSTNAME=localhost
+#export DBCONFIG_DATABASES_0__PORT=5332
 # The CATALOG is the database name
-#export DBZ_DATABASES_0__CATALOG=source
-#export DBZ_DATABASES_0__USERNAME=postgres
+#export DBCONFIG_DATABASES_0__CATALOG=target
+#export DBCONFIG_DATABASES_0__USERNAME=postgres
 # The password env can be set without specifying it here
 # but the env structure looks like this
-#export DBZ_DATABASES_0__PASSWORD=password
-
-# You can increase the index to configure more than
-# one database for the DMS Reader
-#export DBZ_DATABASES_1__TYPE=ORACLE
-#export DBZ_DATABASES_1__HOSTNAME=localhost
-#export DBZ_DATABASES_1__PORT=1521
-# The CATALOG is the database name
-#export DBZ_DATABASES_1__CATALOG=ORCLCDB/ORCLPDB1
-#export DBZ_DATABASES_1__USERNAME=oracle
-# The password env can be set without specifing it here
-# but the env structure looks like this
-#export DBZ_DATABASES_1__PASSWORD=password
+#export DBCONFIG_DATABASES_0__PASSWORD=password
 
 ##############################################################################
-# DMS Reader object storage config, only necessary for the HCP       #
+# DMS Writer Object storage config, only necessary for appliance/local       #
 ##############################################################################
 #export AWS_ACCESS_KEY_ID=
 #export AWS_SECRET_ACCESS_KEY=
@@ -97,8 +79,9 @@ redirects:
 #export AWS_ENDPOINT_URL_S3=
 #export BUCKET_NAME=
 
+
 ##########################################
-# Optional Parameters Below              #
+# Optional parameters below              #
 ##########################################
 
 # Configure logging
@@ -107,21 +90,21 @@ redirects:
 # Loglevel for a single package
 #export QUARKUS_LOG_CATEGORY__COM_ENTERPRISEDB__LEVEL=DEBUG
 
-cd $(dirname $0)
-java ${JAVA_OPTS} -jar quarkus-run.jar
+cd $(dirname "$0")
+java "${JAVA_OPTS}" -jar quarkus-run.jar
 ```
 
 ## Parameters
 
-### `DBZ_ID`
+### `DBCONFIG_ID`
 
-This is the name you assign to identify a source. This name will later appear as a _source_ in the **Migrate** > **Sources** section of the EDB Postgres AI Console.
+This is the name you assign to identify a destination. This name will later appear as a _destination_ in the **Migrate** > **Destinations** section of the EDB Postgres AI Console.
 
 Consider the following ID guidelines:
 
 - The maximum character length for the ID is 255 characters.
 - You can use lowercase and uppercase characters, numbers, underscores(_) and hyphens(-) for the ID. Other special characters are not supported.
-- The ID must be unique. The source instances cannot have the same ID.
+- The ID must be unique. The target instances cannot have the same ID.
 
 ### `RW_SERVICE_HOST`
 
@@ -131,13 +114,13 @@ Specifies the URL of the service that will host the migration. `transporter-rw-s
 
 Directory path to the `client-key.pem` private key you downloaded from the EDB Postgres AI Console.
 
-The HTTP client of the EDB DMS Reader uses it to perform mTLS authentication with the `transporter-rw-service`.
+The HTTP client of the EDB DMS writer uses it to perform mTLS authentication with the `transporter-rw-service`.
 
 ### `TLS_CERTIFICATE_PATH`
 
 Directory path to the X509 `client-cert.pem` certificate you downloaded from the EDB Postgres AI Console.
 
-The HTTP client of the EDB DMS Reader uses it to perform mTLS authentication with the `transporter-rw-service`.
+The HTTP client of the EDB DMS writer uses it to perform mTLS authentication with the `transporter-rw-service`.
 
 ### `TLS_CA_PATH`
 
@@ -186,48 +169,48 @@ This setting is not required if you are using AWS S3 or S3-compatible storage wi
 ### `BUCKET_NAME`
 Specify the name of the bucket you want to use for the migration. The bucket must be created before starting the migration.
 
-### `DBZ_DATABASES`
+### `DBCONFIG_DATABASES`
 
-This is a list of source database information you require for the EDB DMS Reader be able to read the correct source database information for the migration.
+This is a list of target database information you require for the EDB DMS writer be able to read the correct target database information for the migration.
 
-You can configure the EDB DMS Reader to migrate multiple databases. The `DBZ_DATABASES_0__TYPE` section delimits the information for the first database. You can use `DBZ_DATABASES_1__TYPE` to provide data for a second database. Add more sections to the EDB DMS Reader (`DBZ_DATABASES_2__TYPE`, `DBZ_DATABASES_3__TYPE`) by increasing the index manually.
+You can configure the EDB DMS writer to migrate multiple databases. The `DBCONFIG_DATABASES_0__TYPE` section delimits the information for the first database. You can use `DBCONFIG_DATABASES_1__TYPE` to provide data for a second database. Add more sections to the EDB DMS writer (`DBCONFIG_DATABASES_2__TYPE`, `DBCONFIG_DATABASES_3__TYPE`) by increasing the index manually.
 
-#### `DBZ_DATABASES_0__TYPE`
+#### `DBCONFIG_DATABASES_0__TYPE`
 
-This is the source database type. EDB DMS reader supports `ORACLE` and `POSTGRES`.
+This is the target database type. EDB DMS writer supports `POSTGRES`.
 
-#### `DBZ_DATABASES_0__HOSTNAME`
+#### `DBCONFIG_DATABASES_0__HOSTNAME`
 
-The hostname of the source database.
+The hostname of the target database.
 
-#### `DBZ_DATABASES_0__PORT`
+#### `DBCONFIG_DATABASES_0__PORT`
 
-The port of the source database.
+The port of the target database.
 
-#### `DBZ_DATABASES_0__CATALOG`
+#### `DBCONFIG_DATABASES_0__CATALOG`
 
-The database name in the source database server.
+The database name in the target database server.
 
-#### `DBZ_DATABASES_0__USERNAME`
+#### `DBCONFIG_DATABASES_0__USERNAME`
 
-The database username of the source database.
+The database username of the target database.
 
-#### `DBZ_DATABASES_0__PASSWORD`
+#### `DBCONFIG_DATABASES_0__PASSWORD`
 
-The password for the database username of the source database.
+The password for the database username of the target database.
 
 
-## Running the EDB DMS Reader
+## Running the EDB DMS Writer
 
 1.  Start the migration:
 
     ```shell
-    cd /opt/cdcreader
-    ./run-cdcreader.sh
+    cd /opt/cdcwriter
+    ./run-cdcwriter.sh
     ```
 
-1.  Go to the [EDB Postgres AI Console](https://portal.biganimal.com), and verify that a source with the `DBZ_ID` name is displayed in **Migrate** > **Sources**.
+1.  Go to the [EDB Postgres AI Console](https://portal.biganimal.com), and verify that a destination with the `DBCONFIG_ID` name is displayed in **Migrate** > **Destinations**.
 
-You can select this source for your [migration](create_migration).
+You can select this destination for your [migration](create_migration).
 
 


### PR DESCRIPTION
## What Changed?

Transporter supports a new feature to support migrating to an external target database(DB is not deployed in the HCP)

This feature needs the user to config the transporter-writer. So we need this new document.

Configuring the writer is similar to reader. There are some configuration name differences I need to change.