### PR TITLE
Fix typo in prerequisites documentation

### DIFF
--- a/product_docs/docs/efm/5/installing/prerequisites.mdx
+++ b/product_docs/docs/efm/5/installing/prerequisites.mdx
@@ -68,7 +68,7 @@ Where `x` specifies the Postgres version.
 
 If a primary node restarts, Failover Manager might detect the database is down on the primary node and promote a standby node to the role of primary. If this happens, the Failover Manager agent on the restarted primary node doesn't get a chance to write the `recovery.conf` file, and the `recovery.conf` file prevents the database server from starting. In this case, the rebooted primary node returns to the cluster as a second primary node.
 
-To prevent this condition, ensure that the Failover Manager agent auto starts before the database server. The agent starts in idle mode and checks to see if there's already a primary in the cluster. If there's a primary node, the agent verifies that a `recovery.conf` or `standby.signal` file exists. If neither file exits, the agent creates the `recovery.conf` file.
+To prevent this condition, ensure that the Failover Manager agent auto starts before the database server. The agent starts in idle mode and checks to see if there's already a primary in the cluster. If there's a primary node, the agent verifies that a `recovery.conf` or `standby.signal` file exists. If neither file exists, the agent creates the `recovery.conf` file.
 
 ## Ensure communication through firewalls
 


### PR DESCRIPTION


## What Changed?
Change "exits" to "exists"
