### PR TITLE
Update usage.mdx

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/retrievers/usage.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/retrievers/usage.mdx
@@ -18,7 +18,7 @@ create_retriever_for_table(
 -------------------------------------------------------------------------------
     name                                TEXT,
     model_name,                         TEXT,
-    source_table_name                   regclass,
+    source_table                        regclass,
     source_data_column            TEXT,
     source_data_type                    aidb.RetrieverSourceDataFormat,
     source_key_column                   TEXT DEFAULT 'id',
@@ -37,7 +37,7 @@ create_retriever_for_table(
 SELECT aidb.create_retriever_for_table(
                name => 'test_retriever',
                model_name => 'simple_model',
-               source_table_name => 'test_source_table',
+               source_table => 'test_source_table',
                source_data_column => 'content',
                source_data_type => 'Text'
        );


### PR DESCRIPTION
## What Changed?
Replace the parameter of `source_table_name` with `source_table`. It's correct in the page of `Pipelines retrievers reference` but it's been missed in this page.  


