### PR TITLE
Revert "docs(RMT-2581): Clarify VDP reward policy and eligibility"

### DIFF
--- a/advocacy_docs/security/vulnerability-disclosure-policy.mdx
+++ b/advocacy_docs/security/vulnerability-disclosure-policy.mdx
@@ -57,17 +57,6 @@ Please do not share information about the vulnerability with others until we hav
 
 While we don't have a formal bug bounty program, we recognize and appreciate the valuable role that security researchers play in the discovery and mitigation of vulnerabilities. EnterpriseDB may, at its own discretion, provide rewards for the disclosure of previously unknown vulnerabilities, depending on their severity and impact.
 
-A vulnerability is considered "previously unknown" if EDB is not already aware of it through its internal vulnerability management processes, public disclosures (including, but not limited to, assigned CVEs), or prior reports. We continuously monitor public vulnerability disclosures and run internal scanning and remediation processes against our products and infrastructure. Reports describing issues that EDB is already tracking and working to remediate through these processes will be acknowledged with appreciation, but may be marked as duplicates and are not eligible for rewards.
-
-### Eligibility
-
-We welcome reports from anyone who believes they have identified a vulnerability impacting EnterpriseDB, including current and former employees, contractors, customers, partners, and members of the wider security and PostgreSQL communities. Safe harbor under this policy applies to all good-faith submissions, regardless of the reporter's relationship to EDB.
-
-Reward eligibility, however, is more limited:
-
-* Current EDB employees and contractors are not eligible to receive rewards for vulnerabilities discovered in the course of, or as a result of, their work for EDB.
-* Former EDB employees and contractors are eligible to participate, subject to the same discretion EDB applies to all submissions. EDB reserves the right to decline rewards in cases where there is reason to believe a submission was made in bad faith, relies on non-public information obtained during prior employment, or otherwise represents an abuse of the program.
-
 To be eligible for any reward, EDB may require to you provide your full legal name, address and/or email address.  By participating in our program and accepting any reward, if applicable, you confirm that doing so does not violate your employer's policies or any applicable laws including those relating to anti-corruption, and you also confirm that you are not a government official.
 
 The only form of payment for any determined rewards will be amazon.com gift cards. Any other forms of payment, including (but not limited to) PayPal, other Amazon domains (amazon.ca, amazon.in, etc.) are not available and will not be used.
@@ -131,14 +120,6 @@ Please note that this policy may be updated from time to time. Please refer to t
    <td>Clarify payment method
    </td>
    <td>1.2
-   </td>
-  </tr>
-  <tr>
-   <td>May 7, 2026
-   </td>
-   <td>Clarify reward eligibility for current and former employees, and clarify treatment of vulnerabilities already known to EDB
-   </td>
-   <td>1.3
    </td>
   </tr>
 </table>


### PR DESCRIPTION
Reverts EnterpriseDB/docs#7165

undoing the adding of the security language until approved by Security leadership.