### PR TITLE
Update pgd-settings - default replica identity

### DIFF
--- a/product_docs/docs/pgd/6/reference/tables-views-functions/pgd-settings.mdx
+++ b/product_docs/docs/pgd/6/reference/tables-views-functions/pgd-settings.mdx
@@ -44,7 +44,7 @@ The accepted values are:
 | `default` | Records the old values of the columns of the primary key, if any (this is the default PostgreSQL behavior). |
 | `full` | Records the old values of all columns in the row. |
 | `nothing` | Records no information about the old row. |
-| `auto` | Tables with PK are created with REPLICA IDENTITY DEFAULT, and tables without PK are created with REPLICA IDENTITY FULL. This is the default PGD behavior. |
+| `auto` | Tables are created with REPLICA IDENTITY FULL. This is the default PGD behavior. |
 
 See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY) for more details.
 


### PR DESCRIPTION
Fix on the `auto` value on the current documentation (current pgd 6.0.2).

## What Changed?

auto | Tables with PK are created with REPLICA IDENTITY DEFAULT, and tables without PK are created with REPLICA IDENTITY FULL. This is the default PGD behavior.
-- | --

Should be replaced by:

auto | Tables are created with REPLICA IDENTITY FULL.  This is the default PGD behavior.
-- | --






