### PR TITLE
chore(MIG-6572): Updates self-managed Beacon agent CA fetch guidance

### DIFF
--- a/advocacy_docs/edb-postgres-ai/hybrid-manager/using_hybrid_manager/monitoring/mon_ext_dbs/mon_with_agent/admin_tasks.mdx
+++ b/advocacy_docs/edb-postgres-ai/hybrid-manager/using_hybrid_manager/monitoring/mon_ext_dbs/mon_with_agent/admin_tasks.mdx
@@ -23,14 +23,14 @@ To see the Kubernetes secret containing the root certificate:
 
 ```
 # The certificate is base64 encoded as the data field "public.crt"
-kubectl get secret -n edbpgai-bootstrap beaconator-ca-bundle -o json
+kubectl get secret -n upm-beacon beaconator-ca-bundle -o json
 ```
 
 For a more readable output that only prints the root certificate, ensure you have `jq` and `base64` installed and run:
 
 ```
 # If `jq` and `base64` are available
-kubectl get secret -n edbpgai-bootstrap beaconator-ca-bundle -o json | jq -r '.data."public.crt"' | base64 --decode
+kubectl get secret -n upm-beacon beaconator-ca-bundle -o json | jq -r '.data."public.crt"' | base64 --decode
 ```
 
 This command outputs the contents of the certificate. Send them to the person that requires them through a secure channel. The user will have to store it locally, in crt format.


### PR DESCRIPTION
## What Changed?

The namespace `edbpgai-bootstrap` is not the best location to pull this CA from. The value in `upm-beacon` will work well.