### PR TITLE
Clarify bdr.run_on_all_nodes() behavior

### DIFF
--- a/product_docs/docs/pgd/5.8/ddl/ddl-managing-with-pgd-replication.mdx
+++ b/product_docs/docs/pgd/5.8/ddl/ddl-managing-with-pgd-replication.mdx
@@ -33,8 +33,7 @@ $ddl$);
 ```
 
 We recommend using the [`bdr.run_on_all_nodes()`](/pgd/5.8/reference/functions#bdrrun_on_all_nodes) technique with `CREATE
-INDEX CONCURRENTLY`, noting that DDL replication must be disabled for the whole
-session because `CREATE INDEX CONCURRENTLY` is a multi-transaction command.
+INDEX CONCURRENTLY`.
 Avoid `CREATE INDEX` on production systems
 since it prevents writes while it executes.
 `REINDEX` is replicated in versions 3.6 and earlier but not with PGD 3.7 or later.

--- a/product_docs/docs/pgd/6/reference/ddl/ddl-managing-with-pgd-replication.mdx
+++ b/product_docs/docs/pgd/6/reference/ddl/ddl-managing-with-pgd-replication.mdx
@@ -35,8 +35,7 @@ $ddl$);
 ```
 
 We recommend using the [`bdr.run_on_all_nodes()`](/pgd/latest/reference/tables-views-functions/functions#bdrrun_on_all_nodes) technique with `CREATE
-INDEX CONCURRENTLY`, noting that DDL replication must be disabled for the whole
-session because `CREATE INDEX CONCURRENTLY` is a multi-transaction command.
+INDEX CONCURRENTLY`.
 Avoid `CREATE INDEX` on production systems
 since it prevents writes while it executes.
 Avoid using `REINDEX` because of the AccessExclusiveLocks it holds.


### PR DESCRIPTION
ddl_replication has been disabled when you use bdr.run_on_all_nodes() since bdr 5.8.