### PR TITLE
cli: Add release notes entry for v5.8.1 and v6.0.1 for BDR-6511

### DIFF
--- a/product_docs/docs/pgd/5.8/rel_notes/pgd_5.8.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/5.8/rel_notes/pgd_5.8.1_rel_notes.mdx
@@ -19,6 +19,9 @@ This fix addresses the issue by fetching the value of new socket dirs from the i
 <tr><td>PGD CLI</td><td>5.8.1</td><td><details><summary>Added a more useful error message if CLI cannot find the executable binaries.</summary><hr/><p>This fixes the command crash if the CLI cannot find the binaries like <code>postgres</code>, <code>pg_ctl</code> on the expected path.
 By default it searches the binaries at the path of the <code>pgd</code> binary itself.</p>
 </details></td><td></td></tr>
+<tr><td>PGD CLI</td><td>5.8.1</td><td><details><summary>Fix the broken replication slot issue after rolling Postgres upgrade using <code>pgd node upgrade</code> command.</summary><hr/><p>Merge writer origin positions to the parent origin during node upgrade.
+In PGD 5 and older writer origin names map to parent origin id which may change during inplace upgrade.</p>
+</details></td><td>46412,48747</td></tr>
 <tr><td>BDR</td><td>5.8.1</td><td><details><summary>Ensure that GRANT check for BDR objects works for EPAS object types</summary><hr/><p>The mechanism for determining whether user can be granted permissions
 on BDR extension objects was failing for EPAS-specific objects.
 This is a regression from PGD release 5.7.0 and is now fixed.</p>

--- a/product_docs/docs/pgd/5.8/rel_notes/src/relnote_5.8.1.yml
+++ b/product_docs/docs/pgd/5.8/rel_notes/src/relnote_5.8.1.yml
@@ -60,6 +60,16 @@ relnotes:
   type: Bug Fix
   impact: Medium
 
+- relnote: Fix the broken replication slot issue after rolling Postgres upgrade using `pgd node upgrade` command.
+  details: |
+    Merge writer origin positions to the parent origin during node upgrade.
+    In PGD 5 and older writer origin names map to parent origin id which may change during inplace upgrade.
+  component: PGD CLI
+  jira:  BDR-6511
+  addresses: 46412,48747
+  type: Bug Fix
+  impact: High
+
 - relnote: Fixed rejoin of parted node with same name gets stuck in JOIN_START state.
   details: |
     Rejoin of parted node with same name gets stuck in JOIN_START state. This problem was fixed.
@@ -77,7 +87,7 @@ relnotes:
   addresses: 49022
   type: Bug Fix
   impact: Medium
-  
+
 - relnote: Fixed DROP_REPLICATION_SLOT handling for physical / non-existing slots.
   component: BDR
   details: |
@@ -100,7 +110,7 @@ relnotes:
 - relnote: Ensured physical join does not leave behind a slot that holds WAL.
   component: BDR
   details: |
-    Physical join using bdr_init_physical resulted in creation of an extra slot 
+    Physical join using bdr_init_physical resulted in creation of an extra slot
     after the physical join is over, and can result in holding up WAL. This is a
     regression from BDR release 5.7.0. This is now fixed.
   addresses: 48710, 50099

--- a/product_docs/docs/pgd/6/rel_notes/pgd_6.0.1_rel_notes.mdx
+++ b/product_docs/docs/pgd/6/rel_notes/pgd_6.0.1_rel_notes.mdx
@@ -14,7 +14,7 @@ PGD 6 delivers simpler, more resilient high availability for Postgres. Tradition
 
 - **New built-in Connection Manager**: Automatically routes client connections to the correct node, simplifies application architecture, supports dynamic topology changes, and includes a built-in session pooler and dedicated read/write and read-only ports, all without external software or complex configuration. This new component replaces PGD Proxy, which is no longer available starting with PGD 6.
 - **Predefined Commit Scopes**: Simplify consistency choices with built-in transaction durability profiles—no complicated setup needed. Choose the right balance of performance and protection, with scopes defined in system catalogs and ready to use out of the box.
-- **New CLI command for Cluster Setup**: The [pgd node setup](/pgd/latest/reference/cli/command_ref/node/setup/) command now enables initial cluster creation and node addition directly from the command line. This gives users more flexibility in how they deploy PGD and allows deployment tools to standardize on a consistent method. 
+- **New CLI command for Cluster Setup**: The [pgd node setup](/pgd/latest/reference/cli/command_ref/node/setup/) command now enables initial cluster creation and node addition directly from the command line. This gives users more flexibility in how they deploy PGD and allows deployment tools to standardize on a consistent method.
 
 ## Features
 
