### PR TITLE
Update setting_up_edb_clone_schema.mdx

### DIFF
--- a/product_docs/docs/epas/17/database_administration/14_edb_clone_schema/setting_up_edb_clone_schema.mdx
+++ b/product_docs/docs/epas/17/database_administration/14_edb_clone_schema/setting_up_edb_clone_schema.mdx
@@ -7,18 +7,14 @@ To use EDB Clone Schema, you must first install several extensions along with th
 
 In addition, it might help to modify some configuration parameters in the `postgresql.conf` file of the database servers.
 
-## Installing extensions
+## Installing prerequisite extension packages
 
-On any database to be used as the source or target database by an EDB Clone Schema function, install the following extensions: `postgres_fdw`, `dblink`, `edb_job_scheduler`, and `dbms_job`.
+As prerequisite extension package, `parallel_clone` should be installed first. 
+The syntax to install the package is:
+  ```shell
+  sudo <package-manager> -y install edb-<postgres><postgres_version>-server-parallel-clone
+  ```
 
-```sql
-CREATE EXTENSION postgres_fdw SCHEMA public;
-CREATE EXTENSION dblink SCHEMA public;
-CREATE EXTENSION edb_job_scheduler;
-CREATE EXTENSION dbms_job;
-```
-
-For more information about using the `CREATE EXTENSION` command, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/sql-createextension.html).
 
 ## Modifying the configuration file
 
@@ -29,6 +25,21 @@ Modify the `postgresql.conf` file by adding `$libdir/parallel_clone` and `$libdi
   ```
 
 For the changes to take effect, you must restart the database server.
+
+## Installing extensions
+
+On any database to be used as the source or target database by an EDB Clone Schema function, install the following extensions: `postgres_fdw`, `dblink`, `edb_job_scheduler`, `dbms_job` and `parallel_clone`.
+
+```sql
+CREATE EXTENSION postgres_fdw SCHEMA public;
+CREATE EXTENSION dblink SCHEMA public;
+CREATE EXTENSION edb_job_scheduler;
+CREATE EXTENSION dbms_job;
+CREATE EXTENSION parallel_clone;
+```
+
+For more information about using the `CREATE EXTENSION` command, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/static/sql-createextension.html).
+
 
 ## Installing PL/Perl
 
@@ -87,20 +98,21 @@ To delete a log file, use the `remove_log_file_and_job` function, or delete it m
 ## Installing EDB Clone Schema
 
 Install the EDB Clone Schema on any database to be used as the source or target database by an EDB Clone Schema function.
+1.  The syntax to install the package is:
+  ```shell
+  sudo <package-manager> -y install edb-<postgres><postgres_version>-server-cloneschema
+  ```
 
-1.  If you previously installed an older version of the `edb_cloneschema` extension, run the following command:  
+2.  If you previously installed an older version of the `edb_cloneschema` extension, run the following command:  
 
   ```sql
-  DROP EXTENSION parallel_clone CASCADE;
+  DROP EXTENSION edb_cloneschema CASCADE 
   ```
 
   This command also drops the `edb_cloneschema` extension.
 
-1.  Install the extensions. Make sure that you create the `parallel_clone` extension before creating the `edb_cloneschema` extension.
-
+3.  Install the extensions.
   ```sql
-  CREATE EXTENSION parallel_clone;
-
   CREATE EXTENSION edb_cloneschema;
   ```
 ## Creating Log directory


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

## What Changed?
While validating edb cloneschema, I found that some package installing section is missing and your instruction cannot be performed from top to bottom because you have to modify shared_preload_libraries before `create extension`, otherwise otherwise the `create extension` should be failed. I also move the parallel clone installation part to the top as part of prerequisite extension, in order to avoid any overlooking.

Alongside the draft, why do you leave this as part of [EDB Postgres Advanced Server (EPAS)](https://www.enterprisedb.com/docs/epas/latest/)? Would it be better if this is part of [Postgres extensions available by deployment](https://www.enterprisedb.com/docs/pg_extensions/)?

I appreciate for all your confirming and discussing.

Kind Regards,
Yuki TEi