### PR TITLE
EPRS: replaces em dashes in code snippets with hyphen in commands

### DIFF
--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/04_encrypt_password.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/04_encrypt_password.mdx
@@ -8,7 +8,7 @@ The `encrypt` command encrypts the text supplied in an input file and writes the
 
 ## Synopsis
 
-`-encrypt –input infile –output pwdfile`
+`-encrypt -input infile -output pwdfile`
 
 The text in `infile` is processed using the MD5 encryption algorithm, and the encrypted text is written to file `pwdfile`. Make sure that `infile` contains only the text that you want to encrypt and that there are no extra characters or empty lines before or after the text that you want to encrypt.
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/08_printing_pub_db_details.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/08_printing_pub_db_details.mdx
@@ -8,7 +8,7 @@ The `printpubdbidsdetails` command displays the connection information for each 
 
 ## Synopsis
 
-`-printpubdbidsdetails –repsvrfile pubsvrfile`
+`-printpubdbidsdetails -repsvrfile pubsvrfile`
 
 The output has the following components:
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/12_removing_publication_database.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/12_removing_publication_database.mdx
@@ -10,8 +10,8 @@ The `removepubdb` command removes a publication database definition.
 
 ```shell
 -removepubdb
-  –repsvrfile pubsvrfile
-  –pubdbid dbid
+  -repsvrfile pubsvrfile
+  -pubdbid dbid
 ```
 
 The `pubdbid` parameter identifies the publication database definition to remove.

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/13_get_tables_for_new_publication.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/13_get_tables_for_new_publication.mdx
@@ -8,7 +8,7 @@ The `gettablesfornewpub` command lists the tables and views available for includ
 
 ## Synopsis
 
