### PR TITLE
Correct VIP timeout property reference

### DIFF
--- a/product_docs/docs/efm/5/04_configuring_efm/05_using_vip_addresses.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/05_using_vip_addresses.mdx
@@ -50,7 +50,7 @@ If a VIP address or any address other than the `bind.address` is assigned to a n
 
 The network interface used for the VIP doesn't have to be the same interface used for the Failover Manager agent's [`bind.address`](01_cluster_properties.mdx#bind_address) value. The primary agent drops the VIP as needed during a failover, and Failover Manager verifies that the VIP is no longer available before promoting a standby. A failure of the bind address network leads to primary isolation and failover.
 
-If the VIP uses a different interface from the `bind.address`, you might encounter a timing condition in which the rest of the cluster checks for a reachable VIP before the primary agent drops it. In this case, Failover Manager retries the VIP check for the number of seconds specified in the [`node.timeout`](01_cluster_properties.mdx#node_timeout) property to help ensure that a failover happens as expected.
+If the VIP uses a different interface from the `bind.address`, you might encounter a timing condition in which the rest of the cluster checks for a reachable VIP before the primary agent drops it. In this case, Failover Manager retries the VIP check for the number of seconds specified in the [`check.vip.timeout`](01_cluster_properties.mdx#check_vip_timeout) property to help ensure that a failover happens as expected.
 
 ## The efm_address script
 


### PR DESCRIPTION
Updated reference from 'node.timeout' to 'check.vip.timeout' for clarity on VIP checks during failover.



