### PR TITLE
Update references from efm-50 to efm-53

### DIFF
--- a/product_docs/docs/efm/5/04_configuring_efm/04_extending_efm_permissions.mdx
+++ b/product_docs/docs/efm/5/04_configuring_efm/04_extending_efm_permissions.mdx
@@ -21,7 +21,7 @@ The `efm_db_functions` or `efm_root_functions` scripts perform management functi
 
 The `sudoers` file contains entries that allow the user efm to control the Failover Manager service for clusters owned by postgres or enterprisedb. You can modify a copy of the `sudoers` file to grant permission to efm to manage Postgres clusters owned by other users.
 
-The `efm-50` file is located in `/etc/sudoers.d` and contains the following entries:
+The `efm-53` file is located in `/etc/sudoers.d` and contains the following entries:
 
 ```text
 # Copyright EnterpriseDB Corporation, 2014-2026. All Rights Reserved.
@@ -53,7 +53,7 @@ efm    ALL=(ALL)           NOPASSWD:   /usr/edb/efm-5.3/bin/efm_pgpool_functions
 Defaults:efm !requiretty
 ```
 
-If you're using Failover Manager to monitor clusters that are owned by users other than postgres or enterprisedb, make a copy of the `efm-50` file. Then modify the content to allow the user to access the `efm_functions` script to manage their clusters.
+If you're using Failover Manager to monitor clusters that are owned by users other than postgres or enterprisedb, make a copy of the `efm-53` file. Then modify the content to allow the user to access the `efm_functions` script to manage their clusters.
 
 If an agent can't start because of permission problems, make sure the default `/etc/sudoers` file contains the following line at the end of the file:
 


### PR DESCRIPTION
There were two leftover references to an old efm version.

## What Changed?



<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7196--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->