### PR TITLE
edb_password_history: clarify the encryption used

### DIFF
--- a/product_docs/docs/epas/15/reference/application_programmer_reference/03_system_catalog_tables.mdx
+++ b/product_docs/docs/epas/15/reference/application_programmer_reference/03_system_catalog_tables.mdx
@@ -54,7 +54,7 @@ The `edb_password_history` table contains one row for each password change. The 
 | Column                  | Type          | References      | Description                          |
 | ----------------------- | ------------- | --------------- | ------------------------------------ |
 | `passhistroleid`        | `oid`         | `pg_authid.oid` | The `ID` of a role.                  |
-| `passhistpassword`      | `text`        |                 | Role password in md5 encrypted form. |
+| `passhistpassword`      | `text`        |                 | Role password encrypted according to `password_encryption`. |
 | `passhistpasswordsetat` | `timestamptz` |                 | The time the password was set.       |
 
 ## edb_policy

--- a/product_docs/docs/epas/16/reference/application_programmer_reference/03_system_catalog_tables.mdx
+++ b/product_docs/docs/epas/16/reference/application_programmer_reference/03_system_catalog_tables.mdx
@@ -54,7 +54,7 @@ The `edb_password_history` table contains one row for each password change. The 
 | Column                  | Type          | References      | Description                          |
 | ----------------------- | ------------- | --------------- | ------------------------------------ |
 | `passhistroleid`        | `oid`         | `pg_authid.oid` | The `ID` of a role.                  |
-| `passhistpassword`      | `text`        |                 | Role password in md5 encrypted form. |
+| `passhistpassword`      | `text`        |                 | Role password encrypted according to `password_encryption`. |
 | `passhistpasswordsetat` | `timestamptz` |                 | The time the password was set.       |
 
 ## edb_policy

--- a/product_docs/docs/epas/17/reference/application_programmer_reference/03_system_catalog_tables.mdx
+++ b/product_docs/docs/epas/17/reference/application_programmer_reference/03_system_catalog_tables.mdx
@@ -54,7 +54,7 @@ The `edb_password_history` table contains one row for each password change. The 
 | Column                  | Type          | References      | Description                          |
 | ----------------------- | ------------- | --------------- | ------------------------------------ |
 | `passhistroleid`        | `oid`         | `pg_authid.oid` | The `ID` of a role.                  |
-| `passhistpassword`      | `text`        |                 | Role password in md5 encrypted form. |
+| `passhistpassword`      | `text`        |                 | Role password encrypted according to `password_encryption`. |
 | `passhistpasswordsetat` | `timestamptz` |                 | The time the password was set.       |
 
 ## edb_policy


### PR DESCRIPTION
The way the password is stored is not always hashed with the MD5 method, but is dependent on the method set in the `password_encryption` GUC.
