### PR TITLE
AID-426 - Model sync and QoL changes

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/knowledge_base/performance_tuning.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/knowledge_base/performance_tuning.mdx
@@ -36,7 +36,7 @@ INSERT INTO test_data_10k (id, msg) SELECT generate_series(1, 10000) AS id, 'hel
 The optimal batch size may be very different for different models. Measure and tune the batch size for each different model you want to use.
 ```sql
 SELECT aidb.create_table_knowledge_base(
-    name => 'perf_test_b',
+    name => 'perf_test',
     model_name => 'dummy',  -- use the model you want to optimize for
     source_table => 'test_data_10k',
     source_data_column => 'msg',

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/knowledge_base/usage.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/knowledge_base/usage.mdx
@@ -157,8 +157,8 @@ A view is available that lists all the knowledge_bases. [aidb.knowledge_bases](.
 ```sql
 SELECT * FROM aidb.knowledge_bases;
 __OUTPUT__
- id |        name         |     vector_table_name      | vector_table_key_column | vector_table_vector_column |  model_name  | topk | distance_operator | options | source_table_name | source_table_data_column | source_table_data_column_type | source_table_key_column | source_volume_name
-----+---------------------+----------------------------+-------------------------+----------------------------+--------------+------+-------------------+---------+-------------------+--------------------------+-------------------------------+-------------------------+--------------------
+ id |          name            |       vector_table_name         | vector_table_key_column | vector_table_vector_column |  model_name  | topk | distance_operator | options | source_table_name | source_table_data_column | source_table_data_column_type | source_table_key_column | source_volume_name
+----+--------------------------+---------------------------------+-------------------------+----------------------------+--------------+------+-------------------+---------+-------------------+--------------------------+-------------------------------+-------------------------+--------------------
   2 | test_knowledge_base      | test_knowledge_base_vector      | id                      | embeddings                 | simple_model |    5 | InnerProduct      | {}      | test_source_table | content                  | Text                          | id                      |
   5 | test_knowledge_base_cosa | test_knowledge_base_cosa_vector | id                      | embeddings                 | simple_model |    1 | L2                | {}      | test_source_table | content                  | Text                          | id                      |
   3 | test_knowledge_base_cos  | test_knowledge_base_cos_vector  | id                      | embeddings                 | simple_model |    5 | Cosine            | {}      | test_source_table | content                  | Text                          | id                      |
@@ -170,8 +170,8 @@ We recommend that you select only the columns you're interested in:
 ```sql
 SELECT name, source_table_name FROM aidb.knowledge_bases;
 __OUTPUT__
-        name         | source_table_name
----------------------+-------------------
+        name              | source_table_name
+--------------------------+-------------------
  test_knowledge_base      | test_source_table
  test_knowledge_base_cos  | test_source_table
  test_knowledge_base_cosa | test_source_table

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/examples/chained_preparers.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/examples/chained_preparers.mdx
@@ -25,7 +25,7 @@ SELECT aidb.create_table_preparer(
     destination_table => 'chunked_data__1321',
     destination_data_column => 'chunk',
     destination_key_column => 'id',
-    options => '{"desired_length": 1, "max_length": 1000}'::JSONB  -- Configuration for the ChunkText operation
+    options => '{"desired_length": 1000}'::JSONB  -- Configuration for the ChunkText operation
 );
 ```
 

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/examples/chunk_text.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/examples/chunk_text.mdx
@@ -60,18 +60,6 @@ __OUTPUT__
 (9 rows)
 ```
 
-```sql
--- Semantic chunking to split into the largest continuous semantic chunk that fits in the max_length
-SELECT * FROM aidb.chunk_text('This sentence should be its own chunk. This too.', '{"desired_length": 1, "max_length": 1000}');
-
-__OUTPUT__
- part_id |                 chunk
----------+----------------------------------------
-       0 | This sentence should be its own chunk.
-       1 | This too.
-(2 rows)
-```
-
 ## Preparer with table data source
 
 ```sql
@@ -83,7 +71,7 @@ CREATE TABLE source_table__1628
 );
 INSERT INTO source_table__1628
 VALUES (1, 'This is a significantly longer text example that might require splitting into smaller chunks. The purpose of this function is to partition text data into segments of a specified maximum length, for example, this sentence 145 is characters. This enables processing or storage of data in manageable parts.'),
