### PR TITLE
Clarify password hash synchronization in upgrade docs

### DIFF
--- a/product_docs/docs/pgd/6.4/upgrades/upgrading_major_rolling.mdx
+++ b/product_docs/docs/pgd/6.4/upgrades/upgrading_major_rolling.mdx
@@ -256,9 +256,9 @@ Repeat same steps on all other nodes.
 ### Confirm cluster version
 Confirm the updated cluster version is version 6001 by running `bdr.group_raft_details`.
 
-### Confirm SCRAM hashes
+### Synchronize password hashes
 
-From any of the upgrades nodes, run the following query to ensure that SCRAM hashes are the same across all nodes for each user. This is required before applications switch to Connection Manager.
+From any of the upgrades nodes, run the following query to ensure that password hashes are the same across all nodes for each user. This is required before applications switch to Connection Manager.
 
 ```sql
 DO $$
@@ -266,7 +266,7 @@ DECLARE
     rec RECORD;
     command TEXT;
 BEGIN
-    FOR rec IN SELECT rolname,rolpassword FROM pg_authid WHERE rolcanlogin = true AND rolpassword like 'SCRAM-SHA%'
+    FOR rec IN SELECT rolname,rolpassword FROM pg_authid WHERE rolcanlogin = true
     LOOP
         command := 'ALTER ROLE ' || quote_ident(rec.rolname) || ' WITH ENCRYPTED PASSWORD ' || ''' || rec.rolpassword || ''';
         EXECUTE command;


### PR DESCRIPTION
Updated documentation to clarify that password hashes must be synchronized across nodes, replacing the previous mention of SCRAM hashes.

## What Changed?

