### PR TITLE
Revise SQL example for encode_text function

### DIFF
--- a/product_docs/docs/aidb/7/sql-functions/encode-decode.mdx
+++ b/product_docs/docs/aidb/7/sql-functions/encode-decode.mdx
@@ -11,10 +11,7 @@ AIDB provides a set of SQL functions for performing AI inference directly in que
 Encodes a single text string into a vector using a registered embedding model.
 
 ```sql
-SELECT aidb.encode_text(
-    input   => 'What is pgvector?',
-    options => '{"model": "my_embedder"}'
-);
+SELECT aidb.encode_text('my_embedding_model','What is pgvector?');
 
 __OUTPUT__
                          encode_text

--- a/product_docs/docs/aidb/7/sql-functions/encode-decode.mdx
+++ b/product_docs/docs/aidb/7/sql-functions/encode-decode.mdx
@@ -11,7 +11,7 @@ AIDB provides a set of SQL functions for performing AI inference directly in que
 Encodes a single text string into a vector using a registered embedding model.
 
 ```sql
-SELECT aidb.encode_text('my_embedding_model','What is pgvector?');
+SELECT aidb.encode_text('my_embedder','What is pgvector?');
 
 __OUTPUT__
                          encode_text


### PR DESCRIPTION
Updated SQL example for aidb.encode_text function.

## What Changed?

Update the sql as the given example returns an error with the `No function matches the given name and argument types`

```
edb_admin=# SELECT aidb.encode_text(
edb_admin(#     input   => 'What is pgvector?',
edb_admin(#     options => '{"model": "my_embedding_model"}'
edb_admin(# );
ERROR:  function aidb.encode_text(input => unknown, options => unknown) does not exist
LINE 1: SELECT aidb.encode_text(
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```



<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7173--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->