### PR TITLE
Update running_edb_loader.mdx

### DIFF
--- a/product_docs/docs/epas/15/database_administration/02_edb_loader/invoking_edb_loader/running_edb_loader.mdx
+++ b/product_docs/docs/epas/15/database_administration/02_edb_loader/invoking_edb_loader/running_edb_loader.mdx
@@ -241,12 +241,13 @@ EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 Successfully loaded (4) records
 ```
 
-This example invokes EDB\*Loader using a normal user. For this example, one empty table `bar` is created and a normal user `bob` is created. The `bob` user is granted all privileges on the table `bar`. The CREATE TABLE command creates the empty table. The CREATE USER command creates the user, and the GRANT command gives required privileges to the user `bob` on the `bar` table:
+This example invokes EDB\*Loader using a normal user. For this example, one empty table `bar` is created and a normal user `bob` is created. The `bob` user is granted all privileges on the table `bar`. Also, the `bob` user need to be granted pg_read_server_files role, in oreder to be able to utilize edb_bulkload. The CREATE TABLE command creates the empty table. The CREATE USER command creates the user, and the GRANT command gives required privileges to the user `bob` on the `bar` table and pg_read_server_files role:
 
 ```sql
 CREATE TABLE bar(i int); 
 CREATE USER bob identified by '123';
 GRANT ALL on bar TO bob;
+GRANT pg_read_server_files TO bob;
 ```
 
 The control file and data file:

--- a/product_docs/docs/epas/15/database_administration/02_edb_loader/invoking_edb_loader/running_edb_loader.mdx
+++ b/product_docs/docs/epas/15/database_administration/02_edb_loader/invoking_edb_loader/running_edb_loader.mdx
@@ -241,7 +241,7 @@ EDB*Loader: Copyright (c) 2007-2021, EnterpriseDB Corporation.
 Successfully loaded (4) records
 ```
 
-This example invokes EDB\*Loader using a normal user. For this example, one empty table `bar` is created and a normal user `bob` is created. The `bob` user is granted all privileges on the table `bar`. Also, the `bob` user need to be granted pg_read_server_files role, in oreder to be able to utilize edb_bulkload. The CREATE TABLE command creates the empty table. The CREATE USER command creates the user, and the GRANT command gives required privileges to the user `bob` on the `bar` table and pg_read_server_files role:
+This example invokes EDB\*Loader using a normal user. For this example, one empty table `bar` is created, and a normal user `bob` is created. The `bob` user is granted all privileges on the table `bar`. Also, the `bob` user must be granted the pg_read_server_files role to utilise edb_bulkload. The CREATE TABLE command creates an empty table. The CREATE USER command creates the user, and the GRANT command gives required privileges to the user `bob` on the `bar` table and pg_read_server_files role:
 
 ```sql
 CREATE TABLE bar(i int); 


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
Since we'd receive this error following your instruction invoking edbldr using normal user, I added the "GRANT pg_read_server_files" instruction into this page.

`DETAIL:  Only roles with privileges of the "pg_read_server_files" role may use edb_bulkload from a file.
HINT:  Anyone can use edb_bulkload from stdin.`

Kind Regards,
Yuki Tei
