### PR TITLE
The extension `dbms_scheduler` must be created by user

### DIFF
--- a/product_docs/docs/epas/17/reference/oracle_compatibility_reference/epas_compat_bip_guide/03_built-in_packages/15_dbms_scheduler/index.mdx
+++ b/product_docs/docs/epas/17/reference/oracle_compatibility_reference/epas_compat_bip_guide/03_built-in_packages/15_dbms_scheduler/index.mdx
@@ -13,6 +13,8 @@ The `DBMS_SCHEDULER` package's jobs are scheduled and run in the background by t
 
 The `DBMS_SCHEDULER` package provides a way to create and manage Oracle-style jobs, programs, and job schedules. 
 
+To use the `DBMS_SCHEDULER` package, create the `dbms_scheduler` extension by running `CREATE EXTENSION IF NOT EXISTS dbms_scheduler`.
+
 The `DBMS_SCHEDULER` package implements the following functions and procedures:
 
 | Function/procedure                                                                                                                                | Return type | Description                                                                                                                       |


### PR DESCRIPTION
otherwise calls to the package procedures will be failing.

## What Changed?

Added the instruction to create the required extension.