### PR TITLE
Enhance description of 'auto.failover' property

### DIFF
--- a/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
@@ -669,7 +669,7 @@ db.reuse.connection.count=0
 
 <div id="auto_failover" class="registered_link"></div>
 
-The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`.
+The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`. This property is checked during the promotion steps on a standby and prevents promotion from happening by that agent when `false`. Other steps leading up to promotion still occur, e.g. shutting down a primary database that can no longer be reached.
 
 ```ini
 # Whether or not failover will happen automatically when the primary

--- a/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
@@ -669,7 +669,7 @@ db.reuse.connection.count=0
 
 <div id="auto_failover" class="registered_link"></div>
 
-The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`. This property is checked before the final primary database checks, VIP checks if needed, and before choosing a standby to attempt to promote. Other steps leading up to promotion still occur, e.g. shutting down a primary database that can no longer be reached.
+The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`. Failover Manager checks this property before completing the final primary database checks, running any VIP checks, and choosing a standby to promote. Other steps leading up to promotion still occur—for example, shutting down an unreachable primary.
 
 ```ini
 # Whether or not failover will happen automatically when the primary

--- a/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
@@ -669,7 +669,7 @@ db.reuse.connection.count=0
 
 <div id="auto_failover" class="registered_link"></div>
 
-The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`. This property is checked during the promotion steps on a standby and prevents promotion from happening by that agent when `false`. Other steps leading up to promotion still occur, e.g. shutting down a primary database that can no longer be reached.
+The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`. This property is checked before the final primary database checks, VIP checks if needed, and before choosing a standby to attempt to promote. Other steps leading up to promotion still occur, e.g. shutting down a primary database that can no longer be reached.
 
 ```ini
 # Whether or not failover will happen automatically when the primary

--- a/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/01_cluster_properties.mdx
@@ -669,7 +669,7 @@ db.reuse.connection.count=0
 
 <div id="auto_failover" class="registered_link"></div>
 
-The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`. Failover Manager checks this property before completing the final primary database checks, running any VIP checks, and choosing a standby to promote. Other steps leading up to promotion still occur—for example, shutting down an unreachable primary.
+The `auto.failover` property enables automatic failover. By default, `auto.failover` is set to `true`. Failover Manager checks this property before running any VIP checks, choosing a standby to promote, and signaling that standby agent to begin promotion. Other steps leading up to promotion still occur—for example, shutting down an unreachable primary.
 
 ```ini
 # Whether or not failover will happen automatically when the primary


### PR DESCRIPTION
Expanded explanation of the 'auto.failover' property, detailing its behavior during promotion steps and the conditions under which it prevents promotion.




<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7179--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->