### PR TITLE
PGD: remove reference to "pause_in_standby"

### DIFF
--- a/product_docs/docs/pgd/6/nodes/logical_standby_nodes.mdx
+++ b/product_docs/docs/pgd/6/nodes/logical_standby_nodes.mdx
@@ -14,10 +14,13 @@ A master node can have zero, one, or more logical standby nodes.
     location is always preferred.
 
 Logical standby nodes are nodes that are held in a state of continual recovery,
-constantly updating until they're required. This behavior is similar to how Postgres physical standbys operate while using logical replication for better performance. [`bdr.join_node_group`](/pgd/latest/reference/nodes-management-interfaces#bdrjoin_node_group) has the `pause_in_standby`
-option to make the node stay in halfway-joined as a logical standby node.
+constantly updating until they're required. This behavior is similar to how Postgres physical
+standbys operate, while using logical replication for better performance.
 Logical standby nodes receive changes but don't send changes made locally
 to other nodes.
+
+A logical standby is created by specifying the `node_kind` as `standby` when creating
+the node with [`bdr.create_node`](/pgd/latest/reference/nodes-management-interfaces#bdrpromote_node).
 
 Later, if you want, use
 [`bdr.promote_node`](/pgd/latest/reference/nodes-management-interfaces#bdrpromote_node)

--- a/product_docs/docs/pgd/6/reference/nodes-management-interfaces.mdx
+++ b/product_docs/docs/pgd/6/reference/nodes-management-interfaces.mdx
@@ -294,7 +294,6 @@ Joins the local node to an already existing PGD group.
 bdr.join_node_group (
     join_target_dsn text,
     node_group_name text DEFAULT NULL,
-    pause_in_standby boolean DEFAULT NULL,
     wait_for_completion boolean DEFAULT true,
     synchronize_structure text DEFAULT 'all'
 )
@@ -308,19 +307,13 @@ bdr.join_node_group (
 | `node_group_name`       | Optional name of the PGD group. Defaults to NULL, which tries to detect the group name from information present on the source node.                                                                                                                                                                                                                                                                                           |
 | `wait_for_completion`   | Wait for the join process to complete before returning. Defaults to `true`.                                                                                                                                                                                                                                                                                                                                                   |
 | `synchronize_structure` | Specifies whether to perform database structure (schema) synchronization during the join. `all`, the default setting, synchronizes the complete database structure. `none` does not synchronize any structure. However, data will still be synchronized, meaning the database structure must already be present on the joining node. Note that by design, neither schema nor data will ever be synchronized to witness nodes. |
-| `pause_in_standby`      | Optionally tells the join process to join only as a logical standby node, which can be later promoted to a full member. This option is deprecated and will be disabled or removed in future versions of PGD.                                                                                                                                                                                                                  |
-
-!!! Warning
-    `pause_in_standby` is deprecated since BDR 5.0. The recommended way to create
-    a logical standby is to set `node_kind` to `standby` when creating the node
-    with [`bdr.create_node`](#bdrcreate_node).
 
 If `wait_for_completion` is specified as `false`, the function call returns
 as soon as the joining procedure starts. You can see the progress of the join in
 the log files and the [`bdr.event_summary`](/pgd/latest/reference/catalogs-internal#bdrevent_summary)
 information view. You can call the function [`bdr.wait_for_join_completion()`](#bdrwait_for_join_completion)
 after `bdr.join_node_group()` to wait for the join operation to complete.
-It can emit progress information if called with `verbose_progress` set to `true`.
+It can emit progress information if [`bdr.wait_for_join_completion()`](#bdrwait_for_join_completion) is called with `verbose_progress` set to `true`.
 
 ### Notes
 


### PR DESCRIPTION
## What Changed?

This deprecated parameter was removed from function bdr.join_node_group() in PGD 6.

DOCS-1449.

