### PR TITLE
Clarify that newly-created nodes may be joined

### DIFF
--- a/product_docs/docs/pgd/6.3/node_management/creating_and_joining.mdx
+++ b/product_docs/docs/pgd/6.3/node_management/creating_and_joining.mdx
@@ -30,7 +30,7 @@ other nodes to use to connect to this node.
 When the first PGD node group is created, a default replication set is also created, and all existing tables are added into the set. 
 After that, all tables will have the `bdr.default_replica_identity` value configured as the `REPLICA IDENTITY` for the table.
 
-Once the node group is created, further nodes can be created using [`bdr.create_node(/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdrcreate_node)`](), and then join the PGD group using the [`bdr.join_node_group()`](/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdrjoin_node_group) function.
+Once the node group is created, further nodes can be created using [`bdr.create_node()`](/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdrcreate_node), and then joined to the PGD group using the [`bdr.join_node_group()`](/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdrjoin_node_group) function.
 
 Alternatively, use the command line utility
 [bdr_init_physical](/pgd/latest/reference/tables-views-functions/nodes/#bdr_init_physical) to create a

--- a/product_docs/docs/pgd/6.3/node_management/creating_and_joining.mdx
+++ b/product_docs/docs/pgd/6.3/node_management/creating_and_joining.mdx
@@ -30,7 +30,7 @@ other nodes to use to connect to this node.
 When the first PGD node group is created, a default replication set is also created, and all existing tables are added into the set. 
 After that, all tables will have the `bdr.default_replica_identity` value configured as the `REPLICA IDENTITY` for the table.
 
-Once the node group is created, further nodes can join the PGD group using the [`bdr.join_node_group()`](/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdrjoin_node_group) function.
+Once the node group is created, further nodes can be created using [`bdr.create_node(/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdrcreate_node)`](), and then join the PGD group using the [`bdr.join_node_group()`](/pgd/latest/reference/tables-views-functions/nodes-management-interfaces#bdrjoin_node_group) function.
 
 Alternatively, use the command line utility
 [bdr_init_physical](/pgd/latest/reference/tables-views-functions/nodes/#bdr_init_physical) to create a


### PR DESCRIPTION
Hi,
Greetings. Hope you are doing well and healthy.

## What Changed?
Upon scale-out, one must first bdr.create_node() then bdr.join_node_group() or will receive error.

Kind Regards,
Yuki Tei
