### PR TITLE
Update 05_building_executing_dynamic_sql_statements.mdx

### DIFF
--- a/product_docs/docs/epas/17/application_programming/ecpgplus_guide/05_building_executing_dynamic_sql_statements.mdx
+++ b/product_docs/docs/epas/17/application_programming/ecpgplus_guide/05_building_executing_dynamic_sql_statements.mdx
@@ -249,6 +249,10 @@ static void handle_error(void)
 
 This example shows how to execute a query with a known number of input parameters and with a known number of columns in the result set. This method uses the `PREPARE` statement to parse and plan a query and then opens a cursor and iterates through the result set.
 
+!!! Note of Calling Stored Procedures
+There is a limitation that stored procedure cannot be executed by `CALL` query, if it is a dynamic query using `EXEC SQL PREPARE/EXECUTE`. If you need to include `CALL` query, you must use it only in static SQL and make sure the sql invoked toward EPAS, not community PostgreSQL.
+!!!
+
 ```c
 /***********************************************************/
 #include <stdio.h>

--- a/product_docs/docs/epas/17/application_programming/ecpgplus_guide/05_building_executing_dynamic_sql_statements.mdx
+++ b/product_docs/docs/epas/17/application_programming/ecpgplus_guide/05_building_executing_dynamic_sql_statements.mdx
@@ -250,7 +250,7 @@ static void handle_error(void)
 This example shows how to execute a query with a known number of input parameters and with a known number of columns in the result set. This method uses the `PREPARE` statement to parse and plan a query and then opens a cursor and iterates through the result set.
 
 !!! Note of Calling Stored Procedures
-There is a limitation that stored procedure cannot be executed by `CALL` query, if it is a dynamic query using `EXEC SQL PREPARE/EXECUTE`. If you need to include `CALL` query, you must use it only in static SQL and make sure the sql invoked toward EPAS, not community PostgreSQL.
+Stored procedures cannot be executed using the `CALL` query when they are part of a dynamic query with `EXEC SQL PREPARE/EXECUTE`. If you want to include a `CALL` query, it must be used only in static SQL. Additionally, ensure that the SQL is directed toward EPAS rather than the community version of PostgreSQL.
 !!!
 
 ```c


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
Add note of the limitation that, CALL procedure query is not allowed with dynamic SQL using PREPARE/EXECUTE.
This is added to avoid confusion misuse especially by ECPG newbies.

Please also refer to the case: https://techsupport.enterprisedb.com/company/tickets/46918

Kind Regards,
Yuki Tei