### PR TITLE
Update installing_ecpgplus.mdx

### DIFF
--- a/product_docs/docs/epas/18/application_programming/ecpgplus_guide/installing_ecpgplus.mdx
+++ b/product_docs/docs/epas/18/application_programming/ecpgplus_guide/installing_ecpgplus.mdx
@@ -7,7 +7,7 @@ On Windows, ECPGPlus is installed by the EDB Postgres Advanced Server installati
 
 ## Installing ECPGPlus
 
-On Linux, install with the `edb-as<xx>-server-ecpg-devel` RPM package and `edb-as<xx>-server-devel` RPM package or `edb-as<xx>-server-dev` APT package, where `<xx>` is the EDB Postgres Advanced Server version number. On Linux, the executable is located in:
+On Linux, install the `edb-as<xx>-server-ecpg-devel` RPM package and the `edb-as<xx>-server-devel` RPM package or `edb-as<xx>-server-dev` APT package, where `<xx>` is the EDB Postgres Advanced Server version number. On Linux, the executable is located in:
 
 ```text
 /usr/edb/as18/bin


### PR DESCRIPTION
Hi,
Greetings. Hope you are doing well and healthy.

## What Changed?
From EPAS18, since packaging is altered to deny dependency between EPAS/EPAS-devel package and ecpg package,
edb-asxx-server-ecpg-devel(and -ecpg-lib in dependency) should be installed explicitly in order to utilize ECPG Plus.
Note: Please see details in Support Ticket #56162.

Also, these samples are refer to as14, so I altered them to 18

## Need further discussion
I only tested the new instructions in Almalinux, if Ubuntu package name is different,
please fix my draft.

Kind Regards,
Yuki Tei

