### PR TITLE
separate output from sql

### DIFF
--- a/product_docs/docs/pgd/6.2/conflict-management/conflicts/05_conflict_logging.mdx
+++ b/product_docs/docs/pgd/6.2/conflict-management/conflicts/05_conflict_logging.mdx
@@ -31,7 +31,9 @@ FROM bdr.conflict_history
 WHERE local_time > date_trunc('day', current_timestamp)
 GROUP BY 1,2,3
 ORDER BY 1,2;
+```
 
+```output
  nspname | relname |    date    | count
 ---------+---------+------------+-------
  my_app  | test    | 2019-04-05 |     1


### PR DESCRIPTION
separate output from sql to facilitate easier copying of SQL

## What Changed?

split SQL and its output into two different blocks