### PR TITLE
Drop index advisor references for EPAS 16 and 17

### DIFF
--- a/product_docs/docs/epas/16/database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/12_customized_options.mdx
+++ b/product_docs/docs/epas/16/database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/12_customized_options.mdx
@@ -46,65 +46,6 @@ Specifies the maximum number of concurrent alerts allowed on a system using the 
 
 Specifies the total size of the buffer used for the `DBMS_PIPE` package.
 
-## index_advisor.enabled
-
-**Parameter type:** Boolean
-
-**Default value:** `true`
-
-**Range:** `{true | false}`
-
-**Minimum scope of effect:** Per session
-
-**When value changes take effect:** Immediate
-
-**Required authorization to activate:** Session user
-
-Temporarily suspends Index Advisor in an EDB-PSQL or PSQL session. To use this configuration parameter, the Index Advisor plugin `index_advisor` must be loaded in the EDB-PSQL or PSQL session.
-
-You can load the Index Advisor plugin as follows:
-
-```sql
-$ psql -d edb -U enterprisedb
-Password for user enterprisedb:
-psql (14.0.0)
-Type "help" for help.
-
-edb=# LOAD 'index_advisor';
-LOAD
-```
-
-Use the `SET` command to change the parameter setting to control whether Index Advisor generates an alternative query plan:
-
-```text
-edb=# SET index_advisor.enabled TO off;
-SET
-edb=# EXPLAIN SELECT * FROM t WHERE a < 10000;
-__OUTPUT__
-                     QUERY PLAN
-
--------------------------------------------------------
- Seq Scan on t (cost=0.00..1693.00 rows=9864 width=8)
-   Filter: (a < 10000)
-(2 rows)
-```
-```sql
-edb=# SET index_advisor.enabled TO on;
-SET
-edb=# EXPLAIN SELECT * FROM t WHERE a < 10000;
-__OUTPUT__
-                      QUERY PLAN
------------------------------------------------------------------------------
- Seq Scan on t (cost=0.00..1693.00 rows=9864 width=8)
-   Filter: (a < 10000)
- Result (cost=0.00..327.88 rows=9864 width=8)
-   One-Time Filter: '===[ HYPOTHETICAL PLAN ]==='::text
-   -> Index Scan using "<hypothetical-index>:1" on t (cost=0.00..327.88
- rows=9864 width=8)
-          Index Cond: (a < 10000)
-(6 rows)
-```
-
 ## edb_sql_protect.enabled
 
 **Parameter type:** Boolean

--- a/product_docs/docs/epas/16/reference/database_administrator_reference/02_summary_of_configuration_parameters.mdx
+++ b/product_docs/docs/epas/16/reference/database_administrator_reference/02_summary_of_configuration_parameters.mdx
@@ -202,7 +202,6 @@ These attributes are described by the following columns of the summary table:
 | `ident_file` &mdash; Sets the server's "ident" configuration file. | Cluster         | Restart                                | EPAS account       |
 | `ignore_checksum_failure` &mdash; Continues processing after a checksum failure. | Session         | Immediately                              | Superuser                  |
 | `ignore_system_indexes` &mdash; Disables reading from system indexes. (Can also be set with `PGOPTIONS` at session start.)  | Cluster<br/>Session | Reload<br/>Immediately                       | EPAS account<br/>User  |
-| `index_advisor.enabled`(EPAS only) &mdash; Enables Index Advisor plugin. | Session         | Immediately                              | User                       |
 | `integer_datetimes` &mdash; Datetimes are integer based.  | Cluster         | Preset                                 | n/a                        |
 | `intervalStyle` &mdash; Sets the display format for interval values.  | Session         | Immediately                              | User                       |
 | `join_collapse_limit` &mdash; Sets the `FROM`-list size beyond which `JOIN` constructs are not flattened. | Session         | Immediately                              | User                       |