-`-gettablesfornewpub –repsvrfile repsvrfile –pubdbid dbid`
+`-gettablesfornewpub -repsvrfile repsvrfile -pubdbid dbid`
 
 ## Parameters
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/20_adding_tablefilters_to_publication.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/20_adding_tablefilters_to_publication.mdx
@@ -14,7 +14,7 @@ If the filter rule isn't enabled on a target subscription or non-MDN node, then 
 
 ```shell
 -addfilter pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
 [ -tables schema_t1.table_1 [ schema_t2.table_2 ] ...]
 [ -views schema_v1.view_1 [ schema_v2.view_2 ] ...]
 [ -tablesfilterclause

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/21_updating_tablefilters_to_publication.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/21_updating_tablefilters_to_publication.mdx
@@ -10,7 +10,7 @@ The `updatefilter` command changes the filter clauses of the specified tables or
 
 ```shell
 -updatefilter pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -tablesfilterclause
     "filterid_1:filterclause_1"
   [ "filterid_2:filterclause_2" ] ...

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/22_removing_tablefilters_to_publication.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/22_removing_tablefilters_to_publication.mdx
@@ -10,7 +10,7 @@ The `removefilter` command removes the table filter from the specified publicati
 
 ```shell
 -removefilter pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -filterid filterid
 ```
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/23_print_conflict_resolution_strategy.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/23_print_conflict_resolution_strategy.mdx
@@ -10,7 +10,7 @@ title: "Printing the conflict resolution strategy (printconfresolutionstrategy)"
 
 ```shell
 -printconfresolutionstrategy pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -table schema_t.table_name
 ```
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/24_updating_conflict_resolution_strategy.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/24_updating_conflict_resolution_strategy.mdx
@@ -10,7 +10,7 @@ title: "Updating the conflict resolution strategy (updateconfresolutionstrategy)
 
 ```shell
 -updateconfresolutionstrategy pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -table schema_t.table_name
   -conflictresolution { E | L | N | M | C }
   -standbyconflictresolution { E | L | N | M | C }

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/25_set_pdn_node.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/25_set_pdn_node.mdx
@@ -10,7 +10,7 @@ title: "Setting the master definition node (setasmdn)"
 
 ```shell
 -setasmdn pubdbid
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
 ```
 
 See [Switching the primary definition node](../../06_mmr_operation/08_switching_pdn) for more information on setting the primary definition node.

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/26_set_controller.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/26_set_controller.mdx
@@ -10,7 +10,7 @@ The `setascontroller` command designates a publication database as the controlle
 
 ```shell
 -setascontroller pubdbid
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
 ```
 
 See [Switching the controller database](../../07_common_operations/07_switching_controller_db/#switching_controller_db) for information on setting the controller database.

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/27_validate_a_publication.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/27_validate_a_publication.mdx
@@ -10,7 +10,7 @@ The `validatepub` command checks whether any of the definitions of the tables in
 
 ```shell
 -validatepub pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -repgrouptype { m | s }
 ```
 !!! note

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/28_validate_all_publications.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/28_validate_all_publications.mdx
@@ -10,7 +10,7 @@ The `validatepubs` command checks whether any of the definitions of the tables s
 
 ```shell
 -validatepubs
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -pubdbid dbid
   -repgrouptype { m | s }
 ```

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/29_removing_a_publication.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/29_removing_a_publication.mdx
@@ -10,7 +10,7 @@ The `removepub` command removes one or more publications.
 
 ```shell
 -removepub pubname_1 [ pubname_2 ] ...
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -repgrouptype { m | s }
   [ -force ]
 ```

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/30_replicating_ddl_changes_cli.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/30_replicating_ddl_changes_cli.mdx
@@ -10,7 +10,7 @@ The `replicateddl` command applies an `ALTER TABLE` statement to a publication t
 
 ```shell
 -replicateddl pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -table schema_t.table_name
   -ddlscriptfile script_file
 ```

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/33_printing_subscription_db_details.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/33_printing_subscription_db_details.mdx
@@ -8,7 +8,7 @@ title: "Printing Subscription Database Details (printsubdbidsdetails)"
 
 ## Synopsis
 
-`-printsubdbidsdetails –repsvrfile subsvrfile`
+`-printsubdbidsdetails -repsvrfile subsvrfile`
 
 The output has the following components:
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/35_removing_subscription_database_cli.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/35_removing_subscription_database_cli.mdx
@@ -8,7 +8,7 @@ title: "Removing a subscription database (removesubdb)"
 
 ## Synopsis
 
-`-removesubdb –repsvrfile subsvrfile –subdbid dbid`
+`-removesubdb -repsvrfile subsvrfile -subdbid dbid`
 
 The subscription database definition to remove is identified by the `subdbid` parameter.
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/41_taking_mmr_snapshot.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/41_taking_mmr_snapshot.mdx
@@ -10,7 +10,7 @@ title: "Take a multi-master snapshot (dommrsnapshot)"
 
 ```shell
 -dommrsnapshot pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
   -pubhostdbid dbid
 [ -verboseSnapshotOutput { true | false } ]
 ```

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/42_perform_synchronization.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/42_perform_synchronization.mdx
@@ -13,7 +13,7 @@ The `dosynchronize` command performs synchronization replication on the specifie
   -repsvrfile { subsvrfile | pubsvrfile }
 [ -repgrouptype { s | m } ]
 For a single-master replication system use:
--dosynchronize subname –repsvrfile subsvrfile
+-dosynchronize subname -repsvrfile subsvrfile
 ```
 
 **For a multi-master replication system use:**

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/43_configure_smr_schedule.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/43_configure_smr_schedule.mdx
@@ -9,7 +9,7 @@ title: "Configuring a single-master schedule (confschedule)"
 ## Synopsis
 
 ```shell
--confschedule subname –repsvrfile subsvrfile
+-confschedule subname -repsvrfile subsvrfile
 { -remove | -jobtype { s | t }
   { -realtime no_of_sec |
     -daily hour minute |

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/44_configure_mmr_schedule.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/44_configure_mmr_schedule.mdx
@@ -13,7 +13,7 @@ title: "Configuring a multi-master schedule (confschedulemmr)"
 
 ```shell
 -confschedulemmr pubdbid -pubname pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
 { -remove |
   { -realtime no_of_sec |
     -daily hour minute |

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/45_print_schedule.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/45_print_schedule.mdx
@@ -13,7 +13,7 @@ The `printschedule` command displays a recurring replication schedule.
   -repsvrfile { subsvrfile | pubsvrfile }
 [ -repgrouptype { s | m } ]
 For a single-master replication system use:
--printschedule subname –repsvrfile subsvrfile
+-printschedule subname -repsvrfile subsvrfile
 ```
 
 **For a multi-master replication system:**

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/47_removing_subscription_cli.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/47_removing_subscription_cli.mdx
@@ -8,7 +8,7 @@ title: "Removing a subscription (removesub)"
 
 ## Synopsis
 
-`-removesub subname –repsvrfile subsvrfile`
+`-removesub subname -repsvrfile subsvrfile`
 
 See [Removing a subscription](../../05_smr_operation/05_managing_subscription/#removing-a-subscription) for more information.
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/48_schedule_shadow_table_history_clean.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/48_schedule_shadow_table_history_clean.mdx
@@ -9,7 +9,7 @@ The `confcleanupjob` command creates a schedule for when to delete shadow table 
 ## Synopsis
 
 ```shell
--confcleanupjob pubdbid –repsvrfile pubsvrfile
+-confcleanupjob pubdbid -repsvrfile pubsvrfile
 { -disable | -enable
   { -minutely no_of_minutes |
     -hourly no_of_hours |
@@ -89,7 +89,7 @@ This example schedules the shadow table history cleanup to run every Wednesday a
 ```shell
 $ java -jar edb-repcli.jar -confcleanupjob 1 \
 >   -repsvrfile ~/pubsvrfile.prop \
->   -enable –weekly WEDNESDAY 8
+>   -enable -weekly WEDNESDAY 8
 Configuring cleanup job ...
 Cleanup job configured.
 ```

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/49_clean_shadow_table_history.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/49_clean_shadow_table_history.mdx
@@ -10,7 +10,7 @@ The `cleanshadowhistforpub` command deletes the shadow table history for the spe
 
 ```shell
 -cleanshadowhistforpub pubname
-  –repsvrfile pubsvrfile
+  -repsvrfile pubsvrfile
 [ -mmrdbid dbid_1[,dbid_2 ] ...]
 ```
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/50_clean_replication_history.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/50_clean_replication_history.mdx
@@ -8,7 +8,7 @@ The `cleanrephistoryforpub` command deletes the replication history for the spec
 
 ## Synopsis
 
-`-cleanrephistoryforpub pubname –repsvrfile pubsvrfile`
+`-cleanrephistoryforpub pubname -repsvrfile pubsvrfile`
 
 See [Cleaning up replication history](../../07_common_operations/05_managing_history/#clean_up_replication_history) for more information.
 

--- a/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/51_clean_all_replication_history.mdx
+++ b/product_docs/docs/eprs/7/08_xdb_cli/03_xdb_cli_commands/51_clean_all_replication_history.mdx
@@ -8,7 +8,7 @@ The `cleanrephistory` command deletes the replication history for all publicatio
 
 ## Synopsis
 
-`-cleanrephistory –repsvrfile pubsvrfile`
+`-cleanrephistory -repsvrfile pubsvrfile`
 
 See [Cleaning up replication history](50_clean_replication_history/#clean_replication_history) for more information.
 

--- a/product_docs/docs/eprs/7/09_data_validator/02_perform_datavalidation.mdx
+++ b/product_docs/docs/eprs/7/09_data_validator/02_perform_datavalidation.mdx
@@ -17,7 +17,7 @@ Similarly for Windows hosts, issue the following:
 The general command format for invoking the Data Validator is the following:
 
 ```shell
-./runValidation.sh { –ss | --source-schema } schema_name
+./runValidation.sh { -ss | --source-schema } schema_name
   [ option ] ...
 ```
 
@@ -26,14 +26,14 @@ The general command format for invoking the Data Validator is the following:
 For Windows hosts, the command format is the following:
 
 ```shell
-runValidation { –ss | --source-schema } schema_name
+runValidation { -ss | --source-schema } schema_name
   [ option ] ...
 ```
 
 The following option displays the Data Validator version:
 
 ```shell
-./runValidation.sh { –v | --version }
+./runValidation.sh { -v | --version }
 ```
 
 
@@ -53,7 +53,7 @@ EnterpriseDB DataValidator Build 3
 
 The following option displays the help information.
 
-``./runValidation.sh { –h | --help }``
+``./runValidation.sh { -h | --help }``
 
 For example,
 
@@ -101,7 +101,7 @@ OPTIONS:
 The general syntax for all options except for `--version` and `--help` is shown by the following:
 
 ```shell
-./runValidation.sh –ss schema
+./runValidation.sh -ss schema
   [ -ts schema ]
   [ -it table_1 [,table_2 ] ... ]
   [ -et table_1 [,table_2 ] ... ]


### PR DESCRIPTION
## What Changed?

There is a bug where in some documented command flags/arguments, they are introduced by an em dash instead of a hyphen. This is causing customers to get the `Error: Invalid combination of arguments.` when copy-pasting from the docs. 

https://enterprisedb.atlassian.net/browse/XDB-2369

I did a global search in the */eprs/* documentation and found more instances.

PS: The difference is not that visible here in GH, but VSCode displayed it better: 

<img width="514" alt="Screenshot 2025-04-03 at 18 15 40" src="https://github.com/user-attachments/assets/808b82ea-33d8-4bd2-b453-3305b662b6bc" />
