### PR TITLE
Add max_active_replication_origins on PG 18+

### DIFF
--- a/product_docs/docs/pgd/6.1/reference/postgres-configuration.mdx
+++ b/product_docs/docs/pgd/6.1/reference/postgres-configuration.mdx
@@ -42,6 +42,7 @@ which vary according to the size and scale of the cluster:
     removed from a PGD group.
 -   `max_wal_senders` &mdash; Two needed for every peer node.
 -   `max_replication_slots` &mdash; Two needed for every peer node.
+-   `max_active_replication_origins` &mdash; Three needed for every peer node. Available only on PG18+.
 -   `wal_sender_timeout` and `wal_receiver_timeout` &mdash; The default of one minute is usually sufficient, but large transactions may require longer than this amount of time to process. Since the WAL sender must process the full size of the transaction before transmitting it to a waiting replication connection, Postgres can see that as a timeout. If the problem is actually due to a large transaction, raising wal_sender_timeout to a higher value, like `3600s` or higher, and reloading the server could solve the problem. Additionally, this setting determines how
     quickly a node considers its CAMO partner as disconnected or
     reconnected. See [CAMO failure scenarios](commit-scopes/camo#failure-scenarios) for

--- a/product_docs/docs/pgd/6/reference/postgres-configuration.mdx
+++ b/product_docs/docs/pgd/6/reference/postgres-configuration.mdx
@@ -42,6 +42,7 @@ which vary according to the size and scale of the cluster:
     removed from a PGD group.
 -   `max_wal_senders` &mdash; Two needed for every peer node.
 -   `max_replication_slots` &mdash; Two needed for every peer node.
+-   `max_active_replication_origins` &mdash; Three needed for every peer node. Available only on PG18+.
 -   `wal_sender_timeout` and `wal_receiver_timeout` &mdash; The default of one minute is usually sufficient, but large transactions may require longer than this amount of time to process. Since the WAL sender must process the full size of the transaction before transmitting it to a waiting replication connection, Postgres can see that as a timeout. If the problem is actually due to a large transaction, raising wal_sender_timeout to a higher value, like `3600s` or higher, and reloading the server could solve the problem. Additionally, this setting determines how
     quickly a node considers its CAMO partner as disconnected or
     reconnected. See [CAMO failure scenarios](commit-scopes/camo#failure-scenarios) for


### PR DESCRIPTION
The max_active_replication_origins parameter was introduced in PostgreSQL 18 and is not available in earlier versions.

BDR-7069

## What Changed?

