### PR TITLE
Update edb_loader_control_file_parameters.mdx

### DIFF
--- a/product_docs/docs/epas/17/reference/database_administrator_reference/edb_loader_control_file_parameters.mdx
+++ b/product_docs/docs/epas/17/reference/database_administrator_reference/edb_loader_control_file_parameters.mdx
@@ -135,7 +135,7 @@ Use the following parameters when [building the EDB\*Loader control file](/epas/
 
 ## PRESERVE BLANKS
 
- The `PRESERVE BLANKS` option works only with the `OPTIONALLY ENCLOSED BY` clause. It retains leading and trailing whitespaces for both delimited and predetermined size fields. 
+ The `PRESERVE BLANKS` option retains leading and trailing whitespaces for both delimited and predetermined size fields. 
  
  In case of `NO PRESERVE BLANKS`, if the fields are delimited, then only leading whitespaces are omitted. If any trailing whitespaces are present, they are left intact. In the case of predetermined-sized fields with `NO PRESERVE BLANKS`, the trailing whitespaces are omitted. Any leading whitespaces are left intact. 
 


### PR DESCRIPTION
Hi team,
Greetings. We are contacting you as per below change.

## What Changed?
`The PRESERVE BLANKS option works only with the OPTIONALLY ENCLOSED BY clause. `

This phrase is not correct because, OPTIONALLY ENCLOSED BY clause is only needed when input file is a
Delimiter-separated field data file, but no needed if it is a Fixed-width field data file.

And also, when using Delimiter-separated field data file, only TERMINATED clause is needed and it will work
without OPTIONALLY ENCL.OSED BY clause

Kind Regards,
Yuki Tei