### PR TITLE
Fix: correct helm template validation command for HM install

### DIFF
--- a/product_docs/docs/edb-postgres-ai/1.3/hybrid-manager/install/environment_prep.mdx
+++ b/product_docs/docs/edb-postgres-ai/1.3/hybrid-manager/install/environment_prep.mdx
@@ -700,10 +700,17 @@ Before proceeding to deployment, validate both your configuration file and the r
 
 Ensure your `values.yaml` is valid and can be processed by Helm.
 
-Replace `<your-registry-url>` with the registry you defined in `values.yaml` (e.g., `docker.enterprisedb.com` or your internal Harbor/Artifactory).
+First, add and update the Helm repository:
 
 ```bash
-helm template edb-pgai oci://<your-registry-url>/pgai-platform/edb-pgai \
+helm repo add enterprisedb-edbpgai "https://downloads.enterprisedb.com/${EDB_SUBSCRIPTION_TOKEN}/pgai-platform/helm/charts/"
+helm repo update
+```
+
+Then validate your `values.yaml` against the Helm chart:
+
+```bash
+helm template edbpgai-bootstrap enterprisedb-edbpgai/edbpgai-bootstrap \
   --values values.yaml \
   --version <target-version> > /dev/null
 ```

--- a/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/install/install_guide/environment_prep.mdx
+++ b/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/install/install_guide/environment_prep.mdx
@@ -337,8 +337,17 @@ If this command completes without error, your manifest syntax is valid.
 
 **Bootstrap method:** Ensure your `values.yaml` can be processed by Helm. Replace `<your-registry-url>` with the registry you defined in `values.yaml` (e.g., `docker.enterprisedb.com` or your internal Harbor/Artifactory).
 
+First, run `add` and `update` the Helm repository:
+
 ```bash
-helm template edb-pgai oci://<your-registry-url>/pgai-platform/edb-pgai \
+helm repo add enterprisedb-edbpgai "https://downloads.enterprisedb.com/${EDB_SUBSCRIPTION_TOKEN}/pgai-platform/helm/charts/"
+helm repo update
+```
+
+Then validate your `values.yaml` against the Helm chart:
+
+```bash
+helm template edbpgai-bootstrap enterprisedb-edbpgai/edbpgai-bootstrap \
   --values values.yaml \
   --version <target-helm-version> > /dev/null
 ```

--- a/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/install/install_guide/environment_prep.mdx
+++ b/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/install/install_guide/environment_prep.mdx
@@ -335,7 +335,7 @@ kubectl apply --dry-run=client -f hybridmanager.yaml
 
 If this command completes without error, your manifest syntax is valid.
 
-**Bootstrap method:** Ensure your `values.yaml` can be processed by Helm. Replace `<your-registry-url>` with the registry you defined in `values.yaml` (e.g., `docker.enterprisedb.com` or your internal Harbor/Artifactory).
+**Bootstrap method:** Ensure your `values.yaml` can be processed by Helm.
 
 First, run `add` and `update` the Helm repository:
 


### PR DESCRIPTION
## What Changed?

Updated the Helm template command and added the required 'helm repo add' and 'helm repo update' commands as prerequisites for successful execution.


<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7155--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->