--- a/product_docs/docs/epas/17/database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/12_customized_options.mdx
+++ b/product_docs/docs/epas/17/database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/12_customized_options.mdx
@@ -46,65 +46,6 @@ Specifies the maximum number of concurrent alerts allowed on a system using the 
 
 Specifies the total size of the buffer used for the `DBMS_PIPE` package.
 
-## index_advisor.enabled
-
-**Parameter type:** Boolean
-
-**Default value:** `true`
-
-**Range:** `{true | false}`
-
-**Minimum scope of effect:** Per session
-
-**When value changes take effect:** Immediate
-
-**Required authorization to activate:** Session user
-
-Temporarily suspends Index Advisor in an EDB-PSQL or PSQL session. To use this configuration parameter, the Index Advisor plugin `index_advisor` must be loaded in the EDB-PSQL or PSQL session.
-
-You can load the Index Advisor plugin as follows:
-
-```sql
-$ psql -d edb -U enterprisedb
-Password for user enterprisedb:
-psql (14.0.0)
-Type "help" for help.
-
-edb=# LOAD 'index_advisor';
-LOAD
-```
-
-Use the `SET` command to change the parameter setting to control whether Index Advisor generates an alternative query plan:
-
-```text
-edb=# SET index_advisor.enabled TO off;
-SET
-edb=# EXPLAIN SELECT * FROM t WHERE a < 10000;
-__OUTPUT__
-                     QUERY PLAN
-
--------------------------------------------------------
- Seq Scan on t (cost=0.00..1693.00 rows=9864 width=8)
-   Filter: (a < 10000)
-(2 rows)
-```
-```sql
-edb=# SET index_advisor.enabled TO on;
-SET
-edb=# EXPLAIN SELECT * FROM t WHERE a < 10000;
-__OUTPUT__
-                      QUERY PLAN
------------------------------------------------------------------------------
- Seq Scan on t (cost=0.00..1693.00 rows=9864 width=8)
-   Filter: (a < 10000)
- Result (cost=0.00..327.88 rows=9864 width=8)
-   One-Time Filter: '===[ HYPOTHETICAL PLAN ]==='::text
-   -> Index Scan using "<hypothetical-index>:1" on t (cost=0.00..327.88
- rows=9864 width=8)
-          Index Cond: (a < 10000)
-(6 rows)
-```
-
 ## edb_sql_protect.enabled
 
 **Parameter type:** Boolean

--- a/product_docs/docs/epas/17/reference/database_administrator_reference/02_summary_of_configuration_parameters.mdx
+++ b/product_docs/docs/epas/17/reference/database_administrator_reference/02_summary_of_configuration_parameters.mdx
@@ -201,7 +201,6 @@ These attributes are described by the following columns of the summary table:
 | `ident_file` &mdash; Sets the server's "ident" configuration file. | Cluster         | Restart                                | EPAS account       |
 | `ignore_checksum_failure` &mdash; Continues processing after a checksum failure. | Session         | Immediately                              | Superuser                  |
 | `ignore_system_indexes` &mdash; Disables reading from system indexes. (Can also be set with `PGOPTIONS` at session start.)  | Cluster<br/>Session | Reload<br/>Immediately                       | EPAS account<br/>User  |
-| `index_advisor.enabled`(EPAS only) &mdash; Enables Index Advisor plugin. | Session         | Immediately                              | User                       |
 | `integer_datetimes` &mdash; Datetimes are integer based.  | Cluster         | Preset                                 | n/a                        |
 | `intervalStyle` &mdash; Sets the display format for interval values.  | Session         | Immediately                              | User                       |
 | `join_collapse_limit` &mdash; Sets the `FROM`-list size beyond which `JOIN` constructs are not flattened. | Session         | Immediately                              | User                       |


### PR DESCRIPTION
The index advisor was removed in EPAS 16, so its settings shouldn't be referenced in 16 or 17 or 18...

## What Changed?

Removed the references to settings `index_advisor.enable` from 16 and 17