### PR TITLE
Add PGD6 release note for BDR-3767.

### DIFF
--- a/product_docs/docs/pgd/6/rel_notes/pgd_6.0.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/6/rel_notes/pgd_6.0.0_rel_notes.mdx
@@ -128,6 +128,11 @@ Commands that display more than one resource will sort output by each resource c
 </details></td><td></td></tr>
 <tr><td><details><summary>Subscriber-only nodes replication.</summary><hr/><p>Subscriber-only nodes now receive data only after it has been replicated to majority of data nodes. This does not require any special configuration. Subsequently bdr.standby_slot_names and bdr.standby_slots_min_confirmed options are removed as similar physical standby functionality is provided in pg_failover_slots extension and in PG17+.</p>
 </details></td><td></td></tr>
+<tr><td><details><summary>DDL operations disabled by default on subscriber-only nodes</summary><hr/><p>DDL operations are prohibited on subscriber only node as these only
+ever receive data from their upstream, and do not participate in voting.
+DDL is permitted when <code>bdr.permit_unsafe_commands</code> is <code>true</code>,
+but that DDL is not replicated.</p>
+</details></td><td></td></tr>
 <tr><td><details><summary>Remove the deprecated legacy CLI commands.</summary><hr/><p>Remove the old (PGD 5 and below) CLI commands, which were deprecated but supported for backward compatibility.</p>
 </details></td><td></td></tr>
 <tr><td><details><summary>Commit scope logic is now only run on data nodes.</summary><hr/><p>Previously, non-data nodes would attempt to handle, but not process commit scope logic, which could lead to confusing, albeit harmless log messages.</p>

--- a/product_docs/docs/pgd/6/rel_notes/src/relnote_6.0.0.yml
+++ b/product_docs/docs/pgd/6/rel_notes/src/relnote_6.0.0.yml
@@ -352,6 +352,18 @@ relnotes:
   type: Enhancement
   impact: Medium
 
+- relnote: DDL operations disabled by default on subscriber-only nodes
+  component: BDR
+  details: |
+    DDL operations are prohibited on subscriber only node as these only
+    ever receive data from their upstream, and do not participate in voting.
+    DDL is permitted when `bdr.permit_unsafe_commands` is `true`,
+    but that DDL is not replicated.
+  jira: BDR-3767
+  addresses: ""
+  type: Enhancement
+  impact: Medium
+
 - relnote: Fixed deadlock issue in bdr_init_physical.
   component: BDR
   details: |


### PR DESCRIPTION
## What Changed

Late addition to BDR source tree relnotes, see BDR commit f86b846d4.

Note: seems this update was intended for 5.8.0 as well, but seems to have missed the cut-off.