### PR TITLE
quick and dirty product name replacement

### DIFF
--- a/advocacy_docs/playground/1/01_examples/expression-replacement.mdx
+++ b/advocacy_docs/playground/1/01_examples/expression-replacement.mdx
@@ -1,0 +1,43 @@
+---
+title: "{{name.ln}} examples"
+navTitle: "{{name.short}}"
+description: "{{name.ln}} v{{version.full}} provides functionality for replacing simple expressions representing product names and versions"
+displayBanner: "{{name.ln}} v{{version.full}} is not a real product, but it plays one in the playground"
+product: "Expression Replacement"
+version: "1.0.1"
+---
+
+
+
+This functionality allows for writing documentation when the future (or current) name of a product is subject to change. It is based on the metadata in `src/constants/products.js` combined with product names and versions (defined via either filesystem or frontmatter) and allows multiple forms of a product name as well as transformations of semantic version numbers. 
+
+## Example products.js data definition
+
+```javascript
+"Expression Replacement": {
+  name: "Name and Version Expression Replacement Syntax",
+  shortName: "Expression Replacement",
+  abbreviation: "ExpRel",
+  commonCommandName: "{{name().type}}",
+}
+```
+
+## Examples of invocation
+
+| Expression                                        | Replacement                                   | Source                                                                                            |
+|---------------------------------------------------|-----------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `\{{name.ln}}`                                    | {{name.ln}}                                   | product definition - `.name`                                                                      |
+| `\{{name.short}}`                                 | {{name.short}}                                | product definition - `.shortName`                                                                 |
+| `\{{name.abbr}}`                                  | {{name.abbr}}                                 | product definition - `.abbreviation`                                                              |
+| `\{{name.ccn}}`                                   | {{name.ccn}}                                  | product definition - `.commonCommandName`                                                         |
+| `\{{name(pgd).short}}`                            | {{name(pgd).short}}                           | PGD product definition - `.shortName`                                                             |
+| `\{{version.full}}`                               | {{version.full}}                              | frontmatter - `version:`                                                                          |
+| `\{{version(pgd).short}}`                         | {{version(pgd).short}}                        | filesystem directory version for latest product version                                           |
+| `\{{version(pgd).major}}.\{{version(pgd).minor}}` | {{version(pgd).major}}.{{version(pgd).minor}} | frontmatter - `version:` for latest product version. Parsed as semver, truncated at minor version |
+ 
+## Scope
+
+Expressions should be parsed in all Markdown elements containing rendered content, including code blocks and inline code. Frontmatter-sourced version information is not currently available in code. 
+
+Additionally, expressions will be replaced in certain frontmatter-defined values; initially, these include "title", "navTitle", "description" and "displayBanner".
+

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -380,6 +380,7 @@ module.exports = {
         ],
         remarkPlugins: [
           [require("./src/plugins/code-in-tables")],
+          [require("./src/plugins/replacement-expression")],
           [
             require("remark-admonitions"),
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "relgen": "file:tools/automation/generators/relgen",
         "remark-admonitions": "github:josh-heyer/remark-admonitions",
         "sass": "^1.77.6",
+        "semver": "^7.7.1",
         "truncate-utf8-bytes": "^1.0.2",
         "unist-util-visit-parents": "^3.1.1"
       },
@@ -2927,6 +2928,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@mdx-js/mdx/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/@mdx-js/mdx/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3361,6 +3371,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/@parcel/core/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/@parcel/diagnostic": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.2.tgz",
@@ -3589,6 +3608,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/node-resolver-core/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/@parcel/optimizer-terser": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.2.tgz",
@@ -3632,6 +3660,15 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@parcel/package-manager/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@parcel/packager-js": {
@@ -3791,6 +3828,15 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@parcel/transformer-js/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@parcel/transformer-json": {
@@ -4840,36 +4886,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
@@ -4992,31 +5008,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5024,11 +5015,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "4.33.0",
@@ -7005,6 +6991,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/clipboardy/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/clipboardy/node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7593,36 +7588,6 @@
       "peerDependencies": {
         "webpack": "^4.27.0 || ^5.0.0"
       }
-    },
-    "node_modules/css-loader/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/css-loader/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/css-loader/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/css-minimizer-webpack-plugin": {
       "version": "2.0.0",
@@ -9253,31 +9218,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/eslint/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9288,11 +9228,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/eslint/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/esniff": {
       "version": "2.0.1",
@@ -10149,17 +10084,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
@@ -10175,20 +10099,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/supports-color": {
@@ -10209,11 +10119,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -10656,31 +10561,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/gatsby-cli/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-cli/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/gatsby-cli/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10691,11 +10571,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/gatsby-cli/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/gatsby-core-utils": {
       "version": "3.25.0",
@@ -10894,36 +10769,6 @@
       "peerDependencies": {
         "gatsby": "^4.0.0-next"
       }
-    },
-    "node_modules/gatsby-plugin-manifest/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-plugin-manifest/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-plugin-manifest/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/gatsby-plugin-mdx": {
       "version": "3.20.0",
@@ -11387,36 +11232,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-    },
-    "node_modules/gatsby-plugin-sharp/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-plugin-sharp/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-plugin-sharp/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/gatsby-plugin-sitemap": {
       "version": "5.25.0",
@@ -12045,36 +11860,6 @@
         "gatsby-plugin-sharp": "^4.0.0-next"
       }
     },
