### PR TITLE
docs(ET-2898): add null character limitation for oracle and tsvector …

### DIFF
--- a/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/limitations.mdx
+++ b/advocacy_docs/edb-postgres-ai/migration-etl/data-migration-service/limitations.mdx
@@ -25,7 +25,7 @@ These are the known issues, limitations, and notes for:
 
 A limited number of Oracle data types and features aren't supported by EDB Data Migration Service (EDB DMS).
 
-See the [Debezium documentation](https://debezium.io/documentation/reference/2.2/connectors/oracle.html#oracle-data-type-mappings) for detailed comments on supported data types. 
+See the [Debezium documentation](https://debezium.io/documentation/reference/2.2/connectors/oracle.html#oracle-data-type-mappings) for detailed comments on supported data types.
 
 Unsupported Oracle data types include:
 
@@ -42,6 +42,8 @@ Unsupported Oracle data types include:
 EDB DMS supports replicating Oracle tables that contain BLOB, CLOB, or NCLOB columns only if these also have the primary key constraint. If the tables don't have the primary key constraint, the streaming replication will only support INSERT operations.
 
 `BINARY_FLOAT` and `BINARY_DOUBLE` types in Oracle that might contain `Nan`, `+INF`, and `-INF` values are not supported by EDB DMS.
+
+For text field types like `VARCHAR` and `CLOB` in Oracle that might contain null character(0x00) values are not supported by EDB DMS.
 
 ### Oracle 21c databases
 
@@ -63,11 +65,37 @@ The EDB DMS doesn't support migrating tables with columns that have user-defined
 -   XML
 -   POINT
 -   LTREE
+-   TSVECTOR
+
+### TSVECTOR type migration workaround
+
+This workaround based on the following example `messages` table:
+```sql
+CREATE TABLE messages (
+    title       text,
+    body        text,
+    tsv         tsvector
+);
+```
+The first option is creating a trigger to update the `tsvector` field automatically:
+```sql
+CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
+ON messages FOR EACH ROW EXECUTE FUNCTION
+tsvector_update_trigger(tsv, 'pg_catalog.english', title, body);
+```
+This CREATE TRIGGER statement should execute before the migration created and after the target table created.
+
+To make sure the trigger to compute the tsvector field for every row. Since this trigger will not compute the
+
+tsvector field for existing rows, you can run the following UPDATE statement after the migration is complete:
+```sql
+UPDATE messages SET tsv = to_tsvector('english', CONCAT(title, ' ', body)) WHERE tsv IS NULL;
+```
 
 ### Incorrect failure messages
 
-The `postgresConfigValidation.sh` script referenced in [Preparing Postgres database sources](/edb-postgres-ai/hybrid-manager/using_hybrid_manager/migration/migration_guides/self_managed_pg_to_hm_managed/preparing_source_pg_db/) incorrectly reports failures for the `max_wal_size` database parameter check and for the replication slot check. 
+The `postgresConfigValidation.sh` script referenced in [Preparing Postgres database sources](/edb-postgres-ai/hybrid-manager/using_hybrid_manager/migration/migration_guides/self_managed_pg_to_hm_managed/preparing_source_pg_db/) incorrectly reports failures for the `max_wal_size` database parameter check and for the replication slot check.
 
-The script reports a failure for the `max_wal_size` check, if the parameter is set to a value lower than 8 GB. Although this is a recommended setting for many production workloads, setting the parameter to a lower value doesn't prevent a migration from being performed. 
+The script reports a failure for the `max_wal_size` check, if the parameter is set to a value lower than 8 GB. Although this is a recommended setting for many production workloads, setting the parameter to a lower value doesn't prevent a migration from being performed.
 
 In addition, the Postgres configuration validation script also performs a check to see if a replication slot with a slot name matching the migration user/role was created. This is an outdated check that is no longer needed because the EDB DMS Reader automatically creates and manages the required replication slot. You can ignore the failure message related to the replication slot. The check will be removed in a future version of the `postgresConfigValidation.sh` script.


### PR DESCRIPTION
…workaround for pg

## What Changed?

Add 1 limitation for Oracle source and 1 for Postgres source

1. DMS does not support Oracle text fields like VARCHAR and CLOB that contains null character(0x00)
2. DMS does not support Postgres TSVECTOR field and we provide a workaround to compute this field