### PR TITLE
Update role-management.mdx to reflect new role sync feature

### DIFF
--- a/product_docs/docs/pgd/5.9/security/role-management.mdx
+++ b/product_docs/docs/pgd/5.9/security/role-management.mdx
@@ -19,19 +19,9 @@ You can disable this automatic replication behavior by turning off the [`bdr.rol
 
 New PGD nodes that are added using [`bdr_init_physical`](/pgd/5.9/reference/nodes/#bdr_init_physical) will automatically replicate the roles from other nodes of the PGD cluster.
 
-If a PGD node is joined to a PGD group manually, without using `bdr_init_physical`, existing roles aren't copied to the newly joined node. This is intentional behavior to ensure that access isn't accidentally granted.
+Starting with PGD 5.9.0, when a PGD node is manually joined to a PGD group without using bdr_init_physical, existing roles are automatically copied to the newly joined node. This means that you no longer need to create roles manually on the new node before joining it to the group.
 
-Roles, by default, have access to all databases. Automatically copying users to a newly created node would therefore open the possibility of unintentionally exposing a database that exists on the node. If the PGD cluster had a user Alice, and Alice was automatically created on a newly joined node, by directly connecting to that node, Alice would have access to all the databases on that node. PGD therefore doesn't copy over existing roles. In this situation, we recommend that you copy over roles manually.
-
-PostgreSQL allows you to dump all roles with the command:
-
-```
-pg_dumpall --roles-only > roles.sql
-```
-
-You can then edit the file `roles.sql` to remove unwanted users before running the file's commands on the newly created node.
-
-When joining a new node, the “No unreplicated roles” rule also applies. If an object in the database to be replicated relies on an unreplicated role in an (unreplicated) local database, then the join fails when it attempts to replicate that object.
+When roles are copied to a new node, if there are existing roles (or tablespaces) with the same name, the new node's existing roles (or tablespaces) will be updated to share the same settings (including passwords) as the roles (or tablespaces) on the source node in the join operation.
 
  
 ## Connections and roles


### PR DESCRIPTION
In 5.9.0 roles are synced at node join. This needs to be reflected in the documentation.

## What Changed?

