### PR TITLE
Update upgrading_major_rolling.mdx

### DIFF
--- a/product_docs/docs/pgd/5.6/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/5.6/upgrades/upgrading_major_rolling.mdx
@@ -35,6 +35,10 @@ This command outputs a list of the different groups/subgroups running in your cl
 
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node. Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node

--- a/product_docs/docs/pgd/5.7/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/5.7/upgrades/upgrading_major_rolling.mdx
@@ -47,6 +47,10 @@ To keep the number of planned switchovers to a minimum, when upgrading a subgrou
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node. 
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node
@@ -250,7 +254,7 @@ This command halts the server on kaboom. Your cluster continues running using th
 
 ### Install PGD and utilities
 
-Next, install the new version of Postgres (PG16) and the upgrade tool:
+Next, install the new version of Postgres (PG17) and the upgrade tool:
 
 ```bash
 sudo apt install edb-bdr5-pg17 edb-bdr-utilities
@@ -319,7 +323,7 @@ Feb 11 18:14:25 kaboom systemd[1]: Stopped Postgres 16 (TPA).
 
 ### Swap PGDATA directories for version upgrade
 
-Next, swap the PG15 and PG16 data directories: 
+Next, swap the PG16 and PG17 data directories: 
 
 ```bash
 sudo mv /opt/postgres/data /opt/postgres/dataold
@@ -531,7 +535,7 @@ Stopping new PG instance
 
 The Postgres service on the system is configured to start the old version of Postgres (PG16). You need to modify the `postgres.service` file to start the new version (PG17). 
 
-You can do this using `sed` to replace the old version number `15` with `16` throughout the file. 
+You can do this using `sed` to replace the old version number `16` with `17` throughout the file. 
 
 ```bash
 sudo sed -i -e  's/16/17/g' /etc/systemd/system/postgres.service

--- a/product_docs/docs/pgd/5.8/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/5.8/upgrades/upgrading_major_rolling.mdx
@@ -47,6 +47,10 @@ To keep the number of planned switchovers to a minimum, when upgrading a subgrou
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node. 
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node
@@ -250,7 +254,7 @@ This command halts the server on kaboom. Your cluster continues running using th
 
 ### Install PGD and utilities
 
-Next, install the new version of Postgres (PG16) and the upgrade tool:
+Next, install the new version of Postgres (PG17) and the upgrade tool:
 
 ```bash
 sudo apt install edb-bdr5-pg17 edb-bdr-utilities
@@ -319,7 +323,7 @@ Feb 11 18:14:25 kaboom systemd[1]: Stopped Postgres 16 (TPA).
 
 ### Swap PGDATA directories for version upgrade
 
-Next, swap the PG15 and PG16 data directories: 
+Next, swap the PG16 and PG17 data directories: 
 
 ```bash
 sudo mv /opt/postgres/data /opt/postgres/dataold
@@ -531,7 +535,7 @@ Stopping new PG instance
 
 The Postgres service on the system is configured to start the old version of Postgres (PG16). You need to modify the `postgres.service` file to start the new version (PG17). 
 
-You can do this using `sed` to replace the old version number `15` with `16` throughout the file. 
+You can do this using `sed` to replace the old version number `16` with `17` throughout the file. 
 
 ```bash
 sudo sed -i -e  's/16/17/g' /etc/systemd/system/postgres.service

--- a/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
@@ -50,9 +50,8 @@ To keep the number of planned switchovers to a minimum, when upgrading a subgrou
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node.
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
-!!!Note
-
-Other cluster nodes that do not run a PGD data node (like nodes running `psql`) are linked against the Postgres client libraries. Before upgrading the PGD data nodes, ensure those nodes have the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package matching the new major version to be installed.
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
 !!!
 
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 

--- a/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
@@ -52,9 +52,7 @@ Therefore, you still need to verify that a node isn't the write leader just befo
 
 !!!Note
 
