### PR TITLE
Update commit-scopes.mdx

### DIFF
--- a/product_docs/docs/pgd/6.1/reference/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6.1/reference/commit-scopes/commit-scopes.mdx
@@ -121,4 +121,4 @@ Finally, you can set the default commit_scope for a node using:
 SET bdr.commit_scope = 'example_scope';
 ```
 
-Set `bdr.commit_scope` to `local` to  use the PGD default async replication.
+Set `bdr.commit_scope` to `local` to use the PGD default async replication.


### PR DESCRIPTION
just dropped the "is" from the first line under "How a commit scope is selected"

## What Changed?
