### PR TITLE
Production release: 2025-03-11a

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/models/supported-models/embeddings.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/models/supported-models/embeddings.mdx
@@ -32,7 +32,7 @@ Based on the name of the model, the model provider sets defaults accordingly:
 
 ### Supported OpenAI models
 
-* Any text-embedding model that's supported by OpenAI. This includes `text-embedding-3-small`, `text-embedding-3-large`, and `text-embedding-ada-002`. See a list of supported OpenAI models [here](https://platform.openai.com/docs/guides/embeddings#embedding-models).
+* Any text-embedding model that's supported by OpenAI. This includes `text-embedding-3-small`, and `text-embedding-ada-002`. See a list of supported OpenAI models [here](https://platform.openai.com/docs/guides/embeddings#embedding-models).
 * The default is `text-embedding-3-small`.
 
 ### Supported NIM models
@@ -51,13 +51,13 @@ As this example is defaulting the model to `text-embedding-3-small`, you don't n
 
 ## Creating a specific model
 
-You can create any supported OpenAI embedding model using the `aidb.create_model` function. This example creates a `text-embedding-3-large` model with the name `my_openai_model`:
+You can create any supported OpenAI embedding model using the `aidb.create_model` function. This example creates a `text-embedding-3-small` model with the name `my_openai_model`:
 
 ```sql
 SELECT aidb.create_model(
   'my_openai_model',
   'openai_embeddings',
-  '{"model": "text-embedding-3-large"}'::JSONB,
+  '{"model": "text-embedding-3-small"}'::JSONB,
   '{"api_key": "sk-abc123xyz456def789ghi012jkl345mn"}'::JSONB 
 );
 ```

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/models/using-models.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/models/using-models.mdx
@@ -111,12 +111,12 @@ Creating the OpenAI embeddings model is similar to creating the completions mode
 SELECT aidb.create_model(
   'my_openai_embeddings',
   'openai_embeddings',
-  '{"model": "text-embedding-3-large"}'::JSONB,
+  '{"model": "text-embedding-3-small"}'::JSONB,
   '{"api_key": "sk-abc123xyz456def789ghi012jkl345mn"}'::JSONB
   );
 ```
 
-This command creates the `text-embedding-3-large` model with the name `my_openai_embeddings`. You can then use this model in your Pipelines functions to generate embeddings for text data.
+This command creates the `text-embedding-3-small` model with the name `my_openai_embeddings`. You can then use this model in your Pipelines functions to generate embeddings for text data.
 
 Where models do use credentials, the credentials set in the first use of `create_model` for the model provider are used with all subsequent uses of that model. You can't use different credentials for different models that use the same provider.
 

--- a/product_docs/docs/epas/13/epas_compat_reference/02_the_sql_language/03_functions_and_operators/07_data_type_formatting_functions.mdx
+++ b/product_docs/docs/epas/13/epas_compat_reference/02_the_sql_language/03_functions_and_operators/07_data_type_formatting_functions.mdx
@@ -11,9 +11,10 @@ legacyRedirectsGenerated:
 The Advanced Server formatting functions described in the following table provide a powerful set of tools for converting various data types (date/time, integer, floating point, numeric) to formatted strings and for converting from formatted strings to specific data types. These functions all follow a common calling convention: the first argument is the value to be formatted and the second argument is a string template that defines the output or input format.
 
 | Function                            | Return Type   | Description                                                                                    | Example                                                                                                    | Result                                                |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `TO_CHAR(DATE [, format ])`         | `VARCHAR2`    | Convert a date/time to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR(SYSDATE, 'MM/DD/YYYY HH12:MI:SS AM')`                                                             | `07/25/2007 09:43:02 AM`                              |