-Other cluster nodes that do not run a BDR data node (like PGD-proxy) also link against
-the Postgres client libraries. Before upgrading the data nodes, ensure those nodes have the
-`edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package matching the new major version to be installed.
+Other cluster nodes that do not run a BDR data node (like nodes running `psql`) are linked against the Postgres client libraries. Before upgrading the BDR data nodes, ensure those nodes have the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package matching the new major version to be installed.
 !!!
 
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 

--- a/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
@@ -50,6 +50,13 @@ To keep the number of planned switchovers to a minimum, when upgrading a subgrou
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node.
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!!Note
+
+Other cluster nodes that do not run a BDR data node (like PGD-proxy) also link against
+the Postgres client libraries. Before upgrading the data nodes, ensure those nodes have the
+`edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package matching the new major version to be installed.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node
@@ -273,7 +280,7 @@ This command halts the server on kaboom. Your cluster continues running using th
 
 ### Install PGD and utilities
 
-Next, install the new version of Postgres (PG16) and the upgrade tool:
+Next, install the new version of Postgres (PG17) and the upgrade tool:
 
 ```bash
 sudo apt install edb-bdr5-pg17 edb-bdr-utilities
@@ -342,7 +349,7 @@ Feb 11 18:14:25 kaboom systemd[1]: Stopped Postgres 16 (TPA).
 
 ### Swap PGDATA directories for version upgrade
 
-Next, swap the PG15 and PG16 data directories: 
+Next, swap the PG16 and PG17 data directories: 
 
 ```bash
 sudo mv /opt/postgres/data /opt/postgres/dataold
@@ -556,7 +563,7 @@ Stopping new PG instance
 
 The Postgres service on the system is configured to start the old version of Postgres (PG16). You need to modify the `postgres.service` file to start the new version (PG17). 
 
-You can do this using `sed` to replace the old version number `15` with `16` throughout the file. 
+You can do this using `sed` to replace the old version number `16` with `17` throughout the file. 
 
 ```bash
 sudo sed -i -e  's/16/17/g' /etc/systemd/system/postgres.service

--- a/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/5.9/upgrades/upgrading_major_rolling.mdx
@@ -52,7 +52,7 @@ Therefore, you still need to verify that a node isn't the write leader just befo
 
 !!!Note
 
-Other cluster nodes that do not run a BDR data node (like nodes running `psql`) are linked against the Postgres client libraries. Before upgrading the BDR data nodes, ensure those nodes have the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package matching the new major version to be installed.
+Other cluster nodes that do not run a PGD data node (like nodes running `psql`) are linked against the Postgres client libraries. Before upgrading the PGD data nodes, ensure those nodes have the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package matching the new major version to be installed.
 !!!
 
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 

--- a/product_docs/docs/pgd/6.1/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/6.1/upgrades/upgrading_major_rolling.mdx
@@ -44,6 +44,10 @@ upgrade and then unfence the node after the node upgrade is completed.
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node. 
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node

--- a/product_docs/docs/pgd/6.2/lifecycle/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/6.2/lifecycle/upgrades/upgrading_major_rolling.mdx
@@ -46,6 +46,10 @@ upgrade and then unfence the node after the node upgrade is completed.
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node. 
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node

--- a/product_docs/docs/pgd/6.3/lifecycle/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/6.3/lifecycle/upgrades/upgrading_major_rolling.mdx
@@ -46,6 +46,10 @@ upgrade and then unfence the node after the node upgrade is completed.
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node. 
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node

--- a/product_docs/docs/pgd/6.4/lifecycle/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/6.4/lifecycle/upgrades/upgrading_major_rolling.mdx
@@ -46,6 +46,10 @@ upgrade and then unfence the node after the node upgrade is completed.
 Even though you verified which node is the current write leader for planning purposes, the write leader of a subgroup could change to another node at any moment for operational reasons before you upgrade that node. 
 Therefore, you still need to verify that a node isn't the write leader just before upgrading that node.
 
+!!! Note
+Nodes that run Postgres client tools but not a PGD data node use the Postgres client libraries. Before upgrading the PGD data nodes, upgrade those nodes to the `edb-as<xx>-server-client` (EPAS) or `postgresql-client-<xx>` (PG) package for the new major version.
+!!!
+
 You now have enough information to determine your upgrade order, one subgroup at a time, aiming to upgrade the identified write leader node last in each subgroup. 
 
 ### Perform the upgrade on each node


### PR DESCRIPTION
Support customer complained about this issue in ticket 57673 / BDR-7654. Even though it should be a common practice to upgrade pg client packages (psql) all together when do major upgrade, we are including a note here to not miss this step.

## What Changed?
- Add a new 'Note' in `upgrading-postgres-major-versions` in `Prepare the upgrade` 
- Fix few other typos related to PG versions used in the doc


<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7185--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->