### PR TITLE
edb_otel: add requirement on EPEL for RHEL 9

### DIFF
--- a/advocacy_docs/pg_extensions/otel/installing.mdx
+++ b/advocacy_docs/pg_extensions/otel/installing.mdx
@@ -26,6 +26,11 @@ Before you begin the installation process:
 
   To set up the repository, go to [EDB repositories](https://www.enterprisedb.com/repos-downloads) and follow the instructions provided there.
 
+  If you are using RHEL 9, you also need to install the EPEL repository:
+  ```shell
+  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  ```
+
 
 ### Install the package
 


### PR DESCRIPTION
In RHEL 9, we rely on packages provided by EPEL, such as gRPC or protobuf. Other operating systems may have additional requirements that we may have to add as support of edb_otel extends further.
