### PR TITLE
Update primitives.mdx

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/models/primitives.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/models/primitives.mdx
@@ -41,7 +41,7 @@ For batch inferencing, call `aidb.encode_image_batch`:
 
 ```sql
 -- BYTEA type casting included to demonstrate what data type is used
-select aidb.encode_image_batch('my_bert_model', ARRAY[
+select aidb.encode_image_batch('clip', ARRAY[
     image_of_the_rock_cooking AS BYTEA,
     image_of_miku_singing AS BYTEA,
     image_of_jim_reporting_news AS BYTEA,
@@ -60,7 +60,7 @@ select aidb.decode_text('t5', 'translate to german: hello world');
 For batch inferencing, call `aidb.decode_text_batch`:
 
 ```sql
-select aidb.decode_text_batch('my_bert_model', ARRAY[
+select aidb.decode_text_batch('t5', ARRAY[
     'translate to german: i am an example',
     'summarize: The missile knows where it is at all times. It knows this because it knows where it isn''t. By subtracting where it is from where it isn''t, or where it isn''t from where it is (whichever is greater), it obtains a difference, or deviation. The guidance subsystem uses deviations to generate corrective commands to drive the missile from a position where it is to a position where it isn''t, and arriving at a position where it wasn''t, it now is.'
 ]);


### PR DESCRIPTION
The parameter "my_bert_model" refers to a sentence transformer model, which is incapable of generating embeddings from images or summarising and translating text. I believe this information was mistakenly copied from another source. I have corrected it using the default models supported by AIDB.

## What Changed?

- `aidb.encode_image_batch` function used my_bert_model and was replaced with a clip model capable of generating embeddings from images.

- `aidb.decode_text_batch` function used my_bert_model and was replaced with the t5 model, which is capable of performing summarising and translating tasks.