### PR TITLE
Add node_kind checks on verify command

### DIFF
--- a/product_docs/docs/pgd/6/reference/cli/command_ref/cluster/verify.mdx
+++ b/product_docs/docs/pgd/6/reference/cli/command_ref/cluster/verify.mdx
@@ -36,13 +36,14 @@ With no option set, both setting and arch are verified by default and output is 
 pgd cluster verify
 __OUTPUT__
 ## Architecture
-Check                   Status Groups
------------------------ ------ ------
-Cluster has data nodes  Ok           
-Witness nodes per group Ok           
-Witness-only groups     Ok           
-Data nodes per group    Ok           
-Empty groups            Ok           
+Check                    Status Groups
+------------------------ ------ ------
+Cluster has data nodes   Ok           
+Witness nodes per group  Ok           
+Witness-only groups      Ok           
+Data nodes per group     Ok           
+Empty groups             Ok           
+Nodes have node kind set Ok           
 
 # Settings
 Setting Name                     Status


### PR DESCRIPTION
Add the expected output for node_kind verify check, merged in PR https://github.com/EnterpriseDB/bdr/pull/4229

## What Changed?
The new standard output of `cluster verify` should include a new check message after the last one 'Empty groups'
