### PR TITLE
dbaas no longer in the core scenarios in planning_arch.mdx

### DIFF
--- a/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/install/install_guide/planning_arch.mdx
+++ b/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/install/install_guide/planning_arch.mdx
@@ -228,7 +228,7 @@ The four available scenarios are:
 
 | Module      | Description                                               | Included capabilities                                                                                  |
 |-------------|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `core`      | **Required**. The foundational layer for all deployments. | Estate management, Observability, DBaaS provisioning, and system services (Cert-manager, Istio, etc.). |
+| `core`      | **Required**. The foundational layer for all deployments. | Estate management, Observability, and system services (Cert-manager, Istio, etc.). |
 | `migration` | Enables schema and data migration tools.                  | Migration Portal integration, Data Migration Service (DMS) and other migration services.               |
 | `analytics` | Large-scale data processing and cataloging.               | Lakehouse cluster management, Data Catalog.                                                         |
 | `ai`        | Tools for building and serving generative AI.             | Sovereign AI, model serving (kserve), Langflow, and GenAI builders.                                    |


### PR DESCRIPTION
## What Changed?
Removing the dbaas components from core scenario description. 
