### PR TITLE
docs(CNP-7340): fix migration Helm parameters and add OpenShift instructions

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/migrating_edb_registries.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/migrating_edb_registries.mdx
@@ -180,7 +180,7 @@ For your {{name.ln}} Helm releases, you'll need to update override values for bo
 
 ```shell
 helm upgrade --reuse-values \
-  --set image.repository=docker.enterprisedb.com/k8s/edb-postgres-for-kubernetes \
+  --set image.repository=docker.enterprisedb.com/k8s/edb-postgres-for-cloudnativepg \
   --set image.imageCredentials.username=k8s \
   edb-pg4k \
   edb/edb-postgres-for-kubernetes
@@ -188,11 +188,11 @@ helm upgrade --reuse-values \
 
 (here, `edb-pg4k` and `edb/edb-postgres-for-kubernetes` are the release and pathname used in other examples; substitute your own values)
 
-For your EDB Postgres Distributed for Kubernetes Helm releases, you'll need to override values for both `global.image.repository` and `image.imageCredentials.username`:
+For your EDB Postgres Distributed for Kubernetes Helm releases, you'll need to override values for both `global.repository` and `image.imageCredentials.username`:
 
 ```shell
 helm upgrade --reuse-values \
-  --set global.image.repository=docker.enterprisedb.com/k8s \
+  --set global.repository=docker.enterprisedb.com/k8s \
   --set image.imageCredentials.username=k8s \
   edb-pg4k-pgd \
   edb/edb-postgres-distributed-for-kubernetes

--- a/product_docs/docs/postgres_for_kubernetes/preview/migrating_edb_registries.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/preview/migrating_edb_registries.mdx
@@ -188,11 +188,11 @@ helm upgrade --reuse-values \
 
 (here, `edb-pg4k` and `edb/edb-postgres-for-kubernetes` are the release and repository path name used in other examples; substitute your own values)
 
-For your EDB Postgres Distributed for Kubernetes Helm releases, you'll need to override values for both `global.image.repository` and `image.imageCredentials.username`:
+For your EDB Postgres Distributed for Kubernetes Helm releases, you'll need to override values for both `global.repository` and `image.imageCredentials.username`:
 
 ```shell
 helm upgrade --reuse-values \
-  --set global.image.repository=docker.enterprisedb.com/k8s \
+  --set global.repository=docker.enterprisedb.com/k8s \
   --set image.imageCredentials.username=k8s \
   edb-pg4k-pgd \
   edb/edb-postgres-distributed-for-kubernetes


### PR DESCRIPTION
## What Changed?

  - Add critical warning about updating pull secrets before upgrade
  - Expand OpenShift pull secrets section to cover both installation modes:
    * Cluster-wide (openshift-operators namespace)
    * Namespace-specific (user's chosen namespace)
  - Add commands to identify operator namespace
  - Include verification tip for pull secret creation
  - Fix incorrect Helm migration parameters:
    * Change `global.image.repository` to `global.repository` for PG4K-PGD
    * Update PG4K image name from `edb-postgres-for-kubernetes` to `edb-postgres-for-cloudnativepg` in version 1 docs
  - Align documentation with migration instructions from charts repository commit 674f8a9