### PR TITLE
[DBP-1857]

### DIFF
--- a/product_docs/docs/postgis/3/installing/linux_arm64/postgis_rhel_9.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_arm64/postgis_rhel_9.mdx
@@ -39,12 +39,6 @@ Before you begin the installation process:
 
   1. Follow the instructions for setting up the EDB repository.
 
-- Install the EPEL repository:
-
-  ```shell
-  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-  ```
-
 - Enable additional repositories to resolve dependencies:
 
   ```shell

--- a/product_docs/docs/postgis/3/installing/linux_ppc64le/postgis_rhel_9.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_ppc64le/postgis_rhel_9.mdx
@@ -39,10 +39,6 @@ Before you begin the installation process:
 
   1. Follow the instructions for setting up the EDB repository.
 
-- Install the EPEL repository:
-  ```shell
-  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-  ```
 - Refresh the cache:
   ```shell
   sudo dnf makecache

--- a/product_docs/docs/postgis/3/installing/linux_x86_64/postgis_other_linux_9.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_x86_64/postgis_other_linux_9.mdx
@@ -39,12 +39,6 @@ Before you begin the installation process:
 
   1. Follow the instructions for setting up the EDB repository.
 
-- Install the EPEL repository:
-
-  ```shell
-  sudo dnf -y install epel-release
-  ```
-
 - Enable additional repositories to resolve dependencies:
   ```shell
   sudo dnf config-manager --set-enabled crb

--- a/product_docs/docs/postgis/3/installing/linux_x86_64/postgis_rhel_9.mdx
+++ b/product_docs/docs/postgis/3/installing/linux_x86_64/postgis_rhel_9.mdx
@@ -39,12 +39,6 @@ Before you begin the installation process:
 
   1. Follow the instructions for setting up the EDB repository.
 
-- Install the EPEL repository:
-
-  ```shell
-  sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-  ```
-
 - Enable additional repositories to resolve dependencies:
 
   ```shell


### PR DESCRIPTION
Update postgis docs as RHEL 9 No Longer Requires EPEL because EDB providing those deps in the EDb repos only now.

## What Changed?
Removed epel repo installation steps of the EL9 architectures from postgis installation guide
