### PR TITLE
Rename edb_enable_pruning to enable_partition_pruning

### DIFF
--- a/product_docs/docs/epas/17/database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/05_query_tuning_planner_method_configuration.mdx
+++ b/product_docs/docs/epas/17/database_administration/01_configuration_parameters/03_configuration_parameters_by_functionality/05_query_tuning_planner_method_configuration.mdx
@@ -8,7 +8,7 @@ redirects:
 
 These configuration parameters are used for planner method configuration.
 
-## edb_enable_pruning
+## enable_partition_pruning
 
 **Parameter type:** Boolean
 
@@ -29,5 +29,3 @@ Conversely, *late pruning* means that the query planner prunes partitions after 
 The ability to early prune depends on the nature of the query in the `WHERE` clause. You can use early pruning in only simple queries with constraints like `WHERE column = literal`, for example, `WHERE deptno = 10`.
 
 Don't use early pruning for more complex queries such as `WHERE column = expression`, for example, `WHERE deptno = 10 + 5`.
-
-This parameter is deprecated from version 15 and later. Use `enable_partition_pruning` instead.


### PR DESCRIPTION
This should be a simple edit. this doc page is 2+yrs old Updated parameter name and deprecated notice.

## What Changed?
Rename edb_enable_pruning to enable_partition_pruning