### PR TITLE
PostGIS: update supported platforms

### DIFF
--- a/product_docs/docs/postgis/3/supported_platforms.mdx
+++ b/product_docs/docs/postgis/3/supported_platforms.mdx
@@ -8,14 +8,11 @@ EDB PostGIS is supported on the same platforms as EDB Postgres Advanced Server. 
 
 This table lists the latest PostGIS versions and their supported corresponding EDB Postgres Advanced Server (EPAS) versions. 
 
-| PostGIS | EPAS 17 | EPAS 16 | EPAS 15 | EPAS 14 | EPAS 13 |
+| PostGIS | EPAS 18 | EPAS 17 | EPAS 16 | EPAS 15 | EPAS 14 |
 |---------|---------|---------|---------|---------|---------|
-| 3.5     | Y       | Y       | Y       | Y       | Y       |
-| 3.4     | N       | Y       | Y       | Y       | Y       |
-| 3.3     | N       | N       | Y       | Y       | Y       |
-| 3.2     | N       | N       | Y       | Y       | Y       |
-| 3.1     | N       | N       | N       | Y       | Y       |
-| 3.0     | N       | N       | N       | N       | Y       |
-| 2.5     | N       | N       | N       | N       | N       |
-| 2.4     | N       | N       | N       | N       | N       |
-| 2.3     | N       | N       | N       | N       | N       |
+| 3.6     | Y       | Y       | Y       | Y       | Y       |
+| 3.5     | N       | Y       | Y       | Y       | Y       |
+| 3.4     | N       | N       | Y       | Y       | Y       |
+| 3.3     | N       | N       | N       | Y       | Y       |
+| 3.2     | N       | N       | N       | Y       | Y       |
+| 3.1     | N       | N       | N       | N       | Y       |


### PR DESCRIPTION
This adds v18 to the supported platforms, for PostGIS 3.6, which added support for v18.

It also removes v13 from the table, since it's out of our main supported platforms page and went EOL last month.

Additionally, the oldest version of PostGIS available both on our repositories and in the release notes of our documentation is 3.1. So this also removes the older versions from the supported matrix. Notice that the upgrade steps still cover postgis versions 2.x, which is reasonable since we want to continue guiding customers through the upgrade process into supported versions, just not claim 2.x on its own is supported anymore.

Forgot to post this in the same PR as https://github.com/EnterpriseDB/docs/pull/7034, but it's ok to post separately, as they are related but not interdependent.

