### PR TITLE
Update setup_ha_using_efm.mdx

### DIFF
--- a/product_docs/docs/pem/10/installing/ha/setup_ha_using_efm.mdx
+++ b/product_docs/docs/pem/10/installing/ha/setup_ha_using_efm.mdx
@@ -298,7 +298,7 @@ On each standby, perform the following steps.
     ```shell
     export PEM_SERVER_PASSWORD=pemserver-password-here
     /usr/edb/pem/agent/bin/pemworker --register-agent \
-                                     --pem-server 172.17.0.12 \
+                                     --pem-server 172.16.161.245 \
                                      --pem-user pemserver \
                                      --pem-port 5444 \
                                      -o alert_threads=1 \


### PR DESCRIPTION
The explanation just before the code block indicates to use the VIP but the register command uses a different IP against 172.16.161.245 which is the VIP which is mentioned at the top of the document. Please verify

## What Changed?
Changing the IP: 172.17.0.12 to IP: 172.16.161.245
