### PR TITLE
fix: cnp hibernate status was deprecated

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/kubectl-plugin.mdx
@@ -942,7 +942,7 @@ configuration and the status that PostgreSQL had after it was shut down.
 That can be done with:
 
 ```sh
-kubectl cnp hibernate status <cluster-name>
+kubectl cnp status <cluster-name>
 ```
 
 ### Benchmarking the database with pgbench


### PR DESCRIPTION
## What Changed?
As part of [v1.26.0](https://www.enterprisedb.com/docs/postgres_for_kubernetes/latest/installation_upgrade/#declarative-hibernation-in-the-cnp-plugin), "the hibernate status command has been removed, as its purpose is now fulfilled by the standard status command".

