### PR TITLE
Update kubectl-plugin.mdx: remove duplicate "Configuring auto-completion" section

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
@@ -128,28 +128,6 @@ sudo mv kubectl_complete-cnp /usr/local/bin
 !!! Important
     The name of the script needs to be exactly the one provided since is used by the kubectl auto-complete process
 
-### Configuring auto-completion
-
-To configure auto-completion for the plugin, a helper shell script needs to be
-installed into your current PATH. Assuming the latter contains `/usr/local/bin`,
-this can be done with the following commands:
-
-```sh
-cat > kubectl_complete-cnp <<EOF
-#!/usr/bin/env sh
-
-# Call the __complete command passing it all arguments
-kubectl cnp __complete "\$@"
-EOF
-
-chmod +x kubectl_complete-cnp
-
-# Important: the following command may require superuser permission
-sudo mv kubectl_complete-cnp /usr/local/bin
-```
-
-!!! Important
-    The name of the script needs to be exactly the one provided since it's used by the kubectl auto-complete process
 
 ## Use
 


### PR DESCRIPTION
The section "Configuring auto-completion" was duplicated on the page.

## What Changed?
The duplicate "Configuring auto-completion" section was deleted.
