### PR TITLE
Update before_you_start.mdx

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/before_you_start.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/before_you_start.mdx
@@ -141,7 +141,7 @@ PVC group
   unavailable without adversely impacting the application.
 
 <a id="rpo"></a>RPO
-:  Acronym for "recovery point objective", a calculation of the level of
+: Acronym for "recovery point objective", a calculation of the level of
   acceptable data loss following a disaster recovery scenario.
 
 ## Cloud terminology


### PR DESCRIPTION
current view of the docs.

<img width="508" height="71" alt="image" src="https://github.com/user-attachments/assets/dc6ca23b-73ad-49d0-b1e4-60430ca83eb9" />

the space did not allow the RPO to appear on it's own line.

## What Changed?

RPO would now appear on a new line.