-       (2, 'This sentence should be its own chunk. This too.');
+       (2, 'This is sentence number one. This is sentence number one.');
 
 SELECT aidb.create_table_preparer(
     name => 'preparer__1628',
@@ -94,7 +82,7 @@ SELECT aidb.create_table_preparer(
     destination_data_column => 'chunks',
     source_key_column => 'id',
     destination_key_column => 'id',
-    options => '{"desired_length": 1, "max_length": 1000}'::JSONB  -- Configuration for the ChunkText operation
+    options => '{"desired_length": 120}'::JSONB  -- Configuration for the ChunkText operation
 );
 
 SELECT aidb.bulk_data_preparation('preparer__1628');
@@ -102,12 +90,11 @@ SELECT aidb.bulk_data_preparation('preparer__1628');
 SELECT * FROM chunked_data__1628;
 
 __OUTPUT__
- id | part_id | unique_id |                                                                      chunks
-----+---------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------
+ id | part_id | unique_id |                                                        chunks
+----+---------+-----------+-----------------------------------------------------------------------------------------------------------------------
  1  |       0 | 1.part.0  | This is a significantly longer text example that might require splitting into smaller chunks.
- 1  |       1 | 1.part.1  | The purpose of this function is to partition text data into segments of a specified maximum length, for example, this sentence 145 is characters.
- 1  |       2 | 1.part.2  | This enables processing or storage of data in manageable parts.
- 2  |       0 | 2.part.0  | This sentence should be its own chunk.
- 2  |       1 | 2.part.1  | This too.
-(5 rows)
+ 1  |       1 | 1.part.1  | The purpose of this function is to partition text data into segments of a specified maximum length, for example, this
+ 1  |       2 | 1.part.2  | sentence 145 is characters. This enables processing or storage of data in manageable parts.
+ 2  |       0 | 2.part.0  | This is sentence number one. This is sentence number one.
+(4 rows)
 ```

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/examples/chunk_text_auto_processing.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/examples/chunk_text_auto_processing.mdx
@@ -29,7 +29,7 @@ SELECT aidb.create_table_preparer(
     destination_data_column => 'chunk',
     source_key_column => 'id',
     destination_key_column => 'id',
-    options => '{"desired_length": 1, "max_length": 1000}'::JSONB  -- Configuration for the ChunkText operation
+    options => '{"desired_length": 1000}'::JSONB  -- Configuration for the ChunkText operation
 );
 
 SELECT aidb.set_auto_preparer('preparer__1628', 'Live');

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/primitives.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/primitives.mdx
@@ -31,8 +31,13 @@ __OUTPUT__
 (3 rows)
 ```
 
-- The `desired_length` size is the target size for the chunk. In most cases, this value also serves as the maximum size of the chunk. It's possible for a chunk to be returned that's less than the `desired` value, as adding the next piece of text may have made it larger than the `desired` capacity.
-- The `max_length` size is the maximum possible chunk size that can be generated. Setting this to a value larger than `desired` means that the chunk should be as close to `desired` as possible but can be larger if it means staying at a larger semantic level.
+### Options
+
+- The `desired_length` size is the target length for the chunk, specified in _characters_. In most cases, this value also serves as the maximum size of the chunk. It's possible for a chunk to be returned that's less than the `desired` value, as adding the next semantic unit of text may have made it larger than the `desired` capacity.
+- The `max_length` size is the maximum possible chunk size that should be generated, specified in _characters_. Setting this to a value larger than `desired` means that the chunk should be as close to `desired` as possible but can be larger if it means staying at a larger semantic level.
+  - `max_length` is optional
+
+To preserve as much semantic meaning within a chunk as possible, each chunk is composed of the largest semantic units that can fit in the next given chunk.
 
 !!! Tip
 This operation transforms the shape of the data, automatically unnesting collections by introducing a `part_id` column. See the [unnesting concept](./concepts#unnesting) for more detail.

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/primitives.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/primitives.mdx
@@ -14,7 +14,7 @@ All data preparation operations can be customized with different options. The AP
 
 ## Chunk text
 
-Call `aidb.chunk_text()` to break text into smaller chunks.
+Call `aidb.chunk_text()` to intelligently split long text into smaller, semantically coherent chunks, ideal for processing or storage within LLM context limits.
 
 ```sql
 SELECT * FROM aidb.chunk_text(
@@ -33,11 +33,16 @@ __OUTPUT__
 
 ### Options
 
-- The `desired_length` size is the target length for the chunk, specified in _characters_. In most cases, this value also serves as the maximum size of the chunk. It's possible for a chunk to be returned that's less than the `desired` value, as adding the next semantic unit of text may have made it larger than the `desired` capacity.
-- The `max_length` size is the maximum possible chunk size that should be generated, specified in _characters_. Setting this to a value larger than `desired` means that the chunk should be as close to `desired` as possible but can be larger if it means staying at a larger semantic level.
-  - `max_length` is optional
+- `desired_length` (required): The target chunk size, in characters. This is the size the splitter will try to reach when forming each chunk, while preserving semantic structure. If `max_length` is not provided, `desired_length` also acts as the hard upper limit for the chunk size.
+- `max_length` (optional): The upper bound for chunk size, in characters. If specified, the function will try to generate chunks close to `desired_length` but may extend up to `max_length` to preserve larger semantic units (like full sentences or paragraphs). Chunks will only exceed `desired_length` when it's necessary to avoid cutting across meaningful boundaries.
+  - Specifying `desired_length = max_length` results in fixed-size chunks (e.g., when filling a context window exactly for embeddings).
+  - Use a larger `max_length` if you want to stay within a soft limit but allow some flexibility to preserve higher semantic units, common in RAG, summarization, or Q&A applications.
 
-To preserve as much semantic meaning within a chunk as possible, each chunk is composed of the largest semantic units that can fit in the next given chunk.
+### Algorithm Summary
+
+- Text is split using a hierarchy of semantic boundaries: characters, graphemes, words, sentences, and increasingly long newline sequences (e.g., paragraphs).
+- The splitter attempts to form the largest semantically valid chunk that fits within the specified size range.
+- Chunks may be returned that are shorter than `desired_length` if adding the next semantic unit would exceed max_length.
 
 !!! Tip
 This operation transforms the shape of the data, automatically unnesting collections by introducing a `part_id` column. See the [unnesting concept](./concepts#unnesting) for more detail.

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/volume_destination.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/preparers/volume_destination.mdx
@@ -68,7 +68,7 @@ SELECT aidb.create_volume_preparer(
                operation => 'ChunkText',
                source_volume_name => 'text_files_volume',
                destination_table => 'chunk_output_volume',
-               options => '{"desired_length": 1, "max_length": 100}'::JSONB
+               options => '{"desired_length": 1000}'::JSONB
        );
 
 SELECT aidb.bulk_data_preparation('chunking_example_volumes');

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/reference/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/reference/index.mdx
@@ -23,6 +23,7 @@ navigation:
 * [aidb.delete_model](models#aidbdelete_model)
 * [aidb.get_hcp_models](models#aidbget_hcp_models)
 * [aidb.create_hcp_model](models#aidbcreate_hcp_model)
+* [aidb.sync_hcp_models](models#aidbsync_hcp_models)
 * [aidb.encode_text](models#aidbencode_text)
 * [aidb.encode_text_batch](models#aidbencode_text_batch)
 * [aidb.decode_text](models#aidbdecode_text)

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/reference/models.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/reference/models.mdx
@@ -161,7 +161,7 @@ __OUTPUT__
 | `delete_model` | jsonb | The name, provider, and options of the deleted model |
 
 
-### `aidb.get_hcp_models`
+### `aidb.list_hcp_models`
 
 Gets models running on the hybrid control plane.
 
@@ -193,6 +193,19 @@ Creates a new model in the system by referencing a running instance in the HCP
 | ---------------- | ---- | ------- | ----------------------------------------- |
 | `name`           | text |         | User-defined name of the model            |
 | `hcp_model_name` | text |         | Name of the model instance running on HCP |
+
+### `aidb.sync_hcp_models`
+
+Creates models in the HCP and sets `is_hcp_model=true`; deletes models with that setting if not found in the HCP.
+
+#### Returns
+
+| Column   | Type | Description                                                                     |
+| -------- | ---- | ------------------------------------------------------------------------------- |
+| `status` | text | Synchronization status; either `deleted`, `unchanged`, `created`, or `skipped`. |
+| `model`  | text | The name the synchronized HCP model.                                            |
+
+
 
 ### `aidb.encode_text`
 

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
@@ -8,6 +8,7 @@ editTarget: originalFilePath
 Released: 26 May 2025
 
 This is a minor release that includes bug fixes.
+Note: this release depends on the new PGFS version 2.0.2. If you're using PGFS together with AIDB, please update PGFS as well.
 
 ## Highlights
 

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
@@ -1,0 +1,15 @@
+---
+title: AI Accelerator - Pipelines 4.1.1 release notes
+navTitle: Version 4.1.1
+originalFilePath: advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
+editTarget: originalFilePath
+---
+
+Released: 26 May 2025
+
+This is a minor release that includes bug fixes.
+
+## Highlights
+
+- Optional highlights here
+

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
@@ -12,7 +12,7 @@ Note: this release depends on the new PGFS version 2.0.2. If you're using PGFS t
 
 ## Highlights
 
-- Optional highlights here
+- Bug fixes and UX enhancements.
 
 ## Enhancements
 
@@ -21,6 +21,17 @@ Note: this release depends on the new PGFS version 2.0.2. If you're using PGFS t
 This is necessary to detect when a listing is complete and recognize which previously seen objects were not encountered any more.
 In this release the method for tracking run IDs is changed to a table column since the Postgres sequence used before did not
 work on Postgres Distributed (PGD) clusters.</p>
+</details></td><td></td></tr>
+<tr><td><details><summary>Support AIDB volumes in arbitrary Postgres schemas</summary><hr/><p>Volumes for AIDB can be created in arbitrary schemas in Postgres either by exlicitly passing a schema to the create function, or by
+setting a &quot;current schema&quot; via the search path. When using volumes in AIDB pipelines, the volume reference needs to be stored.
+AIDB will now store and explicitly use a schema when later executing a pipeline. Previously, the search path was used to find volumes.</p>
+</details></td><td></td></tr>
+<tr><td><details><summary>Background worker dispatcher is no longer persistent</summary><hr/><p>When background workers are enabled for AIDB, a root-worker will start a database dispatcher for each database within the Postgres instance.
+This database dispatcher checks if AIDB is installed in the DB and if any pipelines need to be run in the background.
+The database dispatcher is now no longer a permanent process by default. When a database does not use AIDB, the database dispatcher
+exits and will be re-started to check for AIDB every 2 minutes.
+This avoids holding a permanent connection to the DB that would block e.g. &quot;drop table&quot; commands.
+If AIDB is installed in the DB, then the database dispatcher worker will keep running. Users can drop the extension in order to release the connection.</p>
 </details></td><td></td></tr>
 </tbody></table>
 

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/ai-accelerator_4.1.1_rel_notes.mdx
@@ -13,3 +13,14 @@ This is a minor release that includes bug fixes.
 
 - Optional highlights here
 
+## Enhancements
+
+<table class="table w-100"><thead><tr><th>Description</th><th width="10%">Addresses</th></tr></thead><tbody>
+<tr><td><details><summary>Change the tracking of &quot;run IDs&quot; for volume knowledge bases from a PG sequence to a PG table column</summary><hr/><p>Knowledge bases with volume source need to assign an incrementing ID to each listing done on the source.
+This is necessary to detect when a listing is complete and recognize which previously seen objects were not encountered any more.
+In this release the method for tracking run IDs is changed to a table column since the Postgres sequence used before did not
+work on Postgres Distributed (PGD) clusters.</p>
+</details></td><td></td></tr>
+</tbody></table>
+
+

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/index.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/index.mdx
@@ -4,6 +4,7 @@ navTitle: Release notes
 description: Release notes for EDB Postgres AI - AI Accelerator
 indexCards: none
 navigation:
+  - ai-accelerator_4.1.1_rel_notes
   - ai-accelerator_4.1.0_rel_notes
   - ai-accelerator_4.0.1_rel_notes
   - ai-accelerator_4.0.0_rel_notes
@@ -23,6 +24,7 @@ The EDB Postgres AI - AI Accelerator describes the latest version of AI Accelera
 
 | AI Accelerator version | Release Date |
 |---|---|
+| [4.1.1](./ai-accelerator_4.1.1_rel_notes) | 26 May 2025 |
 | [4.1.0](./ai-accelerator_4.1.0_rel_notes) | 19 May 2025 |
 | [4.0.1](./ai-accelerator_4.0.1_rel_notes) | 09 May 2025 |
 | [4.0.0](./ai-accelerator_4.0.0_rel_notes) | 05 May 2025 |

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
@@ -4,6 +4,7 @@ version: 4.1.1
 date: 26 May 2025
 intro: |
   This is a minor release that includes bug fixes.
+  Note: this release depends on the new PGFS version 2.0.2. If you're using PGFS together with AIDB, please update PGFS as well.
 highlights: |
   - Optional highlights here
 relnotes:

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
+product: AI Accelerator - Pipelines
+version: 4.1.1
+date: 26 May 2025
+intro: |
+  This is a minor release that includes bug fixes.
+highlights: |
+  - Optional highlights here
+relnotes: [] # Remove the [] before adding new relnote entries
+# - relnote: Summary of change
+#   details: |
+#     Words about the change
+#   jira: "AID-410" Jira ticket number 
+#   addresses: ""
+#   type: Enhancement
+#   impact: High

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
@@ -6,7 +6,7 @@ intro: |
   This is a minor release that includes bug fixes.
   Note: this release depends on the new PGFS version 2.0.2. If you're using PGFS together with AIDB, please update PGFS as well.
 highlights: |
-  - Optional highlights here
+  - Bug fixes and UX enhancements.
 relnotes:
  - relnote: Change the tracking of "run IDs" for volume knowledge bases from a PG sequence to a PG table column
    details: |
@@ -15,6 +15,27 @@ relnotes:
      In this release the method for tracking run IDs is changed to a table column since the Postgres sequence used before did not
      work on Postgres Distributed (PGD) clusters.
    jira: "AID-455"
+   addresses: ""
+   type: Enhancement
+   impact: High
+ - relnote: Support AIDB volumes in arbitrary Postgres schemas
+   details: |
+     Volumes for AIDB can be created in arbitrary schemas in Postgres either by exlicitly passing a schema to the create function, or by
+     setting a "current schema" via the search path. When using volumes in AIDB pipelines, the volume reference needs to be stored.
+     AIDB will now store and explicitly use a schema when later executing a pipeline. Previously, the search path was used to find volumes.
+   jira: "AID-407"
+   addresses: ""
+   type: Enhancement
+   impact: High
+ - relnote: Background worker dispatcher is no longer persistent
+   details: |
+     When background workers are enabled for AIDB, a root-worker will start a database dispatcher for each database within the Postgres instance.
+     This database dispatcher checks if AIDB is installed in the DB and if any pipelines need to be run in the background.
+     The database dispatcher is now no longer a permanent process by default. When a database does not use AIDB, the database dispatcher
+     exits and will be re-started to check for AIDB every 2 minutes.
+     This avoids holding a permanent connection to the DB that would block e.g. "drop table" commands.
+     If AIDB is installed in the DB, then the database dispatcher worker will keep running. Users can drop the extension in order to release the connection.
+   jira: "AID-459"
    addresses: ""
    type: Enhancement
    impact: High

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
@@ -6,11 +6,14 @@ intro: |
   This is a minor release that includes bug fixes.
 highlights: |
   - Optional highlights here
-relnotes: [] # Remove the [] before adding new relnote entries
-# - relnote: Summary of change
-#   details: |
-#     Words about the change
-#   jira: "AID-410" Jira ticket number 
-#   addresses: ""
-#   type: Enhancement
-#   impact: High
+relnotes:
+ - relnote: Change the tracking of "run IDs" for volume knowledge bases from a PG sequence to a PG table column
+   details: |
+     Knowledge bases with volume source need to assign an incrementing ID to each listing done on the source.
+     This is necessary to detect when a listing is complete and recognize which previously seen objects were not encountered any more.
+     In this release the method for tracking run IDs is changed to a table column since the Postgres sequence used before did not
+     work on Postgres Distributed (PGD) clusters.
+   jira: "AID-455" Jira ticket number
+   addresses: ""
+   type: Enhancement
+   impact: High

--- a/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
+++ b/advocacy_docs/edb-postgres-ai/ai-accelerator/rel_notes/src/rel_notes_4.1.1.yml
@@ -13,7 +13,7 @@ relnotes:
      This is necessary to detect when a listing is complete and recognize which previously seen objects were not encountered any more.
      In this release the method for tracking run IDs is changed to a table column since the Postgres sequence used before did not
      work on Postgres Distributed (PGD) clusters.
-   jira: "AID-455" Jira ticket number
+   jira: "AID-455"
    addresses: ""
    type: Enhancement
    impact: High

--- a/advocacy_docs/pg_extensions/otel/using.mdx
+++ b/advocacy_docs/pg_extensions/otel/using.mdx
@@ -91,10 +91,10 @@ This custom query adds a count of client backends to the schedule:
 
 ## `edb_otel.pg_exporter_base_definitions`
 
-This view contains the meter (queries and their metrics) definitions that pg_exporter brings by default.  You can refresh them from the [upm-metrics-pg-exporter](https://github.com/EnterpriseDB/upm-metrics-pg-exporter/tree/main/config/collector) or the [pg_exporter collector](https://github.com/Vonng/pg_exporter/tree/main/config/collector) by running `yq` on the directory:
+This view contains the meter (queries and their metrics) definitions that pg_exporter brings by default.  You can refresh them from the [pg_exporter collector](https://github.com/pgsty/pg_exporter/tree/main/config) by running `yq` on the directory:
 
 ```yq
-yq eval-all -o=json '. as $item ireduce ({}; . * $item)' [...]/config/collector/*.yml
+yq eval-all -o=json '. as $item ireduce ({}; . * $item)' [...]/config/*.yml
 ```
 
 ## Job scheduling
@@ -104,7 +104,7 @@ You can use pg_cron to schedule jobs for the pg_exporter. edb_otel has auxiliary
 - The meter name. This is the top key in the YAML files.
 - A scheduling definition. This is a schedule that pg_cron will accept,
 
-For example, the [410-pg_activity.yml](https://github.com/Vonng/pg_exporter/blob/main/config/collector/410-pg_activity.yml) query pulls output from pg_stat_activity. To run this every minute, use the cron syntax: '* * * * *'.  To create the job in pg_cron:
+For example, the [0410-pg_activity.yml](https://github.com/pgsty/pg_exporter/blob/main/config/0410-pg_activity.yml) query pulls output from pg_stat_activity. To run this every minute, use the cron syntax: '* * * * *'.  To create the job in pg_cron:
 
 ```sql
 SELECT edb_otel.schedule_from_pg_exporter_definition(meters->'pg_activity', '* * * * *')

--- a/product_docs/docs/pgd/5.7/index.mdx
+++ b/product_docs/docs/pgd/5.7/index.mdx
@@ -55,6 +55,7 @@ categories:
 pdf: true
 directoryDefaults:
   version: "5.7.0"
+displayBanner: '<b>Warning</b>: You are not reading the most recent version of this documentation.<br/>Documentation improvements are made only to the latest version.<br/>As per semantic versioning, PGD minor releases remain backward compatible and may include important bug fixes and enhancements.<br/> We recommend upgrading the latest minor release as soon as possible.<br/>If you want up-to-date information, read the <a href="https://www.enterprisedb.com/docs/pgd/latest/">latest PGD documentation</a>.'
 ---
 
 


### PR DESCRIPTION
## What Changed?

- Updated docs to reflect changes from [AID-426](https://enterprisedb.atlassian.net/browse/AID-426)
- Added `sync_hcp_models`
- Renamed `get_hcp_models` to `list_hcp_models`.

[AID-426]: https://enterprisedb.atlassian.net/browse/AID-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