### PR TITLE
Update efm.mdx -- remind about the "upstream" property

### DIFF
--- a/product_docs/docs/tpa/23/reference/efm.mdx
+++ b/product_docs/docs/tpa/23/reference/efm.mdx
@@ -57,7 +57,10 @@ restart EFM to activate the changes.
 ### EFM witness
 
 TPA will install and configure EFM as witness on instances whose `role`
-contains `efm-witness`.
+contains `efm-witness`. For such instances the `upstream` property must be specified to point
+to the designated primary database instance.
+
+
 
 ### Repmgr
 


### PR DESCRIPTION
It is created by `tpaexec configure`, but if you edit the config file manually and forget to add it, the resulting error message is utterly misleading.

## What Changed?

Added a sentence about the need of an `upstream` property on EFM witness instances.