### PR TITLE
Add missing entry to wait_states_1.5_rel_notes.mdx

### DIFF
--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.5_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.5_rel_notes.mdx
@@ -9,3 +9,4 @@ This release of Wait States includes:
 | Type        | Description                                                       |
 |-------------|-------------------------------------------------------------------|
 | Enhancement | Included `query_id` in `edb_wait_states_data()` function results. |
+| Bug Fix     | Fix calculation of retention time that led to shorter history.    |


### PR DESCRIPTION
Commit [e4c4b54d1462cf9f115ada932a9d19fa592359b7](https://github.com/EnterpriseDB/edb-modules/commit/e4c4b54d1462cf9f115ada932a9d19fa592359b7), contained in the release of 1.5.0, fixed a miscalculation (integer overflow) of retention time for larger values, that caused history files to be pruned sooner than they should have been.

For some reason, this was not listed in the release notes of 1.5.0.

A customer has just reported the issue while using an older version, so it's best to have it mentioned in the release notes, so we can reference the bug fix in customer cases.
