### PR TITLE
Update registration connection string availability note

### DIFF
--- a/product_docs/docs/pem/10/registering_agent.mdx
+++ b/product_docs/docs/pem/10/registering_agent.mdx
@@ -53,7 +53,7 @@ set PEM_SERVER_PASSWORD=edb
 | `--pem-user`                    | The name of a database user with the pem_admin role and the `rolcreaterole` flag set on the PEM backend database server (the latter is not required if you specify an existing user via `--pem-agent-user` or an agent connection string), or a superuser. This user will be used to connect to the PEM server to perform agent registration. This parameter is required unless `--pem-registration-conn-string` is specified.                                                                                                                                                         |
 | `--pem-agent-user`              | The name of a database user on the PEM backend database server. After registration, the agent will use this user to open connections to the PEM database server to write probe data, evaluate alerts, and so on. This parameter is optional. If omitted, the agent connects using a new user named `agent<N>` created during registration, where `<N>` is the agent ID.  |
 | `--pem-ssl-mode`                | The [SSL mode](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) for the PEM agent user to use (see above). The possible values are `prefer`, `require`, `disable`, `verify-CA`, and `verify-full`. The default value is `require`.                                                                                                              |
-| `--pem-registration-conn-string`| The connection string used to connect to the PEM server during registration. See [Using connection strings](#using-connection-strings). |
+| `--pem-registration-conn-string`| The connection string used to connect to the PEM server during registration. Available in PEM 10.4 and later. See [Using connection strings](#using-connection-strings). |
 | `--cert-path`                   | The complete path to a directory in which to store certificates. If you don't provide a path, certificates are created in `~/.pem` on Linux and `%APPDATA%/pem` on Windows.                                                                                                     |
 | `--config-dir`                  | The directory path for the configuration file. The default is `<pemworker path>/../etc`.                                                                                                                                                                                          |
 | `--display-name`                | A user-friendly name for the agent to display in the PEM browser tree. The default is the host's fully qualified domain name (FQDN), falling back to the hostname if this option isn't set. |
@@ -233,7 +233,7 @@ The following are some advanced options for PEM agent registration.
 
 ### Using connection strings
 
-For finer control over how the PEM agent connects to the PEM backend database, you can specify connection strings.
+Beginning with PEM 10.4, for finer control over how the PEM agent connects to the PEM backend database, you can specify connection strings.
 There are two connection strings you can specify, the *registration connection string and the *agent* connection string.
 These connection strings can be in either key-value or URI format and include any options supported by libpq with the exception of `dbname` which is hardcoded to `pem` and `target_session_attrs` which is hardcoded to `read-write`.
 


### PR DESCRIPTION
Clarified the availability of the registration connection string in PEM 10.4 and later.

## What Changed?

Added notes when the new command line argument became available, to address a customer's complaint. See https://edb.slack.com/archives/CDU4GKHL5/p1785319158167079