### PR TITLE
Update supported versions matrix for postgis 3.5

### DIFF
--- a/product_docs/docs/postgis/3/supported_platforms.mdx
+++ b/product_docs/docs/postgis/3/supported_platforms.mdx
@@ -8,13 +8,14 @@ EDB PostGIS is supported on the same platforms as EDB Postgres Advanced Server. 
 
 This table lists the latest PostGIS versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. 
 
-| PostGIS | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 | EPAS 12 |
+| PostGIS | EPAS 17 | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 |
 |---------|---------|---------|---------|---------|---------|
-| 3.4     | Y       | Y       | Y       | Y       | Y       |
-| 3.3     | N       | Y       | Y       | Y       | Y       |
-| 3.2     | N       | Y       | Y       | Y       | Y       |
-| 3.1     | N       | N       | Y       | Y       | Y       |
-| 3.0     | N       | N       | N       | Y       | Y       |
-| 2.5     | N       | N       | N       | N       | Y       |
+| 3.5     | Y       | Y       | Y       | Y       | Y       |
+| 3.4     | N       | Y       | Y       | Y       | Y       |
+| 3.3     | N       | N       | Y       | Y       | Y       |
+| 3.2     | N       | N       | Y       | Y       | Y       |
+| 3.1     | N       | N       | N       | Y       | Y       |
+| 3.0     | N       | N       | N       | N       | Y       |
+| 2.5     | N       | N       | N       | N       | N       |
 | 2.4     | N       | N       | N       | N       | N       |
 | 2.3     | N       | N       | N       | N       | N       |


### PR DESCRIPTION
This adds EPAS 17 to the list, which is supported starting with postgis 3.5. It also removes EPAS 12, which has gone EOL and did not receive any postgis 3.5 packages.

