### PR TITLE
Update stream-triggers.mdx

### DIFF
--- a/product_docs/docs/pgd/6.2/stream-triggers.mdx
+++ b/product_docs/docs/pgd/6.2/stream-triggers.mdx
@@ -311,7 +311,7 @@ A conflict trigger that applies a delta change on a counter column and uses
 SOURCE_NEW for all other columns:
 
 ```sql
-CREATE OR REPLACE FUNCTION delta_count_trg_func
+CREATE OR REPLACE FUNCTION delta_count_trg_func()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
@@ -336,7 +336,7 @@ $$;
 A transform trigger that logs all changes to a log table instead of applying them:
 
 ```sql
-CREATE OR REPLACE FUNCTION log_change
+CREATE OR REPLACE FUNCTION log_change()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$


### PR DESCRIPTION
Hi,
Greetings.

## What Changed?
Simple syntax error. Every `CREATE FUNTION` query needs "()" after function name even there is no variable, otherwise you will receive:
```
[2026-03-27 15:07:45.738] ERROR:  syntax error at or near "RETURNS"
[2026-03-27 15:07:45.738] LINE 2: RETURNS TRIGGER
```

Kind Regards,
Yuki Tei