### PR TITLE
Update configuring.mdx

### DIFF
--- a/product_docs/docs/pgd/6.2/reference/connection-manager/configuring.mdx
+++ b/product_docs/docs/pgd/6.2/reference/connection-manager/configuring.mdx
@@ -7,13 +7,12 @@ description: How to configure Connection Manager
 
 Connection Manager takes its configuration from the PGD Group options for the group the node is a member of.
 
-These can be configured using the [`bdr.alter_node_group_option`](/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdralter_node_group_option) command, or using the [`pgd group set-option`](/pgd/latest/reference/cli/command_ref/group/set-option/) command.
+These can be configured using the [`pgd group set-option`](/pgd/latest/reference/cli/command_ref/group/set-option/) command.
 
 The following options are available for configuring Connection Manager:
 
 | Option                            | Default                                   | Description                                                                                |
 |-----------------------------------|-------------------------------------------|--------------------------------------------------------------------------------------------|
-| listen_address                    | Postgres's listen address                 | which local addresses it should listen on for client connections                           |
 | read_write_port                   | Postgres's port + 1000<br/>(usually 6432) | which port to listen on for read-write connections                                         |
 | read_only_port                    | read_write_port + 1<br/>(usually 6433) | which port to listen on for read-only connections                                          |
 | http_port                         | read_write_port + 2<br/>(usually 6434) | which http port to listen for REST API calls (for integration purposes)                    |


### PR DESCRIPTION
Hi,
Greetings. Hope you are doing well and healthy.
Please verify with your internal team if the document fix is right.

## What Changed?
discard the listen_address
From ver 6.1, listen_address is no more Connection manager's paramter, user shall modify listen_addresses in the postgresql.conf and hence Connection Manager can read that setting automatically.

discard the bdr. fuction description
No listed parameter can be modified by that function nor show up in the linked page.

Kind Regards,
Yuki Tei

