### PR TITLE
Correct preview version links for both current and preview pages

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/preview_version.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/preview_version.mdx
@@ -38,4 +38,9 @@ are not backwards compatible and could be removed entirely.
 
 ## Current Preview Version
 
-There is no current preview. We'll update this page when the next one is ready!
+The current preview version is **1.28.0-rc1**.
+
+For more information on the current preview version and how to test, please view the links below:
+
+-   [Announcement](/postgres_for_kubernetes/preview/rel_notes/1_28_0-rc1_rel_notes)
+-   [Documentation](/postgres_for_kubernetes/preview/)

--- a/product_docs/docs/postgres_for_kubernetes/preview/preview_version.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/preview/preview_version.mdx
@@ -38,11 +38,9 @@ are not backwards compatible and could be removed entirely.
 
 ## Current Preview Version
 
-There are currently no preview versions available.
-
 The current preview version is **1.28.0-rc1**.
 
 For more information on the current preview version and how to test, please view the links below:
 
--   [Announcement](https://cloudnative-pg.io/releases/cloudnative-pg-1-28.0-rc1-released/)
--   [Documentation](https://cloudnative-pg.io/documentation/preview/)
+-   [Announcement](rel_notes/1_28_0-rc1_rel_notes)
+-   [Documentation](/postgres_for_kubernetes/preview/)


### PR DESCRIPTION
## What Changed?

- point /preview/preview_version announcement & docs links at self
- point /1/preview_version announcement & docs links at /preview