### PR TITLE
pgd: clarify that "transaction_id" is not accessible in SQL.

### DIFF
--- a/product_docs/docs/pgd/6/reference/tables-views-functions/functions.mdx
+++ b/product_docs/docs/pgd/6/reference/tables-views-functions/functions.mdx
@@ -70,8 +70,11 @@ becomes remotely visible.
 
 If a CAMO transaction is in progress, `transaction_id` is updated to show
 the assigned transaction id. You can query this parameter only by using
-using `PQparameterStatus` or equivalent. See [Application use](../commit-scopes/camo#application-use)
+using `PQparameterStatus` or equivalent, and it is not accessible in SQL.
+See [Application use](../commit-scopes/camo#application-use)
 for a usage example.
+
+## Node status functions
 
 ### `bdr.is_node_connected`
 


### PR DESCRIPTION
## What Changed?

Also add a missing heading for the unrelated function references which follow immediately after.

DOCS-1528.



