### PR TITLE
ASP 1.5.0: add release notes

### DIFF
--- a/advocacy_docs/pg_extensions/advanced_storage_pack/rel_notes/src/relnote_1.5.0.yml
+++ b/advocacy_docs/pg_extensions/advanced_storage_pack/rel_notes/src/relnote_1.5.0.yml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/EnterpriseDB/docs/refs/heads/develop/tools/automation/generators/relgen/relnote-schema.json
+product: Advanced Storage Pack
+version: 1.5.0
+date: 23 March 2026
+intro: |
+ Advanced Storage Pack 1.5.0 includes a number of enhancements and bug fixes.
+relnotes:
+- relnote: Bluefin: add `bluefin.estimate_compression[_blocks]()`
+  details: |
+    These functions estimage the compression rate we can obtain if we migrate a target Heap table to Bluefin.
+  jira: ""
+  addresses: ""
+  type: Enhancement
+  impact: Medium
+- relnote: Bluefin: fixed memory leak during index scan
+  details: |
+    The leak caused an increased memory usage, that may exhaust the available memory when dealing with large tables
+  jira: ""
+  addresses: ""
+  type: Bug fix
+  impact: Highest
+- relnote: Bluefin: fix TID scan, that led to crashes and leaks
+  details: |
+    Prior to this, a TID scan led to a server crash due to an assertion failure, plus memory leaks.
+  jira: ""
+  addresses: ""
+  type: Bug fix
+  impact: Medium
+- relnote: Bluefin: fix logical decoding of long tuples compressed with LZ4
+  details: |
+     Both single inserts and multi-insert/COPY paths were fixed.
+  jira: ""
+  addresses: ""
+  type: Bug fix
+  impact: Medium


### PR DESCRIPTION
Adds the release notes for ASP 1.5.0, which was tagged yesterday and is scheduled to be promoted later this week.
