### PR TITLE
Enhance SQL examples in conflict management documentation

### DIFF
--- a/product_docs/docs/pgd/6.2/conflict-management/conflicts/02_types_of_conflict.mdx
+++ b/product_docs/docs/pgd/6.2/conflict-management/conflicts/02_types_of_conflict.mdx
@@ -94,7 +94,9 @@ Some UPDATE operations succeed:
 
 ```sql
 UPDATE pktest SET pk=4 WHERE pk=3;
+```
 
+```text
 SELECT * FROM pktest;
  pk | val
 ----+-----
@@ -107,6 +109,8 @@ Other UPDATE operations fail with constraint errors:
 
 ```sql
 UPDATE pktest SET pk=4 WHERE pk=2;
+```
+```text
 ERROR:  duplicate key value violates unique constraint "pktest_pkey"
 DETAIL:  Key (pk)=(4) already exists
 ```
@@ -122,6 +126,8 @@ node1: UPDATE pktest SET pk=pk+1 WHERE pk = 2;
 node2: UPDATE pktest SET pk=pk+1 WHERE pk = 4;
 
 SELECT * FROM pktest;
+```
+```text
  pk | val
 ----+-----
   3 |   1
@@ -139,16 +145,21 @@ node2: UPDATE pktest SET pk=2 WHERE pk = 3;
 This scenario leaves the data different on each node:
 
 ```sql
-node1:
+--node1:
 SELECT * FROM pktest;
+```
+```text
  pk | val
 ----+-----
   1 |   1
   5 |   3
 (2 rows)
-
-node2:
+```
+```sql
+--node2:
 SELECT * FROM pktest;
+```
+```text
  pk | val
 ----+-----
   2 |   1


### PR DESCRIPTION
Updated SQL examples and added comments for clarity and to allow user to copy-paste SQL easily without pasting text

## What Changed?

split out the SQL and its output

Jira ticket created Docs-3601