### PR TITLE
Revise PgBouncer supported platforms table format

### DIFF
--- a/product_docs/docs/pgbouncer/1/supported_platforms.mdx
+++ b/product_docs/docs/pgbouncer/1/supported_platforms.mdx
@@ -8,23 +8,23 @@ The EDB PgBouncer is supported on the same platforms as EDB Postgres Advanced Se
 
 This table lists the latest EDB PgBouncer versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions.
 
-| EDB PgBouncer | EPAS 17 | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 
-|---------------|---------|---------|---------|---------|---------
-| 1.24          | Y       | Y       | Y       | Y       | Y
-| 1.23          | Y       | Y       | Y       | Y       | Y
-| 1.22          | Y       | Y       | Y       | Y       | Y
-| 1.21          | Y       | Y       | Y       | Y       | Y
-| 1.20          | Y       | Y       | Y       | Y       | Y
-| 1.19          | Y       | Y       | Y       | Y       | Y
-| 1.18          | Y       | Y       | Y       | Y       | Y
-| 1.17          | N       | N       | N       | Y       | Y
-| 1.16          | N       | N       | N       | Y       | Y
-| 1.15          | N       | N       | N       | N       | Y
-| 1.14          | N       | N       | N       | N       | Y
-| 1.13          | N       | N       | N       | N       | N
-| 1.12          | N       | N       | N       | N       | N
-| 1.9           | N       | N       | N       | N       | N
-| 1.7           | N       | N       | N       | N       | N
+| EDB PgBouncer      | EPAS 17 | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 
+|--------------------|---------|---------|---------|---------|---------
+| EDB PgBouncer 1.24 | YES     | YES     | YES     | YES     | YES
+| EDB PgBouncer 1.23 | YES     | YES     | YES     | YES     | YES
+| EDB PgBouncer 1.22 | YES     | YES     | YES     | YES     | YES
+| EDB PgBouncer 1.21 | YES     | YES     | YES     | YES     | YES
+| EDB PgBouncer 1.20 | YES     | YES     | YES     | YES     | YES
+| EDB PgBouncer 1.19 | YES     | YES     | YES     | YES     | YES
+| EDB PgBouncer 1.18 | YES     | YES     | YES     | YES     | YES
+| EDB PgBouncer 1.17 | NO      | NO      | NO      | YES     | YES
+| EDB PgBouncer 1.16 | NO      | NO      | NO      | YES     | YES
+| EDB PgBouncer 1.15 | NO      | NO      | NO      | NO      | YES
+| EDB PgBouncer 1.14 | NO      | NO      | NO      | NO      | YES
+| EDB PgBouncer 1.13 | NO      | NO      | NO      | NO      | NO
+| EDB PgBouncer 1.12 | NO      | NO      | NO      | NO      | NO
+| EDB PgBouncer 1.9  | NO      | NO      | NO      | NO      | NO
+| EDB PgBouncer 1.7  | NO      | NO      | NO      | NO      | NO
 
 
 The documented and supported functionality of each version of EDB PgBouncer is the same. The information in this documentation applies to all supported versions of EDB PgBouncer.


### PR DESCRIPTION
## What Changed?
Updated the supported platforms table to use 'YES' and 'NO' instead of 'Y' and 'N', and mention the PgBouncer version verbose.

## Why changed?
This is required to make RAI (AI agent) to understand the tabular format.

**PLEASE DO NOT MERGE THIS PR!** See the comment below for more details.
