### PR TITLE
EFM: add text about multi-host drivers not including everything

### DIFF
--- a/product_docs/docs/efm/5/efm_deploy_arch/04_efm_client_connect_failover.mdx
+++ b/product_docs/docs/efm/5/efm_deploy_arch/04_efm_client_connect_failover.mdx
@@ -32,7 +32,7 @@ You don't need to configure the virtual IP configuration in `efm.properties` (`v
 
 ### Configuring Client Connection failover
 
-The following is a list of some drivers that support multi-host connection strings. This list is not exhaustive.
+Here is a non-exhaustive list of drivers that support multi-host connection strings:
 
  Driver          | Client Connection failover support| Version supported       | Configuration 
 -----------------|-----------------------------------|-------------------------|---------------------------------


### PR DESCRIPTION
Added a statement that this list doesn't mean every driver in the world that will work. If something isn't on this list, it doesn't mean it's won't work with EFM (or anything else that manages the primary in a streaming replication cluster).



