### PR TITLE
Specify database name in psql command

### DIFF
--- a/product_docs/docs/pem/10/certificates/index.mdx
+++ b/product_docs/docs/pem/10/certificates/index.mdx
@@ -405,7 +405,7 @@ PGSSLMODE=require
 
 export PGHOST PGPORT PGUSER PGSSLCERT PGSSLKEY PGSSLMODE
 
-<psql_path> -A -t -c "SELECT version()"
+<psql_path> -A -t -d pem -c "SELECT version()"
 ```
 
 Where:


### PR DESCRIPTION
Updated the command to include the database name 'pem' for the psql query.

## What Changed?

