### PR TITLE
Update PostgREST installation steps

### DIFF
--- a/advocacy_docs/supported-open-source/postgrest/installing.mdx
+++ b/advocacy_docs/supported-open-source/postgrest/installing.mdx
@@ -26,14 +26,10 @@ Before you begin the installation process:
 The syntax for the package install command is:
 
 ```shell
-# For SLES, CentOS, RHEL and its derivatives
-sudo <package-manager> -y install edb-<postgres><postgres_version>-postgrest2
-
-# For Debian and Ubuntu
-sudo <package-manager> -y install edb-<postgres><postgres_version>-postgrest2
+sudo <package-manager> -y install edb-postgrest
 ```
 
-Where: 
+Where:
 - `<package-manager>`is the package manager used with your operating system:
 
   | Package manager |             Operating system     |
@@ -42,21 +38,9 @@ Where:
   | zypper          | SLES                             |
   | apt-get         | Debian and derivatives           |
 
-- `<postgres>` is the distribution of Postgres you're using:
-
- |    Postgres distribution     |   Value    |
- | ---------------------------- | ---------- |
- | PostgreSQL                   | pg         |
-
-- `<postgres_version>` is the version of Postgres you're using.
-
-For example, to install postgREST for EDB Postgres 15 on a RHEL 8 platform:
+For example, to install postgREST on a RHEL 8 platform:
 
 ```shell
-sudo dnf -y install edb-pg15-postgrest2
+sudo dnf -y install edb-postgrest
 ```
-
-
-
-
 


### PR DESCRIPTION
The package name for the next version is edb-postgrest.

This is the name that should have been used all along, since the package does not depend on the major version or variant.

The next package will also have the provides/conflicts/replaces metadata fields to account for past edb-postgrest12 and edb-postgrest14 packages, allowing easy upgrade from them.

## What Changed?

