### PR TITLE
Update knowledge_bases.mdx

### DIFF
--- a/advocacy_docs/edb-postgres-ai/ai-factory/pipeline/reference/knowledge_bases.mdx
+++ b/advocacy_docs/edb-postgres-ai/ai-factory/pipeline/reference/knowledge_bases.mdx
@@ -171,7 +171,8 @@ SELECT aidb.create_table_knowledge_base(
                model_name => 'bert',
                source_table => 'test_source_table',
                source_data_column => 'content',
-               source_data_type => 'Text'
+               source_key_column => 'doc_id',
+               source_data_format => 'Text'
        );
 ```
 


### PR DESCRIPTION
## What Changed?
The `aidb.create_table_knowledge_base` command example used a non-exist parameter `source_data_type`, it should be `source_data_format`. It is also missing the parameter `source_key_column`


https://edb.slack.com/archives/C06Q8CY9RJ9/p1758695675181899