### PR TITLE
Update 08_mtk_command_options.mdx

### DIFF
--- a/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
+++ b/product_docs/docs/migration_toolkit/55/07_invoking_mtk/08_mtk_command_options.mdx
@@ -404,7 +404,7 @@ Use the migration options to control the details of the migration process.
 Truncate the data from the table before importing new data. Use this option with the `-dataOnly` option.
 
 !!!note
-If -truncLoad is spcified, all indexes and constraints are dropped before data laod and recreated afterward. Hence if data load is failed, indexes and constraints might be lacking. Manual operation might be necessary, depending on the situation.
+If `-truncLoad` is specified, all indexes and constraints are dropped before data load and recreated afterwards. Hence, if the data load fails, it may lead to a lack of indexes, constraints and triggers. Manual intervention might be necessary, depending on the situation.
 !!!
 
 ### `-enableConstBeforeDataLoad`


### PR DESCRIPTION
Hi team,
Greetings.

## What Changed?
We got to know that only -trunLoad will drop/recreate indexes/constraints, user should know this before using it.

Kind Regards,
Yuki Tei
