### PR TITLE
Clarify the assumptions about the key path provided

### DIFF
--- a/product_docs/docs/tde/15/secure_key/index.mdx
+++ b/product_docs/docs/tde/15/secure_key/index.mdx
@@ -41,7 +41,7 @@ The `wrap` and `unwrap` commands are assumed to run with the current working dir
 
 When you initialize a server with TDE, the `initdb` command adds the `data_encryption_key_unwrap_command` parameter in the `postgresql.conf` configuration file. The string specified in `data_encryption_key_unwrap_command` can then unwrap (decrypt) the data encryption key.
 
-The commands must contain a placeholder `%p`, which is replaced with the path to the file containing the key to unwrap. Since the commands are assumed to run with the Postgres data directory as the current working directory, the key path name provided can be relative to the data directory. The command must print the unwrapped (decrypted) key to its standard output.
+The commands must contain the placeholder `%p`, which will be replaced by the path to the file containing the key to unwrap. Since the command runs from the data directory, the key path provided by `%p` can be relative to that directory. The command must print the unwrapped (decrypted) key to its standard output.
 
 ## Providing the wrapping and unwrapping commands to TDE
 


### PR DESCRIPTION
See this Slack discussion https://edb.slack.com/archives/CDTA6PCJV/p1758928515169919

In some cases the path provided is absolute, sometimes it's relative. If the command runs, as assumed, in the Postgres data directory, this makes no difference. However, if the current directory changes at run time, the wrap/unwrap commands will have trouble locating the key file if the relative path were used.

## What Changed?

Clarified the conditions under which the wrap/unwrap commands are executed, and the assumptions about the `%p` variable substitution.

Based on a real customer scenario.