### PR TITLE
Update using.mdx

### DIFF
--- a/advocacy_docs/pg_extensions/sqlprofiler/using.mdx
+++ b/advocacy_docs/pg_extensions/sqlprofiler/using.mdx
@@ -59,7 +59,7 @@ sp_activate(
 Start a new trace named 'tracefortestuser', for user with OID 0011, on database with OID 134, with a maximum trace log size of 25MB, for queries that run at least 10 seconds, up to 30 minutes:
 
   ```sql
-  SELECT sp_activate(tracefortestuser,0011,134,25,10000,30);
+  SELECT sp_activate('tracefortestuser','0011','134',25,10000,'30 minutes');
   ```
 
 


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
Changed some argument values because part of them cannot be implicitly type casted, which leads to "No function matches the given name and argument types" error.

Your original SQL sample is:
SELECT sp_activate(tracefortestuser,0011,134,25,10000,30);

tracefortestuser => 'tracefortestuser' : Cannot be without single-quotation or will be see as unknown identifier.
0011 => '0011': Cannot be casted to oidvector as long as it is integer.
134 => '134': Cannot be casted to oidvector as long as it is integer.
30 => '30 minutes' : Cannot be casted to interval as long as it is integer. If you means 30 minutes then it should be as string like this.

Kind Regards,
Yuki Tei