### PR TITLE
Clarify that this is specific to TDE

### DIFF
--- a/product_docs/docs/tde/15/upgrading.mdx
+++ b/product_docs/docs/tde/15/upgrading.mdx
@@ -18,7 +18,7 @@ This table provides an overview of supported use cases.
 | Maintain the Postgres distribution and rotate encryption keys | Encrypted EDB Postgres Advanced Server 15     | Encrypted EDB Postgres Advanced Server 15 with new encryption keys |
 
 !!! Important
-    Both source and target servers must be in the same Postgres major version. pg_upgrade only supports upgrades between minor versions.
+    Both source and target servers must be in the same Postgres major version. pg_upgrade only supports upgrades between minor versions on TDE-enabled databases.
 
 ## Tutorials 
 


### PR DESCRIPTION
## What Changed?

...pg_upgrade is just fine for major version upgrades in general, but cannot be used in this scenario for TDE-enabled databases
