### PR TITLE
PGD: correct DDL command handling matrix for CLUSTER

### DIFF
--- a/product_docs/docs/pgd/6.1/reference/ddl/ddl-command-handling.mdx
+++ b/product_docs/docs/pgd/6.1/reference/ddl/ddl-command-handling.mdx
@@ -34,14 +34,14 @@ under the following table.
 | ALTER INDEX                      | Y                                             | Y                                          | DDL                                              |
 | ALTER LANGUAGE                   | Y                                             | Y                                          | DDL                                              |
 | ALTER LARGE OBJECT               | N                                             | N                                          | N                                                |
-| ALTER MATERIALIZED VIEW          | Y                                             | Y                                          | DML                                                |
+| ALTER MATERIALIZED VIEW          | Y                                             | Y                                          | DML                                              |
 | ALTER OPERATOR                   | Y                                             | Y                                          | DDL                                              |
 | ALTER OPERATOR CLASS             | Y                                             | Y                                          | DDL                                              |
 | ALTER OPERATOR FAMILY            | Y                                             | Y                                          | DDL                                              |
 | ALTER PACKAGE                    | Y                                             | Y                                          | DDL                                              |
 | ALTER POLICY                     | Y                                             | Y                                          | DDL                                              |
 | ALTER PROCEDURE                  | Y                                             | Y                                          | DDL                                              |
