### PR TITLE
Update how_pg_upgrade_works.mdx

### DIFF
--- a/product_docs/docs/epas/17/upgrading/major_upgrade/how_pg_upgrade_works.mdx
+++ b/product_docs/docs/epas/17/upgrading/major_upgrade/how_pg_upgrade_works.mdx
@@ -26,5 +26,11 @@ DROP EXTENSION edb_dblink_libpq;
 
 When you finish upgrading, you can use the `CREATE EXTENSION` command to add the current versions of the extensions to your installation.
 
+If you're utilizing EDB Postgres Advanced Server on Windows, make sure that adminpack extension is deleted from each database because this feature is removed from this version without any alternative.
+
+```sql
+DROP EXTENSION adminpack;
+```
+
 !!! Note
     If the upgrade involves a change in the on-disk representation of database objects or data, or if it involves a change in the binary representation of data types, `pg_upgrade` can't perform the upgrade. To upgrade, you have to `pg_dump` the old data and then import that data to the new cluster.


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
Since adminpack has been implemented automatically following community policy, this pg_upgrade to EPAS17 on windows will 100% failed due to "Failed to load library" error.
User should first remove adminpack manually in the source databases.

Kind Regards,
Yuki Tei