### PR TITLE
Adding Windows example to Compiling and linking a program page in OCL

### DIFF
--- a/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
+++ b/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
@@ -57,24 +57,24 @@ This example compiles and links the sample program `edb_demo.c` in a Windows 64 
 
 1. Change to the `samples` directory in the `edb-oci` installation directory:
 
-   ```text
+   ```powershell
    cd "c:\Program Files\edb\oci\samples"
    ```
 
 1. Compile the sample assuming Oracle headers are in `c:\oracle_client\include\`:
 
-   ```text
+   ```powershell
    cl edb_demo.c /I c:\oracle_client\include\ -D WIN32 /link /libpath:"c:\Program Files\edb\oci\lib\" edboci.lib
    ```
 
 1. Set the path to include the path to `edb-oci` dlls:
 
-   ```text
+   ```powershell
    set path=%path%;C:\Program Files\edb\oci\;C:\Program Files\edb\oci\lib
    ```
 
 1. Finally, run the sample:
 
-   ```text
+   ```powershell
    edb_demo.exe
    ```

--- a/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
+++ b/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
@@ -13,9 +13,10 @@ The EDB Open Client Library allows applications written using the Oracle Call In
 
 The files are installed in the `oci/lib` subdirectory.
 
-## Compiling and linking a sample program
+## Compiling and linking a sample program in Linux
 
-This example compiles and links the sample program `edb_demo.c` in a Linux environment. The `edb_demo.c` file is located in the `oci/samples` subdirectory.
+This example compiles and links the sample program `edb_demo.c` in a Linux environment. 
+The `edb_demo.c` file is located in the `oci/samples` subdirectory.
 
 1.  Set `ORACLE_HOME` to the complete pathname of the Oracle home directory, for example:
 
@@ -39,3 +40,33 @@ This example compiles and links the sample program `edb_demo.c` in a Linux envir
     cd $EDB_HOME/oci/samples
     make
     ```
+
+## Compiling and linking a sample program in Windows
+
+This example compiles and links the sample program edb_demo.c in a Windows 64 bit environment.
+
+1. In Visual Studio Code 64-bit for Windows, open a terminal to conduct the compiling and linking procedure.
+
+1. Change to the `samples` directory in the `edb-oci` installation directory:
+
+```bash
+cd "c:\Program Files\edb\oci\samples"
+```
+
+1. Compile the sample assuming Oracle headers are in `c:\oracle_client\include\`:
+
+```bash
+cl edb_demo.c /I c:\oracle_client\include\ -D WIN32 /link /libpath:"c:\Program Files\edb\oci\lib\" edboci.lib
+```
+
+1. Set the path to include the path to `edb-oci` dlls:
+
+```bash
+set path=%path%;C:\Program Files\edb\oci\;C:\Program Files\edb\oci\lib
+```
+
+1. Finally, run the sample:
+
+```bash
+edb_demo.exe
+```

--- a/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
+++ b/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
@@ -44,7 +44,7 @@ The `edb_demo.c` file is located in the `oci/samples` subdirectory.
 
 1.  Compile and link the OCL API program:
 
-    ```text
+    ```bash
     cd $EDB_HOME/oci/samples
     make
     ```
@@ -57,24 +57,24 @@ This example compiles and links the sample program `edb_demo.c` in a Windows 64 
 
 1. Change to the `samples` directory in the `edb-oci` installation directory:
 
-   ```bash
+   ```text
    cd "c:\Program Files\edb\oci\samples"
    ```
 
 1. Compile the sample assuming Oracle headers are in `c:\oracle_client\include\`:
 
-   ```bash
+   ```text
    cl edb_demo.c /I c:\oracle_client\include\ -D WIN32 /link /libpath:"c:\Program Files\edb\oci\lib\" edboci.lib
    ```
 
 1. Set the path to include the path to `edb-oci` dlls:
 
-   ```bash
+   ```text
    set path=%path%;C:\Program Files\edb\oci\;C:\Program Files\edb\oci\lib
    ```
 
 1. Finally, run the sample:
 
-   ```bash
+   ```text
    edb_demo.exe
    ```

--- a/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
+++ b/product_docs/docs/ocl_connector/17/04_open_client_library/03_compiling_and_linking_a_program.mdx
@@ -20,19 +20,27 @@ The `edb_demo.c` file is located in the `oci/samples` subdirectory.
 
 1.  Set `ORACLE_HOME` to the complete pathname of the Oracle home directory, for example:
 
-    `export ORACLE_HOME=/usr/lib/oracle/xe/app/oracle/product/10.2.0/server`
+    ```bash
+    export ORACLE_HOME=/usr/lib/oracle/xe/app/oracle/product/10.2.0/server
+    ```
 
 1.  Set `EDB_HOME` to the complete pathname of the home directory, for example:
 
-    `export EDB_HOME=/usr/edb`
+    ```bash
+    export EDB_HOME=/usr/edb
+    ```
 
 1.  Set `LD_LIBRARY_PATH` to the complete path of `libpthread.so`. By default, `libpthread.so` is located in `/lib64`.
 
-    `export LD_LIBRARY_PATH=/lib64/lib:$LD_LIBRARY_PATH`
+    ```bash
+    export LD_LIBRARY_PATH=/lib64/lib:$LD_LIBRARY_PATH
+    ```
 
 1.  Set `LD_LIBRARY_PATH` to include the EDB Postgres Advanced Server Open Client library. By default, `libedboci.so` is located in `$EDB_HOME/oci/lib`.
 
-    `export LD_LIBRARY_PATH=$EDB_HOME/oci:$EDB_HOME/oci/lib:$LD_LIBRARY_PATH`
+    ```bash
+    export LD_LIBRARY_PATH=$EDB_HOME/oci:$EDB_HOME/oci/lib:$LD_LIBRARY_PATH
+    ```
 
 1.  Compile and link the OCL API program:
 
@@ -43,30 +51,30 @@ The `edb_demo.c` file is located in the `oci/samples` subdirectory.
 
 ## Compiling and linking a sample program in Windows
 
-This example compiles and links the sample program edb_demo.c in a Windows 64 bit environment.
+This example compiles and links the sample program `edb_demo.c` in a Windows 64 bit environment.
 
 1. In Visual Studio Code 64-bit for Windows, open a terminal to conduct the compiling and linking procedure.
 
 1. Change to the `samples` directory in the `edb-oci` installation directory:
 
-```bash
-cd "c:\Program Files\edb\oci\samples"
-```
+   ```bash
+   cd "c:\Program Files\edb\oci\samples"
+   ```
 
 1. Compile the sample assuming Oracle headers are in `c:\oracle_client\include\`:
 
-```bash
-cl edb_demo.c /I c:\oracle_client\include\ -D WIN32 /link /libpath:"c:\Program Files\edb\oci\lib\" edboci.lib
-```
+   ```bash
+   cl edb_demo.c /I c:\oracle_client\include\ -D WIN32 /link /libpath:"c:\Program Files\edb\oci\lib\" edboci.lib
+   ```
 
 1. Set the path to include the path to `edb-oci` dlls:
 
-```bash
-set path=%path%;C:\Program Files\edb\oci\;C:\Program Files\edb\oci\lib
-```
+   ```bash
+   set path=%path%;C:\Program Files\edb\oci\;C:\Program Files\edb\oci\lib
+   ```
 
 1. Finally, run the sample:
 
-```bash
-edb_demo.exe
-```
+   ```bash
+   edb_demo.exe
+   ```


### PR DESCRIPTION
## What Changed?
- Ported in instructions from eng and edited for Docs compliance.
