### PR TITLE
Edits to ldap sync pr6566

### DIFF
--- a/advocacy_docs/pg_extensions/ldap_sync/installing.mdx
+++ b/advocacy_docs/pg_extensions/ldap_sync/installing.mdx
@@ -25,7 +25,7 @@ Before you begin the installation process:
 - Install the [plpython3u](https://www.postgresql.org/docs/current/plpython.html) procedural language to run ldap2pg. 
 
 !!! Note
-    plpython3u is an "untrusted" language and thus a potential security risk.
+plpython3u is an "untrusted" language and thus a potential security risk.
 !!!
 
 - Install [ldap2pg](https://ldap2pg.readthedocs.io/en/latest/).

--- a/advocacy_docs/pg_extensions/ldap_sync/installing.mdx
+++ b/advocacy_docs/pg_extensions/ldap_sync/installing.mdx
@@ -22,7 +22,11 @@ Before you begin the installation process:
 
 - Install [pg_cron](https://github.com/citusdata/pg_cron)
 
-- Install the [plpython3u](https://www.postgresql.org/docs/current/plpython.html) procedural language to run ldap2pg. Note that `plpython3u` is a potential security risk as it's an “untrusted” language. 
+- Install the [plpython3u](https://www.postgresql.org/docs/current/plpython.html) procedural language to run ldap2pg. 
+
+!!! Note
+    plpython3u is an "untrusted" language and thus a potential security risk.
+!!!
 
 - Install [ldap2pg](https://ldap2pg.readthedocs.io/en/latest/).
 


### PR DESCRIPTION
Rather than using "Note that" in text, a potential security risk deserves to be pulled out to an admonition.



