### PR TITLE
Fixed arg order error

### DIFF
--- a/advocacy_docs/dev-guides/deploy/docker.mdx
+++ b/advocacy_docs/dev-guides/deploy/docker.mdx
@@ -44,7 +44,7 @@ docker pull postgres
 Run a new container with the PostgreSQL image:
 
 ```
-docker run --name my_postgres -d postgres -e POSTGRES_PASSWORD=mysecretpassword -v my_pgdata:/var/lib/postgresql/data -p 5432:5432
+docker run --name my_postgres -d -e POSTGRES_PASSWORD=mysecretpassword -v my_pgdata:/var/lib/postgresql/data -p 5432:5432 postgres
 ```
 
 #### `--name my_postgres`
@@ -54,10 +54,6 @@ The `--name` flag tells Docker to create a new container named `my_postgres`.
 #### `-d` 
 
 The `-d` flag tells Docker to run the container in detached mode. This means the container runs in the background and doesn't block the terminal.
-
-#### `postgres`
-
-This is the name of the image to run. Docker uses this name to pull the image from Docker Hub if it isn't already present on the local machine.  If you don't pull it, this command automatically pulls the PostgreSQL image.
 
 #### `-e POSTGRES_PASSWORD=mysecretpassword`
 
@@ -71,6 +67,11 @@ These writes are persisted outside the container in a Docker volume. The command
 #### `-p 5432:5432`
 
 The `-p` flag maps the container’s port 5432 to the host machine’s port 5432. Port 5432 is Postgres's default port for communications. Using this flag allows you to access the PostgreSQL database from your host machine.
+
+#### `postgres`
+
+This is the name of the image to run. Docker uses this name to pull the image from Docker Hub if it isn't already present on the local machine.  If you don't pull it, this command automatically pulls the PostgreSQL image.
+
 
 ## Verifying the container is running
 
@@ -90,7 +91,7 @@ can start using it.
 To access the PostgreSQL database without any additional tools, you can use the following command to open a PostgreSQL prompt:
 
 ```
-docker exec \-it my\_postgres psql \-U postgres
+docker exec -it my_postgres psql -U postgres
 ```
 
 This command logs into the Docker container and runs the `psql` command as the postgres user from there.
@@ -160,7 +161,7 @@ postgresql://postgres:mysecretpassword@localhost:5432/postgres
 3. Re-create the container with the same volume:
 
    ```
-   docker run --name my_postgres -d postgres -e POSTGRES_PASSWORD=mysecretpassword -v my_pgdata:/var/lib/postgresql/data -p 5432:5432
+   docker run --name my_postgres -d -e POSTGRES_PASSWORD=mysecretpassword -v my_pgdata:/var/lib/postgresql/data -p 5432:5432 postgres
    ```
 
 4. Verify data persistence.  


### PR DESCRIPTION
`postgres` the image name has to be at the end of all the options because any arguments after the image name is interpreted as the command to be run.

Prior to the fix, `POSTGRES_PASSWORD` will be interpreted as commands and fail to set resulting in a container that won't start.

After the fix, the environment variable will be correctly parsed into the compose file and can be seen in `docker inspect`.

Additionally, I removed the extra escapes (i.e., `\`) that aren't needed in the bash command.

## What Changed?

