### PR TITLE
Create wait_states_1.6_rel_notes.mdx

### DIFF
--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release notes for Wait States version 1.6
-navTitle: "Version 1.6"
+navTitle: "Version 1.6.0"
 ---
 Release date: 17 Jul 2026
 

--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
@@ -8,4 +8,4 @@ This release of Wait States includes:
 
 | Type        | Description                                                       |
 |-------------|-------------------------------------------------------------------|
-| Bug Fix     | Fixed incorrect queryId attribution in edb_wait_states when backends exit or error mid-query.  |
+| Bug Fix     | Fixed incorrect `query_id` attribute in edb_wait_states when backends exit or error mid-query.  |

--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
@@ -1,0 +1,11 @@
+---
+title: Release notes for Wait States version 1.6
+navTitle: "Version 1.6"
+---
+Release date: 17 Jul 2026
+
+This release of Wait States includes:
+
+| Type        | Description                                                       |
+|-------------|-------------------------------------------------------------------|
+| Bug Fix     | Fix edb_wait_states segementation fault brings down EPAS issue.    |

--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
@@ -8,4 +8,4 @@ This release of Wait States includes:
 
 | Type        | Description                                                       |
 |-------------|-------------------------------------------------------------------|
-| Bug Fix     | Fix edb_wait_states segementation fault brings down EPAS issue.    |
+| Bug Fix     | Fixed incorrect queryId attribution in edb_wait_states when backends exit or error mid-query.  |

--- a/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
+++ b/advocacy_docs/pg_extensions/wait_states/rel_notes/wait_states_1.6_rel_notes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Release notes for Wait States version 1.6
+title: Release notes for Wait States version 1.6.0
 navTitle: "Version 1.6.0"
 ---
 Release date: 17 Jul 2026


### PR DESCRIPTION
Hi,
Greetings. Hope you are doing well and healthy

## What Changed?
Since edb_wait_states is released on Jul 17th. Release note should be published.
Also, since a bug might bring EPAS down is fixed, users shall be encouraged to version up.
Fresh update for release note is vital.

Kind Regards,
Yuki Tei