### PR TITLE
Update OAuth support note in webhooks documentation

### DIFF
--- a/product_docs/docs/pem/10/monitoring_performance/notifications/webhooks.mdx
+++ b/product_docs/docs/pem/10/monitoring_performance/notifications/webhooks.mdx
@@ -115,7 +115,7 @@ To mark a webhook for deletion, in the Webhooks table, select the webhook name a
 ## Authenticating webhook requests using OAuth
 
 !!! Note Provisional
-    Support for this feature is provisional. This means it is ready for production use, but that ...
+    Support for this feature is provisional. This means it is ready for production use, but that future minor releases may make breaking changes.
 
 When OAuth is configured for a webhook endpoint:
 


### PR DESCRIPTION
Clarified the note regarding the provisional support for OAuth feature in webhook requests.

## What Changed?

