### PR TITLE
remove redundant note on wal_sender_timeout

### DIFF
--- a/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
@@ -798,12 +798,6 @@ The database parameter `synchronous_standby_names` on the primary node specifies
 reconfigure.num.sync=false
 ```
 
-!!! Note
-
-    If you're using the `reconfigure.num.sync` property, make sure that the `wal_sender_timeout` value in the primary database is set to at least 10 seconds less than the `efm.node.timeout` value.
-
-
-
 <div id="reconfigure_num_sync_max" class="registered_link"></div>
 
 Use the `reconfigure.num.sync.max` property to specify the maximum number to which num-sync can be raised when a standby is added to the cluster.


### PR DESCRIPTION
We (ok, I) somehow ended up with two different notes about wal_sender_timeout when using efm's sync standby properties. Only one of these was now correct; I removed the other.


