### PR TITLE
Remove architecture diagram from overview

### DIFF
--- a/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/overview/architecture.mdx
+++ b/product_docs/docs/edb-postgres-ai/innovation-release/hybrid-manager/overview/architecture.mdx
@@ -4,8 +4,6 @@ navTitle: Architecture
 description: Overview of core components and design principles that enable Hybrid Manager to orchestrate and manage Postgres clusters across varied environments.
 ---
 
-![High-level diagram of Hybrid Manager's architecture](../images/hcp_high-level_light.svg)
-
 The outermost containers of the diagram illustrate a Kubernetes cluster running on a cloud service provider's infrastructure, such as [AKS on Azure](https://azure.microsoft.com/en-us/products/kubernetes-service), [EKS on AWS](https://aws.amazon.com/eks/) or [GKE on GCP](https://cloud.google.com/kubernetes-engine), or on-premises infrastructure. "On-premises" in this context includes deployments on physical servers (bare metal), virtual machines, or private clouds hosted within an organization’s infrastructure. 
 
 Working inward through the diagram, the three main logical groupings are:


### PR DESCRIPTION
Removed the high-level diagram of Hybrid Manager's architecture from the documentation as requested per @aaronsonntag .

## What Changed?



<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7172--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->