### PR TITLE
Fix links from edb_otel to pg_exporter

### DIFF
--- a/advocacy_docs/pg_extensions/otel/using.mdx
+++ b/advocacy_docs/pg_extensions/otel/using.mdx
@@ -91,10 +91,10 @@ This custom query adds a count of client backends to the schedule:
 
 ## `edb_otel.pg_exporter_base_definitions`
 
-This view contains the meter (queries and their metrics) definitions that pg_exporter brings by default.  You can refresh them from the [upm-metrics-pg-exporter](https://github.com/EnterpriseDB/upm-metrics-pg-exporter/tree/main/config/collector) or the [pg_exporter collector](https://github.com/Vonng/pg_exporter/tree/main/config/collector) by running `yq` on the directory:
+This view contains the meter (queries and their metrics) definitions that pg_exporter brings by default.  You can refresh them from the [pg_exporter collector](https://github.com/pgsty/pg_exporter/tree/main/config) by running `yq` on the directory:
 
 ```yq
-yq eval-all -o=json '. as $item ireduce ({}; . * $item)' [...]/config/collector/*.yml
+yq eval-all -o=json '. as $item ireduce ({}; . * $item)' [...]/config/*.yml
 ```
 
 ## Job scheduling
@@ -104,7 +104,7 @@ You can use pg_cron to schedule jobs for the pg_exporter. edb_otel has auxiliary
 - The meter name. This is the top key in the YAML files.
 - A scheduling definition. This is a schedule that pg_cron will accept,
 
-For example, the [410-pg_activity.yml](https://github.com/Vonng/pg_exporter/blob/main/config/collector/410-pg_activity.yml) query pulls output from pg_stat_activity. To run this every minute, use the cron syntax: '* * * * *'.  To create the job in pg_cron:
+For example, the [0410-pg_activity.yml](https://github.com/pgsty/pg_exporter/blob/main/config/0410-pg_activity.yml) query pulls output from pg_stat_activity. To run this every minute, use the cron syntax: '* * * * *'.  To create the job in pg_cron:
 
 ```sql
 SELECT edb_otel.schedule_from_pg_exporter_definition(meters->'pg_activity', '* * * * *')


### PR DESCRIPTION
The paths are valid for `upm-metrics-pg-exporter`, but not for `pg_exporter`.

Since the former is not public-facing, it probably shouldn't be in public docs anyway, so remove it and fix the paths into `pg_exporter` appropriately, which is to remove the `/collector/` component and `0410-pg_activity.yml` instead of `410-pg_activity.yml`.
