### PR TITLE
Update commit-scopes.mdx

### DIFF
--- a/product_docs/docs/pgd/6.4/commit-scopes/commit-scopes.mdx
+++ b/product_docs/docs/pgd/6.4/commit-scopes/commit-scopes.mdx
@@ -107,13 +107,13 @@ SELECT bdr.alter_node_group_option(
 You can also make this change using PGD CLI:
 
 ```
-pgd set-group-options example-bdr-group --option default_commit_scope=example_scope
+pgd group example-bdr-group set-option default_commit_scope "example_scope"
 ```
 
 And you can clear the default using PGD CLI by setting the value to `local`:
 
 ```
-pgd set-group-options example-bdr-group --option default_commit_scope=local
+pgd group example-bdr-group set-option default_commit_scope "local"
 ```
 
 Finally, you can set the default commit_scope for a node using:


### PR DESCRIPTION
Hi,
Greetings. Hope you are doing well and healthy.

## What Changed?
Fixed the pgd command example to fit latest version.
If you copy & paste the current example, you will receive:
```
[enterprisedb@ip-172-17-18-62 ~]$ pgd set-group-options group-1 --option default_commit_scope = 'lag protect'
error: unrecognized subcommand 'set-group-options'

  tip: a similar subcommand exists: 'group'

Usage: pgd [OPTIONS] <COMMAND>

For more information, try '--help'
```

Kind Regards,
Yuki Tei
