### PR TITLE
Update updating_an_rpm_installation.mdx

### DIFF
--- a/product_docs/docs/epas/17/installing/linux_install_details/updating_an_rpm_installation.mdx
+++ b/product_docs/docs/epas/17/installing/linux_install_details/updating_an_rpm_installation.mdx
@@ -5,13 +5,13 @@ description: "Describes how to upgrade your repository configuration file and up
 
 If you have an existing EDB Postgres Advanced Server RPM installation, you can use yum or dnf to upgrade your repository configuration file and update to a more recent product version. 
 
-To update the `edb.repo` file, assume superuser privileges and enter:
+To update the `enterprisedb-enterprise.repo` file, assume superuser privileges and enter:
 
 ```text
-dnf upgrade edb-repo
+dnf upgrade enterprisedb-enterprise
 ```
 
-`dnf` updates the `edb.repo` file to enable access to the current EDB repository, configured to connect with the credentials specified in your `edb.repo` file. Then, you can use `dnf` to upgrade all packages whose names include the expression `edb`:
+`dnf` updates the `enterprisedb-enterprise.repo` file to enable access to the current EDB repository. Then, you can use `dnf` to upgrade all packages whose names include the expression `edb`:
 
 ```text
 dnf upgrade edb*


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
As long as your repository repos1.0 is upgraded to repos1.0 and is no longer available, the new repository name should be 'enterprisedb-enterprise'. Also, your gpg key is now managed by curl online script, not by local key. so you don't need to modify your credential in your /etc/yum.repos.d/ configuration file.

Kind Regards,
Yuki Tei

