### PR TITLE
Update 05_pg_upgrade_troubleshooting.mdx

### DIFF
--- a/product_docs/docs/epas/17/upgrading/major_upgrade/05_pg_upgrade_troubleshooting.mdx
+++ b/product_docs/docs/epas/17/upgrading/major_upgrade/05_pg_upgrade_troubleshooting.mdx
@@ -34,4 +34,4 @@ If the original EDB Postgres Advanced Server cluster included libraries that are
 4.  After you resolve any remaining problems noted in the consistency checks, invoke `pg_upgrade` to perform the data migration from the old cluster to the new cluster.
 
 !!! Note
-    Since adminpack extension is removed in this version without any alternative. Please remove it in the previous version before upgrade, instead of performing above instructions.
+    The adminpack extension has been removed in this version with no replacement. It must be removed in the previous version prior to the upgrade, instead of applying the steps described above.

--- a/product_docs/docs/epas/17/upgrading/major_upgrade/05_pg_upgrade_troubleshooting.mdx
+++ b/product_docs/docs/epas/17/upgrading/major_upgrade/05_pg_upgrade_troubleshooting.mdx
@@ -32,3 +32,6 @@ If the original EDB Postgres Advanced Server cluster included libraries that are
 4.  Resume the upgrade process. Invoke `pg_upgrade` to perform consistency checking.
 
 4.  After you resolve any remaining problems noted in the consistency checks, invoke `pg_upgrade` to perform the data migration from the old cluster to the new cluster.
+
+!!! Note
+    Since adminpack extension is removed in this version without any alternative. Please remove it in the previous version before upgrade, instead of performing above instructions.


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
Since adminpack is removed without any alternative in this release, you cannot follow the steps to resolve "Failed to load library" error. Instead of them, you should remove adminpack manually from current databases.

Kind Regards,
Yuki Tei