### PR TITLE
Clarify that only some logging parameters are fixed

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/postgresql_conf.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/postgresql_conf.mdx
@@ -188,7 +188,7 @@ network disruptions. For more details, refer to the
 
 The operator requires PostgreSQL to output its log in CSV format, and the
 instance manager automatically parses it and outputs it in JSON format.
-For this reason, all log settings in PostgreSQL are fixed and cannot be
+For this reason, some log settings in PostgreSQL, listed [in this section](#fixed-parameters), are fixed and cannot be
 changed.
 
 For further information, please refer to the ["Logging" section](logging.md).


### PR DESCRIPTION
The sentence erroneously states that _all_ logging parameters are fixed.

## What Changed?

"all" -> "some"; add link to the fixed parameters section