### PR TITLE
Change EDB repository access links to new URLs

### DIFF
--- a/product_docs/docs/ocl_connector/13/04_open_client_library/01_installing_and_configuring_the_ocl_connector.mdx
+++ b/product_docs/docs/ocl_connector/13/04_open_client_library/01_installing_and_configuring_the_ocl_connector.mdx
@@ -40,7 +40,7 @@ subscription-manager repos --enable "rhel-*-optional-rpms" --enable "rhel-*-extr
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
- <https://info.enterprisedb.com/rs/069-ALB-339/images/Repository%20Access%2004-09-2019.pdf>
+ <https://www.enterprisedb.com/docs/repos/getting_started/with_cli/get_your_token/>
 
 After receiving your repository credentials you can:
 
@@ -107,7 +107,7 @@ subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
- <https://info.enterprisedb.com/rs/069-ALB-339/images/Repository%20Access%2004-09-2019.pdf>
+ <https://www.enterprisedb.com/docs/repos/getting_started/with_cli/get_your_token/>
 
 After receiving your repository credentials you can:
 
@@ -170,7 +170,7 @@ yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarc
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
- <https://info.enterprisedb.com/rs/069-ALB-339/images/Repository%20Access%2004-09-2019.pdf>
+ <https://www.enterprisedb.com/docs/repos/getting_started/with_cli/get_your_token/>
 
 After receiving your repository credentials you can:
 
@@ -236,7 +236,7 @@ dnf config-manager --set-enabled PowerTools
 
 You must also have credentials that allow access to the EDB repository. For information about requesting credentials, visit:
 
- <https://info.enterprisedb.com/rs/069-ALB-339/images/Repository%20Access%2004-09-2019.pdf>
+ <https://www.enterprisedb.com/docs/repos/getting_started/with_cli/get_your_token/>
 
 After receiving your repository credentials you can:
 
@@ -316,7 +316,7 @@ You can use the zypper package manager to install the connector on an SLES 12 ho
 
 After creating the repository configuration files, use the `zypper refresh` command to refresh the metadata on your SLES host to include the EDB repositories.
 
-When prompted for a `User Name` and `Password`, provide your connection credentials for the EDB repository. To request credentials for the repository, visit [the EDB website](https://www.enterprisedb.com/repository-access-request).
+To request token for the repository, visit [the EDB website](https://www.enterprisedb.com/docs/repos/getting_started/with_cli/get_your_token/).
 
 Before installing EDB Postgres Advanced Server or supporting components, you must also add SUSEConnect and the SUSE Package Hub extension to the SLES host, and register the host with SUSE, allowing access to SUSE repositories. Use the commands:
 
@@ -335,7 +335,7 @@ Then, you can use the zypper utility to install the connector:
 
 ## Installing the Connector on a Debian or Ubuntu Host
 
-To install a DEB package on a Debian or Ubuntu host, you must have credentials that allow access to the EDB repository. To request credentials for the repository, visit [the EDB website](https://www.enterprisedb.com/repository-access-request).
+To install a DEB package on a Debian or Ubuntu host, you must have credentials that allow access to the EDB repository. To request credentials for the repository, visit [the EDB website](https://www.enterprisedb.com/docs/repos/getting_started/with_cli/get_your_token/).
 
 The following steps will walk you through on using the EDB apt repository to install a DEB package. When using the commands, replace the `username` and `password` with the credentials provided by EDB.
 


### PR DESCRIPTION
Updated links for EDB repository access credentials.

## What Changed?
Updates URLs: Replaces outdated configuration links with the correct Repos 2.0 links.

## Pending
Update authentication instructions: Replaces old username/password steps with the new Token 2.0 procedures.