### PR TITLE
Update installing_epas_using_local_repository.mdx

### DIFF
--- a/product_docs/docs/epas/17/installing/linux_install_details/installing_epas_using_local_repository.mdx
+++ b/product_docs/docs/epas/17/installing/linux_install_details/installing_epas_using_local_repository.mdx
@@ -38,7 +38,7 @@ To create and use a local repository, you must:
 
 -   Install your preferred webserver on the host that acts as your local repository, and ensure that the repository directory is accessible to the other servers on your network.
 
--   On each isolated database server, configure yum or dnf to pull updates from the mirrored repository on your local network. For example, you might create a repository configuration file called `/etc/yum.repos.d/edb-repo` with connection information that specifies:
+-   On each isolated database server, configure yum or dnf to pull updates from the mirrored repository on your local network. For example, you might create a repository configuration file called `/etc/yum.repos.d/edb.repo` with connection information that specifies:
 
     ```text
     [edbas17]


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
Since historically in Repos1.0 edb-repo rpm package generates /etc/yum.repos.d/edb.repo, it is better to change the sample name to the same, or the Repos2.0's enterprisedb-enterprise.repo, so it will not cause confusion to the package name.

Kind Regards,
Yuki Tei
