### PR TITLE
Changes for supported upgrade paths for 5.9 for review

### DIFF
--- a/product_docs/docs/pgd/5.6/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/5.6/upgrades/upgrade_paths.mdx
@@ -17,7 +17,7 @@ Upgrades from PGD 4 to PGD 5 are supported from version 4.3.0 or later.
 
 The following table provides a full list of possible upgrade paths from PGD 4 to PGD 5. Check the "From version" column to confirm the minimum required PGD 4 release necessary before upgrading to your desired PGD 5 target version.
 
-See [Upgrading within 4](/pgd/4/upgrades/upgrade_paths/#upgrading-within-version-4) for instructions on upgrading within PGD 4 to reach the required version.
+See [Upgrading within version 4](/pgd/4/upgrades/upgrade_paths/#upgrading-within-version-4) for instructions on upgrading within PGD 4 to reach the required version.
 
 | From version | To version 
 | ---- | -- 

--- a/product_docs/docs/pgd/5.7/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/5.7/upgrades/upgrade_paths.mdx
@@ -18,7 +18,7 @@ Upgrades from PGD 4 to PGD 5 are supported from version 4.3.0 or later.
 The following table provides a full list of possible upgrade paths from PGD 4 to PGD 5. Check the "From version" column to confirm the minimum required PGD 4 release necessary before upgrading to your des
 ired PGD 5 target version.
 
-See [Upgrading within 4](/pgd/4/upgrades/upgrade_paths/#upgrading-within-version-4) for instructions on upgrading within PGD 4 to reach the required version.
+See [Upgrading within version 4](/pgd/4/upgrades/upgrade_paths/#upgrading-within-version-4) for instructions on upgrading within PGD 4 to reach the required version.
 
 | From version | To version 
 | ---- | -- 

--- a/product_docs/docs/pgd/5.9/upgrades/upgrade_paths.mdx
+++ b/product_docs/docs/pgd/5.9/upgrades/upgrade_paths.mdx
@@ -18,7 +18,7 @@ Upgrades from PGD 4 to PGD 5 are supported from version 4.3.0 or later.
 The following table provides a full list of possible upgrade paths from PGD 4 to PGD 5. Check the "From version" column to confirm the minimum required PGD 4 release necessary before upgrading to your des
 ired PGD 5 target version.
 
-See [Upgrading within 4](/pgd/4/upgrades/upgrade_paths/#upgrading-within-version-4) for instructions on upgrading within PGD 4 to reach the required version.
+See [Upgrading within version 4](/pgd/4/upgrades/upgrade_paths/#upgrading-within-version-4) for instructions on upgrading within PGD 4 to reach the required version.
 
 | From version | To version (range)
 | ----- | -------------- 


### PR DESCRIPTION
Changes for supported upgrade paths for 5.9 for review.

Assuming 5.8 doc is stating things upto 5.8 latest release hence can keep 
https://www.enterprisedb.com/docs/pgd/5.8/upgrades/upgrade_paths/
as is which has To Version with "or later"

Assumption: Here or later does not include 5.9 as this is 5.8 doc.

Fixes BDR-7237

## What Changed?

