### PR TITLE
Update authentication details in API documentation

### DIFF
--- a/product_docs/docs/pem/10/pem_rest_api/index.mdx
+++ b/product_docs/docs/pem/10/pem_rest_api/index.mdx
@@ -230,7 +230,7 @@ Status Code **201**
 
 !!! info
 
-    Unlike other API calls, this operation does not use token-based authentication; supply username and password instead.
+    Unlike other API calls, this operation doesn't use token-based authentication; instead, supply the username and password.
 
 
 

--- a/product_docs/docs/pem/10/pem_rest_api/index.mdx
+++ b/product_docs/docs/pem/10/pem_rest_api/index.mdx
@@ -230,7 +230,7 @@ Status Code **201**
 
 !!! info
 
-    This operation does not require authentication
+    Unlike other API calls, this operation does not use token-based authentication; supply username and password instead.
 
 
 


### PR DESCRIPTION
Clarified authentication method for the operation in the API documentation. The current note is confusing.

## What Changed?

The note says the call to obtain the API token "does not require authentication", which is false; it simply use a different authentication method.