### PR TITLE
docs(pgd): Clarify origin_node_group matching semantics for 5.9 and 6.4

### DIFF
--- a/product_docs/docs/pgd/5.9/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/5.9/commit-scopes/commit-scopes.mdx
@@ -40,7 +40,14 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-A commit scope will not be used if it is not local and the node where the commit is being run on is not directly or indirectly related to the origin_node_group.
+How a rule's `origin_node_group` is matched depends on how the commit scope is activated:
+
+- As a **default commit scope** (configured via a group's `default_commit_scope`), PGD walks up the group tree from the node's group, so a rule defined on a parent or top-level group applies to subgroup nodes.
+- Activated explicitly via `SET [LOCAL] bdr.commit_scope`, the rule is matched only against the node's **own group**. If no rule has that exact group as its `origin_node_group`, no commit scope applies and the transaction silently falls back to async replication.
+
+!!! Note
+Setting `bdr.commit_scope` to a scope whose rules are all defined on a parent group does not raise an error, but the scope is not applied and the commit uses async replication. To use such a scope with `SET LOCAL bdr.commit_scope` on a subgroup node, create the rule with that subgroup as `origin_node_group`.
+!!!
 
 ## Creating a Commit Scope
 

--- a/product_docs/docs/pgd/5.9/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/5.9/commit-scopes/commit-scopes.mdx
@@ -40,12 +40,12 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-How a rule's `origin_node_group` is matched depends on how the commit scope is activated:
+A rule's `origin_node_group` is matched differently depending on how the commit scope is activated:
 
-- As a **default commit scope** (configured via a group's `default_commit_scope`), PGD walks up the group tree from the node's group, so a rule defined on a parent or top-level group applies to subgroup nodes.
-- Activated explicitly via `SET [LOCAL] bdr.commit_scope`, the rule is matched only against the node's **own group**. If no rule has that exact group as its `origin_node_group`, no commit scope applies and the transaction silently falls back to async replication.
+- As a default commit scope set via a group's `default_commit_scope`, PGD ascends the group tree from the node's group, so a rule defined on a parent or top-level group applies to subgroup nodes.
+- Activated explicitly via `SET [LOCAL] bdr.commit_scope`, the rule is matched only against the node's own group. If no rule has that exact group as its `origin_node_group`, no commit scope applies and the transaction silently falls back to async replication.
 
-!!! Note
+!!! Warning
 Setting `bdr.commit_scope` to a scope whose rules are all defined on a parent group does not raise an error, but the scope is not applied and the commit uses async replication. To use such a scope with `SET LOCAL bdr.commit_scope` on a subgroup node, create the rule with that subgroup as `origin_node_group`.
 !!!
 

--- a/product_docs/docs/pgd/6.1/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6.1/commit-scopes/commit-scopes.mdx
@@ -43,7 +43,14 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-A commit scope will not be used if it is not local and the node where the commit is being run on is not directly or indirectly related to the origin_node_group.
+A rule's `origin_node_group` is matched differently depending on how the commit scope is activated:
+
+- As a default commit scope set via a group's `default_commit_scope`, PGD ascends the group tree from the node's group, so a rule defined on a parent or top-level group applies to subgroup nodes.
+- Activated explicitly via `SET [LOCAL] bdr.commit_scope`, the rule is matched only against the node's own group. If no rule has that exact group as its `origin_node_group`, no commit scope applies and the transaction silently falls back to async replication.
+
+!!! Warning
+Setting `bdr.commit_scope` to a scope whose rules are all defined on a parent group does not raise an error, but the scope is not applied and the commit uses async replication. To use such a scope with `SET LOCAL bdr.commit_scope` on a subgroup node, create the rule with that subgroup as `origin_node_group`.
+!!!
 
 ## Creating a Commit Scope
 

--- a/product_docs/docs/pgd/6.2/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6.2/commit-scopes/commit-scopes.mdx
@@ -43,7 +43,14 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-A commit scope will not be used if it is not local and the node where the commit is being run on is not directly or indirectly related to the origin_node_group.
+A rule's `origin_node_group` is matched differently depending on how the commit scope is activated:
+
+- As a default commit scope set via a group's `default_commit_scope`, PGD ascends the group tree from the node's group, so a rule defined on a parent or top-level group applies to subgroup nodes.
+- Activated explicitly via `SET [LOCAL] bdr.commit_scope`, the rule is matched only against the node's own group. If no rule has that exact group as its `origin_node_group`, no commit scope applies and the transaction silently falls back to async replication.
+
+!!! Warning
+Setting `bdr.commit_scope` to a scope whose rules are all defined on a parent group does not raise an error, but the scope is not applied and the commit uses async replication. To use such a scope with `SET LOCAL bdr.commit_scope` on a subgroup node, create the rule with that subgroup as `origin_node_group`.
+!!!
 
 ## Creating a Commit Scope
 

--- a/product_docs/docs/pgd/6.3/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6.3/commit-scopes/commit-scopes.mdx
@@ -43,7 +43,14 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-A commit scope will not be used if it is not local and the node where the commit is being run on is not directly or indirectly related to the origin_node_group.
+A rule's `origin_node_group` is matched differently depending on how the commit scope is activated:
+
+- As a default commit scope set via a group's `default_commit_scope`, PGD ascends the group tree from the node's group, so a rule defined on a parent or top-level group applies to subgroup nodes.
+- Activated explicitly via `SET [LOCAL] bdr.commit_scope`, the rule is matched only against the node's own group. If no rule has that exact group as its `origin_node_group`, no commit scope applies and the transaction silently falls back to async replication.
+
+!!! Warning
+Setting `bdr.commit_scope` to a scope whose rules are all defined on a parent group does not raise an error, but the scope is not applied and the commit uses async replication. To use such a scope with `SET LOCAL bdr.commit_scope` on a subgroup node, create the rule with that subgroup as `origin_node_group`.
+!!!
 
 ## Creating a Commit Scope
 

--- a/product_docs/docs/pgd/6.4/achieving-durability/custom-scopes.mdx
+++ b/product_docs/docs/pgd/6.4/achieving-durability/custom-scopes.mdx
@@ -21,7 +21,7 @@ Each clause pairs a "who confirms?" with a "how?". Combine as many clauses as yo
 When you create a custom commit scope, you define:
 
 - A unique name via `commit_scope_name`, used to reference and assign the scope to a node group or individual transaction
-- Which group the scope applies to, via `origin_node_group`. Only transactions originating from nodes in this group use the scope
+- Which group the scope applies to, via `origin_node_group`. Transactions originating from nodes in this group or any of its subgroups use the scope
 - A `rule` string specifying who confirms and how:
   - The confirming nodes are expressed as a [commit scope group specifier](/pgd/current/commit-scopes/origin_groups/), which defines how many must confirm and which group they come from.
   - The type of confirmation is the [commit kind](#choosing-a-commit-kind), whether that means durability, quorum agreement, bounded lag, or single-commit enforcement.

--- a/product_docs/docs/pgd/6.4/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6.4/commit-scopes/commit-scopes.mdx
@@ -43,7 +43,7 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-A commit scope rule applies to a transaction when the originating node's group matches the rule's `origin_node_group` or is a descendant of it. PGD matches by walking up the group tree from the node's own group, most-specific first, so a rule defined on a parent or top-level group also applies to transactions originating in its subgroups. If no rule matches and the scope isn't `local`, the transaction uses PGD's default async replication.
+A commit scope rule applies to a transaction when the originating node's group is the rule's `origin_node_group` or one of its subgroups. PGD determines the match by ascending the group tree from the node's own group, most-specific first, so a rule defined on a parent or top-level group also applies to transactions originating in its subgroups. If no rule matches and the scope isn't `local`, the transaction uses PGD's default async replication.
 
 ## Creating a Commit Scope
 

--- a/product_docs/docs/pgd/6.4/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6.4/commit-scopes/commit-scopes.mdx
@@ -43,7 +43,7 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-A commit scope will not be used if it is not local and the node where the commit is being run on is not directly or indirectly related to the origin_node_group.
+A commit scope rule applies to a transaction when the originating node's group matches the rule's `origin_node_group` or is a descendant of it. PGD matches by walking up the group tree from the node's own group, most-specific first, so a rule defined on a parent or top-level group also applies to transactions originating in its subgroups. If no rule matches and the scope isn't `local`, the transaction uses PGD's default async replication.
 
 ## Creating a Commit Scope
 

--- a/product_docs/docs/pgd/6/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6/commit-scopes/commit-scopes.mdx
@@ -43,7 +43,14 @@ If not specified, the system will search for a default commit scope. Default com
 
 If no default_commit_scope is found then the node's GUC, bdr.commit_scope is used. And if that isn't set or is set to `local` then no commit scope applies and PGD's async replication is used.
 
-A commit scope will not be used if it is not local and the node where the commit is being run on is not directly or indirectly related to the origin_node_group.
+A rule's `origin_node_group` is matched differently depending on how the commit scope is activated:
+
+- As a default commit scope set via a group's `default_commit_scope`, PGD ascends the group tree from the node's group, so a rule defined on a parent or top-level group applies to subgroup nodes.
+- Activated explicitly via `SET [LOCAL] bdr.commit_scope`, the rule is matched only against the node's own group. If no rule has that exact group as its `origin_node_group`, no commit scope applies and the transaction silently falls back to async replication.
+
+!!! Warning
+Setting `bdr.commit_scope` to a scope whose rules are all defined on a parent group does not raise an error, but the scope is not applied and the commit uses async replication. To use such a scope with `SET LOCAL bdr.commit_scope` on a subgroup node, create the rule with that subgroup as `origin_node_group`.
+!!!
 
 ## Creating a Commit Scope
 


### PR DESCRIPTION
In 5.9 the GUC-override path matched only the node's own group, while the default_commit_scope path walked ancestors — an asymmetry that caused silent async fallback when SET LOCAL bdr.commit_scope was used with a scope defined on a parent group. In 6.4 the GUC path was fixed to also walk ancestors (commit 776e243b13), so both paths now behave consistently.

Replace the vague "directly or indirectly related" sentence in both versions with precise, version-accurate descriptions. The 5.9 entry explains the route-dependent split and adds a warning callout for the silent-fallback trap. The 6.4 entry describes the unified ancestor-walk behaviour.

BDR-7611



<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7187--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->