### PR TITLE
fix(UPM-52839): removed mention of PCI from security page

### DIFF
--- a/advocacy_docs/edb-postgres-ai/cloud-service/security/compliance_and_certifications.mdx
+++ b/advocacy_docs/edb-postgres-ai/cloud-service/security/compliance_and_certifications.mdx
@@ -29,11 +29,3 @@ The General Data Protection Regulation (GDPR) is a regulation in European Union 
 
 GDPR compliance implies both privacy and security mechanisms definition, enforcement, and control, including evidence collection. 
 Cloud Service supports GDPR at service level, which means Cloud Service protects the personal data and privacy of EU citizens.
-
-## PCI DSS
-
-The Payment Card Industry Data Security Standard (PCI DSS) is a set of security standards designed to ensure that companies that accept, process, store, or transmit credit card information maintain a secure environment. See the [PCI Security Council](https://www.pcisecuritystandards.org/) website for more information about PCI.
- 
-Cloud Service is compliant with PCI. A PCI Qualified Security Assessor (QSA) certifies compliance. To achieve compliance with PCI DSS on a Cloud Service cluster, any information related to payments or other personally identifiable information (PII) must be encrypted, tokenized, or masked before being written to Cloud Service. You can do this from your customer application or through a third-party solution such as Satori.
- 
-Contact your EDB sales representative if you want to learn more about achieving PCI DSS compliance with your Cloud Service clusters.


### PR DESCRIPTION
## What Changed?

Removed mention of PCI from security compliance and certifications page

Scope/rationale is from

[UPM-52839](https://enterprisedb.atlassian.net/browse/UPM-52839)

which is itself derived from

[SECA-989](https://enterprisedb.atlassian.net/browse/SECA-989)

[UPM-52839]: https://enterprisedb.atlassian.net/browse/UPM-52839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SECA-989]: https://enterprisedb.atlassian.net/browse/SECA-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