### PR TITLE
Update epas15_2_0_rel_notes.mdx

### DIFF
--- a/product_docs/docs/epas/15/epas_rel_notes/epas15_2_0_rel_notes.mdx
+++ b/product_docs/docs/epas/15/epas_rel_notes/epas15_2_0_rel_notes.mdx
@@ -33,3 +33,4 @@ EDB Postgres Advanced Server 15.2.0 includes the following enhancements and bug 
 | Enhancement    | `index _advisor` is now a separate extension, but continues to be packaged with EDB Postgres Advanced Server. | Index advisor |
 | Enhancement    | `sql_profiler` is now a separate extension and is no longer packaged with EDB Postgres Advanced Server. | SQL Profiler |
 | Change | The Windows installer no longer installs pgAdmin, and the parallel-clone and clonescheme extensions are no longer included in an EDB Postgres Advanced Server installation. To download pgAdmin, see the [pgAdmin download page](https://www.pgadmin.org/download/). |
+| Change | The DBMS_CRYPTO.ENCRYPTO/DECRYPTO procedure has been wrongly accept any lengh of key. From this version, only the correct key length is acceptable. |

--- a/product_docs/docs/epas/15/epas_rel_notes/epas15_2_0_rel_notes.mdx
+++ b/product_docs/docs/epas/15/epas_rel_notes/epas15_2_0_rel_notes.mdx
@@ -33,4 +33,4 @@ EDB Postgres Advanced Server 15.2.0 includes the following enhancements and bug 
 | Enhancement    | `index _advisor` is now a separate extension, but continues to be packaged with EDB Postgres Advanced Server. | Index advisor |
 | Enhancement    | `sql_profiler` is now a separate extension and is no longer packaged with EDB Postgres Advanced Server. | SQL Profiler |
 | Change | The Windows installer no longer installs pgAdmin, and the parallel-clone and clonescheme extensions are no longer included in an EDB Postgres Advanced Server installation. To download pgAdmin, see the [pgAdmin download page](https://www.pgadmin.org/download/). |
-| Change | The DBMS_CRYPTO.ENCRYPTO/DECRYPTO procedure has been wrongly accept any lengh of key. From this version, only the correct key length is acceptable. |
+| Change | In earlier versions, the DBMS_CRYPTO.ENCRYPT and DECRYPT procedures incorrectly accepted keys of any length. From this version onward, only keys of the correct length are permitted. |


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
DBMS_CRYPTO.ENCRYPT/DECRYPT procedure strengthen the restriction of input value of key variable, in which, it start only accepting correct length from this version. In the user's point of view, it can be an incompatibility that database might not able to decrypt the password encrypted in previous versions due to "invalid key length" error.

So there is a need to raise caution in release note to users.

Kind Regards,
Yuki Tei