### PR TITLE
Add clarification to the local.timeout.final property

### DIFF
--- a/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
@@ -432,9 +432,9 @@ The following properties apply to the local server:
 
 -   The `local.period` property specifies the number of seconds between attempts to contact the database server.
 -   The `local.timeout` property specifies the number of seconds an agent waits for a positive response from the local database server.
--   The `local.timeout.final` property specifies the number of seconds an agent waits after the previous checks have failed to contact the database server on the current node. If a response isn't received from the database within the number of seconds specified by the `local.timeout.final` property, the database is assumed to have failed.
+-   The `local.timeout.final` property specifies the maximum amount of time in seconds an agent waits after the previous checks have failed to contact the database server on the current node. If the final connection attempt fails, or a response isn't received from the database within this time, the database is assumed to have failed.
 
-For example, given the default values of these properties, a check of the local database happens once every 10 seconds. If an attempt to contact the local database doesn't come back positive within 60 seconds, Failover Manager makes a final attempt to contact the database. If a response isn't received within 10 seconds, Failover Manager declares database failure and notifies the administrator listed in the `user.email` property. These properties aren't required on a dedicated witness node.
+For example, given the default values of these properties, a check of the local database happens once every 10 seconds. If an attempt to contact the local database doesn't come back positive within 60 seconds, Failover Manager makes a final attempt to contact the database. If the connection fails or a response isn't received within 10 seconds, Failover Manager moves to the next step of asking the rest of the cluster if the database is reachable. These properties aren't required on a dedicated witness node.
 
 ```ini
 # These properties apply to the connection(s) EFM uses to monitor


### PR DESCRIPTION
The point is that this property defines a maximum amount of time for an agent to wait IF NECESSARY, not a length of time that it waits before doing things normally.

## What Changed?

