### PR TITLE
Update CVE-2025-14038 advisory date

### DIFF
--- a/advocacy_docs/security/advisories/index.mdx
+++ b/advocacy_docs/security/advisories/index.mdx
@@ -57,7 +57,7 @@ When pglogical attempts to replicate data, it does not verify it is using a repl
 <details><summary><h3 style="display:inline"> CVE-2025-14038 </h3>
 <span>
 &nbsp;&nbsp;<a href="cve202514038">Read Advisory</a>
-&nbsp;&nbsp;Updated: </span><span>2025/15/03</span>
+&nbsp;&nbsp;Updated: </span><span>2025/12/15</span>
 <h4>Unauthenticated gRPC API Access</h4>
 <h5> Hybrid Manager (HM)</h5>
 </summary>


### PR DESCRIPTION
Updated: 2025/15/03 
should be a typo.

need to update to:
 Updated: 2025/12/15

## What Changed?