-| `TO_CHAR(TIMESTAMP [, format ])`    | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (CURRENT_TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                                  | `08/13/2015 08:55:22 PM`                              |
+|-------------------------------------|---------------|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `TO_CHAR(DATE [, format ])`         | `VARCHAR2`    | Convert a date/time to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (SYSDATE::PG_CATALOG.DATE, 'MM/DD/YYYY')`                                                         | `07/25/2007`                                          |
+| `TO_CHAR(TIMESTAMP [, format ])`    | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                       | `08/13/2015 08:55:22 PM`                              |
+| `TO_CHAR(TIMESTAMPTZ [, format])`   | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMPTZ, 'MM/DD/YYYY HH12:MI:SS AM TZ')`                                  | `03/11/2025 09:40:27 AM IST`                          |
 | `TO_CHAR(INTEGER [, format ])`      | `VARCHAR2`    | Convert an integer to a string with output, `format`                                           | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
 | `TO_CHAR(NUMBER [, format ])`       | `VARCHAR2`    | Convert a decimal number to a string with output, `format`                                     | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
 | `TO_CHAR(DOUBLE PRECISION, format)` | `VARCHAR2`    | Convert a floating-point number to a string with output, `format`                              | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
@@ -22,29 +23,67 @@ The Advanced Server formatting functions described in the following table provid
 | `TO_TIMESTAMP(string, format)`      | `TIMESTAMPTZ` | Convert a timestamp formatted string to a `TIMESTAMPTZ` data type                              | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
 | `TO_TIMESTAMP_TZ(string, format)`   | `TIMESTAMPTZ` | Convert a timestamp formatted string to a `TIMESTAMPTZ` data type                              | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
 
+!!!note
+The `TO_CHAR(TIMESTAMPTZ)` function is now Oracle compatible and not PostgreSQL compatible. As a result, you may observe some differences in functionality compared to the earlier version. 
+!!!
+
 ## TO_CHAR, TO_DATE, TO_TIMESTAMP, and TO_TIMESTAMP_TZ
 
 In an output template string (for `TO_CHAR`), there are certain patterns that are recognized and replaced with appropriately-formatted data from the value to be formatted. Any text that is not a template pattern is simply copied verbatim. Similarly, in an input template string (for anything but `TO_CHAR`), template patterns identify the parts of the input data string to be looked at and the values to be found there.
 
 If you do not specify a date, month, or year when calling `TO_TIMESTAMP`, `TO_TIMESTAMP_TZ` or `TO_DATE`, then by default the output format considers the first date of a current month or current year respectively. In the following example, date, month, and year is not specified in the input string; `TO_TIMESTAMP`, `TO_TIMESTAMP_TZ`, and `TO_DATE` returns a default value of the first date of a current month and current year.
 
-```text
+```sql
 edb=# select to_timestamp('12', 'HH');
+__OUTPUT__
       to_timestamp
 ---------------------------
  01-MAY-20 12:00:00 +05:30
 (1 row)
+```
 
+```sql
 edb=# select to_timestamp_tz('12', 'HH');
+__OUTPUT__
       to_timestamp_tz
 ---------------------------
  01-MAY-20 12:00:00 +05:30
 (1 row)
+```
 
+```sql
 edb=# select to_date('12', 'HH');
+__OUTPUT__
       to_date
 --------------------
  01-MAY-20 12:00:00
+(1 row)
+```
+
+```sql
+edb=# select to_char(sysdate, 'MISP');
+__OUTPUT__
+ to_char 
+---------
+ sixteen
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'HH24SP') from dual;
+__OUTPUT__
+ to_char 
+---------
+ twelve
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'MM-DD-YYYY HH24:MM:SS TZ') from dual;
+__OUTPUT__
+         to_char         
+-------------------------
+ 01-30-2020 17:01:14 IST
 (1 row)
 ```
 

--- a/product_docs/docs/epas/14/epas_compat_reference/02_the_sql_language/03_functions_and_operators/07_data_type_formatting_functions.mdx
+++ b/product_docs/docs/epas/14/epas_compat_reference/02_the_sql_language/03_functions_and_operators/07_data_type_formatting_functions.mdx
@@ -12,16 +12,21 @@ legacyRedirectsGenerated:
 The EDB Postgres Advanced Server formatting functions provide a powerful set of tools for converting various data types (date/time, integer, floating point, numeric) to formatted strings and for converting from formatted strings to specific data types. These functions all follow a common calling convention: the first argument is the value to format and the second argument is a string template that defines the output or input format.
 
 | Function                            | Return type   | Description                                                                                    | Example                                                                                                    | Result                                                |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `TO_CHAR(DATE [, format ])`         | `VARCHAR2`    | Convert a date/time to a string with output `format`. If omitted default format is DD-MON-YY. | `TO_CHAR(SYSDATE, 'MM/DD/YYYY HH12:MI:SS AM')`                                                             | `07/25/2007 09:43:02 AM`                              |
-| `TO_CHAR(TIMESTAMP [, format ])`    | `VARCHAR2`    | Convert a timestamp to a string with output `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (CURRENT_TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                                  | `08/13/2015 08:55:22 PM`                              |
-| `TO_CHAR(INTEGER [, format ])`      | `VARCHAR2`    | Convert an integer to a string with output `format`.                                           | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
-| `TO_CHAR(NUMBER [, format ])`       | `VARCHAR2`    | Convert a decimal number to a string with output `format`.                                     | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
-| `TO_CHAR(DOUBLE PRECISION, format)` | `VARCHAR2`    | Convert a floating-point number to a string with output `format`.                              | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
+|-------------------------------------|---------------|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `TO_CHAR(DATE [, format ])`         | `VARCHAR2`    | Convert a date/time to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (SYSDATE::PG_CATALOG.DATE, 'MM/DD/YYYY')`                                                         | `07/25/2007`                                          |
+| `TO_CHAR(TIMESTAMP [, format ])`    | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                       | `08/13/2015 08:55:22 PM`                              |
+| `TO_CHAR(TIMESTAMPTZ [, format])`   | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY. | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMPTZ, 'MM/DD/YYYY HH12:MI:SS AM TZ')`                                  | `03/11/2025 09:40:27 AM IST`                          |
+| `TO_CHAR(INTEGER [, format ])`      | `VARCHAR2`    | Convert an integer to a string with output, `format`.                                          | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
+| `TO_CHAR(NUMBER [, format ])`       | `VARCHAR2`    | Convert a decimal number to a string with output, `format`.                                    | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
+| `TO_CHAR(DOUBLE PRECISION, format)` | `VARCHAR2`    | Convert a floating-point number to a string with output, `format`.                             | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
 | `TO_DATE(string [, format ])`       | `TIMESTAMP`   | Convert a date or timestamp formatted string to a `TIMESTAMP` data type.                       | `TO_DATE('2007-07-04 13:39:10', 'YYYY-MM-DD HH24:MI:SS')` <br /><br />`TO_DATE('2007-07-04','YYYY-MM-DD')` | `04-JUL-07 13:39:10` <br /><br />`04-JUL-07 00:00:00` |
-| `TO_NUMBER(string [, format ])`     | `NUMBER`      | Convert a number formatted string to a `NUMBER` data type.                                      | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
-| `TO_TIMESTAMP(string, format)`      | `TIMESTAMPTZ` | Convert a timestamp formatted string to a `TIMESTAMPTZ` data type.                              | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
-| `TO_TIMESTAMP_TZ(string, format)`   | `TIMESTAMPTZ` | Convert a timestamp formatted string to a `TIMESTAMPTZ` data type.                              | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
+| `TO_NUMBER(string [, format ])`     | `NUMBER`      | Convert a number formatted string to a `NUMBER` data type.                                     | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
+| `TO_TIMESTAMP(string, format)`      | `TIMESTAMPTZ` | Convert a timestamp formatted string to a `TIMESTAMPTZ` data type.                             | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
+| `TO_TIMESTAMP_TZ(string, format)`   | `TIMESTAMPTZ` | Convert a timestamp formatted string to a `TIMESTAMPTZ` data type.                             | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
+
+!!!note
+The `TO_CHAR(TIMESTAMPTZ)` function is Oracle compatible and not PostgreSQL compatible from version 13 onwards. As a result, you may observe some differences in functionality compared to the earlier version. 
+!!!
 
 ## TO_CHAR, TO_DATE, TO_TIMESTAMP, and TO_TIMESTAMP_TZ
 
@@ -29,23 +34,48 @@ In an output template string (for `TO_CHAR`), certain patterns are recognized an
 
 If you don't specify a date, month, or year when calling `TO_TIMESTAMP`, `TO_TIMESTAMP_TZ`, or `TO_DATE`, then by default the output format considers the first date of a current month or current year. In the following example, date, month, and year isn't specified in the input string. `TO_TIMESTAMP`, `TO_TIMESTAMP_TZ`, and `TO_DATE` returns a default value of the first date of a current month and current year.
 
-```text
+```sql
 edb=# select to_timestamp('12', 'HH');
+__OUTPUT__
       to_timestamp
 ---------------------------
  01-MAY-20 12:00:00 +05:30
 (1 row)
+```
 
+```sql
 edb=# select to_timestamp_tz('12', 'HH');
+__OUTPUT__
       to_timestamp_tz
 ---------------------------
  01-MAY-20 12:00:00 +05:30
 (1 row)
+```
 
+```sql
 edb=# select to_date('12', 'HH');
+__OUTPUT__
       to_date
 --------------------
  01-MAY-20 12:00:00
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'HH24SP') from dual;
+__OUTPUT__
+ to_char 
+---------
+ twelve
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'MM-DD-YYYY HH24:MM:SS TZ') from dual;
+__OUTPUT__
+         to_char         
+-------------------------
+ 01-30-2020 17:01:14 IST
 (1 row)
 ```
 

--- a/product_docs/docs/epas/15/reference/sql_reference/03_functions_and_operators/07_data_type_formatting_functions.mdx
+++ b/product_docs/docs/epas/15/reference/sql_reference/03_functions_and_operators/07_data_type_formatting_functions.mdx
@@ -14,48 +14,55 @@ The EDB Postgres Advanced Server formatting functions provide a powerful set of 
 
 ## Overview of data type formatting functions
 
-| Function                            | Return type   | Description                                                                                    | Example                                                                                                    | Result                                                |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `TO_BLOB(raw)`                      | `BLOB`        | Convert a `RAW` value to `BLOB` value.                                                         | `TO_BLOB('abc')`                                                                                           | `\x616263`                                            |
-| `TO_CLOB(string)`                   | `CLOB`        | Convert a `CHAR`, `VARCHAR`, `VARCHAR2`, `NCHAR`, `NVARCHAR2`, or `CLOB` values to `CLOB` values. | `TO_CLOB('aaaa')`                                                                                       | `aaaa`                                                |
-| `TO_CHAR(DATE [, format ])`         | `VARCHAR2`    | Convert a date/time to a string with output, `format`. The default format is DD-MON-YY.        | `TO_CHAR(SYSDATE, 'MM/DD/YYYY HH12:MI:SS AM')`                                                             | `07/25/2007 09:43:02 AM`                              |
-| `TO_CHAR(TIMESTAMP [, format ])`    | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. The default format is DD-MON-YY.        | `TO_CHAR (CURRENT_TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                                  | `08/13/2015 08:55:22 PM`                              |
-| `TO_CHAR(INTEGER [, format ])`      | `VARCHAR2`    | Convert an integer to a string with output, `format`                                           | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
-| `TO_CHAR(NUMBER [, format ])`       | `VARCHAR2`    | Convert a decimal number to a string with output, `format`                                     | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
-| `TO_CHAR(DOUBLE PRECISION, format)` | `VARCHAR2`    | Convert a floating-point number to a string with output, `format`                              | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
-| `TO_DATE(string [, format ])`       | `TIMESTAMP`   | Convert a date or timestamp formatted string to a `TIMESTAMP` data type                        | `TO_DATE('2007-07-04 13:39:10', 'YYYY-MM-DD HH24:MI:SS')` <br /><br />`TO_DATE('2007-07-04','YYYY-MM-DD')` | `04-JUL-07 13:39:10` <br /><br />`04-JUL-07 00:00:00` |
-| `TO_DSINTERVAL(string)`             | `INTERVAL DAY TO SECOND` | Convert a character string of `CHAR`, `VARCHAR2`, `NCHAR`, or `NVARCHAR2` datatype to an INTERVAL DAY TO SECOND type. | `TO_DSINTERVAL('80 13:30:00')`                                           | `80 days 13:30:00`                                    |
-| `TO_NCHAR(string)`                  | `NVARCHAR2`   | Convert a `character string`, `CHAR`, `VARCHAR2`, `CLOB`, or `NCLOB` value to the national character set. | `TO_NCHAR('test')`                                                                              | `test`                                                | 
-| `TO_NCHAR(number [, format])`       | `NVARCHAR2`   | Convert a number formatted string to a national character data type.                           | `TO_NCHAR(7654321, 'C9G999G999D99')`                                                                       | `7,654,321.00`                                        |
-| `TO_NCHAR(DATE  [, format ])`       | `NVARCHAR2`   | Convert a date/time to a formatted string of national character data type.                     | `TO_NCHAR(timestamp '2022-04-20 17:31:12.66', 'Day: MONTH DD, YYYY')`                                      | `Wednesday: APRIL     20, 2022`                       |
-| `TO_NUMBER(string [, format ])`     | `NUMBER`      | Convert a number formatted string to a `NUMBER` data type.                                      | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
-| `TO_TIMESTAMP(string, format)`      | `TIMESTAMPTZ` | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                   | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
-| `TO_TIMESTAMP_TZ(string, format)`   | `TIMESTAMPTZ` | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                   | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
-| `FROM_TZ(timestamp_value, timezone_value)` | `TIMESTAMPTZ` | Convert a timestamp value and a timezone to a TIMESTAMP WITH TIME ZONE value.            | `FROM_TZ(TIMESTAMP '2017-08-08 08:09:10', 'Asia/Kolkata')`                                                 | `08-AUG-17 08:09:10 +05:30`                           |
+| Function                                   | Return type              | Description                                                                                                           | Example                                                                                                    | Result                                                |
+|--------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `TO_BLOB(raw)`                             | `BLOB`                   | Convert a `RAW` value to `BLOB` value.                                                                                | `TO_BLOB('abc')`                                                                                           | `\x616263`                                            |
+| `TO_CLOB(string)`                          | `CLOB`                   | Convert a `CHAR`, `VARCHAR`, `VARCHAR2`, `NCHAR`, `NVARCHAR2`, or `CLOB` values to `CLOB` values.                     | `TO_CLOB('aaaa')`                                                                                          | `aaaa`                                                |
+| `TO_CHAR(DATE [, format ])`                | `VARCHAR2`               | Convert a date/time to a string with output, `format`. The default format is DD-MON-YY.                               | `TO_CHAR (SYSDATE::PG_CATALOG.DATE, 'MM/DD/YYYY')`                                                         | `07/25/2007`                                          |
+| `TO_CHAR(TIMESTAMP [, format ])`           | `VARCHAR2`               | Convert a timestamp to a string with output, `format`. The default format is DD-MON-YY.                               | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                       | `08/13/2015 08:55:22 PM`                              |
+| `TO_CHAR(TIMESTAMPTZ [, format])`          | `VARCHAR2`               | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY.                        | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMPTZ, 'MM/DD/YYYY HH12:MI:SS AM TZ')`                                  | `03/11/2025 09:40:27 AM IST`                          |
+| `TO_CHAR(INTEGER [, format ])`             | `VARCHAR2`               | Convert an integer to a string with output, `format`                                                                  | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
+| `TO_CHAR(NUMBER [, format ])`              | `VARCHAR2`               | Convert a decimal number to a string with output, `format`                                                            | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
+| `TO_CHAR(DOUBLE PRECISION, format)`        | `VARCHAR2`               | Convert a floating-point number to a string with output, `format`                                                     | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
+| `TO_DATE(string [, format ])`              | `TIMESTAMP`              | Convert a date or timestamp formatted string to a `TIMESTAMP` data type                                               | `TO_DATE('2007-07-04 13:39:10', 'YYYY-MM-DD HH24:MI:SS')` <br /><br />`TO_DATE('2007-07-04','YYYY-MM-DD')` | `04-JUL-07 13:39:10` <br /><br />`04-JUL-07 00:00:00` |
+| `TO_DSINTERVAL(string)`                    | `INTERVAL DAY TO SECOND` | Convert a character string of `CHAR`, `VARCHAR2`, `NCHAR`, or `NVARCHAR2` datatype to an INTERVAL DAY TO SECOND type. | `TO_DSINTERVAL('80 13:30:00')`                                                                             | `80 days 13:30:00`                                    |
+| `TO_NCHAR(string)`                         | `NVARCHAR2`              | Convert a `character string`, `CHAR`, `VARCHAR2`, `CLOB`, or `NCLOB` value to the national character set.             | `TO_NCHAR('test')`                                                                                         | `test`                                                |
+| `TO_NCHAR(number [, format])`              | `NVARCHAR2`              | Convert a number formatted string to a national character data type.                                                  | `TO_NCHAR(7654321, 'C9G999G999D99')`                                                                       | `7,654,321.00`                                        |
+| `TO_NCHAR(DATE  [, format ])`              | `NVARCHAR2`              | Convert a date/time to a formatted string of national character data type.                                            | `TO_NCHAR(timestamp '2022-04-20 17:31:12.66', 'Day: MONTH DD, YYYY')`                                      | `Wednesday: APRIL     20, 2022`                       |
+| `TO_NUMBER(string [, format ])`            | `NUMBER`                 | Convert a number formatted string to a `NUMBER` data type.                                                            | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
+| `TO_TIMESTAMP(string, format)`             | `TIMESTAMPTZ`            | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                                         | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
+| `TO_TIMESTAMP_TZ(string, format)`          | `TIMESTAMPTZ`            | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                                         | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
+| `FROM_TZ(timestamp_value, timezone_value)` | `TIMESTAMPTZ`            | Convert a timestamp value and a timezone to a TIMESTAMP WITH TIME ZONE value.                                         | `FROM_TZ(TIMESTAMP '2017-08-08 08:09:10', 'Asia/Kolkata')`                                                 | `08-AUG-17 08:09:10 +05:30`                           |
+
+!!!note
+The `TO_CHAR(TIMESTAMPTZ)` function is Oracle compatible and not PostgreSQL compatible from version 13 onwards. As a result, you may observe some differences in functionality compared to the earlier version. 
+!!!
 
 ## Altering the output format
 
 You can alter the output format of `TO_DSINTERVAL(string)` using the `intervalstyle` GUC setting. For example:
 
-    ```sql
-    edb=# SET intervalstyle = 'sql_standard';
-    SET
+```sql
+edb=# SET intervalstyle = 'sql_standard';
+SET
 
-    edb=# select to_dsinterval('80 13:30:00') from dual;
-    __OUTPUT__
-    to_dsinterval 
-    ---------------
-    80 13:30:00
-    ```
-    ```sql
-    edb=# SET intervalstyle = 'postgres_verbose';
-    SET
-    edb=# select to_dsinterval('80 13:30:00') from dual;
-    __OUTPUT__
-       to_dsinterval        
-    ----------------------------
-    @ 80 days 13 hours 30 mins
-    ```
+edb=# select to_dsinterval('80 13:30:00') from dual;
+__OUTPUT__
+to_dsinterval 
+---------------
+80 13:30:00
+```
+
+```sql
+edb=# SET intervalstyle = 'postgres_verbose';
+SET
+
+edb=# select to_dsinterval('80 13:30:00') from dual;
+__OUTPUT__
+   to_dsinterval        
+----------------------------
+@ 80 days 13 hours 30 mins
+```
 
 
 ## TO_CHAR, TO_DATE, TO_TIMESTAMP, and TO_TIMESTAMP_TZ
@@ -72,6 +79,7 @@ __OUTPUT__
  01-MAY-20 12:00:00 +05:30
 (1 row)
 ```
