### PR TITLE
efm doesn't use "superuser" database permissions

### DIFF
--- a/product_docs/docs/efm/5/04_configuring_efm/04_extending_efm_permissions.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/04_extending_efm_permissions.mdx
@@ -12,7 +12,7 @@ legacyRedirectsGenerated:
 
 During the Failover Manager installation, the installer creates a user named efm. efm doesn't have enough privileges to perform management functions that are normally limited to the database owner or operating system superuser.
 
--   When performing management functions requiring database superuser privileges, efm invokes the `efm_db_functions` script.
+-   When performing management functions requiring database privileges, efm invokes the `efm_db_functions` script.
 -   When performing management functions requiring operating system superuser privileges, efm invokes the `efm_root_functions` script.
 -   When assigning or releasing a virtual IP address, efm invokes the `efm_address` script.
 -   When enabling Pgpool integration, efm invokes the `efm_pgpool_functions` script.


### PR DESCRIPTION
This section is about executing scripts as different users, so "superuser" doesn't make any sense here. (When executing sql queries in the database, efm also doesn't use superuser privileges.)

## What Changed?