-    "node_modules/gatsby-transformer-sharp/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-transformer-sharp/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-transformer-sharp/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/gatsby-worker": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/gatsby-worker/-/gatsby-worker-1.25.0.tgz",
@@ -12167,31 +11952,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/gatsby/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/gatsby/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12210,11 +11970,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/gatsby/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -16628,36 +16383,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-abi/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -17554,6 +17279,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/password-prompt/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/password-prompt/node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -17700,18 +17434,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/patch-package/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/patch-package/node_modules/slash": {
@@ -18149,36 +17871,6 @@
         "postcss": "^7.0.0 || ^8.0.1",
         "webpack": "^5.0.0"
       }
-    },
-    "node_modules/postcss-loader/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/postcss-merge-longhand": {
       "version": "5.1.7",
@@ -19749,6 +19441,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/remark-mdx/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/remark-mdx/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -20646,36 +20347,6 @@
         }
       }
     },
-    "node_modules/sass-loader/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/sass-loader/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/sass-loader/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/sass/node_modules/immutable": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
@@ -20730,11 +20401,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -20931,40 +20606,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/sharp/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sharp/node_modules/node-addon-api": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/sharp/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -22963,31 +22608,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/update-notifier/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/update-notifier/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/update-notifier/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -22998,11 +22618,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/update-notifier/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/upper-case": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "relgen": "file:tools/automation/generators/relgen",
     "remark-admonitions": "github:josh-heyer/remark-admonitions",
     "sass": "^1.77.6",
+    "semver": "^7.7.1",
     "truncate-utf8-bytes": "^1.0.2",
     "unist-util-visit-parents": "^3.1.1"
   },

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -14,6 +14,8 @@ import {
   IconList,
   PurlAnchor,
 } from "../components";
+import ProductName from "../components/product-name";
+import ProductVersion from "../components/product-version";
 import { MDXProvider } from "@mdx-js/react";
 import Icon from "../components/icon/";
 
@@ -129,6 +131,8 @@ const Layout = ({
           }
         ></blockquote>
       ),
+      name: ProductName,
+      version: ProductVersion,
       KatacodaPanel: () => (
         <KatacodaPanel katacodaPanelData={katacodaPanelData} />
       ),