@@ -164,6 +164,9 @@ The command now returns valid output for the other components, <code>health</cod
 <tr><td><details><summary>Fix the CLI <code>pgd node show</code> command issue if a non-existent node is specified.</summary><hr/><p>The <code>pgd node show</code> command crashed if a non-existent node is specified to the command.
 The command is fixed to fail gracefully with appropriate error message.</p>
 </details></td><td></td></tr>
+<tr><td><details><summary>Fix the broken replication slot issue after rolling Postgres upgrade using <code>pgd node upgrade</code> command.</summary><hr/><p>Merge writer origin positions to the parent origin during node upgrade.
+In PGD 5 and older writer origin names map to parent origin id which may change during inplace upgrade.</p>
+</details></td><td>46412,48747</td></tr>
 <tr><td><details><summary>Fixed the timestamp parsing issue for <code>pgd replication show</code> CLI command.</summary><hr/><p>The <code>pgd replication show</code> command previously crashed when formatting EPAS timestamps.</p>
 </details></td><td></td></tr>
 <tr><td><details><summary>Fixed issue where parting node may belong to a non-existing group</summary><hr/><p>When parting a given node, that same node may have subscriptions whose

--- a/product_docs/docs/pgd/6/rel_notes/src/relnote_6.0.1.yml
+++ b/product_docs/docs/pgd/6/rel_notes/src/relnote_6.0.1.yml
@@ -7,7 +7,7 @@ intro: |
 highlights: |
   - **New built-in Connection Manager**: Automatically routes client connections to the correct node, simplifies application architecture, supports dynamic topology changes, and includes a built-in session pooler and dedicated read/write and read-only ports, all without external software or complex configuration. This new component replaces PGD Proxy, which is no longer available starting with PGD 6.
   - **Predefined Commit Scopes**: Simplify consistency choices with built-in transaction durability profiles—no complicated setup needed. Choose the right balance of performance and protection, with scopes defined in system catalogs and ready to use out of the box.
-  - **New CLI command for Cluster Setup**: The [pgd node setup](/pgd/latest/reference/cli/command_ref/node/setup/) command now enables initial cluster creation and node addition directly from the command line. This gives users more flexibility in how they deploy PGD and allows deployment tools to standardize on a consistent method. 
+  - **New CLI command for Cluster Setup**: The [pgd node setup](/pgd/latest/reference/cli/command_ref/node/setup/) command now enables initial cluster creation and node addition directly from the command line. This gives users more flexibility in how they deploy PGD and allows deployment tools to standardize on a consistent method.
 relnotes:
 - relnote: Table rewriting `ALTER TABLE... ALTER COLUMN` calls are now supported.
   details: |
@@ -309,6 +309,15 @@ relnotes:
   type: Bug Fix
   impact: High
 
+- relnote: Fix the broken replication slot issue after rolling Postgres upgrade using `pgd node upgrade` command.
+  details: |
+    Merge writer origin positions to the parent origin during node upgrade.
+    In PGD 5 and older writer origin names map to parent origin id which may change during inplace upgrade.
+  jira:  BDR-6511
+  addresses: "46412,48747"
+  type: Bug Fix
+  impact: High
+
 - relnote: Commit scope logic is now only run on data nodes.
   details: |
     Previously, non-data nodes would attempt to handle, but not process commit scope logic, which could lead to confusing, albeit harmless log messages.
@@ -376,7 +385,7 @@ relnotes:
     The `pgd replication show` command previously crashed when formatting EPAS timestamps.
   jira:  BDR-6347
   type: Bug Fix
-  impact: High 
+  impact: High
 
 - relnote: Fix replication breakage with updates to non-unique indexes
   component: BDR
@@ -427,7 +436,7 @@ relnotes:
   addresses: "47233"
   type: Bug Fix
   impact: Medium
-  
+
 - relnote: automatic node sync and reconciliation is enabled by default.
   details: |
     The GUC [`bdr.enable_auto_sync_reconcile`](/pgd/latest/reference/tables-views-functions/pgd-settings#bdrenable_auto_sync_reconcile) was off by default, but is made on by default in 6.0. This GUC setting ensures that when a node is down for some time, all other nodes get caught up equally with respect to this node automatically. It also ensures that if there are any prepared transactions that are orphaned by the node going down, they are resolved, either aborted or committed as per the rules of the commit scope that created them.


### PR DESCRIPTION
## What Changed?

Add release notes entry for v5.8.1 and v6.0.1 for [BDR-6511](https://enterprisedb.atlassian.net/browse/BDR-6511)

[BDR-6511]: https://enterprisedb.atlassian.net/browse/BDR-6511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