### PR TITLE
fixing a sudoers file name

### DIFF
--- a/product_docs/docs/efm/5/04_configuring_efm/04_extending_efm_permissions.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/04_extending_efm_permissions.mdx
@@ -53,7 +53,7 @@ efm    ALL=(ALL)           NOPASSWD:   /usr/edb/efm-5.0/bin/efm_pgpool_functions
 Defaults:efm !requiretty
 ```
 
-If you're using Failover Manager to monitor clusters that are owned by users other than postgres or enterprisedb, make a copy of the `efm-49` file. Then modify the content to allow the user to access the `efm_functions` script to manage their clusters.
+If you're using Failover Manager to monitor clusters that are owned by users other than postgres or enterprisedb, make a copy of the `efm-50` file. Then modify the content to allow the user to access the `efm_functions` script to manage their clusters.
 
 If an agent can't start because of permission problems, make sure the default `/etc/sudoers` file contains the following line at the end of the file:
 


### PR DESCRIPTION
We missed the name efm-49 through two upgrades -- oops.

## What Changed?

