### PR TITLE
pg_cron: add release notes for 1.6.7

### DIFF
--- a/advocacy_docs/pg_extensions/pg_cron/rel_notes/index.mdx
+++ b/advocacy_docs/pg_extensions/pg_cron/rel_notes/index.mdx
@@ -7,4 +7,5 @@ The pg_cron documentation describes the latest version of pg_cron, including min
 
 |               Version               | Release Date |
 | ----------------------------------- | ------------ |
+| [1.6.7](pg_cron_1.6.7_rel_notes) | 25 Nov 2025  |
 | [1.6.4](pg_cron_1.6.4_rel_notes) | 09 Aug 2024  |

--- a/advocacy_docs/pg_extensions/pg_cron/rel_notes/pg_cron_1.6.7_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/pg_cron/rel_notes/pg_cron_1.6.7_rel_notes.mdx
@@ -1,0 +1,6 @@
+---
+title: Release notes for pg_cron version 1.6.7
+navTitle: "Version 1.6.7"
+---
+
+This release brings the bug fixes of 1.6.7 and of previous versions. For the `pg_cron` 1.6.7 release notes, see the [pg_cron 1.6.7 release notes](https://github.com/citusdata/pg_cron/releases/tag/v1.6.7).


### PR DESCRIPTION
This only adds a simple file for the release notes. There's not much more to be said, but maybe there's a better way to phrase it.
Reviews are welcome.