### PR TITLE
Fix typo

### DIFF
--- a/product_docs/docs/pgd/6.1/upgrades/compatibility.mdx
+++ b/product_docs/docs/pgd/6.1/upgrades/compatibility.mdx
@@ -62,7 +62,7 @@ Parting can also take longer than earlier versions since this operation waits ti
 ## Administration function changes
 
 - The `enable_proxy_routing` node group option is now `enable_routing`, although `bdr.alter_node_group_option` still supports the older syntax for backwards compatibility. The views only show the new name.
-- The already deprecated `bdr.alter_node_group_conifg()` was removed. Use `bdr.alter_node_group_option()` instead.
+- The already deprecated `bdr.alter_node_group_config()` was removed. Use `bdr.alter_node_group_option()` instead.
 - The `managed_locally` option in `bdr.autopartition()` was removed. Only locally managed partitions are now supported. At the same time `ap_is_local` was removed from `bdr.autopartition_rules` catalog as well.
 
 ## Other


### PR DESCRIPTION
fix a typo in the name of the deprecated function.


