### PR TITLE
chore: remove deprecated quay.io ref

### DIFF
--- a/product_docs/docs/postgres_for_kubernetes/1/operator_capability_levels.mdx
+++ b/product_docs/docs/postgres_for_kubernetes/1/operator_capability_levels.mdx
@@ -67,7 +67,7 @@ basis.
 
 The operator supports any operand container image containing PostgreSQL.
 While it defaults to the latest stable minor version of the most recent
-Community-supported major version on `quay.io` by EDB, you can override this by
+Community-supported major version on `docker.enterprisedb.com`, you can override this by
 setting the `.spec.imageName` attribute in the `Cluster` resource.
 This direct method supports `imagePullSecrets` for private registries and
 allows the use of both tags and SHA256 digests to ensure container


### PR DESCRIPTION
## What Changed?
- Removed reference to quay.io, deprecated (see: https://www.enterprisedb.com/docs/postgres_for_kubernetes/latest/migrating_edb_registries/)