-| ALTER PROFILE                    | Y                                             | Y                                          | [Details](#bdr_ddl_allowed_CreateAlterProfile)                                              |
+| ALTER PROFILE                    | Y                                             | Y                                          | [Details](#bdr_ddl_allowed_CreateAlterProfile)   |
 | ALTER PUBLICATION                | Y                                             | Y                                          | DDL                                              |
 | ALTER QUEUE                      | Y                                             | Y                                          | DDL                                              |
 | ALTER QUEUE TABLE                | Y                                             | Y                                          | DDL                                              |
@@ -59,7 +59,7 @@ under the following table.
 | ALTER SYNONYM                    | Y                                             | Y                                          | DDL                                              |
 | ALTER SYSTEM                     | Y                                             | N                                          | N                                                |
 | ALTER TABLE                      | [Details](#bdr_ddl_allowed_AlterTableStmt)    | Y                                          | [Details](#bdr_ddl_lock_relation_AlterTableStmt) |
-| ALTER TABLESPACE                 | Y                                             | Y                                          | DDL                                                |
+| ALTER TABLESPACE                 | Y                                             | Y                                          | DDL                                              |
 | ALTER TEXT SEARCH CONFIGURATION  | Y                                             | Y                                          | DDL                                              |
 | ALTER TEXT SEARCH DICTIONARY     | Y                                             | Y                                          | DDL                                              |
 | ALTER TEXT SEARCH PARSER         | Y                                             | Y                                          | DDL                                              |
@@ -74,7 +74,7 @@ under the following table.
 | CLOSE                            | Y                                             | N                                          | N                                                |
 | CLOSE CURSOR                     | Y                                             | N                                          | N                                                |
 | CLOSE CURSOR ALL                 | Y                                             | N                                          | N                                                |
-| CLUSTER                          | Y                                             | N                                          | N                                                |
+| CLUSTER                          | Y                                             | N                                          | DML                                              |
 | COMMENT                          | Y                                             | [Details](#bdr_ddl_can_replicate_comment)  | DDL                                              |
 | COMMIT                           | Y                                             | N                                          | N                                                |
 | COMMIT PREPARED                  | Y                                             | N                                          | N                                                |
@@ -97,7 +97,7 @@ under the following table.
 | CREATE FUNCTION                  | Y                                             | Y                                          | DDL                                              |
 | CREATE INDEX                     | Y                                             | Y                                          | DML                                              |
 | CREATE LANGUAGE                  | Y                                             | Y                                          | DDL                                              |
-| CREATE MATERIALIZED VIEW         | Y                                             | Y                                          | DDL                                                |
+| CREATE MATERIALIZED VIEW         | Y                                             | Y                                          | DDL                                              |
 | CREATE OPERATOR                  | Y                                             | Y                                          | DDL                                              |
 | CREATE OPERATOR CLASS            | Y                                             | Y                                          | DDL                                              |
 | CREATE OPERATOR FAMILY           | Y                                             | Y                                          | DDL                                              |
@@ -105,7 +105,7 @@ under the following table.
 | CREATE PACKAGE BODY              | Y                                             | Y                                          | DDL                                              |
 | CREATE POLICY                    | Y                                             | Y                                          | DML                                              |
 | CREATE PROCEDURE                 | Y                                             | Y                                          | DDL                                              |
-| CREATE PROFILE                   | Y                                             | Y                                          | [Details](#bdr_ddl_allowed_CreateAlterProfile)                                              |
+| CREATE PROFILE                   | Y                                             | Y                                          | [Details](#bdr_ddl_allowed_CreateAlterProfile)   |
 | CREATE PUBLICATION               | Y                                             | Y                                          | DDL                                              |
 | CREATE QUEUE                     | Y                                             | Y                                          | DDL                                              |
 | CREATE QUEUE TABLE               | Y                                             | Y                                          | DDL                                              |
@@ -122,7 +122,7 @@ under the following table.
 | CREATE SYNONYM                   | Y                                             | Y                                          | DDL                                              |
 | CREATE TABLE                     | Y                                             | Y                                          | DDL                                              |
 | CREATE TABLE AS                  | [Details](#bdr_ddl_allowed_CreateTableAsStmt) | Y                                          | DDL                                              |
-| CREATE TABLESPACE                | Y                                             | Y                                          | DDL                                                |
+| CREATE TABLESPACE                | Y                                             | Y                                          | DDL                                              |
 | CREATE TEXT SEARCH CONFIGURATION | Y                                             | Y                                          | DDL                                              |
 | CREATE TEXT SEARCH DICTIONARY    | Y                                             | Y                                          | DDL                                              |
 | CREATE TEXT SEARCH PARSER        | Y                                             | Y                                          | DDL                                              |
@@ -159,7 +159,7 @@ under the following table.
 | DROP FUNCTION                    | Y                                             | Y                                          | DDL                                              |
 | DROP INDEX                       | Y                                             | Y                                          | DDL                                              |
 | DROP LANGUAGE                    | Y                                             | Y                                          | DDL                                              |
-| DROP MATERIALIZED VIEW           | Y                                             | Y                                          | DDL                                               |
+| DROP MATERIALIZED VIEW           | Y                                             | Y                                          | DDL                                              |
 | DROP OPERATOR                    | Y                                             | Y                                          | DDL                                              |
 | DROP OPERATOR CLASS              | Y                                             | Y                                          | DDL                                              |
 | DROP OPERATOR FAMILY             | Y                                             | Y                                          | DDL                                              |
@@ -184,7 +184,7 @@ under the following table.
 | DROP SUBSCRIPTION                | Y                                             | Y                                          | DDL                                              |
 | DROP SYNONYM                     | Y                                             | Y                                          | DDL                                              |
 | DROP TABLE                       | Y                                             | Y                                          | DML                                              |
-| DROP TABLESPACE                  | Y                                             | Y                                          | DDL                                                |
+| DROP TABLESPACE                  | Y                                             | Y                                          | DDL                                              |
 | DROP TEXT SEARCH CONFIGURATION   | Y                                             | Y                                          | DDL                                              |
 | DROP TEXT SEARCH DICTIONARY      | Y                                             | Y                                          | DDL                                              |
 | DROP TEXT SEARCH PARSER          | Y                                             | Y                                          | DDL                                              |
@@ -210,7 +210,7 @@ under the following table.
 | PREPARE                          | Y                                             | N                                          | N                                                |
 | PREPARE TRANSACTION              | Y                                             | N                                          | N                                                |
 | REASSIGN OWNED                   | Y                                             | Y                                          | DDL                                              |
-| REFRESH MATERIALIZED VIEW        | Y                                             | Y                                          | DML                                                |
+| REFRESH MATERIALIZED VIEW        | Y                                             | Y                                          | DML                                              |
 | REINDEX                          | Y                                             | N                                          | N                                                |
 | RELEASE                          | Y                                             | N                                          | N                                                |
 | RESET                            | Y                                             | N                                          | N                                                |


### PR DESCRIPTION
## What Changed?

For command `CLUSTER`, PGD 6 now acquires a global DML lock. Make sure to reflect this in the DDL command handling matrix.

https://enterprisedb.atlassian.net/browse/DOCS-2916