### PR TITLE
Update monitoring_failover_manager.mdx

### DIFF
--- a/product_docs/docs/pem/10/monitoring_failover_manager.mdx
+++ b/product_docs/docs/pem/10/monitoring_failover_manager.mdx
@@ -15,7 +15,7 @@ To monitor the status of a Failover Manager cluster on the Streaming Replication
 
 -   Use the **EFM Cluster Name** field to specify the name of the Failover Manager cluster. The cluster name is the prefix of the name of the cluster properties file. For example, if your cluster properties file is named `efm.properties`, your cluster name is efm.
 
--   Use the **EFM Installation Path** field to specify the location of the Failover Manager binary file. By default, the Failover Manager binary file is installed in `/usr/efm-<X>/bin`, where `<X>` is the EFM version.
+-   Use the **EFM Installation Path** field to specify the location of the Failover Manager binary file. By default, the Failover Manager binary file is installed in `/usr/edb/efm-<X>/bin`, where `<X>` is the EFM version.
 
 !!! Note
 To monitor Failover Manager, the PEM agent executes the `efm cluster-status-json <cluster_name>` command as the user efm. This command fails if the cluster properties file isn't in the efm user's home directory.


### PR DESCRIPTION
Changed path from `/usr/efm-<X>/bin` to `/usr/edb/efm-<X>/bin`

## What Changed?

