### PR TITLE
Version requirements for bdr_init_physical and pgd node setup

### DIFF
--- a/product_docs/docs/pgd/4.4/bdr/nodes.mdx
+++ b/product_docs/docs/pgd/4.4/bdr/nodes.mdx
@@ -1306,6 +1306,10 @@ physical standby of an existing node to a new node in the BDR group.
 
 ### bdr_init_physical
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/4.4/upgrades/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,

--- a/product_docs/docs/pgd/4/bdr/nodes.mdx
+++ b/product_docs/docs/pgd/4/bdr/nodes.mdx
@@ -1306,6 +1306,10 @@ physical standby of an existing node to a new node in the BDR group.
 
 ### bdr_init_physical
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/4/upgrades/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,

--- a/product_docs/docs/pgd/5.6/reference/nodes.mdx
+++ b/product_docs/docs/pgd/5.6/reference/nodes.mdx
@@ -32,6 +32,10 @@ physical copy (`pg_basebackup`) of an existing node.
 
 ### `bdr_init_physical`
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/5.6/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,

--- a/product_docs/docs/pgd/5.7/reference/nodes.mdx
+++ b/product_docs/docs/pgd/5.7/reference/nodes.mdx
@@ -32,6 +32,10 @@ physical copy (`pg_basebackup`) of an existing node.
 
 ### `bdr_init_physical`
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/5.7/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,

--- a/product_docs/docs/pgd/5.8/reference/nodes.mdx
+++ b/product_docs/docs/pgd/5.8/reference/nodes.mdx
@@ -32,6 +32,10 @@ physical copy (`pg_basebackup`) of an existing node.
 
 ### `bdr_init_physical`
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/5.8/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,

--- a/product_docs/docs/pgd/5.9/reference/nodes.mdx
+++ b/product_docs/docs/pgd/5.9/reference/nodes.mdx
@@ -32,6 +32,10 @@ physical copy (`pg_basebackup`) of an existing node.
 
 ### `bdr_init_physical`
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/5.9/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,

--- a/product_docs/docs/pgd/6.1/reference/cli/command_ref/node/setup.mdx
+++ b/product_docs/docs/pgd/6.1/reference/cli/command_ref/node/setup.mdx
@@ -8,6 +8,10 @@ deepToC: true
 
 The `pgd node setup` command is used to configure PGD data nodes in a cluster. It can be used to set up a new node, join an existing node to a cluster, or perform a logical join of a node to the cluster.
 
+!!! important "Version Requirement for Physical Joins"
+When `pgd node setup` performs a physical join (copying data from the remote node when the local node is not up and running), it requires that both the source node and the joining node have exactly the same PGD version. You cannot use physical joins to join a node with a different PGD version to an existing cluster. For rolling upgrades, ensure you use logical joins instead. See [Rolling upgrade using node join](/pgd/latest/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 The behavior of the command depends on the state of the local node and the remote node specified in the command.
 
 If this is the first node in the cluster, `pgd node setup` will perform `initdb` and setup PGD node.

--- a/product_docs/docs/pgd/6.1/reference/tables-views-functions/nodes.mdx
+++ b/product_docs/docs/pgd/6.1/reference/tables-views-functions/nodes.mdx
@@ -38,6 +38,10 @@ This command is deprecated in favor of the using the pgd CLI command [`pgd node 
 `bdr_init_physical` will receive only bug fixes in the future and is not recommended for new installations.
 !!!
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/latest/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,

--- a/product_docs/docs/pgd/6/reference/cli/command_ref/node/setup.mdx
+++ b/product_docs/docs/pgd/6/reference/cli/command_ref/node/setup.mdx
@@ -8,6 +8,10 @@ deepToC: true
 
 The `pgd node setup` command is used to configure PGD data nodes in a cluster. It can be used to set up a new node, join an existing node to a cluster, or perform a logical join of a node to the cluster.
 
+!!! important "Version Requirement for Physical Joins"
+When `pgd node setup` performs a physical join (copying data from the remote node when the local node is not up and running), it requires that both the source node and the joining node have exactly the same PGD version. You cannot use physical joins to join a node with a different PGD version to an existing cluster. For rolling upgrades, ensure you use logical joins instead. See [Rolling upgrade using node join](/pgd/6/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 The behavior of the command depends on the state of the local node and the remote node specified in the command.
 
 If this is the first node in the cluster, `pgd node setup` will perform `initdb` and setup PGD node.

--- a/product_docs/docs/pgd/6/reference/tables-views-functions/nodes.mdx
+++ b/product_docs/docs/pgd/6/reference/tables-views-functions/nodes.mdx
@@ -38,6 +38,10 @@ This command is deprecated in favor of the using the pgd CLI command [`pgd node 
 `bdr_init_physical` will receive only bug fixes in the future and is not recommended for new installations.
 !!!
 
+!!! important "Version Requirement"
+`bdr_init_physical` requires that both the source node and the joining node have exactly the same PGD version. You cannot use this command to join a node with a different PGD version to an existing cluster. This means `bdr_init_physical` cannot be used for rolling upgrades using the node join method. For rolling upgrades, use logical join instead. See [Rolling upgrade using node join](/pgd/6/upgrades/manual_overview/#rolling-upgrade-using-node-join) for more details.
+!!!
+
 This is a regular command that's added to PostgreSQL's bin directory.
 
 You must specify a data directory. If this data directory is empty,


### PR DESCRIPTION
Clarify that bdr_init_physical and pgd node setup cannot be used to bring up a new pgd versioned node against an old pgd versioned node.

BDR-7200

## What Changed?

