### PR TITLE
Correct the SQL query example

### DIFF
--- a/product_docs/docs/pem/10/installing/ha/efm_s1.mdx
+++ b/product_docs/docs/pem/10/installing/ha/efm_s1.mdx
@@ -255,7 +255,7 @@ On each standby, perform the following steps.
 1.  Execute the following SQL on the `pem` database as a superuser, providing the correct server and port for each.
 
     ```sql
-    SELECT pem.register_pem_server(server_id) FROM pem.server WHERE server='172.16.161.201' and port=5444;
+    SELECT pem.register_pem_server(id) FROM pem.server WHERE server='172.16.161.201' and port=5444;
     ```
 
     !!! Info


### PR DESCRIPTION
The example showing how to run the `pem.register_pem_server` function is incorrect.

The column name in the `pem.server` table is `id`, not `server_id`.

## What Changed?

Fixed typo