### PR TITLE
Corrected supported database versions index.mdx

### DIFF
--- a/product_docs/docs/pgd/5.7/index.mdx
+++ b/product_docs/docs/pgd/5.7/index.mdx
@@ -78,7 +78,7 @@ the peer nodes only after the local commit. You can configure additional levels 
 
 ## Compatibility
 
-EDB Postgres Distributed 5 is compatible with PostgreSQL, EDB Postgres Extended, and EDB Postgres Advanced versions 12-17. See [Compatibility](compatibility) for more details, including information about compatibility with different operating systems and architectures.
+EDB Postgres Distributed 5 is compatible with PostgreSQL, EDB Postgres Extended, and EDB Postgres Advanced versions 13-17. See [Compatibility](compatibility) for more details, including information about compatibility with different operating systems and architectures.
 For feature compatibility with compatible servers, see [Choosing a Postgres distribution](planning/choosing_server).
 
 ---


### PR DESCRIPTION
## What Changed?

Before: 
EDB Postgres Distributed 5 is compatible with PostgreSQL, EDB Postgres Extended, and EDB Postgres Advanced versions 12-17

After: 
EDB Postgres Distributed 5 is compatible with PostgreSQL, EDB Postgres Extended, and EDB Postgres Advanced versions 13-17

## Why? 
v12 is End of Life 
