### PR TITLE
Update pgd_5.9.0_rel_notes.mdx to include role synchronization

### DIFF
--- a/product_docs/docs/pgd/5.9/rel_notes/pgd_5.9.0_rel_notes.mdx
+++ b/product_docs/docs/pgd/5.9/rel_notes/pgd_5.9.0_rel_notes.mdx
@@ -35,6 +35,8 @@ This is a minor release of PGD 5, which includes several enhancements and bug fi
 </details></td><td></td></tr>
 <tr><td>BDR</td><td>5.9.0</td><td><details><summary>Enable proxy routing by default for subgroups</summary><hr/><p>Subgroups have proxy routing enabled by default from 5.9.0 however it doesn't impact the existing behavior of subgroups and how to connect to the nodes without proxy.</p>
 </details></td><td></td></tr>
+<tr><td>BDR</td><td>5.9.0</td><td><details><summary>Synchronize roles and tablespaces during logical join</summary><hr/><p>Roles and tablespaces are now synchronized before the schema is restored from the join source node. If there are already existing roles or tablespaces (or EPAS profiles, they will be updated to have the same settings, passwords etc. as the ones from the join source node. System roles (i.e. the ones created by initdb) are not synchronized.</p>
+</details></td><td></td></tr>
 </tbody></table>
 
 


### PR DESCRIPTION
An enhancement was done in 5.9.0 related to replication of roles which missed a mention in release notes.

## What Changed?

