### PR TITLE
Update upgrading_major_rolling.mdx

### DIFF
--- a/product_docs/docs/pgd/6.2/lifecycle/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/6.2/lifecycle/upgrades/upgrading_major_rolling.mdx
@@ -108,7 +108,15 @@ Using the [preliminary order](#prepare-the-upgrade), perform the following steps
     * `postgresql.auto.conf`&mdash; Contains settings set by PostgreSQL, such as those modified by the `ALTER SYSTEM` command.
     * `pg_hba.conf` &mdash; Manages client authentication, specifying which users can connect to which databases from which hosts.
     * The entire `conf.d` directory (if present) &mdash; Allows for organizing configuration settings into separate files for better manageability.
-  * Copy these files and the `conf.d` directory content's necessary lines to the new data directory files you created for the upgraded version of PostgreSQL.
+  * Copy these files and the `conf.d` directory to the new data directory you created for the upgraded version of PostgreSQL.
+
+    !!! Important Major version changes to configuration
+        Major version PostgreSQL releases often come with changes to available server variables (additions, removals, renames) as well as other changes to 
+        how configuration settings are used. Be sure to review all relevant release notes between the version you're upgrading from and the version you're
+        upgrading to to identify any changes that might render your old configuration files invalid.
+
+        You may find it more efficient to copy just the uncommented lines from your existing configuration files into the new ones, checking the documentation
+        for each setting as you go to ensure no further adjustments are needed.
 
 
 * **Verify the Postgres service is inactive**


### PR DESCRIPTION
Hi,
Greetings. Hope you are doing well and healthy.

## What Changed?
#### Suggested fix 1
The PGD package name is no longer bdr. Modify to the same syntax as https://www.enterprisedb.com/docs/pgd/latest/lifecycle/deploying/deploy-manual/03-installing-database-and-pgd/

#### Suggested fix 2
Often postgresql.conf is different between major versions, if you not modify manually but copy the original file,
new cluster shall not start due to errors like: "postgresql.conf contains errors"

Kind Regards,
Yuki Tei