@@ -148,6 +152,7 @@ const Layout = ({
       value={{
         dark: dark,
         toggleDark: toggleDark,
+        baseUrl: baseUrl,
       }}
     >
       <Helmet>

--- a/src/components/product-context.js
+++ b/src/components/product-context.js
@@ -1,0 +1,7 @@
+import React, { useContext } from "react";
+
+const productContext = React.createContext(null);
+
+export default productContext.Provider;
+
+export const useProductContext = () => useContext(productContext);

--- a/src/components/product-name.js
+++ b/src/components/product-name.js
@@ -1,0 +1,14 @@
+import { useProductContext } from "./product-context";
+import { getProductName } from "../constants/expression-replacement";
+
+export default function ProductName({ productShortcode, type }) {
+  const productContext = useProductContext();
+  const { product: currentProduct, absoluteFilePath } = productContext;
+  const errorContext = absoluteFilePath;
+
+  return getProductName({
+    product: productShortcode || currentProduct,
+    type,
+    errorContext,
+  });
+}

--- a/src/components/product-version.js
+++ b/src/components/product-version.js
@@ -1,0 +1,24 @@
+import { useProductContext } from "./product-context";
+import { getProductVersion } from "../constants/expression-replacement";
+
+export default function ProductVersion({ productShortcode, type }) {
+  const productContext = useProductContext();
+  const {
+    product: currentProduct,
+    version: currentVersion,
+    fullVersion: currentFullVersion,
+    productVersions,
+    absoluteFilePath,
+  } = productContext;
+  const errorContext = absoluteFilePath;
+
+  return getProductVersion({
+    product: productShortcode,
+    currentProduct,
+    currentVersion,
+    currentFullVersion,
+    productVersions,
+    type,
+    errorContext,
+  });
+}

--- a/src/constants/expression-replacement.mjs
+++ b/src/constants/expression-replacement.mjs
@@ -1,0 +1,77 @@
+import { products } from "./products.js";
+import semver from "semver";
+
+export const expressionRE = /(?<!\\)\{\{(?<command>\w+)(?:\((?<product>[^)]+)\)){0,1}\.(?<type>[^}]+)\}\}/;
+const nameCodes = {
+  "ln": "name",
+  "short": "shortName",
+  "abbr": "abbreviation",
+  "ccn": "commonCommandName",
+};
+
+
+export default function expressionReplacement({text, currentProduct, currentVersion, currentFullVersion, productVersions, filename, position}) {
+  if (typeof text !== "string" || !text.includes("{{")) return text;
+  
+  if (!currentProduct && filename)
+    currentProduct = filename.split("product_docs/docs/")[1]?.split("/")?.at(0);
+  if (!currentVersion && filename)
+    currentVersion = filename.split("product_docs/docs/")[1]?.split("/")?.at(1);
+
+  let errorContext = filename;
+  if (errorContext && position)
+    errorContext += `:${position.start?.line}:${position.start?.column}`;  
+
+  text = text.replace(new RegExp(expressionRE, 'g'), (match, p1, p2, p3, offset, s, {command, product, type}) => {
+    switch (command) {
+      case "name":
+        return getProductName({product: product || currentProduct, type, errorContext});
+      case "version":
+        return getProductVersion({product, currentProduct, currentVersion, currentFullVersion, productVersions, type, errorContext});
+      default:
+        break;
+    };
+    return match;
+  });
+
+  return text;
+}
+
+export function getProductName({product, type, errorContext}) {
+  const productDef = products[product];
+  if (!productDef) {
+    console.error(`${errorContext} Product ${product} not found for name lookup".`);
+    return "[error]";
+  }
+  const nameType = nameCodes[type];
+  if (!nameType) {
+    console.error(`${errorContext} Unknown name type: ${type} for name lookup".`);
+    return "[error]";
+  }
+  const name = productDef[nameType];
+  if (!name) {
+    console.error(`${errorContext} Product ${product} does not have ${nameType} defined for name lookup".`);
+    return "[error]";
+  }
+  return name;
+}
+
+export function getProductVersion({product, currentProduct, currentVersion, currentFullVersion, productVersions, type, errorContext}) {
+  let version = currentVersion;
+  let fullVersion = currentFullVersion || version;
+  if (product && product !== currentProduct) {
+    version = productVersions ? productVersions[product][0] : "";
+    fullVersion = version;
+  }
+
+  if (type === "full") return fullVersion;
+  if (type === "short") return version;
+  const semantic = semver.valid(semver.coerce(fullVersion));
+  if (!semantic) return version;
+  switch (type) {
+    case "major": return semver.major(semantic);
+    case "minor": return semver.minor(semantic);
+    case "patch": return semver.patch(semantic);
+  };
+  return `[error - don't know what you mean by a '${type}' version]`;
+}

