### PR TITLE
Update primitives.mdx

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/primitives.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/primitives.mdx
@@ -22,7 +22,7 @@ SELECT
     chunk
 FROM aidb.chunk_text(
     input => 'This is a significantly longer text example that might require splitting into smaller chunks. The purpose of this function is to partition text data into segments of a specified maximum length, for example, this sentence 145 is characters. This enables processing or storage of data in manageable parts.',
-    options = '{"desired_length": 120, "max_length": 150}'
+    options => '{"desired_length": 120, "max_length": 150}'
 );
 ```
 


### PR DESCRIPTION
Fixed a typo in the options parameter of the chunk_text function.

## What Changed?

Corrected the syntax in the options parameter from using `=` to the proper arrow function syntax `=>`. This syntax error was causing function failures.