### PR TITLE
Update prerequisites to reflect v5.3 changes

### DIFF
--- a/product_docs/docs/efm/5/installing/prerequisites.mdx
+++ b/product_docs/docs/efm/5/installing/prerequisites.mdx
@@ -101,11 +101,11 @@ The database user specified by the `db.user` property in the `efm.properties` fi
  `pg_wal_replay_pause()`
 
 
-If the `reconfigure.num.sync` or `reconfigure.sync.primary` property is set to `true`, then the `db.user` requires `pg_read_all_stats` privilege and permissions to run `pg_reload_conf()`.
+If the `reconfigure.num.sync` or `reconfigure.sync.primary` property is set to `true`, then the `db.user` requires pg_read_all_stats privilege and permissions to run `pg_reload_conf()`.
 
 For detailed information about each of these functions, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/index.html).
 
-If the `update.physical.slots.period` property is used, then the db.user requires the `REPLICATION` privilege. A database superuser can provide the permissions needed:
+If the `update.physical.slots.period` property is used, then the db.user requires the REPLICATION privilege. A database superuser can provide the permissions needed:
 
 ```sql
 ALTER USER <user_name> REPLICATION;
@@ -117,24 +117,23 @@ The user must also have permissions to read the values of configuration variable
 GRANT pg_read_all_settings TO <user_name>;
 ```
 
-For more information about `pg_read_all_settings`, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/default-roles.html).
+For more information about pg_read_all_settings, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/default-roles.html).
 
-If `auto.rewind` is set to `true`, then the `db.user` requires the `pg_checkpoint` role to be granted, as the Failover Manager agent will issue a `CHECKPOINT` command prior to executing `pg_rewind`.
+If `auto.rewind` is set to `true`, then the `db.user` requires the pg_checkpoint role to be granted, as the Failover Manager agent will issue a `CHECKPOINT` command prior to executing `pg_rewind`.
 
-The required privileges are summarised in the following table:
+The required privileges are summarized in this table:
 
-| Privilege |          Object        | Condition   |
-|-----------|------------------------|-------------|
-| `EXECUTE` | `pg_current_wal_lsn()` | Always required |
-|`EXECUTE` |  `pg_last_wal_replay_lsn()`| Always required |
-|`EXECUTE` | `pg_wal_replay_resume()`| Always required |
-|`EXECUTE` | `pg_wal_replay_pause()` | Always required |
-|`EXECUTE` | `pg_reload_conf()` | When reconfigure.num.sync` or `reconfigure.sync.primary` is `true` |
-|`REPLICATION` | | When `update.physical.slots.period` property in effect (non-zero value) |
+Privilege   | Object                 | Condition
+------------|------------------------|----------
+EXECUTE     | `pg_current_wal_lsn()` | Always required
+EXECUTE     | `pg_last_wal_replay_lsn()` | Always required
+EXECUTE     | `pg_wal_replay_resume()` | Always required
+EXECUTE     | `pg_wal_replay_pause()` | Always required
+EXECUTE     | `pg_reload_conf()` | When `reconfigure.num.sync` or `reconfigure.sync.primary` is `true`
+REPLICATION |  | When the `update.physical.slots.period` property is in effect (non-zero value)
 
-
-| Role                | Condition         |
-|---------------------|-------------------|
-| `pg_read_all_settings` | Always required |
-| `pg_read_all_stats` | When reconfigure.num.sync` or `reconfigure.sync.primary` is `true` |
-| `pg_checkpoint` | When `auto.rewind` is set to `true` |
+Role                  | Condition
+----------------------|----------
+pg_read_all_settings  | Always required
+pg_read_all_stats     | When `reconfigure.num.sync` or `reconfigure.sync.primary` is `true`
+pg_checkpoint         | When `auto.rewind` is set to `true`

--- a/product_docs/docs/efm/5/installing/prerequisites.mdx
+++ b/product_docs/docs/efm/5/installing/prerequisites.mdx
@@ -101,7 +101,7 @@ The database user specified by the `db.user` property in the `efm.properties` fi
  `pg_wal_replay_pause()`
 
 
-If the `reconfigure.num.sync` or `reconfigure.sync.primary` property is set to `true`, then the db.user requires `pg_read_all_stats` privilege and permissions to run `pg_reload_conf()`.
+If the `reconfigure.num.sync` or `reconfigure.sync.primary` property is set to `true`, then the `db.user` requires `pg_read_all_stats` privilege and permissions to run `pg_reload_conf()`.
 
 For detailed information about each of these functions, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/index.html).
 
@@ -118,3 +118,23 @@ GRANT pg_read_all_settings TO <user_name>;
 ```
 
 For more information about `pg_read_all_settings`, see the [PostgreSQL core documentation](https://www.postgresql.org/docs/current/default-roles.html).
+
+If `auto.rewind` is set to `true`, then the `db.user` requires the `pg_checkpoint` role to be granted, as the Failover Manager agent will issue a `CHECKPOINT` command prior to executing `pg_rewind`.
+
+The required privileges are summarised in the following table:
+
+| Privilege |          Object        | Condition   |
+|-----------|------------------------|-------------|
+| `EXECUTE` | `pg_current_wal_lsn()` | Always required |
+|`EXECUTE` |  `pg_last_wal_replay_lsn()`| Always required |
+|`EXECUTE` | `pg_wal_replay_resume()`| Always required |
+|`EXECUTE` | `pg_wal_replay_pause()` | Always required |
+|`EXECUTE` | `pg_reload_conf()` | When reconfigure.num.sync` or `reconfigure.sync.primary` is `true` |
+|`REPLICATION` | | When `update.physical.slots.period` property in effect (non-zero value) |
+
+
+| Role                | Condition         |
+|---------------------|-------------------|
+| `pg_read_all_settings` | Always required |
+| `pg_read_all_stats` | When reconfigure.num.sync` or `reconfigure.sync.primary` is `true` |
+| `pg_checkpoint` | When `auto.rewind` is set to `true` |


### PR DESCRIPTION
In version 5.3, when `auto.rewind` is enabled, EFM issues a CHECKPOINT command (see 5.3 release notes), which requires the corresponding role to be granted. I added this information to the prerequisites page and also summarised all privileges and roles in two tables to make them easier to reference

## What Changed?

Added `pg_checkpoint` privilege to the prerequisites and tables to summarise the necessary privileges and roles.



<!-- draft-deploy start -->
> [!TIP]
> Draft deployment: https://deploy-preview-7204--edb-docs-staging.netlify.app/docs/
<!-- draft-deploy end -->