--- a/src/constants/products.js
+++ b/src/constants/products.js
@@ -1,6 +1,13 @@
-import IconNames from "../components/icon/iconNames";
+import IconNames from "../components/icon/iconNames.js";
 
 export const products = {
+  "Expression Replacement": {
+    name: "Name and Version Expression Replacement Syntax",
+    shortName: "Expression Replacement",
+    abbreviation: "ExpRel",
+    commonCommandName: "{{name(prod).type}}",
+    noSearch: true,
+  },
   bart: {
     name: "Backup and Recovery Tool",
     iconName: IconNames.EDB_BART,
@@ -11,9 +18,16 @@ export const products = {
   edb_plus: { name: "EDB*Plus" },
   efm: { name: "Failover Manager", iconName: IconNames.EDB_EFM },
   "EDB LDAP Sync": { name: "EDB LDAP Sync" },
-  epas: { name: "EDB Postgres Advanced Server", iconName: IconNames.EDB_EPAS },
+  epas: {
+    name: "EDB Postgres Advanced Server",
+    shortName: "Advanced Server",
+    abbreviation: "EPAS",
+    iconName: IconNames.EDB_EPAS,
+  },
   pgd: {
     name: "EDB Postgres Distributed (PGD)",
+    shortName: "EDB Postgres Distributed",
+    abbreviation: "PGD",
     iconName: IconNames.HIGH_AVAILABILITY,
   },
   pge: { name: "EDB Postgres Extended Server", iconName: IconNames.POSTGRESQL },

--- a/src/plugins/replacement-expression.js
+++ b/src/plugins/replacement-expression.js
@@ -1,0 +1,68 @@
+const visit = require("unist-util-visit-parents");
+const { expressionRE } = require("../constants/expression-replacement.mjs");
+let replacer = null;
+let shortcodeRE = null;
+import("../constants/expression-replacement.mjs").then(
+  (module) => (
+    (shortcodeRE = module.expressionRE), (replacer = module.default)
+  ),
+);
+
+// This plugin replaces shortcodes in the form {{name([product]).<type>}} with the actual name of the product
+// The type of name must be one defined in products.js
+function replaceExpressions() {
+  return (tree, file) => {
+    visit(tree, ["text", "code", "inlineCode"], visitor);
+
+    function visitor(node, ancestors) {
+      if (!node.value?.includes("{{")) return;
+      if (["code", "inlineCode"].includes(node.type)) {
+        node.value = replacer({
+          text: node.value,
+          filename: file.path,
+          position: node.position,
+        });
+        return;
+      }
+
+      const addNodes = [];
+      let input = node.value;
+      while (input.length) {
+        const result = expressionRE.exec(input);
+        if (!result) {
+          addNodes.push({
+            type: "text",
+            value: input,
+          });
+          break;
+        }
+        const before = input.slice(0, result.index); // text before the match
+        const after = input.slice(result.index + result[0].length); // text after the match
+        const { command, product, type } = result.groups;
+        let jsx = "";
+        switch (command) {
+          case "name":
+            jsx = `<name productShortcode={${JSON.stringify(product)}} type={${JSON.stringify(type)}} />`;
+            break;
+          case "version":
+            jsx = `<version productShortcode={${JSON.stringify(product)}} type={${JSON.stringify(type)}} />`;
+            break;
+          default:
+            before = before + result[0];
+        }
+        if (before) addNodes.push({ type: "text", value: before });
+        if (jsx)
+          addNodes.push({
+            type: "jsx",
+            value: jsx,
+          });
+        input = after;
+      }
+      const index = ancestors.at(-1).children.indexOf(node);
+      ancestors.at(-1).children.splice(index, 1, ...addNodes); // replace the original node with the new nodes
+      return index + addNodes.length; // return the new index to continue visitings
+    }
+  };
+}
+
+module.exports = replaceExpressions;

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -22,6 +22,7 @@ import {
 } from "../components";
 import { products } from "../constants/products";
 import { FeedbackDropdown } from "../components/feedback-dropdown";
+import ProductContext from "../components/product-context";
 import GithubSlugger from "github-slugger";
 
 export const query = graphql`
@@ -190,6 +191,7 @@ const DocTemplate = ({ data, pageContext }) => {
   }
 
   let title = frontmatter.title;
+
   if (depth === 2 && !navTree.hideVersion) {
     // product version root
     title += ` v${version}`;
@@ -283,7 +285,17 @@ const DocTemplate = ({ data, pageContext }) => {
                 "col-print-12",
               ].join(" ")}
             >
-              <MDXRenderer>{body}</MDXRenderer>
+              <ProductContext
+                value={{
+                  product,
+                  version,
+                  fullVersion: frontmatter.version,
+                  productVersions,
+                  fileAbsolutePath,
+                }}
+              >
+                <MDXRenderer>{body}</MDXRenderer>
+              </ProductContext>
               <Tiles mode={indexCards} node={navRoot} />
               {(!indexCards || indexCards === TileModes.None) && sections && (
                 <Sections sections={sections} />

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -21,6 +21,7 @@ import {
   TileModes,
 } from "../components";
 import GithubSlugger from "github-slugger";
+import ProductContext from "../components/product-context";
 
 export const query = graphql`
   query ($nodeId: String!) {
@@ -207,7 +208,16 @@ const LearnDocTemplate = ({ data, pageContext }) => {
                 "col-print-12",
               ].join(" ")}
             >
-              <MDXRenderer>{mdx.body}</MDXRenderer>
+              <ProductContext
+                value={{
+                  product: frontmatter.product,
+                  version: frontmatter.version,
+                  productVersions,
+                  fileAbsolutePath: mdx.fileAbsolutePath,
+                }}
+              >
+                <MDXRenderer>{mdx.body}</MDXRenderer>
+              </ProductContext>
               <Tiles mode={cardTileMode} node={navRoot} />
             </Col>
 


### PR DESCRIPTION
## What Changed?

Allows expressions like `{{name.ln}}` or `{{name(epas).abbr}}` or `{{version.minor}}` to be used in Markdown, title, description.

Demo: https://deploy-preview-6673--edb-docs-staging.netlify.app/docs/playground/1/01_examples/expression-replacement/ 