### PR TITLE
pgd: add some notes about pgd_bench, scripts and "-m camo"

### DIFF
--- a/product_docs/docs/pgd/6/reference/tables-views-functions/testingandtuning.mdx
+++ b/product_docs/docs/pgd/6/reference/tables-views-functions/testingandtuning.mdx
@@ -43,6 +43,10 @@ When using `-m failover`, an additional option `--retry` is available. This opti
 instructs pgd_bench to retry transactions when there's a failover. The `--retry` 
 option is automatically enabled when `-m camo` is used.
 
+When using `-m camo` and providing a custom script, the SQL commands in the script must
+be wrapped in SQL transaction commands, i.e. the first SQL command must be `BEGIN`,
+and the final SQL command must be `COMMIT`.
+
 #### Setting GUC variables
 
  `-o` or `--set-option`

--- a/product_docs/docs/pgd/6/reference/testing-tuning.mdx
+++ b/product_docs/docs/pgd/6/reference/testing-tuning.mdx
@@ -83,6 +83,12 @@ by PostgreSQL and or any possible extensions, including the BDR extension. It's 
 responsibility to suppress them by setting appropriate variables, such as `client_min_messages`, 
 `bdr.camo_enable_client_warnings`, and so on.
 
+-   `pgd_bench` does not automatically initiate SQL transactions for custom scripts.
+Scripts which are intended to run in an SQL transaction need to include the transaction
+start and end commands. If `pgd_bench` is executed with the `-m`/`--mode` option set
+to `camo`, any custom scripts provided must wrap the SQL commands in a transaction,
+otherwise CAMO functionality will not work as expected.
+
 ## Performance testing and tuning
 
 PGD allows you to issue write transactions onto multiple nodes. Bringing


### PR DESCRIPTION
## What Changed?

Explicitly note that pgd_bench does not automatically initiate database transations, so any custom scripts will need to include SQL transaction statements, particularly for running in CAMO mode.

DOCS-1529


