### PR TITLE
add info about 5.0 version of create-standby

### DIFF
--- a/product_docs/docs/efm/5/07_using_efm_utility.mdx
+++ b/product_docs/docs/efm/5/07_using_efm_utility.mdx
@@ -122,7 +122,7 @@ If the `-prompt` option is specified, the command will output the steps it will 
 - `application.name` specifies the `application_name` to use (if set).
 
 !!!Note
-    This command was introduced in Failover Manager 5.0.
+    This command was introduced in Failover Manager 5.0. In 5.0 only, the command requires superuser privileges to run.
 
 The following example shows the command output when both the `-prompt` and `-slot` options are specified:
 


### PR DESCRIPTION
In 5.0 when the 'efm create-standby' command was introduced, it required superuser privileges to run since it needed to be able to start the db as a service without using the normal efm scripts. In 5.1 this was fixed so that it can be run as the 'efm' user, and the documentation was changed to remove the requirement text, but people will still get caught up on this if using 5.0.

## What Changed?

