### PR TITLE
Update affected_commands.mdx

### DIFF
--- a/product_docs/docs/tde/15/affected_commands.mdx
+++ b/product_docs/docs/tde/15/affected_commands.mdx
@@ -14,4 +14,4 @@ When TDE is enabled, the following commands have TDE-specific options or read TD
 
 ## Other tools affected by TDE
 When TDE is enabled, don't use the `DIRECT=TRUE` option when loading data with EDB*Loader.
-Please see details in [Running a direct path load](docs/epas/18/database_administration/02_edb_loader/invoking_edb_loader/direct_path_load.mdx)
+Please see details in [Running a direct path load](/epas/18/database_administration/02_edb_loader/invoking_edb_loader/direct_path_load.mdx)


### PR DESCRIPTION
Hi,
Greetings. Hope you are doing well and healthy.

## What Changed?
This same issue is found initially in EPAS15 but still exists in EPAS18.
Since its impact is huge, note shall be described in this page. Also, this change should be reflected into all affected versions:
15~18

```
[enterprisedb@edbsup04 ~]$ psql -p 5446
psql (18.3.0)
Type "help" for help.

edb=# SELECT version()
edb-# ;
                                                                     version
-------------------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 18.3 (EnterpriseDB Advanced Server 18.3.0) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11), 64-bit
(1 row)

edb=# CREATE TABLE test(col1 int);
CREATE TABLE
edb=#
\q
[enterprisedb@edbsup04 ~]$ for i in $(seq 1 10)
do
  echo $i
done >> test.txt
[enterprisedb@edbsup04 ~]$ cat test.txt
1
2
3
4
5
6
7
8
9
10

[enterprisedb@edbsup04 ~]$ cat test.ctl
LOAD DATA
  INFILE 'test.txt'
  BADFILE 'test.bad'
APPEND
INTO TABLE test
  FIELDS TERMINATED BY ','
    OPTIONALLY ENCLOSED BY '"'
  TRAILING NULLCOLS
(
  col1
)
[enterprisedb@edbsup04 ~]$ edbldr -p 5446 USERID=enterprisedb/edb CONTROL=test.ctl DIRECT=TRUE
EDB*Loader: Copyright (c) 2007-2025, EnterpriseDB Corporation.

WARNING:  bulk load will not be WAL-logged
HINT:  Continuous archive will not include the loaded data. You must take a new base backup after the load is finished
Successfully processed (10) records
[enterprisedb@edbsup04 ~]$ psql
psql (18.3.0)
Type "help" for help.

edb=#
\q
[enterprisedb@edbsup04 ~]$ psql -p 5446
psql (18.3.0)
Type "help" for help.

edb=# SELECT * FROM test;
ERROR:  invalid page in block 0 of relation "base/14362/16384"
```
Hope you can take a look.

Kind Regards,
Yuki Tei