+
 ```sql
 edb=# select to_timestamp_tz('12', 'HH');
 __OUTPUT__
@@ -80,12 +88,31 @@ __OUTPUT__
  01-MAY-20 12:00:00 +05:30
 (1 row)
 ```
+
 ```sql
 edb=# select to_date('12', 'HH');
 __OUTPUT__
       to_date
 --------------------
  01-MAY-20 12:00:00
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'HH24SP') from dual;
+__OUTPUT__
+ to_char 
+---------
+ twelve
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'MM-DD-YYYY HH24:MM:SS TZ') from dual;
+__OUTPUT__
+         to_char         
+-------------------------
+ 01-30-2020 17:01:14 IST
 (1 row)
 ```
 

--- a/product_docs/docs/epas/16/reference/sql_reference/03_functions_and_operators/07_data_type_formatting_functions.mdx
+++ b/product_docs/docs/epas/16/reference/sql_reference/03_functions_and_operators/07_data_type_formatting_functions.mdx
@@ -14,24 +14,29 @@ The EDB Postgres Advanced Server formatting functions provide a powerful set of 
 
 ## Overview of data type formatting functions
 
-| Function                            | Return type   | Description                                                                                    | Example                                                                                                    | Result                                                |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `TO_BLOB(raw)`                      | `BLOB`        | Convert a `RAW` value to `BLOB` value.                                                         | `TO_BLOB('abc')`                                                                                           | `\x616263`                                            |
-| `TO_CLOB(string)`                   | `CLOB`        | Convert a `CHAR`, `VARCHAR`, `VARCHAR2`, `NCHAR`, `NVARCHAR2`, or `CLOB` values to `CLOB` values. | `TO_CLOB('aaaa')`                                                                                       | `aaaa`                                                |
-| `TO_CHAR(DATE [, format ])`         | `VARCHAR2`    | Convert a date/time to a string with output, `format`. The default format is DD-MON-YY.        | `TO_CHAR(SYSDATE, 'MM/DD/YYYY HH12:MI:SS AM')`                                                             | `07/25/2007 09:43:02 AM`                              |
-| `TO_CHAR(TIMESTAMP [, format ])`    | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. The default format is DD-MON-YY.        | `TO_CHAR (CURRENT_TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                                  | `08/13/2015 08:55:22 PM`                              |
-| `TO_CHAR(INTEGER [, format ])`      | `VARCHAR2`    | Convert an integer to a string with output, `format`                                           | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
-| `TO_CHAR(NUMBER [, format ])`       | `VARCHAR2`    | Convert a decimal number to a string with output, `format`                                     | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
-| `TO_CHAR(DOUBLE PRECISION, format)` | `VARCHAR2`    | Convert a floating-point number to a string with output, `format`                              | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
-| `TO_DATE(string [, format ])`       | `TIMESTAMP`   | Convert a date or timestamp formatted string to a `TIMESTAMP` data type                        | `TO_DATE('2007-07-04 13:39:10', 'YYYY-MM-DD HH24:MI:SS')` <br /><br />`TO_DATE('2007-07-04','YYYY-MM-DD')` | `04-JUL-07 13:39:10` <br /><br />`04-JUL-07 00:00:00` |
-| `TO_DSINTERVAL(string)`             | `INTERVAL DAY TO SECOND` | Convert a character string of `CHAR`, `VARCHAR2`, `NCHAR`, or `NVARCHAR2` datatype to an INTERVAL DAY TO SECOND type. | `TO_DSINTERVAL('80 13:30:00')`                                           | `80 days 13:30:00`                                    |
-| `TO_NCHAR(string)`                  | `NVARCHAR2`   | Convert a `character string`, `CHAR`, `VARCHAR2`, `CLOB`, or `NCLOB` value to the national character set. | `TO_NCHAR('test')`                                                                              | `test`                                                | 
-| `TO_NCHAR(number [, format])`       | `NVARCHAR2`   | Convert a number formatted string to a national character data type.                           | `TO_NCHAR(7654321, 'C9G999G999D99')`                                                                       | `7,654,321.00`                                        |
-| `TO_NCHAR(DATE  [, format ])`       | `NVARCHAR2`   | Convert a date/time to a formatted string of national character data type.                     | `TO_NCHAR(timestamp '2022-04-20 17:31:12.66', 'Day: MONTH DD, YYYY')`                                      | `Wednesday: APRIL     20, 2022`                       |
-| `TO_NUMBER(string [, format ])`     | `NUMBER`      | Convert a number formatted string to a `NUMBER` data type.                                      | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
-| `TO_TIMESTAMP(string, format)`      | `TIMESTAMPTZ` | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                   | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
-| `TO_TIMESTAMP_TZ(string[, format])`   | `TIMESTAMPTZ` | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                   | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
-| `FROM_TZ(timestamp_value, timezone_value)` | `TIMESTAMPTZ` | Convert a timestamp value and a timezone to a TIMESTAMP WITH TIME ZONE value.            | `FROM_TZ(TIMESTAMP '2017-08-08 08:09:10', 'Asia/Kolkata')`                                                 | `08-AUG-17 08:09:10 +05:30`                           |
+| Function                                   | Return type              | Description                                                                                                           | Example                                                                                                    | Result                                                |
+|--------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `TO_CHAR(DATE [, format ])`                | `VARCHAR2`               | Convert a date/time to a string with output, `format`. The default format is DD-MON-YY.                               | `TO_CHAR (SYSDATE::PG_CATALOG.DATE, 'MM/DD/YYYY')`                                                         | `07/25/2007`                                          |
+| `TO_CHAR(TIMESTAMP [, format ])`           | `VARCHAR2`               | Convert a timestamp to a string with output, `format`. The default format is DD-MON-YY.                               | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                       | `08/13/2015 08:55:22 PM`                              |
+| `TO_CHAR(TIMESTAMPTZ [, format])`          | `VARCHAR2`               | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY.                        | `TO_CHAR (CURRENT_TIMESTAMP::TIMESTAMPTZ, 'MM/DD/YYYY HH12:MI:SS AM TZ')`                                  | `03/11/2025 09:40:27 AM IST`                          |
+| `TO_CHAR(INTEGER [, format ])`             | `VARCHAR2`               | Convert an integer to a string with output, `format`                                                                  | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
+| `TO_CHAR(NUMBER [, format ])`              | `VARCHAR2`               | Convert a decimal number to a string with output, `format`                                                            | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
+| `TO_CHAR(DOUBLE PRECISION, format)`        | `VARCHAR2`               | Convert a floating-point number to a string with output, `format`                                                     | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
+| `TO_TIMESTAMP(string, format)`             | `TIMESTAMPTZ`            | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                                         | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
+| `TO_TIMESTAMP_TZ(string[, format])`        | `TIMESTAMPTZ`            | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                                         | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
+| `FROM_TZ(timestamp_value, timezone_value)` | `TIMESTAMPTZ`            | Convert a timestamp value and a timezone to a TIMESTAMP WITH TIME ZONE value.                                         | `FROM_TZ(TIMESTAMP '2017-08-08 08:09:10', 'Asia/Kolkata')`                                                 | `08-AUG-17 08:09:10 +05:30`                           |
+| `TO_DATE(string [, format ])`              | `TIMESTAMP`              | Convert a date or timestamp formatted string to a `TIMESTAMP` data type                                               | `TO_DATE('2007-07-04 13:39:10', 'YYYY-MM-DD HH24:MI:SS')` <br /><br />`TO_DATE('2007-07-04','YYYY-MM-DD')` | `04-JUL-07 13:39:10` <br /><br />`04-JUL-07 00:00:00` |
+| `TO_NCHAR(string)`                         | `NVARCHAR2`              | Convert a `character string`, `CHAR`, `VARCHAR2`, `CLOB`, or `NCLOB` value to the national character set.             | `TO_NCHAR('test')`                                                                                         | `test`                                                |
+| `TO_NCHAR(number [, format])`              | `NVARCHAR2`              | Convert a number formatted string to a national character data type.                                                  | `TO_NCHAR(7654321, 'C9G999G999D99')`                                                                       | `7,654,321.00`                                        |
+| `TO_NCHAR(DATE  [, format ])`              | `NVARCHAR2`              | Convert a date/time to a formatted string of national character data type.                                            | `TO_NCHAR(timestamp '2022-04-20 17:31:12.66', 'Day: MONTH DD, YYYY')`                                      | `Wednesday: APRIL     20, 2022`                       |
+| `TO_NUMBER(string [, format ])`            | `NUMBER`                 | Convert a number formatted string to a `NUMBER` data type.                                                            | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
+| `TO_DSINTERVAL(string)`                    | `INTERVAL DAY TO SECOND` | Convert a character string of `CHAR`, `VARCHAR2`, `NCHAR`, or `NVARCHAR2` datatype to an INTERVAL DAY TO SECOND type. | `TO_DSINTERVAL('80 13:30:00')`                                                                             | `80 days 13:30:00`                                    |
+| `TO_CLOB(string)`                          | `CLOB`                   | Convert a `CHAR`, `VARCHAR`, `VARCHAR2`, `NCHAR`, `NVARCHAR2`, or `CLOB` values to `CLOB` values.                     | `TO_CLOB('aaaa')`                                                                                          | `aaaa`                                                |
+| `TO_BLOB(raw)`                             | `BLOB`                   | Convert a `RAW` value to `BLOB` value.                                                                                | `TO_BLOB('abc')`                                                                                           | `\x616263`                                            |
+
+!!!note
+The `TO_CHAR(TIMESTAMPTZ)` function is Oracle compatible and not PostgreSQL compatible from version 13 onwards. As a result, you may observe some differences in functionality compared to the earlier version. 
+!!!
 
 
 ## Available template patterns for date values
@@ -236,6 +241,24 @@ __OUTPUT__
       to_date
 --------------------
  01-MAY-20 12:00:00
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'HH24SP') from dual;
+__OUTPUT__
+ to_char 
+---------
+ twelve
+(1 row)
+```
+
+```sql
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'MM-DD-YYYY HH24:MM:SS TZ') from dual;
+__OUTPUT__
+         to_char         
+-------------------------
+ 01-30-2020 17:01:14 IST
 (1 row)
 ```
 

