### PR TITLE
Provide a link to the agent configuration parameters

### DIFF
--- a/product_docs/docs/pem/10/registering_agent.mdx
+++ b/product_docs/docs/pem/10/registering_agent.mdx
@@ -117,9 +117,13 @@ The following are some advanced options for PEM agent registration.
 
 Each registered PEM agent must have a unique agent ID. The value `max(id)+1` is assigned to each agent ID unless a value is provided using the `-o` options as shown [in these examples](#overriding-default-configurations---examples).
 
+### Setting other agent configuration parameters
+
+The `-o` command line option allows you to override other agent configuration parameters during registration. For the complete list of these configuration parameters please refer to [this page](/pem/latest/managing_pem_agent/modifying_agent_configuration/).
+
 ### Overriding default configurations - examples
 
-This example shows how to register the PEM agent and override the default configurations.
+These examples show how to register the PEM agent and override the default configurations.
 
 #### Setting the agent ID
 


### PR DESCRIPTION
As suggested by a customer in [this support ticket](https://techsupport.enterprisedb.com/tickets/54064), adding a cross-reference to the list of agent configuration parameters that can be overridden during registration improves usability of the documentation.

## What Changed?

Added a link to the agent configuration parameters.