### PR TITLE
DOCS-1432-Update-Compatibility-Table-2

### DIFF
--- a/product_docs/docs/pgd/6.0/compatibility.mdx
+++ b/product_docs/docs/pgd/6.0/compatibility.mdx
@@ -16,8 +16,6 @@ The following table shows the major versions of PostgreSQL and each version of E
 | 16               | [5.3+](/pgd/5.6/)  |              |
 | 15               | [5](/pgd/5.6/)     |              |
 | 14               | [5](/pgd/5.6/)     | [4](/pgd/4/) |
-| 13               | [5](/pgd/5.6/)     | [4](/pgd/4/) |
-| 12               | [5](/pgd/5.6/)     | [4](/pgd/4/) |
 
 EDB recommends that you use the latest minor version of any Postgres major version with a supported PGD.
 

--- a/product_docs/docs/pgd/6.0/upgrades/compatibility.mdx
+++ b/product_docs/docs/pgd/6.0/upgrades/compatibility.mdx
@@ -2,8 +2,7 @@
 title: Compatibility changes
 ---
 
-Many changes in PGD 5 aren't backward compatible with
-PGD 4 or PGD 3.7.
+Upgrading BDR from 4.x to 6.x is possible.
 
 ## Connection routing
 


### PR DESCRIPTION
Updated the compatibility table to remove compats for pre v14 PG and updated upgrades compatibility page to say that Upgrading from 4.x to 6.x is possible.