--- a/product_docs/docs/epas/17/reference/database_administrator_reference/01_audit_logging_configuration_parameters.mdx
+++ b/product_docs/docs/epas/17/reference/database_administrator_reference/01_audit_logging_configuration_parameters.mdx
@@ -14,7 +14,7 @@ Use the following configuration parameters to control database auditing. See [Su
 
 ## edb_audit
 
- Enables or disables database auditing. The values `xml` or `csv` enable database auditing. These values represent the file format in which to capture auditing information. `none` disables database auditing and is the default.
+ Enables or disables database auditing. The values `XML`,`CSV`, or `JSON` enable database auditing. These values represent the file format in which to capture auditing information. `none` disables database auditing and is the default.
 
 !!! Note
     Set the `logging_collector` parameter to `on` to enable the `edb_audit` parameter.

--- a/product_docs/docs/epas/17/reference/sql_reference/03_functions_and_operators/07_data_type_formatting_functions.mdx
+++ b/product_docs/docs/epas/17/reference/sql_reference/03_functions_and_operators/07_data_type_formatting_functions.mdx
@@ -14,25 +14,29 @@ The EDB Postgres Advanced Server formatting functions provide a powerful set of 
 
 ## Overview of data type formatting functions
 
-| Function                            | Return type   | Description                                                                                    | Example                                                                                                    | Result                                                |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `TO_BLOB(raw)`                      | `BLOB`        | Convert a `RAW` value to `BLOB` value.                                                         | `TO_BLOB('abc')`                                                                                           | `\x616263`                                            |
-| `TO_CLOB(string)`                   | `CLOB`        | Convert a `CHAR`, `VARCHAR`, `VARCHAR2`, `NCHAR`, `NVARCHAR2`, or `CLOB` values to `CLOB` values. | `TO_CLOB('aaaa')`                                                                                       | `aaaa`                                                |
-| `TO_CHAR(DATE [, format ])`         | `VARCHAR2`    | Convert a date/time to a string with output, `format`. The default format is DD-MON-YY.        | `TO_CHAR(SYSDATE, 'MM/DD/YYYY HH12:MI:SS AM')`                                                             | `07/25/2007 09:43:02 AM`                              |
-| `TO_CHAR(TIMESTAMP [, format ])`    | `VARCHAR2`    | Convert a timestamp to a string with output, `format`. The default format is DD-MON-YY.        | `TO_CHAR (CURRENT_TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                                  | `08/13/2015 08:55:22 PM`                              |
-| `TO_CHAR(INTEGER [, format ])`      | `VARCHAR2`    | Convert an integer to a string with output, `format`                                           | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
-| `TO_CHAR(NUMBER [, format ])`       | `VARCHAR2`    | Convert a decimal number to a string with output, `format`                                     | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
-| `TO_CHAR(DOUBLE PRECISION, format)` | `VARCHAR2`    | Convert a floating-point number to a string with output, `format`                              | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
-| `TO_DATE(string [, format ])`       | `TIMESTAMP`   | Convert a date or timestamp formatted string to a `TIMESTAMP` data type                        | `TO_DATE('2007-07-04 13:39:10', 'YYYY-MM-DD HH24:MI:SS')` <br /><br />`TO_DATE('2007-07-04','YYYY-MM-DD')` | `04-JUL-07 13:39:10` <br /><br />`04-JUL-07 00:00:00` |
-| `TO_DSINTERVAL(string)`             | `INTERVAL DAY TO SECOND` | Convert a character string of `CHAR`, `VARCHAR2`, `NCHAR`, or `NVARCHAR2` datatype to an INTERVAL DAY TO SECOND type. | `TO_DSINTERVAL('80 13:30:00')`                                           | `80 days 13:30:00`                                    |
-| `TO_NCHAR(string)`                  | `NVARCHAR2`   | Convert a `character string`, `CHAR`, `VARCHAR2`, `CLOB`, or `NCLOB` value to the national character set. | `TO_NCHAR('test')`                                                                              | `test`                                                | 
-| `TO_NCHAR(number [, format])`       | `NVARCHAR2`   | Convert a number formatted string to a national character data type.                           | `TO_NCHAR(7654321, 'C9G999G999D99')`                                                                       | `7,654,321.00`                                        |
-| `TO_NCHAR(DATE  [, format ])`       | `NVARCHAR2`   | Convert a date/time to a formatted string of national character data type.                     | `TO_NCHAR(timestamp '2022-04-20 17:31:12.66', 'Day: MONTH DD, YYYY')`                                      | `Wednesday: APRIL     20, 2022`                       |
-| `TO_NUMBER(string [, format ])`     | `NUMBER`      | Convert a number formatted string to a `NUMBER` data type.                                      | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
-| `TO_TIMESTAMP(string, format)`      | `TIMESTAMPTZ` | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                   | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
-| `TO_TIMESTAMP_TZ(string[, format])`   | `TIMESTAMPTZ` | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                   | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
-| `FROM_TZ(timestamp_value, timezone_value)` | `TIMESTAMPTZ` | Convert a timestamp value and a timezone to a TIMESTAMP WITH TIME ZONE value.            | `FROM_TZ(TIMESTAMP '2017-08-08 08:09:10', 'Asia/Kolkata')`                                                 | `08-AUG-17 08:09:10 +05:30`                           |
+| Function                                   | Return type              | Description                                                                                                           | Example                                                                                                    | Result                                                |
+|--------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `TO_BLOB(raw)`                             | `BLOB`                   | Convert a `RAW` value to `BLOB` value.                                                                                | `TO_BLOB('abc')`                                                                                           | `\x616263`                                            |
+| `TO_CLOB(string)`                          | `CLOB`                   | Convert a `CHAR`, `VARCHAR`, `VARCHAR2`, `NCHAR`, `NVARCHAR2`, or `CLOB` values to `CLOB` values.                     | `TO_CLOB('aaaa')`                                                                                          | `aaaa`                                                |
+| `TO_CHAR(DATE [, format ])`                | `VARCHAR2`               | Convert a date/time to a string with output, `format`. The default format is DD-MON-YY.                               | `TO_CHAR(SYSDATE::PG_CATALOG.DATE, 'MM/DD/YYYY')`                                                   | `07/25/2007`                                          |
+| `TO_CHAR(TIMESTAMP [, format ])`           | `VARCHAR2`               | Convert a timestamp to a string with output, `format`. The default format is DD-MON-YY.                               | `TO_CHAR(CURRENT_TIMESTAMP::TIMESTAMP, 'MM/DD/YYYY HH12:MI:SS AM')`                                 | `08/13/2015 08:55:22 PM`                              |
+| `TO_CHAR(TIMESTAMPTZ [, format])`          | `VARCHAR2`               | Convert a timestamp to a string with output, `format`. If omitted default format is DD-MON-YY.                        | `TO_CHAR(CURRENT_TIMESTAMP::TIMESTAMPTZ, 'MM/DD/YYYY HH12:MI:SS AM TZ')`                            | `03/11/2025 09:40:27 AM IST`                          |
+| `TO_CHAR(INTEGER [, format ])`             | `VARCHAR2`               | Convert an integer to a string with output, `format`                                                                  | `TO_CHAR(2412, '999,999S')`                                                                                | `2,412+`                                              |
+| `TO_CHAR(NUMBER [, format ])`              | `VARCHAR2`               | Convert a decimal number to a string with output, `format`                                                            | `TO_CHAR(10125.35, '999,999.99')`                                                                          | `10,125.35`                                           |
+| `TO_CHAR(DOUBLE PRECISION, format)`        | `VARCHAR2`               | Convert a floating-point number to a string with output, `format`                                                     | `TO_CHAR (CAST(123.5282 AS REAL), '999.99')`                                                               | `123.53`                                              |
+| `TO_DATE(string [, format ])`              | `TIMESTAMP`              | Convert a date or timestamp formatted string to a `TIMESTAMP` data type                                               | `TO_DATE('2007-07-04 13:39:10', 'YYYY-MM-DD HH24:MI:SS')` <br /><br />`TO_DATE('2007-07-04','YYYY-MM-DD')` | `04-JUL-07 13:39:10` <br /><br />`04-JUL-07 00:00:00` |
+| `TO_DSINTERVAL(string)`                    | `INTERVAL DAY TO SECOND` | Convert a character string of `CHAR`, `VARCHAR2`, `NCHAR`, or `NVARCHAR2` datatype to an INTERVAL DAY TO SECOND type. | `TO_DSINTERVAL('80 13:30:00')`                                                                             | `80 days 13:30:00`                                    |
+| `TO_NCHAR(string)`                         | `NVARCHAR2`              | Convert a `character string`, `CHAR`, `VARCHAR2`, `CLOB`, or `NCLOB` value to the national character set.             | `TO_NCHAR('test')`                                                                                         | `test`                                                |
+| `TO_NCHAR(number [, format])`              | `NVARCHAR2`              | Convert a number formatted string to a national character data type.                                                  | `TO_NCHAR(7654321, 'C9G999G999D99')`                                                                       | `7,654,321.00`                                        |
+| `TO_NCHAR(DATE  [, format ])`              | `NVARCHAR2`              | Convert a date/time to a formatted string of national character data type.                                            | `TO_NCHAR(timestamp '2022-04-20 17:31:12.66', 'Day: MONTH DD, YYYY')`                                      | `Wednesday: APRIL     20, 2022`                       |
+| `TO_NUMBER(string [, format ])`            | `NUMBER`                 | Convert a number formatted string to a `NUMBER` data type.                                                            | `TO_NUMBER('2,412-', '999,999S')`                                                                          | `-2412`                                               |
+| `TO_TIMESTAMP(string, format)`             | `TIMESTAMPTZ`            | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                                         | `TO_TIMESTAMP('05 Dec 2000 08:30:25 pm', 'DD Mon YYYY hh12:mi:ss pm')`                                     | `05-DEC-00 20:30:25 +05:30`                           |
+| `TO_TIMESTAMP_TZ(string[, format])`        | `TIMESTAMPTZ`            | Convert a timestamp formatted string to a TIMESTAMP WITH TIME ZONE data type.                                         | `TO_TIMESTAMP_TZ ('2003/12/13 10:13:18 -8:00', 'YYYY/MM/DD HH:MI:SS TZH:TZM')`                             | `13-DEC-03 23:43:18 +05:30`                           |
+| `FROM_TZ(timestamp_value, timezone_value)` | `TIMESTAMPTZ`            | Convert a timestamp value and a timezone to a TIMESTAMP WITH TIME ZONE value.                                         | `FROM_TZ(TIMESTAMP '2017-08-08 08:09:10', 'Asia/Kolkata')`                                                 | `08-AUG-17 08:09:10 +05:30`                           |
 
+!!!note
+The `TO_CHAR(TIMESTAMPTZ)` function is Oracle compatible and not PostgreSQL compatible from version 13 onwards. As a result, you may observe some differences in functionality compared to the earlier version. 
+!!!
 
 ## Available template patterns for date values
 
@@ -236,6 +240,24 @@ __OUTPUT__
       to_date
 --------------------
  01-MAY-20 12:00:00
+(1 row)
+```
+
+```
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'HH24SP') from dual;
+__OUTPUT__
+ to_char 
+---------
+ twelve
+(1 row)
+```
+
+```
+edb=# select to_char(cast('30-JAN-20 05:37:14 PM +05:30' as timestamp with time zone), 'MM-DD-YYYY HH24:MM:SS TZ') from dual;
+__OUTPUT__
+         to_char         
+-------------------------
+ 01-30-2020 17:01:14 IST
 (1 row)
 ```
 

--- a/product_docs/docs/eprs/7/10_appendix/02_resolving_problems/01_error_messages.mdx
+++ b/product_docs/docs/eprs/7/10_appendix/02_resolving_problems/01_error_messages.mdx
@@ -688,3 +688,75 @@ select pg_reload_conf();
 ```
 
 This way, tcp_keepalive messages won't let the connection become idle and Replication Server won't report a broken connection.
+
+**Problem**
+
+`ORA-17056: Non-supported character set (add orai18n.jar in the classpath)`
+
+**Resolution** 
+
+Occurs when [adding an Oracle Publication Database](/eprs/latest/05_smr_operation/01_prerequisites/04_preparing_pub_database/#oracle-publication-database) and Oracle is installed using the JA16SJIS character set encoding. This may happen even if `orai18n.jar` is explicitely added to the `/lib/jdbc` folder.
+
+To work around this issue, update the `runPubserver` script to ensure that the `/lib/jdbc` folder contents, including `orai18n.jar`, are included in the Java classpath.
+
+1.  Ensure that `orai18n.jar` is placed in the following directory: 
+
+    ```
+    XDB_HOME/lib/jdbc
+    ```
+
+    If it isn't, place it there before you continue with the following steps.
+
+1.  Navigate to the directory containing the `runPubserver` script:
+
+    #### In Windows: 
+
+    ```
+    C:\Program Files\edb\EnterpriseDB-xDBReplicationServer\bin\runPubserver.bat
+    ```
+
+    #### In Linux: 
+
+    ```
+    /usr/edb/xdb/bin/runPubserver.sh
+    ```
+
+1.  Find the following command in the script and update it.
+
+    #### In Windows:
+
+    Update `-jar edb-repserver.jar` to `-cp edb-repserver.jar;..\lib\*` so the required libraries are in the classpath. Also add `com.edb.replication.backend.ReplicationServer` to reference the main class properly.
+
+    From: 
+    ```shell
+    # OUTDATED COMMAND
+    cscript //NOLOGO ..\etc\sysconfig\runJavaApplication.vbs ..\etc\sysconfig\xdbReplicationServer-7.config "%PUB_JAVA_HEAP_SIZE% -XX:ErrorFile=__HOMEPATH__\.enterprisedb\xdb\7\pubserver_pid_%%p.log -Djava.library.path=. -Djava.awt.headless=true -jar edb-repserver.jar pubserver %PUBPORT% ..\etc"
+    ```
+
+    To: 
+    ```shell
+    cscript //NOLOGO ..\etc\sysconfig\runJavaApplication.vbs ..\etc\sysconfig\xdbReplicationServer-7.config "%PUB_JAVA_HEAP_SIZE% -XX:ErrorFile=%HOMEPATH%\.enterprisedb\xdb\7.10\pubserver_pid_%%p.log -Djava.library.path=. -Djava.awt.headless=true -cp edb-repserver.jar;..\lib\* com.edb.replication.backend.ReplicationServer pubserver %PUBPORT% ..\etc"
+    ```
+
+    #### In Linux: 
+
+    Update `-jar /usr/edb/xdb/bin/edb-repserver.jar` to `-cp /usr/edb/xdb/bin/edb-repserver.jar:../lib/*` so the required libraries are in the classpath. Also add `com.edb.replication.backend.ReplicationServer` to reference the main class properly.
+
+    From:
+
+    ```shell
+    # OUTDATED COMMAND
+    export LD_LIBRARY_PATH=/usr/edb/xdb/lib/xdb:$LD_LIBRARY_PATH
+    . /usr/edb/xdb/etc/sysconfig/xdbReplicationServer-7.config; . /usr/edb/xdb/etc/sysconfig/runJavaApplication.sh; cd /usr/edb/xdb/bin; runJREApplication -XX:-UsePerfData $PUB_JAVA_HEAP_SIZE -XX:ErrorFile=/var/log/edb/xdb/pubserver_pid_%p.log -Djava.library.path=/usr/edb/xdb/bin -Djava.awt.headless=true $ALLOW_REFLECTION -jar /usr/edb/xdb/bin/edb-repserver.jar pubserver $PUBPORT
+    ```
+
+    To: 
+
+    ```shell
+    export LD_LIBRARY_PATH=/usr/edb/xdb/lib/xdb:$LD_LIBRARY_PATH
+    . /usr/edb/xdb/etc/sysconfig/xdbReplicationServer-7.config; . /usr/edb/xdb/etc/sysconfig/runJavaApplication.sh; cd /usr/edb/xdb/bin; runJREApplication -XX:-UsePerfData $PUB_JAVA_HEAP_SIZE -XX:ErrorFile=/var/log/edb/xdb/pubserver_pid_%p.log -Djava.library.path=/usr/edb/xdb/bin -Djava.awt.headless=true $ALLOW_REFLECTION -cp /usr/edb/xdb/bin/edb-repserver.jar:../lib/* com.edb.replication.backend.ReplicationServer pubserver $PUBPORT
+    ```
+
+1.  Save the script and exit the editor. Restart the Publication Server to apply the changes.
+
+1.  Ensure the `ORA-17056` error message no longer appears and verify that the Publication Database was added successfully.

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/12400_rel_notes.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/12400_rel_notes.mdx
@@ -1,0 +1,12 @@
+---
+title: "EDB PgBouncer 1.24.0.0 release notes"
+navTitle: Version 1.24.0.0
+---
+
+Released: 11 Mar 2024
+
+EDB PgBouncer 1.24.0.0 includes the following upstream merge:
+
+| Type           | Description                                                                                                                                       |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| Upstream merge | Merged with community PgBouncer 1.24.0.0. See the community [Release Notes](https://www.pgbouncer.org/changelog.html#pgbouncer-124x) for details. |

--- a/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/index.mdx
+++ b/product_docs/docs/pgbouncer/1/pgbouncer_rel_notes/index.mdx
@@ -3,6 +3,7 @@ title: "Release notes"
 redirects:
   - ../01_whats_new/
 navigation:
+  - 12400_rel_notes
   - 12310_rel_notes
   - 12300_rel_notes
   - 02_12210_rel_notes
@@ -20,6 +21,7 @@ The EDB PgBouncer documentation describes the latest version of EDB PgBouncer 1,
 
 |            Version             | Release date |                               Upstream merges                                |
 | ------------------------------ | ------------ | ---------------------------------------------------------------------------- |
+| [1.24.0.0](12400_rel_notes)    | 11 Mar 2025  | Upstream [1.24.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-124x) |
 | [1.23.1.0](12310_rel_notes)    | 22 Aug 2024  | Upstream [1.23.1.0](https://www.pgbouncer.org/changelog.html#pgbouncer-123x) |
 | [1.23.0.0](12300_rel_notes)    | 01 Aug 2024  | Upstream [1.23.0.0](https://www.pgbouncer.org/changelog.html#pgbouncer-123x) |
 | [1.22.1.0](02_12210_rel_notes) | 16 Apr 2024  | Upstream [1.22.1.0](https://www.pgbouncer.org/changelog.html#pgbouncer-122x) |


### PR DESCRIPTION
## What Changed?
#6593 : EPRS: added workaround for ORA-17056
#6576 : EPAS - Update to_char(timestamptz) function from v13 to 17
#6598 : pgbouncer - release notes
#6597 : EPAS - Added JSON format to edb_audit parameter
#6595 : Remove references to text-embedding-3-large
